### PR TITLE
[Feat: formData] Add chips to indicate chosen files in formData

### DIFF
--- a/components/http/http-body-parameters.vue
+++ b/components/http/http-body-parameters.vue
@@ -54,12 +54,14 @@
           @keyup.prevent="setRouteQueryState"
         />
         <div v-else class="file-chips-container">
-          <deletable-chip
-            v-for="(file, i) in Array.from(bodyParams[index].value)"
-            :key="`body-param=${index}-file-${i}`"
-          >
-            {{ file.name }}
-          </deletable-chip>
+          <div class="file-chips-wrapper">
+            <deletable-chip
+              v-for="(file, i) in Array.from(bodyParams[index].value)"
+              :key="`body-param=${index}-file-${i}`"
+            >
+              {{ file.name }}
+            </deletable-chip>
+          </div>
         </div>
       </li>
       <div>
@@ -95,7 +97,7 @@
       <div v-if="contentType === 'multipart/form-data'">
         <li>
           <label for="attachment" class="p-0">
-            <button class="icon" @click="$refs.attachment[index].click()">
+            <button class="w-full icon" @click="$refs.attachment[index].click()">
               <i class="material-icons">attach_file</i>
             </button>
           </label>
@@ -134,12 +136,15 @@
 <style scoped lang="scss">
 .file-chips-container {
   @apply flex;
-  @apply flex-wrap;
-  @apply overflow-auto;
   @apply flex-1;
+  @apply whitespace-no-wrap;
+  @apply overflow-auto;
   @apply bg-bgDarkColor;
 
-  max-height: 56px;
+  .file-chips-wrapper {
+    @apply flex;
+    @apply w-0;
+  }
 }
 </style>
 

--- a/components/http/http-body-parameters.vue
+++ b/components/http/http-body-parameters.vue
@@ -170,7 +170,7 @@ export default {
       const { files } = event.target
       this.$store.commit("setFilesBodyParams", {
         index,
-        value: files,
+        value: Array.from(files),
       })
       this.$toast.info(
         "Form data files will not be synced with local session storage!", 
@@ -179,11 +179,14 @@ export default {
     },
     requestBodyParamIsFile(index) {
       const bodyParamValue = this.bodyParams?.[index]?.value
-      const isFile = bodyParamValue instanceof FileList
+      const isFile = bodyParamValue?.[0] instanceof File
       return isFile
     },
-    chipDelete(index, i) {
-      console.log(index, i)
+    chipDelete(paramIndex, fileIndex) {
+      this.$store.commit("removeFile", {
+        index: paramIndex,
+        fileIndex,
+      })
     },
   },
   computed: {

--- a/components/http/http-body-parameters.vue
+++ b/components/http/http-body-parameters.vue
@@ -182,7 +182,6 @@ export default {
     requestBodyParamIsFile(index) {
       const bodyParamValue = this.bodyParams?.[index]?.value
       const isFile = bodyParamValue instanceof FileList
-      console.log(bodyParamValue)
       return isFile
     }
   },

--- a/components/http/http-body-parameters.vue
+++ b/components/http/http-body-parameters.vue
@@ -172,6 +172,10 @@ export default {
         index,
         value: files,
       })
+      this.$toast.info(
+        "Form data files will not be synced with local session storage!", 
+        { icon: "folder" }
+      )
     },
     requestBodyParamIsFile(index) {
       const bodyParamValue = this.bodyParams?.[index]?.value

--- a/components/http/http-body-parameters.vue
+++ b/components/http/http-body-parameters.vue
@@ -39,6 +39,7 @@
       </li>
       <li>
         <input
+          v-if="!requestBodyParamIsFile(index)"
           :placeholder="`value ${index + 1}`"
           :value="param.value"
           @change="
@@ -53,6 +54,15 @@
           "
           @keyup.prevent="setRouteQueryState"
         />
+        <div v-else class="file-chips-container">
+          <deletable-chip 
+            class="file-chip"
+            v-for="(file, i) in Array.from(bodyParams[index].value)" 
+            :key="`body-param=${index}-file-${i}`"
+          >
+            {{ file.name }}
+          </deletable-chip>
+        </div>
       </li>
       <div>
         <li>
@@ -126,8 +136,25 @@
   </div>
 </template>
 
+<style scoped lang="scss">
+$fileChipMargin: 4px;
+$fileChipsContainerMaxHeight: 56px;
+
+.file-chips-container {
+  display: flex;
+  flex-wrap: wrap;
+  overflow-y: scroll;
+  max-height: $fileChipsContainerMaxHeight;
+}
+.file-chip {
+  margin: $fileChipMargin;
+}
+</style>
+
 <script>
+import deletableChip from '../ui/deletable-chip.vue'
 export default {
+  components: { deletableChip },
   props: {
     bodyParams: { type: Array, default: () => [] },
   },
@@ -151,6 +178,12 @@ export default {
         index,
         value: files,
       })
+    },
+    requestBodyParamIsFile(index) {
+      const bodyParamValue = this.bodyParams?.[index]?.value
+      const isFile = bodyParamValue instanceof FileList
+      console.log(bodyParamValue)
+      return isFile
     }
   },
   computed: {

--- a/components/http/http-body-parameters.vue
+++ b/components/http/http-body-parameters.vue
@@ -54,9 +54,8 @@
           @keyup.prevent="setRouteQueryState"
         />
         <div v-else class="file-chips-container">
-          <deletable-chip 
-            class="file-chip"
-            v-for="(file, i) in Array.from(bodyParams[index].value)" 
+          <deletable-chip
+            v-for="(file, i) in Array.from(bodyParams[index].value)"
             :key="`body-param=${index}-file-${i}`"
           >
             {{ file.name }}
@@ -133,22 +132,19 @@
 </template>
 
 <style scoped lang="scss">
-$fileChipMargin: 4px;
-$fileChipsContainerMaxHeight: 56px;
-
 .file-chips-container {
-  display: flex;
-  flex-wrap: wrap;
-  overflow-y: scroll;
-  max-height: $fileChipsContainerMaxHeight;
-}
-.file-chip {
-  margin: $fileChipMargin;
+  @apply flex;
+  @apply flex-wrap;
+  @apply overflow-auto;
+  @apply flex-1;
+  @apply bg-bgDarkColor;
+
+  max-height: 56px;
 }
 </style>
 
 <script>
-import deletableChip from '../ui/deletable-chip.vue'
+import deletableChip from "../ui/deletable-chip.vue"
 export default {
   components: { deletableChip },
   props: {
@@ -179,7 +175,7 @@ export default {
       const bodyParamValue = this.bodyParams?.[index]?.value
       const isFile = bodyParamValue instanceof FileList
       return isFile
-    }
+    },
   },
   computed: {
     contentType() {

--- a/components/http/http-body-parameters.vue
+++ b/components/http/http-body-parameters.vue
@@ -57,7 +57,8 @@
           <div class="file-chips-wrapper">
             <deletable-chip
               v-for="(file, i) in Array.from(bodyParams[index].value)"
-              :key="`body-param=${index}-file-${i}`"
+              :key="`body-param-${index}-file-${i}`"
+              @chip-delete="chipDelete(index, i)"
             >
               {{ file.name }}
             </deletable-chip>
@@ -149,9 +150,7 @@
 </style>
 
 <script>
-import deletableChip from "../ui/deletable-chip.vue"
 export default {
-  components: { deletableChip },
   props: {
     bodyParams: { type: Array, default: () => [] },
   },
@@ -180,6 +179,9 @@ export default {
       const bodyParamValue = this.bodyParams?.[index]?.value
       const isFile = bodyParamValue instanceof FileList
       return isFile
+    },
+    chipDelete(index, i) {
+      console.log(index, i)
     },
   },
   computed: {

--- a/components/http/http-body-parameters.vue
+++ b/components/http/http-body-parameters.vue
@@ -47,8 +47,7 @@
             // only
             $store.commit('setValueBodyParams', {
               index,
-              value:
-                contentType !== 'multipart/form-data' ? $event.target.value : [$event.target.value],
+              value: $event.target.value
             })
           "
           @keyup.prevent="setRouteQueryState"
@@ -169,8 +168,7 @@ export default {
     },
     setRequestAttachment(event, index) {
       const { files } = event.target
-      this.$emit("set-request-attachment", files)
-      this.$store.commit("setValueBodyParams", {
+      this.$store.commit("setFilesBodyParams", {
         index,
         value: files,
       })

--- a/components/ui/deletable-chip.vue
+++ b/components/ui/deletable-chip.vue
@@ -1,0 +1,31 @@
+<template>
+  <span class="chip">
+    <span><slot></slot></span>
+    <i @click="$emit('chip-delete')" class="material-icons close-button">
+      close
+    </i>
+  </span>
+</template>
+
+<style scoped lang="scss">
+$borderRadius: 4px;
+$padding: 0 12px;
+$closeButtonSpacing: 6px;
+$height: 32px;
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  color: var(--act-color);
+  background: var(--ac-color);
+  border-radius: $borderRadius;
+  padding: $padding;
+  font-weight: 700;
+  height: $height;
+}
+
+.close-button {
+  margin-left: $closeButtonSpacing;
+  margin-right: -4px;
+}
+</style>

--- a/components/ui/deletable-chip.vue
+++ b/components/ui/deletable-chip.vue
@@ -15,7 +15,6 @@
   @apply rounded-lg;
   @apply m-1;
   @apply pl-4;
-  @apply h-12;
   @apply bg-bgDarkColor;
   @apply text-fgColor;
   @apply font-mono;

--- a/components/ui/deletable-chip.vue
+++ b/components/ui/deletable-chip.vue
@@ -1,31 +1,33 @@
 <template>
   <span class="chip">
     <span><slot></slot></span>
-    <i @click="$emit('chip-delete')" class="material-icons close-button">
-      close
-    </i>
+    <button class="p-2 icon" @click="$emit('chip-delete')">
+      <i class="material-icons close-button"> close </i>
+    </button>
   </span>
 </template>
 
 <style scoped lang="scss">
-$borderRadius: 4px;
-$padding: 0 12px;
-$closeButtonSpacing: 6px;
-$height: 32px;
-
 .chip {
-  display: inline-flex;
-  align-items: center;
-  color: var(--act-color);
-  background: var(--ac-color);
-  border-radius: $borderRadius;
-  padding: $padding;
-  font-weight: 700;
-  height: $height;
+  @apply inline-flex;
+  @apply items-center;
+  @apply justify-center;
+  @apply rounded-lg;
+  @apply m-1;
+  @apply pl-4;
+  @apply h-12;
+  @apply bg-bgDarkColor;
+  @apply text-fgColor;
+  @apply font-mono;
+  @apply font-normal;
+  @apply transition;
+  @apply ease-in-out;
+  @apply duration-150;
+  @apply border;
+  @apply border-brdColor;
 }
 
 .close-button {
-  margin-left: $closeButtonSpacing;
-  margin-right: -4px;
+  @apply text-base;
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1306,8 +1306,12 @@ export default {
       if (this.contentType === "multipart/form-data") {
         const formData = new FormData()
         for (const bodyParam of this.bodyParams) {
-          for (const file of bodyParam.value) {
-            formData.append(bodyParam.key, file)
+          if (bodyParam.value instanceof FileList) {
+            for (const file of bodyParam.value) {
+              formData.append(bodyParam.key, file)
+            }
+          } else {
+              formData.append(bodyParam.key, bodyParam.value)
           }
         }
         requestBody = formData
@@ -1609,7 +1613,9 @@ export default {
       const deep = (key) => {
         const haveItems = [...this[key]].length
         if (haveItems && this[key]["value"] !== "") {
-          return `${key}=${JSON.stringify(this[key])}&`
+          // Exclude files fro  query params
+          const filesRemoved = this[key].filter((item) => !(item?.value instanceof FileList))
+          return `${key}=${JSON.stringify(filesRemoved)}&`
         }
         return ""
       }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1306,7 +1306,7 @@ export default {
       if (this.contentType === "multipart/form-data") {
         const formData = new FormData()
         for (const bodyParam of this.bodyParams) {
-          if (bodyParam.value instanceof FileList) {
+          if (bodyParam?.value?.[0] instanceof File) {
             for (const file of bodyParam.value) {
               formData.append(bodyParam.key, file)
             }
@@ -1614,7 +1614,7 @@ export default {
         const haveItems = [...this[key]].length
         if (haveItems && this[key]["value"] !== "") {
           // Exclude files fro  query params
-          const filesRemoved = this[key].filter((item) => !(item?.value instanceof FileList))
+          const filesRemoved = this[key].filter((item) => !(item?.value?.[0] instanceof File))
           return `${key}=${JSON.stringify(filesRemoved)}&`
         }
         return ""

--- a/plugins/vuex-persist.js
+++ b/plugins/vuex-persist.js
@@ -1,5 +1,7 @@
 import VuexPersistence from "vuex-persist"
 
 export default ({ store }) => {
-  new VuexPersistence().plugin(store)
+  new VuexPersistence({ 
+    filter: (mutation) => mutation.type !== "setFilesBodyParams" 
+  }).plugin(store)
 }

--- a/store/mutations.js
+++ b/store/mutations.js
@@ -107,6 +107,14 @@ export default {
     request.bodyParams[index].value = value
   },
 
+  // While this mutation is same as the setValueBodyParams above, it is excluded
+  // from vuex-persist. We will commit this mutation while adding a file
+  // param as there is no way to serialize File objects and thus we cannot 
+  // persist file objects in localStorage
+  setFilesBodyParams({ request }, { index, value }) {
+    request.bodyParams[index].value = value
+  },
+
   setActiveBodyParams({ request }, { index, value }) {
     if (!request.bodyParams[index].hasOwnProperty("active")) {
       Vue.set(request.bodyParams[index], "active", value)

--- a/store/mutations.js
+++ b/store/mutations.js
@@ -115,6 +115,10 @@ export default {
     request.bodyParams[index].value = value
   },
 
+  removeFile({ request }, { index, fileIndex }) {
+    request.bodyParams[index].value.splice(fileIndex, 1)
+  },
+
   setActiveBodyParams({ request }, { index, value }) {
     if (!request.bodyParams[index].hasOwnProperty("active")) {
       Vue.set(request.bodyParams[index], "active", value)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7272103/107982850-ba6d4900-6fff-11eb-8ed0-e604d21ddeb5.png)

Per the image above, chips have been added to denote the files that have been chosen. This feature is still currently incomplete.

Todo:

- [x] Pressing close button on chip will lead to removal of file
- [x] Set max width of request body value field when file names are too long
- [x] Check preservation of responsive design
- [x] ~~Make sure Vuex persist works with `File` objects~~
File objects cannot be recreated, and this thus means that we will not be able to restore a user's files in a request after a reload. FormData file fields also will not be able to be synced/exported. Thus, we should exclude file fields from vuex and store them instead in a component's state.