### PR TITLE
Show graphql error message

### DIFF
--- a/packages/hoppscotch-app/components/graphql/RequestOptions.vue
+++ b/packages/hoppscotch-app/components/graphql/RequestOptions.vue
@@ -447,7 +447,7 @@ const runQuery = async () => {
       icon: "done",
     })
   } catch (e: any) {
-    response.value = `${e}. ${t("error.check_console_details")}`
+    response.value = `${e}.\n\n${t("error.check_console_details")}`
     nuxt.value.$loading.finish()
 
     $toast.error(`${e} ${t("error.f12_details")}`, {

--- a/packages/hoppscotch-app/components/graphql/RequestOptions.vue
+++ b/packages/hoppscotch-app/components/graphql/RequestOptions.vue
@@ -447,10 +447,12 @@ const runQuery = async () => {
       icon: "done",
     })
   } catch (e: any) {
-    response.value = `${e}.\n\n${t("error.check_console_details")}`
+    response.value = `${e}`
     nuxt.value.$loading.finish()
 
-    $toast.error(`${e} ${t("error.f12_details")}`, {
+    $toast.error(
+      `${t("error.something_went_wrong")}. ${t("error.check_console_details")}`,
+      {
       icon: "error_outline",
     })
     console.error(e)

--- a/packages/hoppscotch-app/components/graphql/RequestOptions.vue
+++ b/packages/hoppscotch-app/components/graphql/RequestOptions.vue
@@ -453,8 +453,9 @@ const runQuery = async () => {
     $toast.error(
       `${t("error.something_went_wrong")}. ${t("error.check_console_details")}`,
       {
-      icon: "error_outline",
-    })
+        icon: "error_outline",
+      }
+    )
     console.error(e)
   }
 

--- a/packages/hoppscotch-app/helpers/strategies/AxiosStrategy.js
+++ b/packages/hoppscotch-app/helpers/strategies/AxiosStrategy.js
@@ -52,12 +52,13 @@ const axiosWithoutProxy = async (req, _store) => {
       cancelToken: (cancelSource && cancelSource.token) || "",
       responseType: "arraybuffer",
     })
-
     return res
   } catch (e) {
     if (axios.isCancel(e)) {
       // eslint-disable-next-line no-throw-literal
       throw "cancellation"
+    } else if (e.response.data) {
+      throw new Error(Buffer.from(e.response.data, "base64"))
     } else {
       console.error(e)
       throw e

--- a/packages/hoppscotch-app/helpers/strategies/AxiosStrategy.js
+++ b/packages/hoppscotch-app/helpers/strategies/AxiosStrategy.js
@@ -1,6 +1,7 @@
 import axios from "axios"
 import { decodeB64StringToArrayBuffer } from "../utils/b64"
 import { settingsStore } from "~/newstore/settings"
+import { JsonFormattedError } from "~/helpers/utils/JsonFormattedError"
 
 let cancelSource = axios.CancelToken.source()
 
@@ -39,7 +40,6 @@ const axiosWithProxy = async (req) => {
       // eslint-disable-next-line no-throw-literal
       throw "cancellation"
     } else {
-      console.error(e)
       throw e
     }
   }
@@ -57,10 +57,11 @@ const axiosWithoutProxy = async (req, _store) => {
     if (axios.isCancel(e)) {
       // eslint-disable-next-line no-throw-literal
       throw "cancellation"
-    } else if (e.response.data) {
-      throw new Error(Buffer.from(e.response.data, "base64"))
+    } else if (e.response?.data) {
+      throw new JsonFormattedError(
+        JSON.parse(Buffer.from(e.response.data, "base64").toString("utf8"))
+      )
     } else {
-      console.error(e)
       throw e
     }
   }

--- a/packages/hoppscotch-app/helpers/utils/JsonFormattedError.ts
+++ b/packages/hoppscotch-app/helpers/utils/JsonFormattedError.ts
@@ -1,0 +1,5 @@
+export class JsonFormattedError extends Error {
+  constructor(jsonObject: any) {
+    super(JSON.stringify(jsonObject, null, 2))
+  }
+}


### PR DESCRIPTION
Fix proposal (very simple) for request #1828 

I was not clear from the original ticket what the requirements were. 
- Like the toast message format might not be ideal. Maybe could indicate that it was a HTTP 400 error for example instead of the entire error message. 
- Also, should we continue to say to go and check the logs for futher details?
- I did not test with proxies. Seems like the request made is different in that case. (not using `responseType: "arraybuffer"`

Let me know what you think. thanks

![error-message](https://user-images.githubusercontent.com/9750058/135760952-98517338-1bbd-4407-a600-93f0fb761a20.gif)
