### PR TITLE
feat: nested variable name resolution

### DIFF
--- a/packages/hoppscotch-app/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-app/components/smart/EnvInput.vue
@@ -28,6 +28,7 @@ import IntervalTree from "node-interval-tree"
 import debounce from "lodash/debounce"
 import isUndefined from "lodash/isUndefined"
 import { tippy } from "vue-tippy"
+import { parseTemplateString } from "../../helpers/templating"
 import { aggregateEnvs$ } from "~/newstore/environments"
 import { useReadonlyStream } from "~/helpers/utils/composables"
 
@@ -65,7 +66,7 @@ export default defineComponent({
       debouncedHandler: null,
       highlight: [
         {
-          text: /(<<\w+>>)/g,
+          text: /(<<(?:[^<>]+|<<(?:[^<>]+|<<[^<>]*>>)*>>)*>>)/g,
           style:
             "cursor-help transition rounded px-1 focus:outline-none mx-0.5",
         },
@@ -207,9 +208,12 @@ export default defineComponent({
         result += this.safe_tags_replace(
           this.internalValue.substring(startingPosition, position.start)
         )
-        const envVar = this.internalValue
+        const rawEnvVar = this.internalValue
           .substring(position.start, position.end + 1)
           .slice(2, -2)
+
+        const envVar = parseTemplateString(rawEnvVar, this.aggregateEnvs)
+
         result += `<span class="${highlightPositions[k].style} ${
           this.aggregateEnvs.find((k) => k.key === envVar)?.value === undefined
             ? "bg-red-400 text-red-50 hover:bg-red-600"

--- a/packages/hoppscotch-app/helpers/templating.ts
+++ b/packages/hoppscotch-app/helpers/templating.ts
@@ -4,12 +4,10 @@ export function parseBodyEnvVariables(
   body: string,
   env: Environment["variables"]
 ) {
-  return body.replace(/<<\w+>>/g, (key) => {
-    const found = env.find((envVar) => envVar.key === key.replace(/[<>]/g, ""))
-    return found ? found.value : key
-  })
+  return innerParse(body, env)
 }
 
+const searchTerm = /<<(\w+)>>/g // "<<myVariable>>"
 export function parseTemplateString(
   str: string,
   variables: Environment["variables"]
@@ -17,9 +15,18 @@ export function parseTemplateString(
   if (!variables || !str) {
     return str
   }
-  const searchTerm = /<<([^>]*)>>/g // "<<myVariable>>"
-  return decodeURI(encodeURI(str)).replace(
+
+  return innerParse(decodeURI(encodeURI(str)), variables)
+}
+
+function innerParse(str: string, variables: Environment["variables"]): string {
+  const result = str.replace(
     searchTerm,
     (_, p1) => variables.find((x) => x.key === p1)?.value || ""
   )
+  if (result === str) {
+    return result
+  }
+
+  return innerParse(result, variables)
 }


### PR DESCRIPTION
### Description
This PR adds handling for nested(dynamic) variable names.

This code should handle infinite depth in actual variable value resolution, but only support 2 levels deep for highlighting and tooltips due to the restrictions on using Regex directly without regression for matching <<>>.

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation (Don't believe so, though potentially?)
- [ ] I have updated the documentation as required
- [x ] All the tests have passed

### Additional Information
Previously <<<<**env**>>_var>> would not resolve
Now if <<**env**>> is defined as "dev" at environment level and <<dev_var>> is defined at global, this will resolve