### PR TITLE
Preliminary naming of form data fields support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN npm run generate
 ENV HOST 0.0.0.0
 EXPOSE 3000
 
-CMD ["npm", "run"]
+CMD ["npm", "run", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN npm run generate
 ENV HOST 0.0.0.0
 EXPOSE 3000
 
-CMD ["npm", "run", "start"]
+CMD ["npm", "run"]

--- a/components/http/http-body-parameters.vue
+++ b/components/http/http-body-parameters.vue
@@ -80,6 +80,25 @@
           </button>
         </li>
       </div>
+      <div v-if="contentType === 'multipart/form-data'">
+        <li>
+          <label for="attachment" class="p-0">
+            <button
+              class="icon"
+              @click="$refs.attachment[index].click()"
+            >
+              <i class="material-icons">attach_file</i>
+            </button>
+          </label>
+          <input
+            ref="attachment"
+            name="attachment"
+            type="file"
+            @change="setRequestAttachment($event, index)"
+            multiple
+          />
+        </li>
+      </div>
       <div>
         <li>
           <button
@@ -119,14 +138,17 @@ export default {
       this.$emit("remove-request-body-param", index)
     },
     addRequestBodyParam() {
-      console.log(this.contentType)
       this.$emit("add-request-body-param")
     },
+    setRequestAttachment(event, index) {
+      const { files } = event.target
+      this.$emit("set-request-attachment", index, files)
+    }
   },
   computed: {
     contentType() {
       return this.$store.state.request.contentType
     }
-  }
+  },
 }
 </script>

--- a/components/http/http-body-parameters.vue
+++ b/components/http/http-body-parameters.vue
@@ -119,8 +119,14 @@ export default {
       this.$emit("remove-request-body-param", index)
     },
     addRequestBodyParam() {
+      console.log(this.contentType)
       this.$emit("add-request-body-param")
     },
   },
+  computed: {
+    contentType() {
+      return this.$store.state.request.contentType
+    }
+  }
 }
 </script>

--- a/components/http/http-body-parameters.vue
+++ b/components/http/http-body-parameters.vue
@@ -42,9 +42,13 @@
           :placeholder="`value ${index + 1}`"
           :value="param.value"
           @change="
+            // if input is form data, set value to be an array containing the value
+            // only
             $store.commit('setValueBodyParams', {
               index,
-              value: $event.target.value,
+              value: contentType !== 'multipart/form-data' 
+                ? $event.target.value 
+                : [$event.target.value]
             })
           "
           @keyup.prevent="setRouteQueryState"
@@ -142,7 +146,11 @@ export default {
     },
     setRequestAttachment(event, index) {
       const { files } = event.target
-      this.$emit("set-request-attachment", index, files)
+      this.$emit("set-request-attachment", files)
+      this.$store.commit('setValueBodyParams', {
+        index,
+        value: files,
+      })
     }
   },
   computed: {

--- a/helpers/utils/contenttypes.js
+++ b/helpers/utils/contenttypes.js
@@ -5,6 +5,7 @@ export const knownContentTypes = [
   "application/vnd.api+json",
   "application/xml",
   "application/x-www-form-urlencoded",
+  "multipart/form-data",
   "text/html",
   "text/plain",
 ]

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -880,6 +880,7 @@ export default {
     canListParameters() {
       return (
         this.contentType === "application/x-www-form-urlencoded" ||
+        this.contentType === "multipart/form-data" ||
         isJSONContentType(this.contentType)
       )
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -160,6 +160,7 @@
                   @set-route-query-state="setRouteQueryState"
                   @remove-request-body-param="removeRequestBodyParam"
                   @add-request-body-param="addRequestBodyParam"
+                  @set-request-attachment="setRequestAttachment"
                 />
                 <http-raw-body
                   v-else
@@ -1610,6 +1611,9 @@ export default {
     addRequestBodyParam() {
       this.$store.commit("addBodyParams", { key: "", value: "", active: true })
       return false
+    },
+    setRequestAttachment(index, attachments) {
+      this.files.splice(index, 1, attachments)
     },
     removeRequestBodyParam(index) {
       // .slice() gives us an entirely new array rather than giving us just the reference

--- a/store/state.js
+++ b/store/state.js
@@ -13,6 +13,7 @@ export default () => ({
     headers: [],
     params: [],
     bodyParams: [],
+    formData: new FormData(),
     rawParams: "",
     rawInput: false,
     requestType: "",

--- a/store/state.js
+++ b/store/state.js
@@ -13,7 +13,6 @@ export default () => ({
     headers: [],
     params: [],
     bodyParams: [],
-    formData: new FormData(),
     rawParams: "",
     rawInput: false,
     requestType: "",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7272103/107940058-9e978200-6fc2-11eb-94ac-29ff88601b3d.png)

Add support for `multipart/form-data` content-type. When `mutipart-form-data` is chosen, an attachment icon appears in each request body line. This allows the attachment of files with named keys in the existing UI. Filename parsing and most of the UI side of things are not implemented yet and thus the ugly `[object FileList]` is being displayed.

Multiple files can be uploaded into a single field too!