### PR TITLE
Add search input & capability to graphql types and fields

### DIFF
--- a/components/graphql/field.vue
+++ b/components/graphql/field.vue
@@ -27,7 +27,8 @@
 
 <style scoped lang="scss">
 .field-highlighted {
-  color: #ffff00;
+  @apply border-b-2;
+  @apply border-acColor;
 }
 </style>
 

--- a/components/graphql/field.vue
+++ b/components/graphql/field.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-2 m-2 border-b border-dashed border-brdColor">
-    <div class="field-title">
+    <div class="field-title" :class="{ 'field-highlighted': isHighlighted }">
       {{ fieldName }}
       <span v-if="fieldArgs.length > 0">
         (
@@ -25,11 +25,18 @@
   </div>
 </template>
 
+<style scoped lang="scss">
+.field-highlighted {
+  color: #ffff00;
+}
+</style>
+
 <script>
 export default {
   props: {
     gqlField: Object,
     jumpTypeCallback: Function,
+    isHighlighted: { type: Boolean, default: false },
   },
 
   computed: {

--- a/components/graphql/type.vue
+++ b/components/graphql/type.vue
@@ -21,7 +21,7 @@
 
 <style scoped lang="scss">
 .type-highlighted {
-  color: #ffff00;
+  @apply text-acColor;
 }
 </style>
 

--- a/components/graphql/type.vue
+++ b/components/graphql/type.vue
@@ -1,23 +1,44 @@
 <template>
   <div class="p-2 m-2">
-    <div class="font-bold type-title">{{ gqlType.name }}</div>
+    <div class="font-bold type-title" :class="{ 'type-highlighted': isHighlighted }">
+      {{ gqlType.name }}
+    </div>
     <div class="mt-2 text-fgLightColor type-desc" v-if="gqlType.description">
       {{ gqlType.description }}
     </div>
     <div v-if="gqlType.getFields">
       <h5>{{ $t("fields") }}</h5>
       <div v-for="field in gqlType.getFields()" :key="field.name">
-        <field :gqlField="field" :jumpTypeCallback="jumpTypeCallback" />
+        <field
+          :gqlField="field"
+          :isHighlighted="isFieldHighlighted({ field })"
+          :jumpTypeCallback="jumpTypeCallback"
+        />
       </div>
     </div>
   </div>
 </template>
+
+<style scoped lang="scss">
+.type-highlighted {
+  color: #ffff00;
+}
+</style>
 
 <script>
 export default {
   props: {
     gqlType: {},
     jumpTypeCallback: Function,
+    isHighlighted: { type: Boolean, default: false },
+    highlightedFields: { type: Array, default: [] },
+  },
+  methods: {
+    isFieldHighlighted({ field }) {
+      return !!this.highlightedFields.find(
+        (highlightedField) => highlightedField.name === field.name
+      )
+    },
   },
 }
 </script>

--- a/helpers/codegen/generators/go-native.js
+++ b/helpers/codegen/generators/go-native.js
@@ -22,7 +22,13 @@ export const GoNativeCodegen = {
     let genHeaders = []
     // initial request setup
     let requestBody = rawInput ? rawParams : rawRequestBody
+    if (method == "GET") {
+      requestString.push(
+        `req, err := http.NewRequest("${method}", "${url}${pathName}${queryString}")\n`
+      )
+    }
     if (["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
+      genHeaders.push(`req.Header.Set("Content-Type", "${contentType}")\n`)
       if (isJSONContentType(contentType)) {
         requestString.push(`var reqBody = []byte(\`${requestBody}\`)\n\n`)
         requestString.push(
@@ -36,7 +42,6 @@ export const GoNativeCodegen = {
     }
 
     // headers
-    genHeaders.push(`req.Header.Set("Content-Type", "${contentType}")\n`)
     // auth
     if (auth === "Basic Auth") {
       const basic = `${httpUser}:${httpPassword}`

--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -491,7 +491,6 @@ export default {
 
         return isFilterTextMatchingAtLeastOneField
       })
-      return types
     },
     getSpecialKey: getPlatformSpecialKey,
     doPrettifyQuery() {

--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -456,8 +456,8 @@ export default {
 
       const isFilterTextFoundInDescription = graphqlFieldObject.description
         .toLowerCase()
-        .includes(text)
-      const isFilterTextFoundInName = graphqlFieldObject.name.toLowerCase().includes(text)
+        .includes(normalizedText)
+      const isFilterTextFoundInName = graphqlFieldObject.name.toLowerCase().includes(normalizedText)
 
       return isFilterTextFoundInDescription || isFilterTextFoundInName
     },
@@ -470,6 +470,7 @@ export default {
     },
     getFilteredGraphqlTypes({ filterText, types }) {
       if (!filterText) return types
+
       return types.filter((type) => {
         const isFilterTextMatching = this.isTextFoundInGraphqlFieldObject({
           text: filterText,

--- a/pages/graphql.vue
+++ b/pages/graphql.vue
@@ -295,7 +295,12 @@
 
                 <tab v-if="gqlTypes.length > 0" :id="'types'" :label="$t('types')" ref="typesTab">
                   <div v-for="type in filteredGqlTypes" :key="type.name" :id="`type_${type.name}`">
-                    <type :gqlType="type" :jumpTypeCallback="handleJumpToType" />
+                    <type
+                      :gqlType="type"
+                      :isHighlighted="isGqlTypeHighlighted({ gqlType: type })"
+                      :highlightedFields="getGqlTypeHighlightedFields({ gqlType: type })"
+                      :jumpTypeCallback="handleJumpToType"
+                    />
                   </div>
                 </tab>
               </div>
@@ -451,6 +456,28 @@ export default {
     }
   },
   methods: {
+    isGqlTypeHighlighted({ gqlType }) {
+      if (!this.graphqlFieldsFilterText) return false
+
+      return this.isTextFoundInGraphqlFieldObject({
+        text: this.graphqlFieldsFilterText,
+        graphqlFieldObject: gqlType,
+      })
+    },
+    getGqlTypeHighlightedFields({ gqlType }) {
+      if (!this.graphqlFieldsFilterText) return []
+
+      const fields = Object.values(gqlType._fields || {})
+
+      if (!fields || fields.length === 0) return []
+
+      return fields.filter((field) => {
+        return this.isTextFoundInGraphqlFieldObject({
+          text: this.graphqlFieldsFilterText,
+          graphqlFieldObject: field,
+        })
+      })
+    },
     isTextFoundInGraphqlFieldObject({ text, graphqlFieldObject }) {
       const normalizedText = text.toLowerCase()
 


### PR DESCRIPTION
Related issue #1188 

The PR adds basic filtering for `queryFields`, `mutationFields`, `subscriptionFields` and `gqlTypes`.

The value provided to the search input is used to match on `fieldName` and `description` fields.

`gqlTypes` are handled differently as we also filter on `gqlTypes._fields` array.

Some improvements for an other PR could be to highlight matched text (?)
Also, `gqlTypes._fields` filtering could be improved by keeping only matched fields as it can be confusing to see the whole Schema and having to scroll until you find concerned field

**Unfiltered results**

![image](https://user-images.githubusercontent.com/7238941/94995395-4d03d300-059e-11eb-9110-9d2a22c4e75f.png)


**Filtered results**

![image](https://user-images.githubusercontent.com/7238941/94995407-5a20c200-059e-11eb-86cd-39a0e073f797.png)
