### PR TITLE
Fix folder editing

### DIFF
--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -173,7 +173,7 @@ export default {
       this.syncCollections()
     },
     editFolder(payload) {
-      const { collectionIndex, folder, folderIndex } = payload
+      const { collection, collectionIndex, folder, folderIndex } = payload
       this.$data.editingCollection = collection
       this.$data.editingCollectionIndex = collectionIndex
       this.$data.editingFolder = folder


### PR DESCRIPTION
Getting a `collection is not defined` error when trying to edit a folder in a collection. Fixed by including missing destructure statement. 