### PR TITLE
Show sub-folders first instead of requests

### DIFF
--- a/components/collections/Folder.vue
+++ b/components/collections/Folder.vue
@@ -52,23 +52,6 @@
       </v-popover>
     </div>
     <div v-show="showChildren || isFiltered">
-      <ul class="flex-col">
-        <li
-          v-for="(request, index) in folder.requests"
-          :key="index"
-          class="flex ml-8 border-l border-brdColor"
-        >
-          <CollectionsRequest
-            :request="request"
-            :collection-index="collectionIndex"
-            :folder-index="folderIndex"
-            :folder-name="folder.name"
-            :request-index="index"
-            :doc="doc"
-            @edit-request="$emit('edit-request', $event)"
-          />
-        </li>
-      </ul>
       <ul v-if="folder.folders && folder.folders.length" class="flex-col">
         <li
           v-for="(subFolder, subFolderIndex) in folder.folders"
@@ -83,6 +66,23 @@
             :folder-path="`${folderPath}/${subFolderIndex}`"
             @add-folder="$emit('add-folder', $event)"
             @edit-folder="$emit('edit-folder', $event)"
+            @edit-request="$emit('edit-request', $event)"
+          />
+        </li>
+      </ul>
+      <ul class="flex-col">
+        <li
+          v-for="(request, index) in folder.requests"
+          :key="index"
+          class="flex ml-8 border-l border-brdColor"
+        >
+          <CollectionsRequest
+            :request="request"
+            :collection-index="collectionIndex"
+            :folder-index="folderIndex"
+            :folder-name="folder.name"
+            :request-index="index"
+            :doc="doc"
             @edit-request="$emit('edit-request', $event)"
           />
         </li>


### PR DESCRIPTION
Sub-folders show at the bottom of the list. You have to scroll all the way down to reach a folder you want to access.
Depends on user preference I believe but makes more sense the other way round

Before
![image](https://user-images.githubusercontent.com/20691885/111909472-43ecbc80-8a7f-11eb-810e-61b36e75bbd8.png)


After
![image](https://user-images.githubusercontent.com/20691885/111909516-6da5e380-8a7f-11eb-8dee-6878bbc475c5.png)
