### PR TITLE
fixed path parameter encoding and URL updation

### DIFF
--- a/helpers/templating.js
+++ b/helpers/templating.js
@@ -3,5 +3,6 @@ export default function parseTemplateString(string, variables) {
     return string
   }
   const searchTerm = /<<([^>]*)>>/g // "<<myVariable>>"
-  return decodeURI(encodeURI(string)).replace(searchTerm, (match, p1) => variables[p1] || "")
+  string = new URL(string).toString();
+  return decodeURI(string).replace(searchTerm, (match, p1) => variables[p1] || "")
 }

--- a/helpers/utils/uri.js
+++ b/helpers/utils/uri.js
@@ -3,7 +3,7 @@ export function parseUrlAndPath(value) {
   try {
     let url = new URL(value)
     result.url = url.origin
-    result.path = url.pathname
+    result.path = decodeURIComponent(url.pathname)
   } catch (error) {
     let uriRegex = value.match(/^((http[s]?:\/\/)?(<<[^\/]+>>)?[^\/]*|)(\/?.*)$/)
     result.url = uriRegex[1]

--- a/helpers/utils/uri.js
+++ b/helpers/utils/uri.js
@@ -3,7 +3,7 @@ export function parseUrlAndPath(value) {
   try {
     let url = new URL(value)
     result.url = url.origin
-    result.path = decodeURIComponent(url.pathname)
+    result.path = url.pathname
   } catch (error) {
     let uriRegex = value.match(/^((http[s]?:\/\/)?(<<[^\/]+>>)?[^\/]*|)(\/?.*)$/)
     result.url = uriRegex[1]

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -906,19 +906,19 @@ export default {
       },
       set(value) {
         this.$store.commit("setState", { value, attribute: "uri" })
-        let url = value
-        if ((this.preRequestScript && this.showPreRequestScript) || hasPathParams(this.params)) {
-          let environmentVariables = getEnvironmentVariablesFromScript(this.preRequestScript)
-          environmentVariables = addPathParamsToVariables(this.params, environmentVariables)
-          url = parseTemplateString(value, environmentVariables)
-        }
-        let result = parseUrlAndPath(url)
-        this.url = result.url
-        this.path = result.path
       },
     },
     url: {
       get() {
+        let url = this.uri.toString()
+        if ((this.preRequestScript && this.showPreRequestScript) || hasPathParams(this.params)) {
+          let environmentVariables = getEnvironmentVariablesFromScript(this.preRequestScript)
+          environmentVariables = addPathParamsToVariables(this.params, environmentVariables)
+          url = parseTemplateString(this.uri.toString(), environmentVariables)
+        }
+        let result = parseUrlAndPath(url)
+        this.url = result.url
+        this.path = result.path
         return this.$store.state.request.url
       },
       set(value) {
@@ -1088,6 +1088,7 @@ export default {
         return this.$store.state.request.params
       },
       set(value) {
+        console.log(value)
         this.$store.commit("setState", { value, attribute: "params" })
       },
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1088,7 +1088,6 @@ export default {
         return this.$store.state.request.params
       },
       set(value) {
-        console.log(value)
         this.$store.commit("setState", { value, attribute: "params" })
       },
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -851,7 +851,6 @@ export default {
       // @TODO: Convert all variables to single request variable
       if (!newValue) return
       this.uri = newValue.url + newValue.path
-      this.url = newValue.url
       this.path = newValue.path
       this.method = newValue.method
       this.auth = newValue.auth
@@ -902,7 +901,7 @@ export default {
     },
     uri: {
       get() {
-        return this.$store.state.request.uri ? this.$store.state.request.uri : this.url + this.path
+        return this.$store.state.request.uri;
       },
       set(value) {
         this.$store.commit("setState", { value, attribute: "uri" })
@@ -1281,7 +1280,6 @@ export default {
       this.name = entry.name
       this.method = entry.method
       this.uri = entry.url + entry.path
-      this.url = entry.url
       this.path = entry.path
       this.showPreRequestScript = entry.usesPreScripts
       this.preRequestScript = entry.preRequestScript
@@ -1747,9 +1745,8 @@ export default {
       try {
         const parsedCurl = parseCurlCommand(text)
         const { origin, pathname } = new URL(parsedCurl.url.replace(/"/g, "").replace(/'/g, ""))
-        this.url = origin
         this.path = pathname
-        this.uri = this.url + this.path
+        this.uri = origin + this.path
         this.headers = []
         if (parsedCurl.headers) {
           for (const key of Object.keys(parsedCurl.headers)) {
@@ -1815,9 +1812,8 @@ export default {
           break
         default:
           this.method = "GET"
-          this.url = "https://httpbin.org"
+          this.uri = "https://httpbin.org/get"
           this.path = "/get"
-          this.uri = this.url + this.path
           this.name = "Untitled request"
           this.bodyParams = []
           this.rawParams = "{}"

--- a/store/state.js
+++ b/store/state.js
@@ -2,7 +2,7 @@ export default () => ({
   request: {
     name: "Untitled request",
     method: "GET",
-    uri: "",
+    uri: "https://httpbin.org/get",
     url: "https://httpbin.org",
     path: "/get",
     auth: "None",


### PR DESCRIPTION
Changed the parseTemplateString function. new URL(string).toString() would take care of bad format URLs instead of calling encodeURI explicitly as was done in this [commit](https://github.com/hoppscotch/hoppscotch/commit/9ac0cf140657167974d7b8b7015c851347139dcd#diff-ed425e40c260457bd7cafb88cf0ddc51b1895c787b93dc81c6fc31bf9496f911) to ensure double encoding doesn't occur on the URLs.

Also changed the way updation happens for URLs. On getting a URL, I am regenerating it from the URI and parameters instead of creating it in advance. Creating in advance is an issue when the parameter values are changed as mentioned in issue #1452

Solves #1451 #1452 