### PR TITLE
fixes empty url bug during importing postman json

### DIFF
--- a/components/collections/ImportExport.vue
+++ b/components/collections/ImportExport.vue
@@ -334,12 +334,12 @@ export default {
       }
 
       pwRequest.name = name
-      if (request.url){
-      let requestObjectUrl = request.url.raw.match(/^(.+:\/\/[^\/]+|{[^\/]+})(\/[^\?]+|).*$/)
-      if (requestObjectUrl) {
-        pwRequest.url = requestObjectUrl[1]
-        pwRequest.path = requestObjectUrl[2] ? requestObjectUrl[2] : ""
-      }
+      if (request.url) {
+        let requestObjectUrl = request.url.raw.match(/^(.+:\/\/[^\/]+|{[^\/]+})(\/[^\?]+|).*$/)
+        if (requestObjectUrl) {
+          pwRequest.url = requestObjectUrl[1]
+          pwRequest.path = requestObjectUrl[2] ? requestObjectUrl[2] : ""
+        }
       }
       pwRequest.method = request.method
       let itemAuth = request.auth ? request.auth : ""
@@ -368,15 +368,15 @@ export default {
           delete header.type
         }
       }
-    if(request.url){
-      let requestObjectParams = request.url.query
-      if (requestObjectParams) {
-        pwRequest.params = requestObjectParams
-        for (let param of pwRequest.params) {
-          delete param.disabled
+      if (request.url) {
+        let requestObjectParams = request.url.query
+        if (requestObjectParams) {
+          pwRequest.params = requestObjectParams
+          for (let param of pwRequest.params) {
+            delete param.disabled
+          }
         }
       }
-    }
       if (request.body) {
         if (request.body.mode === "urlencoded") {
           let params = request.body.urlencoded

--- a/components/collections/ImportExport.vue
+++ b/components/collections/ImportExport.vue
@@ -334,10 +334,12 @@ export default {
       }
 
       pwRequest.name = name
+      if (request.url){
       let requestObjectUrl = request.url.raw.match(/^(.+:\/\/[^\/]+|{[^\/]+})(\/[^\?]+|).*$/)
       if (requestObjectUrl) {
         pwRequest.url = requestObjectUrl[1]
         pwRequest.path = requestObjectUrl[2] ? requestObjectUrl[2] : ""
+      }
       }
       pwRequest.method = request.method
       let itemAuth = request.auth ? request.auth : ""
@@ -366,6 +368,7 @@ export default {
           delete header.type
         }
       }
+    if(request.url){
       let requestObjectParams = request.url.query
       if (requestObjectParams) {
         pwRequest.params = requestObjectParams
@@ -373,6 +376,7 @@ export default {
           delete param.disabled
         }
       }
+    }
       if (request.body) {
         if (request.body.mode === "urlencoded") {
           let params = request.body.urlencoded


### PR DESCRIPTION
When importing a Postman Collection if the url is empty this throws a `Cannot read property 'raw' of null` and `Cannot read property 'query` error this pr fixes that.

You can recreate the error and test this pr with this postman file 
[test.postman_collection.zip](https://github.com/hoppscotch/hoppscotch/files/6308109/test.postman_collection.zip)

---

Fixed #1587
