### PR TITLE
fix: gql headers not passed properly (HOPP-55)

### DIFF
--- a/helpers/GQLConnection.ts
+++ b/helpers/GQLConnection.ts
@@ -195,7 +195,7 @@ export class GQLConnection {
       method: "post",
       url,
       headers: {
-        ...headers,
+        ...finalHeaders,
         "content-type": "application/json",
       },
       data: JSON.stringify({


### PR DESCRIPTION
Fix GraphQL headers not being passed properly into the GQL requests.