### PR TITLE
Fix: http page headers suggestions overlapped issue

### DIFF
--- a/components/ui/tabs.vue
+++ b/components/ui/tabs.vue
@@ -30,7 +30,6 @@
   @apply flex-col;
   @apply flex-no-wrap;
   @apply flex-1;
-  @apply overflow-hidden;
 
   .tabs {
     @apply scrolling-touch;


### PR DESCRIPTION
Fixes issue #1222

The header dropdown was being cut off due to the parent container .tabs having overflow set to hidden so have removed this property from the styles and this has fixed the issue:

<img width="353" alt="Screenshot 2020-10-03 at 19 38 27" src="https://user-images.githubusercontent.com/42917940/94999412-2b601700-05b1-11eb-8701-671c20b5e0a7.png">
