### PR TITLE
chore: remove stray debugger

### DIFF
--- a/helpers/teams/TeamMemberAdapter.ts
+++ b/helpers/teams/TeamMemberAdapter.ts
@@ -75,8 +75,6 @@ export default class TeamMemberAdapter {
         },
       })
 
-      debugger
-
       result.push(...response.data.team.members)
 
       if ((response.data.team.members as any[]).length === 0) break


### PR DESCRIPTION
Found a stray `debugger` while browsing the code, removed it for you