### PR TITLE
feat: add JSON-LD to the list of known content types

### DIFF
--- a/helpers/utils/contenttypes.js
+++ b/helpers/utils/contenttypes.js
@@ -1,7 +1,8 @@
 export const knownContentTypes = [
   "application/json",
-  "application/vnd.api+json",
+  "application/ld+json",
   "application/hal+json",
+  "application/vnd.api+json",
   "application/xml",
   "application/x-www-form-urlencoded",
   "text/html",


### PR DESCRIPTION
Add [JSON-LD](https://json-ld.org/) to the list of known content types. It's a standard and a format commonly used by web APIs and in the Linked Data ecosystem (Schema.org, SOLID, ActivityPub...).

It's also used by default by [API Platform](https://api-platform.com) that I maintain. I will probably create more following PR to ensure that Hoppscotch and API Platform play well together!