### PR TITLE
Fixed sidenav animation

### DIFF
--- a/components/layout/sidenav.vue
+++ b/components/layout/sidenav.vue
@@ -204,9 +204,8 @@ nav.primary-nav {
     @apply text-fgLightColor;
     @apply fill-current;
     @apply outline-none;
-    @apply transition;
-    @apply ease-in-out;
-    @apply duration-200;
+    transition: 0.2s ease;
+    border-radius: 50%;
 
     &:hover {
       @apply text-fgColor;

--- a/components/layout/sidenav.vue
+++ b/components/layout/sidenav.vue
@@ -204,8 +204,11 @@ nav.primary-nav {
     @apply text-fgLightColor;
     @apply fill-current;
     @apply outline-none;
-    transition: 0.2s ease;
+    @apply transition;
+    @apply ease-in-out;
+    @apply duration-200;
     border-radius: 50%;
+    transition-property: all !important;
 
     &:hover {
       @apply text-fgColor;


### PR DESCRIPTION
**Bug fixed**
Sidenav animation did not work

**To Reproduce**
Click on the sidenav icons. The animation is abrupt.

**Expected behavior**
The icon should slowly expand when it becomes active.

**Explanation**

- The `border-radius` on the nav link icons was set to `9999px`, hence transitioning to `16px` in 200ms did produce a noticeable change. 

- `transition-property` on the `nav > a` tags did not include border-radius.

- These were most likely due to Tailwind CSS (or that's what I understood from `@apply`)

**Solution**

- Set `border-radius` to `50%` for a circle instead of using `9999px`.

- Set `transition-property` to `all !important` for `nav > a` links.

I have verified that this fixes the animation.