### PR TITLE
fix:add 'helpers' folder to docker compose volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "./static:/app/static"
       - "./store:/app/store"
       - "./components:/app/components"
+      - "./helpers:/app/helpers"
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
Hi,

I was playing with the repository so I can learn how to add a code generator for the issue https://github.com/hoppscotch/hoppscotch/issues/1190 and found that the `helpers` folder was not mapped in `docker-compose.yml`.

I added it so hot-reload can work while editing code generators.

Seems like `functions`, `lang` and `netlify` folders are missing too. I didn't add them as I don't need them for now and I don't know docker enough to know what is the impact but I can edit the PR if you want them to be added.