### PR TITLE
[Feat:Teams] Team collections tab and View team collections

### DIFF
--- a/components/collections/choose-collection-type.vue
+++ b/components/collections/choose-collection-type.vue
@@ -10,7 +10,6 @@
             <tab
                 :id="'team-collections'"
                 :label="'Team Collections'"
-                :selected="false"
             >
                 <ul>
                     <li>
@@ -41,10 +40,7 @@
 </template>
 
 <script>
-import tabs from '../ui/tabs';
 import gql from "graphql-tag"
-
-var teamCollectionsTab = document.getElementById('team-collections')
 
 export default {
     props: {

--- a/components/collections/choose-collection-type.vue
+++ b/components/collections/choose-collection-type.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="show">
-        <tabs style="m-4" :id="'collections_tab'" v-on:tab-changed="updateCollectionsType">
+        <tabs styles="m-4" :id="'collections_tab'" v-on:tab-changed="updateCollectionsType">
             <tab
                 :id="'my-collections'"
                 :label="'My Collections'"

--- a/components/collections/choose-collection-type.vue
+++ b/components/collections/choose-collection-type.vue
@@ -1,0 +1,85 @@
+<template>
+    <div v-if="show">
+        <tabs style="m-4" :id="'collections_tab'" v-on:tab-changed="updateCollectionsType">
+            <tab
+                :id="'my-collections'"
+                :label="'My Collections'"
+                :selected="true"
+            >
+            </tab>
+            <tab
+                :id="'team-collections'"
+                :label="'Team Collections'"
+                :selected="false"
+            >
+                <ul>
+                    <li>
+                        <label for="select_team"> Select Team: </label>
+                        <span class="select-wrapper">
+                            <select 
+                            type="text" 
+                            id="team"
+                            class="team"
+                            v-model="selectedTeam"
+                            autofocus
+                            >
+                                <option
+                                v-for="(team, index) in myTeams"
+                                :key="index"
+                                :value="team"
+                                >
+                                {{ team.name }}
+                                </option>
+                            </select>
+                        </span>
+                    </li>
+                </ul>
+            </tab>
+        </tabs>
+
+    </div>
+</template>
+
+<script>
+import tabs from '../ui/tabs';
+import gql from "graphql-tag"
+
+var teamCollectionsTab = document.getElementById('team-collections')
+
+export default {
+    props: {
+        collectionsType: Object,
+        show: Boolean
+    },
+    apollo: {    
+        myTeams: {
+            query: gql`
+                query GetMyTeams {
+                    myTeams {
+                        id
+                        name
+                    }
+                }
+            `,
+            pollInterval: 10000,
+        }
+    },
+    computed: {
+        selectedTeam() {
+            if(this.myTeams == null) return {name: 'Loading'}
+            if(this.collectionsType.selectedTeam == null) {
+                this.collectionsType.selectedTeam = this.myTeams[0]
+                this.$emit('collectionsType-updated');
+            }
+            return this.collectionsType.selectedTeam
+        },
+    },
+    methods: {
+        updateCollectionsType(tabID) {
+            this.collectionsType.type = tabID
+            this.$emit('collectionsType-updated');
+
+        }
+    }
+}
+</script>

--- a/components/ui/tabs.vue
+++ b/components/ui/tabs.vue
@@ -115,6 +115,7 @@ export default {
       this.tabs.forEach((tab) => {
         tab.isActive = tab.id == id
       })
+      this.$emit('tab-changed', id)
     },
   },
 }


### PR DESCRIPTION
**Changes:**
* Implemented integration of teams with collections in collections/index.vue 
* switching between My Collections and Team Collections and choosing team under Team Collections
* viewing team collections

**Remaining tasks:**
* Add, edit, delete and import collection/folders are still to be implemented for teams (coming in another PR).
* collection fetch requests need to be of type "no-cache" (coming in another PR)
* All text is as strings and not in the $t("..") format.

**Preview:**

![Screenshot 2021-02-11 at 2 39 01 PM](https://user-images.githubusercontent.com/45964755/107739713-80feba00-6d2f-11eb-9df4-1f1790ff463d.png)

