### PR TITLE
Fix: ios home bar covers content

### DIFF
--- a/assets/scss/styles.scss
+++ b/assets/scss/styles.scss
@@ -761,6 +761,7 @@ section {
 
   main {
     padding: 0 8px 68px;
+    margin-bottom: env(safe-area-inset-bottom);
   }
 
   ul,

--- a/components/layout/sidenav.vue
+++ b/components/layout/sidenav.vue
@@ -300,6 +300,7 @@ nav.secondary-nav {
     @apply justify-between;
     @apply bg-bgDarkColor;
     @apply space-y-0;
+    padding-bottom: env(safe-area-inset-bottom);
 
     a {
       @apply bg-transparent;


### PR DESCRIPTION
Fixes issue #1003 

Adds extra spacing to account for the home bar on some iPhone devices, using the safe-area-inset-bottom env variable.