### PR TITLE
Fixed firefox addon link in header

### DIFF
--- a/components/layout/pw-header.vue
+++ b/components/layout/pw-header.vue
@@ -136,7 +136,7 @@
         </p>
         <div>
           <a
-            href="https://addons.mozilla.org/en-US/firefox/addon/postwoman"
+            href="https://addons.mozilla.org/en-US/firefox/addon/hoppscotch"
             target="_blank"
             rel="noopener"
           >


### PR DESCRIPTION
Hi, this is a PR to fix the Addon link as detailed in #1146 