### PR TITLE
fix: duplicated input ids

### DIFF
--- a/components/collections/Add.vue
+++ b/components/collections/Add.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelAdd">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelAdd"
         v-model="name"
         class="input"
         type="text"

--- a/components/collections/AddFolder.vue
+++ b/components/collections/AddFolder.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelAddFolder">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelAddFolder"
         v-model="name"
         class="input"
         type="text"

--- a/components/collections/Edit.vue
+++ b/components/collections/Edit.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelEdit">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelEdit"
         v-model="name"
         class="input"
         type="text"

--- a/components/collections/EditFolder.vue
+++ b/components/collections/EditFolder.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelEditFolder">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelEditFolder"
         v-model="name"
         class="input"
         type="text"

--- a/components/collections/EditRequest.vue
+++ b/components/collections/EditRequest.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelEditReq">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelEditReq"
         v-model="requestUpdateData.name"
         class="input"
         type="text"

--- a/components/collections/SaveRequest.vue
+++ b/components/collections/SaveRequest.vue
@@ -9,15 +9,15 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("token_req_name") }}</label>
+      <label for="selectLabelSaveReq">{{ $t("token_req_name") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelSaveReq"
         v-model="requestData.name"
         class="input"
         type="text"
         @keyup.enter="saveRequestAs"
       />
-      <label for="selectLabel">Select location</label>
+      <label>Select location</label>
       <!-- <input class="input" readonly :value="path" /> -->
 
       <CollectionsGraphql

--- a/components/collections/graphql/Add.vue
+++ b/components/collections/graphql/Add.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelGqlAdd">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelGqlAdd"
         v-model="name"
         class="input"
         type="text"

--- a/components/collections/graphql/AddFolder.vue
+++ b/components/collections/graphql/AddFolder.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelGqlAddFolder">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelGqlAddFolder"
         v-model="name"
         class="input"
         type="text"

--- a/components/collections/graphql/Edit.vue
+++ b/components/collections/graphql/Edit.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelGqlEdit">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelGqlEdit"
         v-model="name"
         class="input"
         type="text"

--- a/components/collections/graphql/EditFolder.vue
+++ b/components/collections/graphql/EditFolder.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelGqlEditFolder">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelGqlEditFolder"
         v-model="name"
         class="input"
         type="text"

--- a/components/collections/graphql/EditRequest.vue
+++ b/components/collections/graphql/EditRequest.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelGqlEditReq">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelGqlEditReq"
         v-model="requestUpdateData.name"
         class="input"
         type="text"

--- a/components/environments/Add.vue
+++ b/components/environments/Add.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelEnvAdd">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelEnvAdd"
         v-model="name"
         class="input"
         type="text"

--- a/components/environments/Edit.vue
+++ b/components/environments/Edit.vue
@@ -9,9 +9,9 @@
       </div>
     </template>
     <template #body>
-      <label for="selectLabel">{{ $t("label") }}</label>
+      <label for="selectLabelEnvEdit">{{ $t("label") }}</label>
       <input
-        id="selectLabel"
+        id="selectLabelEnvEdit"
         v-model="name"
         class="input"
         type="text"


### PR DESCRIPTION
There are some duplicated inputs' ids on the page. 
To reproduce:
- click "save to collections"(gql or home page - that's doesn't matter) and check out the id of the "Request name" input.
- click "new" and compare the "Label" input id with the one from the first step. they are the same.
Sometimes duplicated ids  can lead to some really weird behavior. in this case if you click on the label from the second step - input from the first one gets focused.