### PR TITLE
style: shifted sidebar to bottom of page

### DIFF
--- a/packages/hoppscotch-app/layouts/default.vue
+++ b/packages/hoppscotch-app/layouts/default.vue
@@ -11,6 +11,7 @@
           :horizontal="!(windowInnerWidth.x.value >= 768)"
         >
           <Pane
+            v-if="windowInnerWidth.x.value >= 768"
             style="width: auto; height: auto"
             class="hide-scrollbar !overflow-auto"
           >
@@ -30,6 +31,13 @@
             </Splitpanes>
           </Pane>
         </Splitpanes>
+      </Pane>
+      <Pane
+        v-if="windowInnerWidth.x.value < 768"
+        style="width: auto; height: auto"
+        class="hide-scrollbar !overflow-auto"
+      >
+        <AppSidenav />
       </Pane>
       <Pane style="height: auto">
         <AppFooter />


### PR DESCRIPTION
Shifted the side bar from the top to the bottom of the page for better mobile usability.
<img width="560" alt="Screenshot" src="https://user-images.githubusercontent.com/70131076/136143617-724f1bc5-04f4-4b90-9a24-69b66d9cb3db.png">
