### PR TITLE
Removed Redundant code in nuxt.config.js

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,5 +1,3 @@
-require("dotenv").config()
-
 // Common options
 export const options = {
   name: "Hoppscotch",


### PR DESCRIPTION
nuxt.config.js seems to already have access to all the environment variables present in root directory's .env file via `process.env.VARIABLE_NAME`. So, this require statement can be removed