### PR TITLE
change UI to save request in my-collection

### DIFF
--- a/components/collections/collection.vue
+++ b/components/collections/collection.vue
@@ -8,7 +8,7 @@
       @drop="dragging = false"
       @dragleave="dragging = false"
       @dragend="dragging = false"
-      @click="$emit('select-folder', '')"
+      @click="$emit('select-folder', { name: '', id: collection.id })"
     >
       <button class="icon" @click="toggleShowChildren">
         <i class="material-icons" v-show="!showChildren && !isFiltered">arrow_right</i>
@@ -106,7 +106,15 @@
             @edit-folder="$emit('edit-folder', $event)"
             @edit-request="$emit('edit-request', $event)"
             @update-team-collections="$emit('update-team-collections')"
-            @select-folder="$emit('select-folder', folder.name + '/' + $event)"
+            @select-folder="
+              $emit('select-folder', {
+                name:
+                  (collectionsType.type == 'my-collections' ? folder.name : folder.title) +
+                  '/' +
+                  $event.name,
+                id: $event.id,
+              })
+            "
           />
         </li>
       </ul>
@@ -117,7 +125,9 @@
           class="ml-8 border-l border-brdColor"
         >
           <request
-            :request="request"
+            :request="
+              collectionsType.type === 'my-collections' ? request : JSON.parse(request.request)
+            "
             :collection-index="collectionIndex"
             :folder-index="-1"
             :folder-name="collection.name"
@@ -203,7 +213,6 @@ export default {
         team_utils
           .getCollectionRequests(this.$apollo, this.collection.id)
           .then((requests) => {
-            console.log(requests)
             this.$set(this.collection, "requests", requests)
           })
           .catch((error) => {

--- a/components/collections/folder.vue
+++ b/components/collections/folder.vue
@@ -8,7 +8,7 @@
       @drop="dragging = false"
       @dragleave="dragging = false"
       @dragend="dragging = false"
-      @click="$emit('select-folder', '')"
+      @click="$emit('select-folder', { name: '', id: folder.id })"
     >
       <div>
         <button class="icon" @click="toggleShowChildren">
@@ -60,7 +60,9 @@
           class="flex ml-8 border-l border-brdColor"
         >
           <request
-            :request="request"
+            :request="
+              collectionsType.type == 'my-collections' ? request : JSON.parse(request.request)
+            "
             :collection-index="collectionIndex"
             :folder-index="folderIndex"
             :folder-name="folder.name"
@@ -88,7 +90,9 @@
             @edit-folder="$emit('edit-folder', $event)"
             @edit-request="$emit('edit-request', $event)"
             @update-team-collections="$emit('update-team-collections')"
-            @select-folder="$emit('select-folder', subFolder.name + '/' + $event)"
+            @select-folder="
+              $emit('select-folder', { name: subFolder.name + '/' + $event.name, id: subFolder.id })
+            "
           />
         </li>
       </ul>

--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -5,6 +5,7 @@
         aria-label="Search"
         type="search"
         :placeholder="$t('search')"
+        v-if="!saveRequest"
         v-model="filterText"
         class="rounded-t-lg"
       />
@@ -102,8 +103,14 @@
             @select-collection="$emit('use-collection', index)"
             @select-folder="
               $emit('select-folder', {
-                folderName: collection.name + '/' + $event,
-                collectionIndex: index,
+                folderName:
+                  (collectionsType.type == 'my-collections' ? collection.name : collection.title) +
+                  '/' +
+                  $event.name,
+                collectionIndex: collectionsType.type == 'my-collections' ? index : $event.id,
+                collectionsType: collectionsType,
+                folderId: $event.id,
+                coll: collection,
               })
             "
           />
@@ -156,7 +163,6 @@ export default {
       teamCollections: {},
     }
   },
-
   apollo: {
     myTeams: {
       query: gql`
@@ -169,6 +175,11 @@ export default {
         }
       `,
       pollInterval: 10000,
+    },
+  },
+  watch: {
+    "collectionsType.type": function emitstuff() {
+      this.$emit("update-collection", this.$data.collectionsType.type)
     },
   },
   computed: {
@@ -253,6 +264,7 @@ export default {
   methods: {
     updateTeamCollections() {
       console.log(this.collectionsType)
+      this.$emit("select-collection-type")
       if (this.collectionsType.selectedTeam == undefined) return
       team_utils
         .rootCollectionsOfTeam(this.$apollo, this.collectionsType.selectedTeam.id)

--- a/components/collections/save-request-as.vue
+++ b/components/collections/save-request-as.vue
@@ -13,32 +13,9 @@
     <div slot="body" class="flex flex-col">
       <label for="selectLabel">{{ $t("token_req_name") }}</label>
       <input type="text" id="selectLabel" v-model="requestData.name" @keyup.enter="saveRequestAs" />
-      <ul>
-        <li>
-          <label for="selectCollection">{{ $t("collection") }}</label>
-          <span class="select-wrapper">
-            <select type="text" id="selectCollection" v-model="requestData.collectionIndex">
-              <option :key="undefined" :value="undefined" hidden disabled selected>
-                {{ $t("select_collection") }}
-              </option>
-              <option
-                v-for="(collection, index) in $store.state.postwoman.collections"
-                :key="index"
-                :value="index"
-              >
-                {{ collection.name }}
-              </option>
-            </select>
-          </span>
-        </li>
-      </ul>
-      <label>{{ $t("folder") }}</label>
-      <autocomplete
-        :placeholder="$t('search')"
-        :source="folders"
-        :spellcheck="false"
-        v-model="requestData.folderName"
-      />
+      <label for="selectLabel">Request path</label>
+      <input readonly :value="path" />
+      <collections @select-folder="changeRequestDetails($event)" :saveRequest="true" />
       <ul>
         <li>
           <label for="selectRequest">{{ $t("request") }}</label>
@@ -80,6 +57,7 @@ export default {
   data() {
     return {
       defaultRequestName: "Untitled Request",
+      path: "Path will appear here",
       requestData: {
         name: undefined,
         collectionIndex: undefined,
@@ -143,6 +121,11 @@ export default {
     },
   },
   methods: {
+    changeRequestDetails(data) {
+      this.$data.requestData.folderName = data.folderName.split("/").slice(-2)[0]
+      this.$data.requestData.collectionIndex = data.collectionIndex
+      this.$data.path = data.folderName
+    },
     syncCollections() {
       if (fb.currentUser !== null) {
         if (fb.currentSettings[0].value) {

--- a/helpers/teams/utils.js
+++ b/helpers/teams/utils.js
@@ -1,268 +1,292 @@
 import gql from "graphql-tag"
 
 async function createTeam(apollo, name) {
-    return apollo.mutate({
-        mutation: gql`
-          mutation($name: String!) {
-            createTeam(name: $name) {
-              name
-            }
-          }
-        `,
-        variables: {
-          name: name,
-        },
-    })
+  return apollo.mutate({
+    mutation: gql`
+      mutation($name: String!) {
+        createTeam(name: $name) {
+          name
+        }
+      }
+    `,
+    variables: {
+      name: name,
+    },
+  })
 }
 
 async function addTeamMemberByEmail(apollo, userRole, userEmail, teamID) {
-    return apollo.mutate({
+  return apollo.mutate({
+    mutation: gql`
+      mutation addTeamMemberByEmail(
+        $userRole: TeamMemberRole!
+        $userEmail: String!
+        $teamID: String!
+      ) {
+        addTeamMemberByEmail(userRole: $userRole, userEmail: $userEmail, teamID: $teamID) {
+          role
+        }
+      }
+    `,
+    variables: {
+      userRole: userRole,
+      userEmail: userEmail,
+      teamID: teamID,
+    },
+  })
+}
+
+async function renameTeam(apollo, name, teamID) {
+  return apollo.mutate({
+    mutation: gql`
+      mutation renameTeam($newName: String!, $teamID: String!) {
+        renameTeam(newName: $newName, teamID: $teamID) {
+          id
+        }
+      }
+    `,
+    variables: {
+      newName: name,
+      teamID: teamID,
+    },
+  })
+}
+
+async function deleteTeam(apollo, teamID) {
+  let response = undefined
+  while (true) {
+    response = await apollo.mutate({
       mutation: gql`
-        mutation addTeamMemberByEmail($userRole: TeamMemberRole!, $userEmail: String!, $teamID: String!) {
-          addTeamMemberByEmail(userRole: $userRole, userEmail: $userEmail, teamID: $teamID) {
-            role
+        mutation($teamID: String!) {
+          deleteTeam(teamID: $teamID)
+        }
+      `,
+      variables: {
+        teamID: teamID,
+      },
+    })
+    if (response != undefined) break
+  }
+  return response
+}
+
+async function exitTeam(apollo, teamID) {
+  apollo.mutate({
+    mutation: gql`
+      mutation($teamID: String!) {
+        leaveTeam(teamID: $teamID)
+      }
+    `,
+    variables: {
+      teamID: teamID,
+    },
+  })
+}
+
+async function rootCollectionsOfTeam(apollo, teamID) {
+  var collections = []
+  var cursor = ""
+  while (true) {
+    var response = await apollo.query({
+      query: gql`
+        query rootCollectionsOfTeam($teamID: String!, $cursor: String!) {
+          rootCollectionsOfTeam(teamID: $teamID, cursor: $cursor) {
+            id
+            title
           }
         }
       `,
       variables: {
-        userRole: userRole,
-        userEmail: userEmail,
         teamID: teamID,
+        cursor: cursor,
       },
+      fetchPolicy: "no-cache",
     })
-
-}
-
-async function renameTeam(apollo, name, teamID) {
-    return apollo.mutate({
-        mutation: gql`
-        mutation renameTeam($newName: String!, $teamID: String!) {
-            renameTeam(newName: $newName, teamID: $teamID) {
-            id
-            }
-        }
-        `,
-        variables: {
-        newName: name,
-        teamID: teamID,
-        },
+    if (response.data.rootCollectionsOfTeam.length == 0) break
+    response.data.rootCollectionsOfTeam.forEach((collection) => {
+      collections.push(collection)
     })
-}
-
-async function deleteTeam(apollo, teamID){
-    let response = undefined
-    while (true){
-        response = await apollo.mutate({
-            mutation: gql`
-              mutation($teamID: String!) {
-                deleteTeam(teamID: $teamID)
-              }
-            `,
-            variables: {
-              teamID: teamID,
-            },
-        })
-        if (response != undefined) break;
-    }
-    return response
-
-}
-
-async function exitTeam(apollo, teamID) {
-    apollo.mutate({
-      mutation: gql`
-        mutation($teamID: String!) {
-          leaveTeam(teamID: $teamID)
-        }
-      `,
-      variables: {
-        teamID: teamID,
-      },
-    })
-}
-
-
-async function rootCollectionsOfTeam(apollo, teamID) {
-    var collections = [];
-    var cursor = "";
-    while(true) {
-        var response = await apollo.query({
-            query: gql`
-            query rootCollectionsOfTeam($teamID: String!, $cursor: String!) {
-              rootCollectionsOfTeam(teamID: $teamID, cursor: $cursor) {
-                id
-                title
-              }
-            }`,
-            variables: {
-                teamID: teamID,
-                cursor: cursor
-            },
-            fetchPolicy: 'no-cache'
-        })
-        if(response.data.rootCollectionsOfTeam.length == 0) break;
-        response.data.rootCollectionsOfTeam.forEach((collection) => {
-            collections.push(collection);
-        });
-        cursor = collections[collections.length - 1].id;
-    }
-    return collections;
+    cursor = collections[collections.length - 1].id
+  }
+  return collections
 }
 
 async function getCollectionChildren(apollo, collectionID) {
-    var children = [];
-    var response = await apollo.query({
-        query: gql`
-        query getCollectionChildren($collectionID: String!) {
-            collection(collectionID: $collectionID) {
-                children {
-                    id
-                    title
-                }
-            }
+  var children = []
+  var response = await apollo.query({
+    query: gql`
+      query getCollectionChildren($collectionID: String!) {
+        collection(collectionID: $collectionID) {
+          children {
+            id
+            title
+          }
         }
-        `,
-        variables: {
-            collectionID: collectionID,
-        },
-        fetchPolicy: 'no-cache'
-
-    });
-    response.data.collection.children.forEach((child) => {
-        children.push(child);
-    });
-    return children;
+      }
+    `,
+    variables: {
+      collectionID: collectionID,
+    },
+    fetchPolicy: "no-cache",
+  })
+  response.data.collection.children.forEach((child) => {
+    children.push(child)
+  })
+  return children
 }
 
 async function getCollectionRequests(apollo, collectionID) {
-    var requests = [];
-    var cursor = "";
-    while(true) {
-        var response = await apollo.query({
-            query: gql`
-            query getCollectionRequests($collectionID: String!, $cursor: String!) {
-                requestsInCollection(collectionID: $collectionID, cursor: $cursor) {
-                    id
-                    title
-                    request
-                }
-            }
-            `,
-            variables: {
-                collectionID: collectionID,
-                cursor: cursor
-            },
-            fetchPolicy: 'no-cache'
-
-        });
-        if(response.data.requestsInCollection.length == 0) {
-            break;
+  var requests = []
+  var cursor = ""
+  while (true) {
+    var response = await apollo.query({
+      query: gql`
+        query getCollectionRequests($collectionID: String!, $cursor: String) {
+          requestsInCollection(collectionID: $collectionID, cursor: $cursor) {
+            id
+            title
+            request
+          }
         }
-        response.data.requestsInCollection.forEach((request) => {
-            requests.push(requests);
-        });
-        cursor = requests[requests.length - 1].id;
+      `,
+      variables: {
+        collectionID: collectionID,
+        cursor: cursor,
+      },
+      fetchPolicy: "no-cache",
+    })
+
+    response.data.requestsInCollection.forEach((request) => {
+      requests.push(request)
+    })
+
+    if (response.data.requestsInCollection.length < 10) {
+      break
     }
-    return requests;
+    cursor = requests[requests.length - 1].id
+  }
+  return requests
 }
 
-async function renameCollection(apollo, title, id){
-    let response = undefined
-    while (true){
-        response = await apollo.mutate({
-          mutation: gql`
-            mutation($newTitle: String!, $collectionID: String!) {
-              renameCollection(newTitle: $newTitle, collectionID: $collectionID) {
-                id
-              }
+async function renameCollection(apollo, title, id) {
+  let response = undefined
+  while (true) {
+    response = await apollo.mutate({
+      mutation: gql`
+        mutation($newTitle: String!, $collectionID: String!) {
+          renameCollection(newTitle: $newTitle, collectionID: $collectionID) {
+            id
+          }
+        }
+      `,
+      variables: {
+        newTitle: title,
+        collectionID: id,
+      },
+    })
+    if (response != undefined) break
+  }
+  return response
+}
+
+async function addChildCollection(apollo, title, id) {
+  let response = undefined
+  while (true) {
+    response = await apollo.mutate({
+      mutation: gql`
+        mutation($childTitle: String!, $collectionID: String!) {
+          createChildCollection(childTitle: $childTitle, collectionID: $collectionID) {
+            id
+          }
+        }
+      `,
+      variables: {
+        childTitle: title,
+        collectionID: id,
+      },
+    })
+    if (response != undefined) break
+  }
+  return response
+}
+
+async function deleteCollection(apollo, id) {
+  let response = undefined
+  while (true) {
+    response = await apollo.mutate({
+      mutation: gql`
+        mutation($collectionID: String!) {
+          deleteCollection(collectionID: $collectionID)
+        }
+      `,
+      variables: {
+        collectionID: id,
+      },
+    })
+    if (response != undefined) break
+  }
+  return response
+}
+
+async function createNewRootCollection(apollo, title, id) {
+  let response = undefined
+  while (true) {
+    response = await apollo.mutate({
+      mutation: gql`
+        mutation($title: String!, $teamID: String!) {
+          createRootCollection(title: $title, teamID: $teamID) {
+            id
+          }
+        }
+      `,
+      variables: {
+        title: title,
+        teamID: id,
+      },
+    })
+    if (response != undefined) break
+  }
+  return response
+}
+
+async function saveRequestAsTeams(apollo, request, title, teamID, collectionID) {
+  await apollo.mutate({
+    mutation: gql`
+      mutation($data: CreateTeamRequestInput!, $collectionID: String!) {
+        createRequestInCollection(data: $data, collectionID: $collectionID) {
+          collection {
+            id
+            team {
+              id
+              name
             }
-          `,
-          variables: {
-            newTitle: title,
-            collectionID: id,
-          },
-        })
-        if (response != undefined) break;
-    }
-    return response
-
+          }
+        }
+      }
+    `,
+    variables: {
+      collectionID: collectionID,
+      data: {
+        teamID: teamID,
+        title: title,
+        request: request,
+      },
+    },
+  })
 }
-
-async function addChildCollection(apollo, title, id){
-    let response = undefined
-    while (true){
-        response = await apollo.mutate({
-            mutation: gql`
-              mutation($childTitle: String!, $collectionID: String!) {
-                createChildCollection(childTitle: $childTitle, collectionID: $collectionID) {
-                  id
-                }
-              }
-            `,
-            variables: {
-              childTitle: title,
-              collectionID: id,
-            },
-        })
-        if (response != undefined) break;
-    }
-    return response
-
-}
-
-async function deleteCollection(apollo, id){
-    let response = undefined
-    while (true){
-        response = await apollo.mutate({
-            mutation: gql`
-              mutation($collectionID: String!) {
-                deleteCollection(collectionID: $collectionID) 
-              }
-            `,
-            variables: {
-              collectionID: id,
-            },
-        })
-        if (response != undefined) break;
-    }
-    return response
-
-}
-
-async function createNewRootCollection(apollo, title, id){
-    let response = undefined
-    while (true){
-        response = await apollo.mutate({
-            mutation: gql`
-              mutation($title: String!, $teamID: String!) {
-                createRootCollection(title: $title, teamID: $teamID) {
-                  id
-                }
-              }
-            `,
-            variables: {
-              title: title,
-              teamID: id,
-            },
-          })
-        if (response != undefined) break;
-    }
-    return response
-
-}
-
 
 export default {
-    rootCollectionsOfTeam: rootCollectionsOfTeam,
-    getCollectionChildren: getCollectionChildren,
-    getCollectionRequests: getCollectionRequests,
-    renameCollection: renameCollection,
-    addChildCollection: addChildCollection,
-    deleteCollection: deleteCollection,
-    createNewRootCollection: createNewRootCollection,
-    createTeam: createTeam,
-    addTeamMemberByEmail: addTeamMemberByEmail,
-    renameTeam: renameTeam,
-    deleteTeam: deleteTeam,
-    exitTeam: exitTeam
+  rootCollectionsOfTeam: rootCollectionsOfTeam,
+  getCollectionChildren: getCollectionChildren,
+  getCollectionRequests: getCollectionRequests,
+  saveRequestAsTeams: saveRequestAsTeams,
+  renameCollection: renameCollection,
+  addChildCollection: addChildCollection,
+  deleteCollection: deleteCollection,
+  createNewRootCollection: createNewRootCollection,
+  createTeam: createTeam,
+  addTeamMemberByEmail: addTeamMemberByEmail,
+  renameTeam: renameTeam,
+  deleteTeam: deleteTeam,
+  exitTeam: exitTeam,
 }


### PR DESCRIPTION
re-utilize collections component to select folder and collections


**checks:**

- [x] save request to root collection
- [x] save request to folder
- [x] save request to nested folder
- [x] replace/overwrite old request
- [x] remember location after making a change in request object (renaming request) / losing mouse focus (search ?)
- ~[ ] persist visual indication on selected location even after losing mouse focus~
- [x] mobile / touch device support

**remarks:**
- [ ] save modal is too crowded:
  - [x] remove search
  - [ ] show request path under collections selector
  - [ ] combine request path with request selector
  - [ ] remove request selector and show requests in collections selector
- [ ] allow users to create / edit / delete collections / folders from save request modal - enable overflow button?
- [ ] row-wrapper trigger change location - move select location action to expand / collapse button?