### PR TITLE
fix: auth header doubling in codegen

### DIFF
--- a/helpers/codegen/codegen.ts
+++ b/helpers/codegen/codegen.ts
@@ -142,10 +142,20 @@ function getCodegenGeneralRESTInfo(
     urlObj.searchParams.append(key, value)
   })
 
+  // Remove authorization headers if auth is specified (because see #1798)
+  const finalHeaders =
+    request.auth.authActive && request.auth.authType !== "none"
+      ? request.effectiveFinalHeaders
+          .filter((x) => x.key.toLowerCase() !== "authorization")
+          .map((x) => ({ ...x, active: true }))
+      : request.effectiveFinalHeaders.map((x) => ({ ...x, active: true }))
+
+  console.log(finalHeaders)
+
   return {
     name: request.name,
     uri: request.effectiveFinalURL,
-    headers: request.effectiveFinalHeaders.map((x) => ({ ...x, active: true })),
+    headers: finalHeaders,
     params: request.effectiveFinalParams.map((x) => ({ ...x, active: true })),
     method: request.method,
     url: urlObj.origin,


### PR DESCRIPTION
fixes #1798 

The issue was because the finally calculated headers also contain the calculated authorization headers. This patch removes the header letting the codegen just use the auth state to determine