### PR TITLE
Remove extra console log

### DIFF
--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -144,7 +144,6 @@ export default {
         const filteredRequests = []
         const filteredFolders = []
         for (let request of collection.requests) {
-          console.log(request)
           if (request.name.toLowerCase().includes(filterText)) filteredRequests.push(request)
         }
         for (let folder of collection.folders) {


### PR DESCRIPTION
Accidentally left a `console.log` in #1260. This PR fixes that.