### PR TITLE
[Feat/form data] Remove file fields from collections

### DIFF
--- a/store/postwoman.js
+++ b/store/postwoman.js
@@ -264,7 +264,16 @@ export const mutations = {
   },
 
   saveRequestAs({ collections }, payload) {
-    const { request, collectionIndex, folderName, requestIndex } = payload
+    let { request, collectionIndex, folderName, requestIndex } = payload
+
+    // Filter out all file inputs
+    request = { 
+      ...request, 
+      bodyParams: request.bodyParams.filter(
+        param => !(param?.value?.[0] instanceof File)
+      )
+    }
+    console.log(request)
 
     const specifiedCollection = collectionIndex !== undefined
     const specifiedFolder = folderName !== undefined

--- a/store/postwoman.js
+++ b/store/postwoman.js
@@ -269,12 +269,13 @@ export const mutations = {
     // Filter out all file inputs
     request = { 
       ...request, 
-      bodyParams: request.bodyParams.filter(
-        param => !(param?.value?.[0] instanceof File)
+      bodyParams: request.bodyParams.map(
+        param => (param?.value?.[0] instanceof File) 
+          ? { ...param, value: "" }
+          : param
       )
     }
-    console.log(request)
-
+    
     const specifiedCollection = collectionIndex !== undefined
     const specifiedFolder = folderName !== undefined
     const specifiedRequest = requestIndex !== undefined


### PR DESCRIPTION
Since `File` is not serializable, form data fields with files cannot be saved into a collection. Thus, files are filtered out before a request is added to a collection.