### PR TITLE
Add check for active suggestion

### DIFF
--- a/components/ui/autocomplete.vue
+++ b/components/ui/autocomplete.vue
@@ -161,10 +161,15 @@ export default {
           break
 
         case "Tab":
-          event.preventDefault()
           let activeSuggestion = this.suggestions[
             this.currentSuggestionIndex >= 0 ? this.currentSuggestionIndex : 0
           ]
+
+          if (!activeSuggestion) {
+            return
+          }
+
+          event.preventDefault()
           let input = this.text.substring(0, this.selectionStart)
           this.text = input + activeSuggestion
           break


### PR DESCRIPTION
I noticed when trying to tab to the next input in the headers section, it would paste `undefined` into the current input. I've added a check that restores the tab functionality if there are no active suggestions.

Please let me know if there are any issues with this, thanks!