### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/hoppscotch-app/components/profile/Picture.vue
+++ b/packages/hoppscotch-app/components/profile/Picture.vue
@@ -74,7 +74,7 @@ export default defineComponent({
       let color = "#"
       for (let i = 0; i < 3; i++) {
         const value = (hash >> (i * 8)) & 255
-        color += `00${value.toString(16)}`.substr(-2)
+        color += `00${value.toString(16)}`.slice(-2)
       }
       return color
     },

--- a/packages/hoppscotch-app/helpers/oauth.js
+++ b/packages/hoppscotch-app/helpers/oauth.js
@@ -88,7 +88,7 @@ const getTokenConfiguration = async (endpoint) => {
 const generateRandomString = () => {
   const array = new Uint32Array(28)
   window.crypto.getRandomValues(array)
-  return Array.from(array, (dec) => `0${dec.toString(16)}`.substr(-2)).join("")
+  return Array.from(array, (dec) => `0${dec.toString(16)}`.slice(-2)).join("")
 }
 
 /**


### PR DESCRIPTION
### Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information

