### PR TITLE
Enable image lens for WebP

### DIFF
--- a/packages/hoppscotch-app/helpers/lenses/imageLens.ts
+++ b/packages/hoppscotch-app/helpers/lenses/imageLens.ts
@@ -3,7 +3,7 @@ import { Lens } from "./lenses"
 const imageLens: Lens = {
   lensName: "response.image",
   isSupportedContentType: (contentType) =>
-    /\bimage\/(?:gif|jpeg|png|bmp|svg\+xml|x-icon|vnd\.microsoft\.icon)\b/i.test(
+    /\bimage\/(?:gif|jpeg|png|webp|bmp|svg\+xml|x-icon|vnd\.microsoft\.icon)\b/i.test(
       contentType
     ),
   renderer: "imageres",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

### Description
<!-- Add a brief description of the pull request -->

With all major browsers have added support for more than one year (Safari being the latest), we can safely assume WebP is available most of the time.

👇 Meta warning: below is a WebP image showing WebP support

[![](https://caniuse.bitsofco.de/image/webp.webp)](https://caniuse.com/?search=webp)

If the browser really doesn't support WebP, they just get a alt icon and nothing really breaks. That's still better than showing the raw binary:

<img width="559" alt="image" src="https://user-images.githubusercontent.com/44045911/154854704-54c9617c-c762-492c-b5cf-233fb4ef14b9.png">

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
