### PR TITLE
fix: team name validation on add

### DIFF
--- a/packages/hoppscotch-app/helpers/backend/types/TeamName.ts
+++ b/packages/hoppscotch-app/helpers/backend/types/TeamName.ts
@@ -6,7 +6,7 @@ interface TeamNameBrand {
 
 export const TeamNameCodec = t.brand(
   t.string,
-  (x): x is t.Branded<string, TeamNameBrand> => x.trim().length > 6,
+  (x): x is t.Branded<string, TeamNameBrand> => x.trim().length >= 6,
   "TeamName"
 )
 


### PR DESCRIPTION
### Description
I tried to add a new Team to my Profile with exactly 6 characters, validation failed and told me to use min. 6 chars.

- [x] fix team name validation to align with validation message
