### PR TITLE
fix: prevent overwrite of content type

### DIFF
--- a/components/smart/AutoComplete.vue
+++ b/components/smart/AutoComplete.vue
@@ -107,6 +107,9 @@ export default {
     text() {
       this.$emit("input", this.text)
     },
+    value(newValue) {
+      this.text = newValue
+    }
   },
 
   mounted() {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -818,8 +818,8 @@ export default {
     },
     method() {
       this.contentType = ["POST", "PUT", "PATCH", "DELETE"].includes(this.method)
-        ? this.contentType ?? "application/json"
-        : ""
+        ? this.contentType
+        : "application/json"
     },
     preRequestScript(val, oldVal) {
       this.uri = this.uri

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -86,6 +86,7 @@
               <li>
                 <label for="contentType" class="text-sm">{{ $t("content_type") }}</label>
                 <SmartAutoComplete
+                  :key="contentType"
                   :source="validContentTypes"
                   :spellcheck="false"
                   v-model="contentType"
@@ -816,9 +817,9 @@ export default {
       this.editRequest = newValue
       this.showSaveRequestModal = true
     },
-    method() {
+    method(newValue, oldValue) {
       this.contentType = ["POST", "PUT", "PATCH", "DELETE"].includes(this.method)
-        ? "application/json"
+        ? this.contentType ?? "application/json"
         : ""
     },
     preRequestScript(val, oldVal) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -86,7 +86,6 @@
               <li>
                 <label for="contentType" class="text-sm">{{ $t("content_type") }}</label>
                 <SmartAutoComplete
-                  :key="contentType"
                   :source="validContentTypes"
                   :spellcheck="false"
                   v-model="contentType"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -817,7 +817,7 @@ export default {
       this.editRequest = newValue
       this.showSaveRequestModal = true
     },
-    method(newValue, oldValue) {
+    method() {
       this.contentType = ["POST", "PUT", "PATCH", "DELETE"].includes(this.method)
         ? this.contentType ?? "application/json"
         : ""


### PR DESCRIPTION
This PR fixes issue #1691. This fix prevents the changing of HTTP method to overwrite the content type of a request if the content type is already set.  Moreover, the `AutoComplete` component watches for updates to its `value` prop so as to update the input field contents when the `value` prop changes.