### PR TITLE
Add, Delete & Edit functionalities for Team collections, folders and request

### DIFF
--- a/components/collections/collection.vue
+++ b/components/collections/collection.vue
@@ -134,6 +134,7 @@
             :request-index="collectionsType.type === 'my-collections' ? index : request.id"
             :doc="doc"
             :saveRequest="saveRequest"
+            :collectionsType="collectionsType"
             @edit-request="editRequest($event)"
             @select-request="
               $emit('select-folder', {

--- a/components/collections/edit-collection.vue
+++ b/components/collections/edit-collection.vue
@@ -45,7 +45,7 @@ export default {
     show: Boolean,
     editingCollection: Object,
     editingCollectionIndex: Number,
-    collectionsType: Object
+    collectionsType: Object,
   },
   data() {
     return {
@@ -66,7 +66,7 @@ export default {
         return
       }
       console.log(this.collectionsType.type)
-      if(this.collectionsType.type == "my-collections") {
+      if (this.collectionsType.type == "my-collections") {
         const collectionUpdated = {
           ...this.$props.editingCollection,
           name: this.$data.name,
@@ -76,25 +76,26 @@ export default {
           collectionIndex: this.$props.editingCollectionIndex,
         })
         this.syncCollections()
-      }
-      else if(this.collectionsType.type == "team-collections") {
+      } else if (this.collectionsType.type == "team-collections") {
+        console.log(this.collectionsType)
         if (this.collectionsType.selectedTeam.myRole != "VIEWER") {
-          team_utils.renameCollection(this.$apollo, this.$data.name, collectionID)
-          .then((data) => {
-            // Result
-            this.$toast.success("Collection Renamed", {
-              icon: "done",
+          team_utils
+            .renameCollection(this.$apollo, this.$data.name, this.$props.editingCollection.id)
+            .then((data) => {
+              // Result
+              this.$toast.success("Collection Renamed", {
+                icon: "done",
+              })
+              console.log(data)
+              this.$emit("update-team-collections")
             })
-            console.log(data)
-            this.$emit('update-team-collections');
-          })
-          .catch((error) => {
-            // Error
-            this.$toast.error(this.$t("error_occurred"), {
-              icon: "done",
+            .catch((error) => {
+              // Error
+              this.$toast.error(this.$t("error_occurred"), {
+                icon: "done",
+              })
+              console.error(error)
             })
-            console.error(error)
-          })
         }
       }
       this.hideModal()

--- a/components/collections/edit-collection.vue
+++ b/components/collections/edit-collection.vue
@@ -65,7 +65,6 @@ export default {
         this.$toast.info(this.$t("invalid_collection_name"))
         return
       }
-      console.log(this.collectionsType.type)
       if (this.collectionsType.type == "my-collections") {
         const collectionUpdated = {
           ...this.$props.editingCollection,
@@ -77,7 +76,6 @@ export default {
         })
         this.syncCollections()
       } else if (this.collectionsType.type == "team-collections") {
-        console.log(this.collectionsType)
         if (this.collectionsType.selectedTeam.myRole != "VIEWER") {
           team_utils
             .renameCollection(this.$apollo, this.$data.name, this.$props.editingCollection.id)
@@ -86,7 +84,6 @@ export default {
               this.$toast.success("Collection Renamed", {
                 icon: "done",
               })
-              console.log(data)
               this.$emit("update-team-collections")
             })
             .catch((error) => {

--- a/components/collections/edit-request.vue
+++ b/components/collections/edit-request.vue
@@ -38,6 +38,7 @@
 
 <script>
 import { fb } from "~/helpers/fb"
+import team_utils from "~/helpers/teams/utils"
 
 export default {
   props: {
@@ -46,7 +47,8 @@ export default {
     folderIndex: Number,
     folderName: String,
     request: Object,
-    requestIndex: Number,
+    requestIndex: [String, Number],
+    collectionsType: Object,
   },
   data() {
     return {
@@ -68,17 +70,38 @@ export default {
         ...this.$props.request,
         name: this.$data.requestUpdateData.name || this.$props.request.name,
       }
-
-      this.$store.commit("postwoman/editRequest", {
-        requestCollectionIndex: this.$props.collectionIndex,
-        requestFolderName: this.$props.folderName,
-        requestFolderIndex: this.$props.folderIndex,
-        requestNew: requestUpdated,
-        requestIndex: this.$props.requestIndex,
-      })
-
+      console.log(this.$props.request)
+      if (this.$props.collectionsType.type == "my-collections") {
+        this.$store.commit("postwoman/editRequest", {
+          requestCollectionIndex: this.$props.collectionIndex,
+          requestFolderName: this.$props.folderName,
+          requestFolderIndex: this.$props.folderIndex,
+          requestNew: requestUpdated,
+          requestIndex: this.$props.requestIndex,
+        })
+        this.syncCollections()
+      } else if (this.$props.collectionsType.type == "team-collections") {
+        if (this.collectionsType.selectedTeam.myRole != "VIEWER") {
+          let requestName = this.$data.requestUpdateData.name || this.$props.request.name
+          team_utils
+            .updateRequest(this.$apollo, requestUpdated, requestName, this.$props.requestIndex)
+            .then((data) => {
+              // Result
+              this.$toast.success("Request Renamed", {
+                icon: "done",
+              })
+              this.$emit("update-team-collections")
+            })
+            .catch((error) => {
+              // Error
+              this.$toast.error(this.$t("error_occurred"), {
+                icon: "done",
+              })
+              console.error(error)
+            })
+        }
+      }
       this.hideModal()
-      this.syncCollections()
     },
     hideModal() {
       this.$emit("hide-modal")

--- a/components/collections/edit-request.vue
+++ b/components/collections/edit-request.vue
@@ -70,7 +70,6 @@ export default {
         ...this.$props.request,
         name: this.$data.requestUpdateData.name || this.$props.request.name,
       }
-      console.log(this.$props.request)
       if (this.$props.collectionsType.type == "my-collections") {
         this.$store.commit("postwoman/editRequest", {
           requestCollectionIndex: this.$props.collectionIndex,

--- a/components/collections/folder.vue
+++ b/components/collections/folder.vue
@@ -68,6 +68,7 @@
             :request-index="collectionsType.type === 'my-collections' ? index : request.id"
             :doc="doc"
             :saveRequest="saveRequest"
+            :collectionsType="collectionsType"
             @edit-request="$emit('edit-request', $event)"
             @select-request="
               $emit('select-folder', {

--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -304,7 +304,6 @@ export default {
       if (!shouldDisplay) this.resetSelectedData()
     },
     editCollection(collection, collectionIndex) {
-      console.log(collection)
       this.$data.editingCollection = collection
       this.$data.editingCollectionIndex = collectionIndex
       this.displayModalEdit(true)
@@ -370,7 +369,6 @@ export default {
       this.syncCollections()
     },
     editRequest(payload) {
-      console.log("payload", payload)
       const { collectionIndex, folderIndex, folderName, request, requestIndex } = payload
       this.$data.editingCollectionIndex = collectionIndex
       this.$data.editingFolderIndex = folderIndex

--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -51,7 +51,9 @@
       :folder-name="editingFolderName"
       :request="editingRequest"
       :request-index="editingRequestIndex"
+      :collectionsType="collectionsType"
       @hide-modal="displayModalEditRequest(false)"
+      @update-team-collections="updateTeamCollections"
     />
     <import-export-collections
       :show="showModalImportExport"
@@ -302,6 +304,7 @@ export default {
       if (!shouldDisplay) this.resetSelectedData()
     },
     editCollection(collection, collectionIndex) {
+      console.log(collection)
       this.$data.editingCollection = collection
       this.$data.editingCollectionIndex = collectionIndex
       this.displayModalEdit(true)
@@ -367,6 +370,7 @@ export default {
       this.syncCollections()
     },
     editRequest(payload) {
+      console.log("payload", payload)
       const { collectionIndex, folderIndex, folderName, request, requestIndex } = payload
       this.$data.editingCollectionIndex = collectionIndex
       this.$data.editingFolderIndex = folderIndex

--- a/components/collections/index.vue
+++ b/components/collections/index.vue
@@ -27,6 +27,7 @@
       :editing-collection-index="editingCollectionIndex"
       :collectionsType="collectionsType"
       @hide-modal="displayModalEdit(false)"
+      @update-team-collections="updateTeamCollections"
     />
     <add-folder
       :show="showModalAddFolder"

--- a/components/collections/request.vue
+++ b/components/collections/request.vue
@@ -111,7 +111,6 @@ export default {
       dataTransfer.setData("requestIndex", this.$props.requestIndex)
     },
     removeRequest() {
-      console.log("remove", this.$props.collectionsType)
       if (this.$props.collectionsType.type == "my-collections") {
         this.$store.commit("postwoman/removeRequest", {
           collectionIndex: this.$props.collectionIndex,

--- a/components/collections/request.vue
+++ b/components/collections/request.vue
@@ -61,6 +61,7 @@
 
 <script>
 import { fb } from "~/helpers/fb"
+import team_utils from "~/helpers/teams/utils"
 
 export default {
   props: {
@@ -71,6 +72,7 @@ export default {
     requestIndex: [Number, String],
     doc: Boolean,
     saveRequest: Boolean,
+    collectionsType: Object,
   },
   data() {
     return {
@@ -109,15 +111,35 @@ export default {
       dataTransfer.setData("requestIndex", this.$props.requestIndex)
     },
     removeRequest() {
-      this.$store.commit("postwoman/removeRequest", {
-        collectionIndex: this.$props.collectionIndex,
-        folderName: this.$props.folderName,
-        requestIndex: this.$props.requestIndex,
-      })
-      this.$toast.error(this.$t("deleted"), {
-        icon: "delete",
-      })
-      this.syncCollections()
+      console.log("remove", this.$props.collectionsType)
+      if (this.$props.collectionsType.type == "my-collections") {
+        this.$store.commit("postwoman/removeRequest", {
+          collectionIndex: this.$props.collectionIndex,
+          folderName: this.$props.folderName,
+          requestIndex: this.$props.requestIndex,
+        })
+        this.$toast.error(this.$t("deleted"), {
+          icon: "delete",
+        })
+        this.syncCollections()
+      } else if (this.$props.collectionsType.type == "team-collections") {
+        team_utils
+          .deleteRequest(this.$apollo, this.$props.requestIndex)
+          .then((data) => {
+            // Result
+            this.$toast.success(this.$t("deleted"), {
+              icon: "delete",
+            })
+          })
+          .catch((error) => {
+            // Error
+            this.$toast.error(this.$t("error_occurred"), {
+              icon: "done",
+            })
+            console.error(error)
+          })
+        this.$data.confirmRemove = false
+      }
     },
     getRequestLabelColor(method) {
       return this.requestMethodLabels[method.toLowerCase()] || this.requestMethodLabels.default

--- a/helpers/teams/utils.js
+++ b/helpers/teams/utils.js
@@ -189,6 +189,30 @@ async function renameCollection(apollo, title, id) {
   return response
 }
 
+async function updateRequest(apollo, request, requestName, requestID) {
+  let response = undefined
+  while (true) {
+    response = await apollo.mutate({
+      mutation: gql`
+        mutation($data: UpdateTeamRequestInput!, $requestID: String!) {
+          updateRequest(data: $data, requestID: $requestID) {
+            id
+          }
+        }
+      `,
+      variables: {
+        data: {
+          request: JSON.stringify(request),
+          title: requestName,
+        },
+        requestID: requestID,
+      },
+    })
+    if (response != undefined) break
+  }
+  return response
+}
+
 async function addChildCollection(apollo, title, id) {
   let response = undefined
   while (true) {
@@ -302,6 +326,7 @@ export default {
   saveRequestAsTeams: saveRequestAsTeams,
   overwriteRequestTeams: overwriteRequestTeams,
   renameCollection: renameCollection,
+  updateRequest: updateRequest,
   addChildCollection: addChildCollection,
   deleteCollection: deleteCollection,
   createNewRootCollection: createNewRootCollection,

--- a/helpers/teams/utils.js
+++ b/helpers/teams/utils.js
@@ -252,6 +252,24 @@ async function deleteCollection(apollo, id) {
   return response
 }
 
+async function deleteRequest(apollo, requestID) {
+  let response = undefined
+  while (true) {
+    response = await apollo.mutate({
+      mutation: gql`
+        mutation($requestID: String!) {
+          deleteRequest(requestID: $requestID)
+        }
+      `,
+      variables: {
+        requestID: requestID,
+      },
+    })
+    if (response != undefined) break
+  }
+  return response
+}
+
 async function createNewRootCollection(apollo, title, id) {
   let response = undefined
   while (true) {
@@ -329,6 +347,7 @@ export default {
   updateRequest: updateRequest,
   addChildCollection: addChildCollection,
   deleteCollection: deleteCollection,
+  deleteRequest: deleteRequest,
   createNewRootCollection: createNewRootCollection,
   createTeam: createTeam,
   addTeamMemberByEmail: addTeamMemberByEmail,


### PR DESCRIPTION
Fixed bugs for add, delete, and edit for team collections and folders. And implement edit and delete functions for team requests. This PR achieves the following
1. Collection 
  * Add - Done
  * Delete - Done
  * Edit - Done
2. Folder
  * Add - Successful but needs a refresh to get reflected in UI
  * Delete - Done
  * Edit - Successful, requires a refresh
3. Request
  * Add - Successful, requires a refresh
  * Delete - Successful, requires a refresh
  * Edit - Successful, requires a refresh