### PR TITLE
Feat: Add, delete and edit team collection -  Raghav

### DIFF
--- a/components/collections/add-collection.vue
+++ b/components/collections/add-collection.vue
@@ -38,10 +38,12 @@
 
 <script>
 import { fb } from "~/helpers/fb"
+import gql from "graphql-tag"
 
 export default {
   props: {
     show: Boolean,
+    collectionsType: Object
   },
   data() {
     return {
@@ -61,11 +63,48 @@ export default {
         this.$toast.info(this.$t("invalid_collection_name"))
         return
       }
-      this.$store.commit("postwoman/addNewCollection", {
-        name: this.$data.name,
-      })
-      this.$emit("hide-modal")
-      this.syncCollections()
+      if(this.collectionsType.type == "my-collections" ) {
+        this.$store.commit("postwoman/addNewCollection", {
+          name: this.$data.name,
+        })
+        this.syncCollections()
+      }
+      else if (this.collectionsType.type == "team-collections") {
+        if (this.collectionsType.selectedTeam.myRole != "VIEWER") {
+          this.$apollo
+          .mutate({
+            // Query
+            mutation: gql`
+              mutation($title: String!, $teamID: String!) {
+                createRootCollection(title: $title, teamID: $teamID) {
+                  id
+                }
+              }
+            `,
+            // Parameters
+            variables: {
+              title: this.$data.name,
+              teamID: this.collectionsType.selectedTeam.id,
+            },
+          })
+          .then((data) => {
+            // Result
+            this.$toast.success(this.$t("collection_added"), {
+              icon: "done",
+            })
+            console.log(data)
+            this.$emit('update-team-collections');
+          })
+          .catch((error) => {
+            // Error
+            this.$toast.error(this.$t("error_occurred"), {
+              icon: "done",
+            })
+            console.error(error)
+          })
+        }
+      }
+      this.hideModal()
     },
     hideModal() {
       this.$emit("hide-modal")

--- a/components/collections/choose-collection-type.vue
+++ b/components/collections/choose-collection-type.vue
@@ -64,6 +64,7 @@ export default {
                     myTeams {
                         id
                         name
+                        myRole
                     }
                 }
             `,

--- a/components/collections/collection.vue
+++ b/components/collections/collection.vue
@@ -40,13 +40,25 @@
               </button>
             </div>
             <div>
-              <button class="icon" @click="$emit('edit-collection')" v-close-popover>
+              <button v-if="collectionsType.type=='team-collections' && collectionsType.selectedTeam.myRole == 'VIEWER'" class="icon" @click="$emit('edit-collection')" v-close-popover disabled>
+                <i class="material-icons">create</i>
+                <div  v-tooltip.left="$t('disable_new_collection')">
+                  <span>{{ $t("edit") }}</span>
+                </div>
+              </button>
+              <button v-else class="icon" @click="$emit('edit-collection')" v-close-popover>
                 <i class="material-icons">create</i>
                 <span>{{ $t("edit") }}</span>
               </button>
             </div>
             <div>
-              <button class="icon" @click="confirmRemove = true" v-close-popover>
+              <button v-if="collectionsType.type=='team-collections' && collectionsType.selectedTeam.myRole == 'VIEWER'" class="icon" @click="confirmRemove = true" v-close-popover disabled>
+                <i class="material-icons">add</i>
+                <div  v-tooltip.left="$t('disable_new_collection')">
+                  <span>{{ $t("delete") }}</span>
+                </div>
+              </button>
+              <button v-else class="icon" @click="confirmRemove = true" v-close-popover>
                 <i class="material-icons">delete</i>
                 <span>{{ $t("delete") }}</span>
               </button>
@@ -189,13 +201,48 @@ export default {
       }
     },
     removeCollection() {
-      this.$store.commit("postwoman/removeCollection", {
-        collectionIndex: this.collectionIndex,
-      })
-      this.$toast.error(this.$t("deleted"), {
-        icon: "delete",
-      })
-      this.syncCollections()
+      if(this.collectionsType.type == "my-collections" ) {
+        this.$store.commit("postwoman/removeCollection", {
+          collectionIndex: this.collectionIndex,
+        })
+        this.$toast.error(this.$t("deleted"), {
+          icon: "delete",
+        })
+        this.syncCollections()
+      }
+      else if (this.collectionsType.type == "team-collections") {
+        if (this.collectionsType.selectedTeam.myRole != "VIEWER") {
+          this.$apollo
+          .mutate({
+            // Query
+            mutation: gql`
+              mutation($collectionID: String!) {
+                deleteCollection(collectionID: $collectionID) 
+              }
+            `,
+            // Parameters
+            variables: {
+              collectionID: this.collection.id,
+            },
+          })
+          .then((data) => {
+            // Result
+            this.$toast.success(this.$t("deleted"), {
+              icon: "delete",
+            })
+            console.log(data)
+            this.$emit('update-team-collections');
+          })
+          .catch((error) => {
+            // Error
+            this.$toast.error(this.$t("error_occurred"), {
+              icon: "done",
+            })
+            console.error(error)
+          })
+        }
+      }
+      this.confirmRemove = false
     },
     dropEvent({ dataTransfer }) {
       this.dragging = !this.dragging

--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -13,11 +13,16 @@
       :collectionsType="collectionsType" 
       @update-team-collections="updateTeamCollections" 
       :show="showTeamCollections" />
-    <add-collection :show="showModalAdd" @hide-modal="displayModalAdd(false)" />
+    <add-collection 
+      :collectionsType="collectionsType" 
+      :show="showModalAdd" 
+      @update-team-collections="updateTeamCollections"
+      @hide-modal="displayModalAdd(false)" />
     <edit-collection
       :show="showModalEdit"
       :editing-collection="editingCollection"
       :editing-collection-index="editingCollectionIndex"
+      :collectionsType="collectionsType"
       @hide-modal="displayModalEdit(false)"
     />
     <add-folder
@@ -48,7 +53,13 @@
       @hide-modal="displayModalImportExport(false)"
     />
     <div class="border-b row-wrapper border-brdColor">
-      <button class="icon" @click="displayModalAdd(true)">
+      <button v-if="collectionsType.type=='team-collections' && collectionsType.selectedTeam.myRole == 'VIEWER'" class="icon" @click="displayModalAdd(true)" disabled>
+        <i class="material-icons">add</i>
+        <div  v-tooltip.left="$t('disable_new_collection')">
+          <span>{{ $t("new") }}</span>
+        </div>
+      </button>
+      <button v-else class="icon" @click="displayModalAdd(true)">
         <i class="material-icons">add</i>
         <span>{{ $t("new") }}</span>
       </button>
@@ -73,6 +84,7 @@
             @add-folder="addFolder($event)"
             @edit-folder="editFolder($event)"
             @edit-request="editRequest($event)"
+            @update-team-collections="updateTeamCollections"
             @select-collection="$emit('use-collection', collection)"
           />
         </li>
@@ -130,6 +142,7 @@ export default {
                 myTeams {
                     id
                     name
+                    myRole
                 }
             }
         `,

--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -53,7 +53,7 @@
       @hide-modal="displayModalImportExport(false)"
     />
     <div class="border-b row-wrapper border-brdColor">
-      <button v-if="collectionsType.type=='team-collections' && collectionsType.selectedTeam.myRole == 'VIEWER'" class="icon" @click="displayModalAdd(true)" disabled>
+      <button v-if="collectionsType.type=='team-collections' && (collectionsType.selectedTeam == undefined || collectionsType.selectedTeam.myRole == 'VIEWER')" class="icon" @click="displayModalAdd(true)" disabled>
         <i class="material-icons">add</i>
         <div  v-tooltip.left="$t('disable_new_collection')">
           <span>{{ $t("new") }}</span>
@@ -225,6 +225,7 @@ export default {
   },
   methods: {
     updateTeamCollections() {
+      console.log(this.collectionsType)
       if(this.collectionsType.selectedTeam == undefined) return;
       this.$apollo.query({
         query: gql`

--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -320,6 +320,8 @@
   "new_team_created": "New team created",
   "team_saved": "Team saved",
   "team_name_empty": "Team name empty",
+  "disable_new_collection": "You do not have edit access to these collections",
+  "collection_added": "Collection added successfully",
   "team_exited": "Team exited",
   "disable_exit": "Only owner cannot exit the team"
 }


### PR DESCRIPTION
This PR intends to bring add, delete and edit functionalities to team collections.

The changes implemented are:
- Disable the new, edit, and delete collection button for VIEWER
- Implement functions and GraphQL mutations to add, delete and edit team collection

P.S. Folder feature in team collections is not yet implemented and would be implemented next.