### PR TITLE
fix: graphql response vertical alignment

### DIFF
--- a/packages/hoppscotch-app/components/graphql/Response.vue
+++ b/packages/hoppscotch-app/components/graphql/Response.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="sticky top-0 z-10 flex items-center p-4 overflow-auto bg-primary hide-scrollbar whitespace-nowrap"
+    class="sticky top-0 z-10 flex items-start overflow-auto bg-primary hide-scrollbar whitespace-nowrap"
   >
     <div
       v-if="responseString === 'loading'"


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

### Description
<!-- Add a brief description of the pull request -->
Currently the GraphQL response pane is broken for large responses. As the content is aligned to the center you can't scroll up to see the beginning of the response, setting this alignment to `flex-start` allows us to see all the content.
There was also some padding around the response section which made it look different to the REST response pane and also made the response banner appear over the response text, I've removed this padding to make it look the same as the REST response section.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
Screenshots for reference:

#### Before
![Screenshot 2022-03-01 at 09 13 50](https://user-images.githubusercontent.com/16815919/156142121-47724c68-fefa-41a6-bb76-9cf58490f42f.png)

#### After
![Screenshot 2022-03-01 at 09 22 15](https://user-images.githubusercontent.com/16815919/156142149-18043dce-e5a2-407b-9eec-19436aee8a06.png)
