### PR TITLE
WIP Feat/realtime tab session persistence

### DIFF
--- a/components/realtime/socketio.vue
+++ b/components/realtime/socketio.vue
@@ -145,9 +145,7 @@ export default {
         return this.$store.state.socketIO.socket
       },
       set(value) {
-        console.log("i am here")
         this.$store.commit("setSocketIOState", { value, attribute: "socket" })
-        console.log("afterwards")
       },
     },
     log: {
@@ -195,18 +193,14 @@ export default {
       ]
 
       try {
-        console.log("1")
         if (!this.path) {
           this.path = "/socket.io"
         }
-        console.log("2")
         this.socket = new io(this.url, {
           path: this.path,
         })
-        console.log("3")
         // Add ability to listen to all events
         wildcard(io.Manager)(this.socket)
-        console.log("here")
         this.socket.on("connect", () => {
           this.log = [
             {
@@ -260,7 +254,6 @@ export default {
       this.socket = null
     },
     handleError(error) {
-      console.log("now i'm here")
       this.disconnect()
       this.addToLog({
         payload: this.$t("error_occurred"),

--- a/components/realtime/sse.vue
+++ b/components/realtime/sse.vue
@@ -78,6 +78,7 @@ export default {
         try {
           this.sse = new EventSource(this.server)
           this.sse.onopen = (event) => {
+            console.log("here")
             this.connectionSSEState = true
             this.events.log = [
               {

--- a/components/realtime/websocket.vue
+++ b/components/realtime/websocket.vue
@@ -236,6 +236,20 @@ export default {
           break
       }
     },
+    handleRefresh() {
+      // refreshing disconnects socket so we must manually add that to log
+      if (this.socket instanceof WebSocket) {
+        this.addToLog({
+          payload: this.$t("disconnected_from", { name: this.url }),
+          source: "info",
+          color: "#ff5555",
+          ts: new Date().toLocaleTimeString(),
+        })
+      }
+    },
+  },
+  beforeMount() {
+    window.addEventListener("beforeunload", this.handleRefresh)
   },
 }
 </script>

--- a/store/mutations.js
+++ b/store/mutations.js
@@ -3,6 +3,14 @@ export default {
     request[attribute] = value
   },
 
+  setWebSocketState({ ws }, { attribute, value }) {
+    ws[attribute] = value
+  },
+
+  addWebSocketLog({ ws }, object) {
+    ws.log.push(object)
+  },
+
   setGQLState({ gql }, { attribute, value }) {
     gql[attribute] = value
   },

--- a/store/mutations.js
+++ b/store/mutations.js
@@ -19,6 +19,26 @@ export default {
     eventSource.log.push(object)
   },
 
+  setSocketIOState({ socketIO }, { attribute, value }) {
+    socketIO[attribute] = value
+  },
+
+  addSocketIOLog({ socketIO }, object) {
+    socketIO.log.push(object)
+  },
+
+  addSocketIOInputs({ socketIO }, str) {
+    socketIO.inputs.push(str)
+  },
+
+  removeFromSocketIOInputs({ socketIO }, index) {
+    socketIO.inputs.splice(index, 1)
+  },
+
+  setSocketIOInput({ socketIO }, { index, value }) {
+    socketIO.inputs[index] = value
+  },
+
   setGQLState({ gql }, { attribute, value }) {
     gql[attribute] = value
   },

--- a/store/mutations.js
+++ b/store/mutations.js
@@ -11,6 +11,14 @@ export default {
     ws.log.push(object)
   },
 
+  setEventSourceState({ eventSource }, { attribute, value }) {
+    eventSource[attribute] = value
+  },
+
+  addEventSourceLog({ eventSource }, object) {
+    eventSource.log.push(object)
+  },
+
   setGQLState({ gql }, { attribute, value }) {
     gql[attribute] = value
   },

--- a/store/mutations.js
+++ b/store/mutations.js
@@ -43,6 +43,14 @@ export default {
     gql[attribute] = value
   },
 
+  setMQTTState({ mqtt }, { attribute, value }) {
+    mqtt[attribute] = value
+  },
+
+  addMQTTLog({ mqtt }, object) {
+    mqtt.log.push(object)
+  },
+
   setCollapsedSection({ theme }, value) {
     theme.collapsedSections.includes(value)
       ? (theme.collapsedSections = theme.collapsedSections.filter((section) => section !== value))

--- a/store/state.js
+++ b/store/state.js
@@ -18,6 +18,12 @@ export default () => ({
     requestType: "",
     contentType: "",
   },
+  ws: {
+    url: "wss://echo.websocket.org",
+    message: "",
+    log: [],
+    socket: null,
+  },
   gql: {
     url: "https://rickandmortyapi.com/graphql",
     headers: [],

--- a/store/state.js
+++ b/store/state.js
@@ -24,6 +24,11 @@ export default () => ({
     log: [],
     socket: null,
   },
+  eventSource: {
+    server: "https://express-eventsource.herokuapp.com/events",
+    sse: null,
+    log: [],
+  },
   gql: {
     url: "https://rickandmortyapi.com/graphql",
     headers: [],

--- a/store/state.js
+++ b/store/state.js
@@ -29,6 +29,14 @@ export default () => ({
     sse: null,
     log: [],
   },
+  socketIO: {
+    url: "wss://main-daxrc78qyb411dls-gtw.qovery.io",
+    path: "/socket.io",
+    socket: null,
+    log: [],
+    eventName: "",
+    inputs: [],
+  },
   gql: {
     url: "https://rickandmortyapi.com/graphql",
     headers: [],

--- a/store/state.js
+++ b/store/state.js
@@ -37,6 +37,14 @@ export default () => ({
     eventName: "",
     inputs: [],
   },
+  mqtt: {
+    url: "wss://test.mosquitto.org:8081",
+    client: null,
+    pub_topic: "",
+    sub_topic: "",
+    msg: "",
+    log: [],
+  },
   gql: {
     url: "https://rickandmortyapi.com/graphql",
     headers: [],


### PR DESCRIPTION
Hey, sorry for taking so long with this 😕
I was able to add persistence to 3 out of the 4 realtime tabs. It's just SocketIO that's giving me some trouble. What I've done in each tab is move all the data into `vuex` including each client. Like @LeoMartinDev suggested, I changed the connectionStates to be computed from the instance of each client, and renamed all of them to `isConnected`.

SocketIO is giving me trouble because I've followed the same pattern of putting it in `vuex`, but on connect, it says I'm mutating state outside of a store handler for some reason. 

I also haven't added persistence where it stays on the same realtime tab on refresh or going to a different tab. It just always defaults to WebSocket tab. 

Anyways, hope I can get some feedback on this to match coding standards of this repo. Thanks! 🙂