### PR TITLE
fix: broken settings persistence on the home page

### DIFF
--- a/newstore/localpersistence.ts
+++ b/newstore/localpersistence.ts
@@ -2,7 +2,7 @@
 
 import clone from "lodash/clone"
 import assign from "lodash/assign"
-import eq from "lodash/eq"
+import isEmpty from "lodash/isEmpty"
 import {
   settingsStore,
   bulkApplySettings,
@@ -27,39 +27,46 @@ import { replaceEnvironments, environments$ } from "./environments"
 
 function checkAndMigrateOldSettings() {
   const vuexData = JSON.parse(window.localStorage.getItem("vuex") || "{}")
-  if (eq(vuexData, {})) return
+  if (isEmpty(vuexData)) return
 
-  if (vuexData.postwoman && vuexData.postwoman.settings) {
-    const settingsData = clone(defaultSettings)
-    assign(settingsData, vuexData.postwoman.settings)
+  const { postwoman } = vuexData
+
+  if (!isEmpty(postwoman?.settings)) {
+    const settingsData = assign(clone(defaultSettings), postwoman.settings)
 
     window.localStorage.setItem("settings", JSON.stringify(settingsData))
 
-    delete vuexData.postwoman.settings
+    delete postwoman.settings
     window.localStorage.setItem("vuex", JSON.stringify(vuexData))
   }
 
-  if (vuexData.postwoman && vuexData.postwoman.collections) {
-    const restColls = vuexData.postwoman.collections
-    window.localStorage.setItem("collections", JSON.stringify(restColls))
+  if (postwoman?.collections) {
+    window.localStorage.setItem(
+      "collections",
+      JSON.stringify(postwoman.collections)
+    )
 
-    delete vuexData.postwoman.collections
+    delete postwoman.collections
     window.localStorage.setItem("vuex", JSON.stringify(vuexData))
   }
 
-  if (vuexData.postwoman && vuexData.postwoman.collectionsGraphql) {
-    const gqlColls = vuexData.postwoman.collectionsGraphql
-    window.localStorage.setItem("collectionsGraphql", JSON.stringify(gqlColls))
+  if (postwoman?.collectionsGraphql) {
+    window.localStorage.setItem(
+      "collectionsGraphql",
+      JSON.stringify(postwoman.collectionsGraphql)
+    )
 
-    delete vuexData.postwoman.collectionsGraphql
+    delete postwoman.collectionsGraphql
     window.localStorage.setItem("vuex", JSON.stringify(vuexData))
   }
 
-  if (vuexData.postwoman && vuexData.postwoman.environments) {
-    const envs = vuexData.postwoman.environments
-    window.localStorage.setItem("environments", JSON.stringify(envs))
+  if (postwoman?.environments) {
+    window.localStorage.setItem(
+      "environments",
+      JSON.stringify(postwoman.environments)
+    )
 
-    delete vuexData.postwoman.environments
+    delete postwoman.environments
     window.localStorage.setItem("vuex", JSON.stringify(vuexData))
   }
 

--- a/store/postwoman.js
+++ b/store/postwoman.js
@@ -1,52 +1,6 @@
 import Vue from "vue"
 
-export const SETTINGS_KEYS = [
-  /**
-   * Whether or not to enable scrolling to a specified element, when certain
-   * actions are triggered.
-   */
-  "SCROLL_INTO_ENABLED",
-
-  /**
-   * Whether or not requests should be proxied.
-   */
-  "PROXY_ENABLED",
-
-  /**
-   * The URL of the proxy to connect to for requests.
-   */
-  "PROXY_URL",
-
-  /**
-   * The security key of the proxy.
-   */
-  "PROXY_KEY",
-
-  /**
-   * An array of properties to exclude from the URL.
-   * e.g. 'auth'
-   */
-  "URL_EXCLUDES",
-
-  /**
-   * A boolean value indicating whether to use the browser extensions
-   * to run the requests
-   */
-  "EXTENSIONS_ENABLED",
-
-  /**
-   * A boolean value indicating whether Telemetry is enabled.
-   */
-  "TELEMETRY_ENABLED",
-
-  /**
-   * A boolean value indicating whether to use the URL bar experiments
-   */
-  "EXPERIMENTAL_URL_BAR_ENABLED",
-]
-
 export const state = () => ({
-  settings: {},
   editingEnvironment: {},
   selectedRequest: {},
   selectedGraphqlRequest: {},
@@ -54,29 +8,6 @@ export const state = () => ({
 })
 
 export const mutations = {
-  applySetting({ settings }, setting) {
-    if (
-      setting === null ||
-      !(setting instanceof Array) ||
-      setting.length !== 2
-    ) {
-      throw new Error(
-        "You must provide a setting (array in the form [key, value])"
-      )
-    }
-
-    const [key, value] = setting
-    // Do not just remove this check.
-    // Add your settings key to the SETTINGS_KEYS array at the
-    // top of the file.
-    // This is to ensure that application settings remain documented.
-    if (!SETTINGS_KEYS.includes(key)) {
-      throw new Error(`The settings structure does not include the key ${key}`)
-    }
-
-    settings[key] = value
-  },
-
   removeVariables({ editingEnvironment }, value) {
     editingEnvironment.variables = value
   },


### PR DESCRIPTION
The problem:
https://user-images.githubusercontent.com/41614937/128659587-6ebd297b-7f61-4db1-bf04-41c47e4d76f9.mp4

[This line](https://github.com/hoppscotch/hoppscotch/blob/main/newstore/localpersistence.ts#L32) always returns true since vuexData.postwoman.settings is an object(somehow)
[This one](https://github.com/hoppscotch/hoppscotch/blob/main/newstore/localpersistence.ts#L30) also always returns true because we are using shallow comparison for different objects, so _.isEmpty is a better choice here.
I don't fully understand the background of these migrations, but i took responsibility to refactor this file a little bit(the postwoman part of it), looks like it shouldn't break anything

