### PR TITLE
Prevent IMEs from triggering when editing a readonly code editor

### DIFF
--- a/packages/hoppscotch-app/helpers/editor/codemirror.ts
+++ b/packages/hoppscotch-app/helpers/editor/codemirror.ts
@@ -225,6 +225,11 @@ export function useCodemirror(
           }
         }
       ),
+      EditorView.updateListener.of((update) => {
+        if (options.extendedEditorConfig.readOnly) {
+          update.view.contentDOM.inputMode = "none"
+        }
+      }),
       EditorState.changeFilter.of(() => !options.extendedEditorConfig.readOnly),
       placeholderConfig.of(
         placeholder(options.extendedEditorConfig.placeholder ?? "")


### PR DESCRIPTION
This small patch introduces a small update that blocks IMEs from starting composition when editing a readonly code editor instance.

This is especially useful on mobile devices where the virtual keyboard is triggered when the REST Response Body is tapped on which further reduces the screen space.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
Check IME behavior on Android and iOS and see how they react on readonly and readwrite fields.
