### PR TITLE
refactor: CLibcurl Generator.

### DIFF
--- a/helpers/codegen/codegen.js
+++ b/helpers/codegen/codegen.js
@@ -1,4 +1,4 @@
-import { CLibcurlCodegen } from "./generators/c-libcurl"
+import CLibcurlCodegen from "./generators/c-libcurl"
 import { CsRestsharpCodegen } from "./generators/cs-restsharp"
 import { CurlCodegen } from "./generators/curl"
 import { GoNativeCodegen } from "./generators/go-native"

--- a/helpers/codegen/generators/generator.js
+++ b/helpers/codegen/generators/generator.js
@@ -1,0 +1,62 @@
+export default class Generator {
+  constructor() {
+    this.requestString = []
+    this.joinCharacter = ""
+  }
+
+  get defaultGeneratorProperties() {
+    return {
+      url: "",
+      auth: "",
+      bearerToken: "",
+      pathName: "",
+      queryString: "",
+      method: "",
+      rawInput: "",
+      rawRequestBody: "",
+      contentType: "",
+      headers: [],
+    }
+  }
+
+  get isBasicAuthenticationRequest() {
+    return ["Basic Auth"].includes(this.auth)
+  }
+
+  get isTokenAuthenticationRequest() {
+    return ["Bearer Token", "OAuth 2.0"].includes(this.auth)
+  }
+
+  get requestAllowsBody() {
+    return ["POST", "PUT", "PATCH", "DELETE"].includes(this.method)
+  }
+
+  get customRequestHeadersFound() {
+    return this.headers
+  }
+
+  get requestBody() {
+    return this.rawInput ? this.rawParams : this.rawRequestBody
+  }
+
+  get contentIsEncoded() {
+    return this.contentType.includes("x-www-form-urlencoded")
+  }
+
+  resetRequestString() {
+    this.requestString = []
+  }
+
+  generateRequestString() {
+    this.resetRequestString()
+    this.populateRequestString()
+
+    return this.requestString.join(this.joinCharacter)
+  }
+
+  generator(context) {
+    Object.assign(this, this.defaultGeneratorProperties, context)
+
+    return this.generateRequestString()
+  }
+}

--- a/helpers/codegen/generators/generator.js
+++ b/helpers/codegen/generators/generator.js
@@ -7,11 +7,14 @@ export default class Generator {
   get defaultGeneratorProperties() {
     return {
       url: "",
-      auth: "",
-      bearerToken: "",
       pathName: "",
       queryString: "",
+      auth: "",
+      httpUser: "",
+      httpPassword: "",
+      bearerToken: "",
       method: "",
+      rawParams: "",
       rawInput: "",
       rawRequestBody: "",
       contentType: "",


### PR DESCRIPTION
#### Overview:

This PR provides the following: 

- New generic `Generator` class to be used in ongoing refactoring for generators. (`helpers/codegen/generators/generator.js`)
- Refactoring and isolation of methods of the CLibcurl generator found in (`helpers/codegen/generators/c-libcurl.js`)

#### Squashed Commits: 
```
feat: New Generator class to serve as parent class for generators.

refactor: c-libcurl.js export to class instance & isolated methods.

fix: Refactor for CLIBcurlCodegen import to expect default export.

fix: Default generator properties added and reset by generator().

When calling a generator multiple times during testing, because the generator is only
instantiated on export, ie "export default new CLibCurlCodeGen()", any properties assigned to
"this" live past a single generator instance.

The default export new CLibCurlCodeGen() is implemented to reduce additional changes or conditional
logic around old or new generators, so resetting these properties provides a nice abstraction to
ensure properties are fresh when generator() is called.

refactor: Common getters from c-libcurl to base Generator class instance.
```

resolves #1548 