### PR TITLE
fix: scroll ws logger to the bottom on logs update

### DIFF
--- a/packages/hoppscotch-app/components/realtime/Log.vue
+++ b/packages/hoppscotch-app/components/realtime/Log.vue
@@ -17,7 +17,7 @@
         {{ title }}
       </label>
     </div>
-    <div name="log" class="realtime-log">
+    <div ref="logsRef" name="log" class="realtime-log">
       <span v-if="log" class="space-y-2">
         <span
           v-for="(entry, index) in log"
@@ -31,14 +31,37 @@
   </div>
 </template>
 
-<script setup lang="ts">
+<script lang="ts">
+import { defineComponent, ref } from "@nuxtjs/composition-api"
 import { getSourcePrefix as source } from "~/helpers/utils/string"
 
-defineProps({
-  log: { type: Array, default: () => [] },
-  title: {
-    type: String,
-    default: "",
+// when scroll distance to the bottom edge is less than this value
+// there will be scroll to the bottom on logs update
+const BOTTOM_SCROLL_DIST_INNACURACY = 25
+
+export default defineComponent({
+  props: {
+    log: { type: Array, default: () => [] },
+    title: {
+      type: String,
+      default: "",
+    },
+  },
+  setup() {
+    return { logsRef: ref<HTMLDivElement>() }
+  },
+  watch: {
+    log() {
+      const { logsRef: ref } = this
+      if (!ref) return
+      const distToBottom = ref.scrollHeight - ref.scrollTop - ref.clientHeight
+      if (distToBottom < BOTTOM_SCROLL_DIST_INNACURACY) {
+        this.$nextTick(() => (ref.scrollTop = ref.scrollHeight))
+      }
+    },
+  },
+  methods: {
+    source,
   },
 })
 </script>


### PR DESCRIPTION
hello. thix pr changes scroll behavior inside websocket loggers. now it'll scroll to the bottom of the logs on update, but only if current scroll position is at the bottom or pretty near to it(there is a constant called BOTTOM_SCROLL_DIST_INNACURACY that defines that "pretty near")

before:
https://user-images.githubusercontent.com/41614937/140460775-7330e05b-1b52-4027-bd7b-0625b7e227dd.mp4

after
https://user-images.githubusercontent.com/41614937/140460790-6cede525-bba8-4f4e-879d-92ef2e8c44a6.mp4


