### PR TITLE
feat: add `New Request` button for folder and collection

### DIFF
--- a/packages/hoppscotch-app/components/collections/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/AddRequest.vue
@@ -38,6 +38,7 @@ import { defineComponent } from "@nuxtjs/composition-api"
 export default defineComponent({
   props: {
     show: Boolean,
+    folder: { type: Object, default: () => {} },
     folderPath: { type: String, default: null },
     collectionIndex: { type: Number, default: null },
   },
@@ -54,6 +55,7 @@ export default defineComponent({
       }
       this.$emit("add-request", {
         name: this.name,
+        folder: this.folder,
         path: this.folderPath || `${this.collectionIndex}`,
       })
       this.hideModal()

--- a/packages/hoppscotch-app/components/collections/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/AddRequest.vue
@@ -32,38 +32,40 @@
   </SmartModal>
 </template>
 
-<script>
-import { defineComponent } from "@nuxtjs/composition-api"
+<script setup lang="ts">
+import { useRESTRequestName } from "~/newstore/RESTSession"
+import { useI18n, useToast } from "~/helpers/utils/composables"
 
-export default defineComponent({
-  props: {
-    show: Boolean,
-    folder: { type: Object, default: () => {} },
-    folderPath: { type: String, default: null },
-    collectionIndex: { type: Number, default: null },
-  },
-  data() {
-    return {
-      name: null,
-    }
-  },
-  methods: {
-    addRequest() {
-      if (!this.name) {
-        this.$toast.error(`${this.$t("error.empty_req_name")}`)
-        return
-      }
-      this.$emit("add-request", {
-        name: this.name,
-        folder: this.folder,
-        path: this.folderPath || `${this.collectionIndex}`,
-      })
-      this.hideModal()
-    },
-    hideModal() {
-      this.name = null
-      this.$emit("hide-modal")
-    },
-  },
-})
+const toast = useToast()
+const t = useI18n()
+
+const props = defineProps<{
+  show: boolean
+  folder?: object
+  folderPath?: string
+}>()
+
+const emit = defineEmits<{
+  (e: "hide-modal"): void
+  (e: "add-request", v: object): void
+}>()
+
+const name = useRESTRequestName()
+
+const addRequest = () => {
+  if (!name.value) {
+    toast.error(`${t("error.empty_req_name")}`)
+    return
+  }
+  emit("add-request", {
+    name: name.value,
+    folder: props.folder,
+    path: props.folderPath,
+  })
+  hideModal()
+}
+
+const hideModal = () => {
+  emit("hide-modal")
+}
 </script>

--- a/packages/hoppscotch-app/components/collections/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/AddRequest.vue
@@ -39,7 +39,7 @@
 <script setup lang="ts">
 import { ref, watch } from "@nuxtjs/composition-api"
 import { useI18n, useToast } from "~/helpers/utils/composables"
-import { useRESTRequestName } from "~/newstore/RESTSession"
+import { getRESTRequest } from "~/newstore/RESTSession"
 
 const toast = useToast()
 const t = useI18n()
@@ -53,16 +53,26 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: "hide-modal"): void
-  (e: "add-request", v: object): void
+  (
+    e: "add-request",
+    v: {
+      name: string
+      folder: object | undefined
+      path: string | undefined
+    }
+  ): void
 }>()
 
 const name = ref("")
 
-watch(props, (v) => {
-  if (v.show) {
-    name.value = useRESTRequestName().value
+watch(
+  () => props.show,
+  (show) => {
+    if (show) {
+      name.value = getRESTRequest().name
+    }
   }
-})
+)
 
 const addRequest = () => {
   if (!name.value) {

--- a/packages/hoppscotch-app/components/collections/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/AddRequest.vue
@@ -22,7 +22,11 @@
     </template>
     <template #footer>
       <span>
-        <ButtonPrimary :label="$t('action.save')" @click.native="addRequest" />
+        <ButtonPrimary
+          :label="$t('action.save')"
+          :loading="loadingState"
+          @click.native="addRequest"
+        />
         <ButtonSecondary
           :label="$t('action.cancel')"
           @click.native="hideModal"
@@ -41,6 +45,7 @@ const t = useI18n()
 
 const props = defineProps<{
   show: boolean
+  loadingState: boolean
   folder?: object
   folderPath?: string
 }>()
@@ -62,7 +67,6 @@ const addRequest = () => {
     folder: props.folder,
     path: props.folderPath,
   })
-  hideModal()
 }
 
 const hideModal = () => {

--- a/packages/hoppscotch-app/components/collections/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/AddRequest.vue
@@ -2,29 +2,27 @@
   <SmartModal
     v-if="show"
     dialog
-    :title="$t('folder.new')"
+    :title="$t('request.new')"
     @close="$emit('hide-modal')"
   >
     <template #body>
       <div class="flex flex-col px-2">
         <input
-          id="selectLabelGqlAddFolder"
+          id="selectLabelAddRequest"
           v-model="name"
           v-focus
           class="input floating-input"
           placeholder=" "
           type="text"
           autocomplete="off"
-          @keyup.enter="addFolder"
+          @keyup.enter="addRequest"
         />
-        <label for="selectLabelGqlAddFolder">
-          {{ $t("action.label") }}
-        </label>
+        <label for="selectLabelAddRequest">{{ $t("action.label") }}</label>
       </div>
     </template>
     <template #footer>
       <span>
-        <ButtonPrimary :label="$t('action.save')" @click.native="addFolder" />
+        <ButtonPrimary :label="$t('action.save')" @click.native="addRequest" />
         <ButtonSecondary
           :label="$t('action.cancel')"
           @click.native="hideModal"
@@ -34,7 +32,7 @@
   </SmartModal>
 </template>
 
-<script lang="ts">
+<script>
 import { defineComponent } from "@nuxtjs/composition-api"
 
 export default defineComponent({
@@ -49,17 +47,15 @@ export default defineComponent({
     }
   },
   methods: {
-    addFolder() {
+    addRequest() {
       if (!this.name) {
-        this.$toast.error(`${this.$t("folder.name_length_insufficient")}`)
+        this.$toast.error(`${this.$t("error.empty_req_name")}`)
         return
       }
-
-      this.$emit("add-folder", {
+      this.$emit("add-request", {
         name: this.name,
         path: this.folderPath || `${this.collectionIndex}`,
       })
-
       this.hideModal()
     },
     hideModal() {

--- a/packages/hoppscotch-app/components/collections/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/AddRequest.vue
@@ -37,8 +37,9 @@
 </template>
 
 <script setup lang="ts">
-import { useRESTRequestName } from "~/newstore/RESTSession"
+import { ref, watch } from "@nuxtjs/composition-api"
 import { useI18n, useToast } from "~/helpers/utils/composables"
+import { useRESTRequestName } from "~/newstore/RESTSession"
 
 const toast = useToast()
 const t = useI18n()
@@ -55,7 +56,13 @@ const emit = defineEmits<{
   (e: "add-request", v: object): void
 }>()
 
-const name = useRESTRequestName()
+const name = ref("")
+
+watch(props, (v) => {
+  if (v.show) {
+    name.value = useRESTRequestName().value
+  }
+})
 
 const addRequest = () => {
   if (!name.value) {

--- a/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
@@ -37,7 +37,7 @@
 <script setup lang="ts">
 import { ref, watch } from "@nuxtjs/composition-api"
 import { useI18n, useToast } from "~/helpers/utils/composables"
-import { useGQLRequestName } from "~/newstore/GQLSession"
+import { getGQLSession } from "~/newstore/GQLSession"
 
 const toast = useToast()
 const t = useI18n()
@@ -49,16 +49,25 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: "hide-modal"): void
-  (e: "add-request", v: object): void
+  (
+    e: "add-request",
+    v: {
+      name: string
+      path: string | undefined
+    }
+  ): void
 }>()
 
 const name = ref("")
 
-watch(props, (v) => {
-  if (v.show) {
-    name.value = useGQLRequestName().value
+watch(
+  () => props.show,
+  (show) => {
+    if (show) {
+      name.value = getGQLSession().request.name
+    }
   }
-})
+)
 
 const addRequest = () => {
   if (!name.value) {

--- a/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
@@ -34,37 +34,38 @@
   </SmartModal>
 </template>
 
-<script lang="ts">
-import { defineComponent } from "@nuxtjs/composition-api"
+<script setup lang="ts">
+import { useGQLRequestName } from "~/newstore/GQLSession"
+import { useI18n, useToast } from "~/helpers/utils/composables"
 
-export default defineComponent({
-  props: {
-    show: Boolean,
-    folderPath: { type: String, default: null },
-    collectionIndex: { type: Number, default: null },
-  },
-  data() {
-    return {
-      name: null,
-    }
-  },
-  methods: {
-    addRequest() {
-      if (!this.name) {
-        this.$toast.error(`${this.$t("error.empty_req_name")}`)
-        return
-      }
-      this.$emit("add-request", {
-        name: this.name,
-        path: this.folderPath || `${this.collectionIndex}`,
-      })
+const toast = useToast()
+const t = useI18n()
 
-      this.hideModal()
-    },
-    hideModal() {
-      this.name = null
-      this.$emit("hide-modal")
-    },
-  },
-})
+const props = defineProps<{
+  show: boolean
+  folderPath?: string
+}>()
+
+const emit = defineEmits<{
+  (e: "hide-modal"): void
+  (e: "add-request", v: object): void
+}>()
+
+const name = useGQLRequestName()
+
+const addRequest = () => {
+  if (!name.value) {
+    toast.error(`${t("error.empty_req_name")}`)
+    return
+  }
+  emit("add-request", {
+    name: name.value,
+    path: props.folderPath,
+  })
+  hideModal()
+}
+
+const hideModal = () => {
+  emit("hide-modal")
+}
 </script>

--- a/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
@@ -24,11 +24,7 @@
     </template>
     <template #footer>
       <span>
-        <ButtonPrimary
-          :label="$t('action.save')"
-          :loading="loadingState"
-          @click.native="addRequest"
-        />
+        <ButtonPrimary :label="$t('action.save')" @click.native="addRequest" />
         <ButtonSecondary
           :label="$t('action.cancel')"
           @click.native="hideModal"
@@ -47,7 +43,6 @@ const t = useI18n()
 
 const props = defineProps<{
   show: boolean
-  loadingState: boolean
   folderPath?: string
 }>()
 
@@ -67,6 +62,7 @@ const addRequest = () => {
     name: name.value,
     path: props.folderPath,
   })
+  hideModal()
 }
 
 const hideModal = () => {

--- a/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
@@ -24,7 +24,11 @@
     </template>
     <template #footer>
       <span>
-        <ButtonPrimary :label="$t('action.save')" @click.native="addRequest" />
+        <ButtonPrimary
+          :label="$t('action.save')"
+          :loading="loadingState"
+          @click.native="addRequest"
+        />
         <ButtonSecondary
           :label="$t('action.cancel')"
           @click.native="hideModal"
@@ -43,6 +47,7 @@ const t = useI18n()
 
 const props = defineProps<{
   show: boolean
+  loadingState: boolean
   folderPath?: string
 }>()
 
@@ -62,7 +67,6 @@ const addRequest = () => {
     name: name.value,
     path: props.folderPath,
   })
-  hideModal()
 }
 
 const hideModal = () => {

--- a/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
@@ -35,8 +35,9 @@
 </template>
 
 <script setup lang="ts">
-import { useGQLRequestName } from "~/newstore/GQLSession"
+import { ref, watch } from "@nuxtjs/composition-api"
 import { useI18n, useToast } from "~/helpers/utils/composables"
+import { useGQLRequestName } from "~/newstore/GQLSession"
 
 const toast = useToast()
 const t = useI18n()
@@ -51,7 +52,13 @@ const emit = defineEmits<{
   (e: "add-request", v: object): void
 }>()
 
-const name = useGQLRequestName()
+const name = ref("")
+
+watch(props, (v) => {
+  if (v.show) {
+    name.value = useGQLRequestName().value
+  }
+})
 
 const addRequest = () => {
   if (!name.value) {

--- a/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/AddRequest.vue
@@ -2,29 +2,29 @@
   <SmartModal
     v-if="show"
     dialog
-    :title="$t('folder.new')"
+    :title="$t('request.new')"
     @close="$emit('hide-modal')"
   >
     <template #body>
       <div class="flex flex-col px-2">
         <input
-          id="selectLabelGqlAddFolder"
+          id="selectLabelGqlAddRequest"
           v-model="name"
           v-focus
           class="input floating-input"
           placeholder=" "
           type="text"
           autocomplete="off"
-          @keyup.enter="addFolder"
+          @keyup.enter="addRequest"
         />
-        <label for="selectLabelGqlAddFolder">
+        <label for="selectLabelGqlAddRequest">
           {{ $t("action.label") }}
         </label>
       </div>
     </template>
     <template #footer>
       <span>
-        <ButtonPrimary :label="$t('action.save')" @click.native="addFolder" />
+        <ButtonPrimary :label="$t('action.save')" @click.native="addRequest" />
         <ButtonSecondary
           :label="$t('action.cancel')"
           @click.native="hideModal"
@@ -49,13 +49,12 @@ export default defineComponent({
     }
   },
   methods: {
-    addFolder() {
+    addRequest() {
       if (!this.name) {
-        this.$toast.error(`${this.$t("folder.name_length_insufficient")}`)
+        this.$toast.error(`${this.$t("error.empty_req_name")}`)
         return
       }
-
-      this.$emit("add-folder", {
+      this.$emit("add-request", {
         name: this.name,
         path: this.folderPath || `${this.collectionIndex}`,
       })

--- a/packages/hoppscotch-app/components/collections/graphql/Collection.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/Collection.vue
@@ -61,11 +61,26 @@
               class="flex flex-col focus:outline-none"
               tabindex="0"
               role="menu"
+              @keyup.r="requestAction.$el.click()"
               @keyup.n="folderAction.$el.click()"
               @keyup.e="edit.$el.click()"
               @keyup.delete="deleteAction.$el.click()"
               @keyup.escape="options.tippy().hide()"
             >
+              <SmartItem
+                ref="requestAction"
+                svg="plus"
+                :label="`${$t('request.new')}`"
+                :shortcut="['R']"
+                @click.native="
+                  () => {
+                    $emit('add-request', {
+                      path: `${collectionIndex}`,
+                    })
+                    options.tippy().hide()
+                  }
+                "
+              />
               <SmartItem
                 ref="folderAction"
                 svg="folder-plus"
@@ -126,6 +141,7 @@
           :collection-index="collectionIndex"
           :doc="doc"
           :is-filtered="isFiltered"
+          @add-request="$emit('add-request', $event)"
           @add-folder="$emit('add-folder', $event)"
           @edit-folder="$emit('edit-folder', $event)"
           @edit-request="$emit('edit-request', $event)"
@@ -196,6 +212,7 @@ export default defineComponent({
     return {
       tippyActions: ref<any | null>(null),
       options: ref<any | null>(null),
+      requestAction: ref<any | null>(null),
       folderAction: ref<any | null>(null),
       edit: ref<any | null>(null),
       deleteAction: ref<any | null>(null),

--- a/packages/hoppscotch-app/components/collections/graphql/Folder.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/Folder.vue
@@ -57,11 +57,24 @@
               class="flex flex-col focus:outline-none"
               tabindex="0"
               role="menu"
+              @keyup.r="requestAction.$el.click()"
               @keyup.n="folderAction.$el.click()"
               @keyup.e="edit.$el.click()"
               @keyup.delete="deleteAction.$el.click()"
               @keyup.escape="options.tippy().hide()"
             >
+              <SmartItem
+                ref="requestAction"
+                svg="plus"
+                :label="`${$t('request.new')}`"
+                :shortcut="['R']"
+                @click.native="
+                  () => {
+                    $emit('add-request', { path: folderPath })
+                    options.tippy().hide()
+                  }
+                "
+              />
               <SmartItem
                 ref="folderAction"
                 svg="folder-plus"
@@ -120,6 +133,7 @@
           :collection-index="collectionIndex"
           :doc="doc"
           :is-filtered="isFiltered"
+          @add-request="$emit('add-request', $event)"
           @add-folder="$emit('add-folder', $event)"
           @edit-folder="$emit('edit-folder', $event)"
           @edit-request="$emit('edit-request', $event)"
@@ -193,6 +207,7 @@ export default defineComponent({
     return {
       tippyActions: ref<any | null>(null),
       options: ref<any | null>(null),
+      requestAction: ref<any | null>(null),
       folderAction: ref<any | null>(null),
       edit: ref<any | null>(null),
       deleteAction: ref<any | null>(null),

--- a/packages/hoppscotch-app/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/index.vue
@@ -49,6 +49,7 @@
         :is-filtered="filterText.length > 0"
         :saving-mode="savingMode"
         @edit-collection="editCollection(collection, index)"
+        @add-request="addRequest($event)"
         @add-folder="addFolder($event)"
         @edit-folder="editFolder($event)"
         @edit-request="editRequest($event)"
@@ -96,6 +97,12 @@
       :editing-collection-name="editingCollection ? editingCollection.name : ''"
       @hide-modal="displayModalEdit(false)"
     />
+    <CollectionsGraphqlAddRequest
+      :show="showModalAddRequest"
+      :folder-path="editingFolderPath"
+      @add-request="onAddRequest($event)"
+      @hide-modal="displayModalAddRequest(false)"
+    />
     <CollectionsGraphqlAddFolder
       :show="showModalAddFolder"
       :folder-path="editingFolderPath"
@@ -136,6 +143,7 @@ import {
   addGraphqlFolder,
   saveGraphqlRequestAs,
 } from "~/newstore/collections"
+import { defaultGQLSession, setGQLSession } from "~/newstore/GQLSession"
 
 export default defineComponent({
   props: {
@@ -156,6 +164,7 @@ export default defineComponent({
       showModalAdd: false,
       showModalEdit: false,
       showModalImportExport: false,
+      showModalAddRequest: false,
       showModalAddFolder: false,
       showModalEditFolder: false,
       showModalEditRequest: false,
@@ -222,6 +231,11 @@ export default defineComponent({
     displayModalImportExport(shouldDisplay) {
       this.showModalImportExport = shouldDisplay
     },
+    displayModalAddRequest(shouldDisplay) {
+      this.showModalAddRequest = shouldDisplay
+
+      if (!shouldDisplay) this.resetSelectedData()
+    },
     displayModalAddFolder(shouldDisplay) {
       this.showModalAddFolder = shouldDisplay
 
@@ -241,6 +255,26 @@ export default defineComponent({
       this.$data.editingCollection = collection
       this.$data.editingCollectionIndex = collectionIndex
       this.displayModalEdit(true)
+    },
+    onAddRequest({ name, path }) {
+      const newRequest = {
+        ...defaultGQLSession.request,
+        name,
+      }
+
+      saveGraphqlRequestAs(path, newRequest)
+      setGQLSession({
+        request: newRequest,
+        schema: "",
+        response: "",
+      })
+
+      this.displayModalAddRequest(false)
+    },
+    addRequest(payload) {
+      const { path } = payload
+      this.$data.editingFolderPath = path
+      this.displayModalAddRequest(true)
     },
     onAddFolder({ name, path }) {
       addGraphqlFolder(name, path)

--- a/packages/hoppscotch-app/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/index.vue
@@ -100,6 +100,7 @@
     <CollectionsGraphqlAddRequest
       :show="showModalAddRequest"
       :folder-path="editingFolderPath"
+      :loading-state="modalLoadingState"
       @add-request="onAddRequest($event)"
       @hide-modal="displayModalAddRequest(false)"
     />
@@ -168,6 +169,7 @@ export default defineComponent({
       showModalAddFolder: false,
       showModalEditFolder: false,
       showModalEditRequest: false,
+      modalLoadingState: false,
       editingCollection: undefined,
       editingCollectionIndex: undefined,
       editingFolder: undefined,
@@ -257,6 +259,8 @@ export default defineComponent({
       this.displayModalEdit(true)
     },
     onAddRequest({ name, path }) {
+      this.modalLoadingState = true
+
       const newRequest = {
         ...getGQLSession().request,
         name,
@@ -269,6 +273,7 @@ export default defineComponent({
         response: "",
       })
 
+      this.modalLoadingState = false
       this.displayModalAddRequest(false)
     },
     addRequest(payload) {

--- a/packages/hoppscotch-app/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/index.vue
@@ -100,7 +100,6 @@
     <CollectionsGraphqlAddRequest
       :show="showModalAddRequest"
       :folder-path="editingFolderPath"
-      :loading-state="modalLoadingState"
       @add-request="onAddRequest($event)"
       @hide-modal="displayModalAddRequest(false)"
     />
@@ -169,7 +168,6 @@ export default defineComponent({
       showModalAddFolder: false,
       showModalEditFolder: false,
       showModalEditRequest: false,
-      modalLoadingState: false,
       editingCollection: undefined,
       editingCollectionIndex: undefined,
       editingFolder: undefined,
@@ -259,8 +257,6 @@ export default defineComponent({
       this.displayModalEdit(true)
     },
     onAddRequest({ name, path }) {
-      this.modalLoadingState = true
-
       const newRequest = {
         ...getGQLSession().request,
         name,
@@ -273,7 +269,6 @@ export default defineComponent({
         response: "",
       })
 
-      this.modalLoadingState = false
       this.displayModalAddRequest(false)
     },
     addRequest(payload) {

--- a/packages/hoppscotch-app/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-app/components/collections/graphql/index.vue
@@ -143,7 +143,7 @@ import {
   addGraphqlFolder,
   saveGraphqlRequestAs,
 } from "~/newstore/collections"
-import { defaultGQLSession, setGQLSession } from "~/newstore/GQLSession"
+import { getGQLSession, setGQLSession } from "~/newstore/GQLSession"
 
 export default defineComponent({
   props: {
@@ -258,7 +258,7 @@ export default defineComponent({
     },
     onAddRequest({ name, path }) {
       const newRequest = {
-        ...defaultGQLSession.request,
+        ...getGQLSession().request,
         name,
       }
 

--- a/packages/hoppscotch-app/components/collections/index.vue
+++ b/packages/hoppscotch-app/components/collections/index.vue
@@ -685,7 +685,7 @@ export default defineComponent({
     },
     onAddRequest({ name, folder, path }) {
       const newRequest = {
-        ...getRESTRequest(),
+        ...cloneDeep(getRESTRequest()),
         name,
       }
 

--- a/packages/hoppscotch-app/components/collections/index.vue
+++ b/packages/hoppscotch-app/components/collections/index.vue
@@ -217,7 +217,7 @@ import {
   editRESTRequest,
   saveRESTRequestAs,
 } from "~/newstore/collections"
-import { setRESTRequest, getDefaultRESTRequest } from "~/newstore/RESTSession"
+import { setRESTRequest, getRESTRequest } from "~/newstore/RESTSession"
 import {
   useReadonlyStream,
   useStreamSubscriber,
@@ -683,7 +683,7 @@ export default defineComponent({
     },
     onAddRequest({ name, folder, path }) {
       const newRequest = {
-        ...getDefaultRESTRequest(),
+        ...getRESTRequest(),
         name,
       }
 

--- a/packages/hoppscotch-app/components/collections/index.vue
+++ b/packages/hoppscotch-app/components/collections/index.vue
@@ -164,6 +164,7 @@
       :show="showModalAddRequest"
       :folder="editingFolder"
       :folder-path="editingFolderPath"
+      :loading-state="modalLoadingState"
       @add-request="onAddRequest($event)"
       @hide-modal="displayModalAddRequest(false)"
     />
@@ -263,6 +264,7 @@ export default defineComponent({
       showModalAddFolder: false,
       showModalEditFolder: false,
       showModalEditRequest: false,
+      modalLoadingState: false,
       editingCollection: undefined,
       editingCollectionIndex: undefined,
       editingFolder: undefined,
@@ -682,6 +684,8 @@ export default defineComponent({
       this.displayModalAddRequest(true)
     },
     onAddRequest({ name, folder, path }) {
+      this.modalLoadingState = true
+
       const newRequest = {
         ...getRESTRequest(),
         name,
@@ -695,6 +699,9 @@ export default defineComponent({
           folderPath: path,
           requestIndex: insertionIndex,
         })
+
+        this.modalLoadingState = false
+        this.displayModalAddRequest(false)
       } else if (
         this.collectionsType.type === "team-collections" &&
         this.collectionsType.selectedTeam.myRole !== "VIEWER"
@@ -708,6 +715,7 @@ export default defineComponent({
           },
         })().then((result) => {
           if (E.isLeft(result)) {
+            this.modalLoadingState = false
             this.$toast.error(this.$t("error.something_went_wrong"))
             console.error(result.left.error)
           } else {
@@ -719,11 +727,11 @@ export default defineComponent({
               collectionID: createRequestInCollection.collection.id,
               teamID: createRequestInCollection.collection.team.id,
             })
+            this.modalLoadingState = false
+            this.displayModalAddRequest(false)
           }
         })
       }
-
-      this.displayModalAddRequest(false)
     },
     duplicateRequest({ folderPath, request, collectionID }) {
       if (this.collectionsType.type === "team-collections") {

--- a/packages/hoppscotch-app/components/collections/index.vue
+++ b/packages/hoppscotch-app/components/collections/index.vue
@@ -684,8 +684,6 @@ export default defineComponent({
       this.displayModalAddRequest(true)
     },
     onAddRequest({ name, folder, path }) {
-      this.modalLoadingState = true
-
       const newRequest = {
         ...getRESTRequest(),
         name,
@@ -700,12 +698,12 @@ export default defineComponent({
           requestIndex: insertionIndex,
         })
 
-        this.modalLoadingState = false
         this.displayModalAddRequest(false)
       } else if (
         this.collectionsType.type === "team-collections" &&
         this.collectionsType.selectedTeam.myRole !== "VIEWER"
       ) {
+        this.modalLoadingState = true
         runMutation(CreateRequestInCollectionDocument, {
           collectionID: folder.id,
           data: {
@@ -714,8 +712,8 @@ export default defineComponent({
             title: name,
           },
         })().then((result) => {
+          this.modalLoadingState = false
           if (E.isLeft(result)) {
-            this.modalLoadingState = false
             this.$toast.error(this.$t("error.something_went_wrong"))
             console.error(result.left.error)
           } else {
@@ -727,7 +725,6 @@ export default defineComponent({
               collectionID: createRequestInCollection.collection.id,
               teamID: createRequestInCollection.collection.team.id,
             })
-            this.modalLoadingState = false
             this.displayModalAddRequest(false)
           }
         })

--- a/packages/hoppscotch-app/components/collections/my/Collection.vue
+++ b/packages/hoppscotch-app/components/collections/my/Collection.vue
@@ -79,12 +79,27 @@
               class="flex flex-col focus:outline-none"
               tabindex="0"
               role="menu"
+              @keyup.r="requestAction.$el.click()"
               @keyup.n="folderAction.$el.click()"
               @keyup.e="edit.$el.click()"
               @keyup.delete="deleteAction.$el.click()"
               @keyup.x="exportAction.$el.click()"
               @keyup.escape="options.tippy().hide()"
             >
+              <SmartItem
+                ref="requestAction"
+                svg="plus"
+                :label="$t('request.new')"
+                :shortcut="['R']"
+                @click.native="
+                  () => {
+                    $emit('add-request', {
+                      path: `${collectionIndex}`,
+                    })
+                    options.tippy().hide()
+                  }
+                "
+              />
               <SmartItem
                 ref="folderAction"
                 svg="folder-plus"
@@ -159,6 +174,7 @@
           :collections-type="collectionsType"
           :is-filtered="isFiltered"
           :picked="picked"
+          @add-request="$emit('add-request', $event)"
           @add-folder="$emit('add-folder', $event)"
           @edit-folder="$emit('edit-folder', $event)"
           @edit-request="$emit('edit-request', $event)"
@@ -233,6 +249,7 @@ export default defineComponent({
     return {
       tippyActions: ref<any | null>(null),
       options: ref<any | null>(null),
+      requestAction: ref<any | null>(null),
       folderAction: ref<any | null>(null),
       edit: ref<any | null>(null),
       deleteAction: ref<any | null>(null),

--- a/packages/hoppscotch-app/components/collections/my/Folder.vue
+++ b/packages/hoppscotch-app/components/collections/my/Folder.vue
@@ -57,12 +57,25 @@
               class="flex flex-col focus:outline-none"
               tabindex="0"
               role="menu"
+              @keyup.r="requestAction.$el.click()"
               @keyup.n="folderAction.$el.click()"
               @keyup.e="edit.$el.click()"
               @keyup.delete="deleteAction.$el.click()"
               @keyup.x="exportAction.$el.click()"
               @keyup.escape="options.tippy().hide()"
             >
+              <SmartItem
+                ref="requestAction"
+                svg="plus"
+                :label="$t('request.new')"
+                :shortcut="['R']"
+                @click.native="
+                  () => {
+                    $emit('add-request', { path: folderPath })
+                    options.tippy().hide()
+                  }
+                "
+              />
               <SmartItem
                 ref="folderAction"
                 svg="folder-plus"
@@ -138,6 +151,7 @@
           :collections-type="collectionsType"
           :folder-path="`${folderPath}/${subFolderIndex}`"
           :picked="picked"
+          @add-request="$emit('add-request', $event)"
           @add-folder="$emit('add-folder', $event)"
           @edit-folder="$emit('edit-folder', $event)"
           @edit-request="$emit('edit-request', $event)"
@@ -222,6 +236,7 @@ export default defineComponent({
     return {
       tippyActions: ref<any | null>(null),
       options: ref<any | null>(null),
+      requestAction: ref<any | null>(null),
       folderAction: ref<any | null>(null),
       edit: ref<any | null>(null),
       deleteAction: ref<any | null>(null),

--- a/packages/hoppscotch-app/components/collections/teams/Collection.vue
+++ b/packages/hoppscotch-app/components/collections/teams/Collection.vue
@@ -80,12 +80,27 @@
               class="flex flex-col focus:outline-none"
               tabindex="0"
               role="menu"
+              @keyup.r="requestAction.$el.click()"
               @keyup.n="folderAction.$el.click()"
               @keyup.e="edit.$el.click()"
               @keyup.delete="deleteAction.$el.click()"
               @keyup.x="exportAction.$el.click()"
               @keyup.escape="options.tippy().hide()"
             >
+              <SmartItem
+                ref="requestAction"
+                svg="plus"
+                :label="t('request.new')"
+                :shortcut="['R']"
+                @click.native="
+                  () => {
+                    $emit('add-request', {
+                      path: `${collectionIndex}`,
+                    })
+                    options.tippy().hide()
+                  }
+                "
+              />
               <SmartItem
                 ref="folderAction"
                 svg="folder-plus"
@@ -157,6 +172,7 @@
           :is-filtered="isFiltered"
           :picked="picked"
           :loading-collection-i-ds="loadingCollectionIDs"
+          @add-request="$emit('add-request', $event)"
           @add-folder="$emit('add-folder', $event)"
           @edit-folder="$emit('edit-folder', $event)"
           @edit-request="$emit('edit-request', $event)"
@@ -248,6 +264,7 @@ export default defineComponent({
     return {
       tippyActions: ref<any | null>(null),
       options: ref<any | null>(null),
+      requestAction: ref<any | null>(null),
       folderAction: ref<any | null>(null),
       edit: ref<any | null>(null),
       deleteAction: ref<any | null>(null),

--- a/packages/hoppscotch-app/components/collections/teams/Collection.vue
+++ b/packages/hoppscotch-app/components/collections/teams/Collection.vue
@@ -95,6 +95,7 @@
                 @click.native="
                   () => {
                     $emit('add-request', {
+                      folder: collection,
                       path: `${collectionIndex}`,
                     })
                     options.tippy().hide()

--- a/packages/hoppscotch-app/components/collections/teams/Folder.vue
+++ b/packages/hoppscotch-app/components/collections/teams/Folder.vue
@@ -73,7 +73,7 @@
                 :shortcut="['R']"
                 @click.native="
                   () => {
-                    $emit('add-request', { path: folderPath })
+                    $emit('add-request', { folder, path: folderPath })
                     options.tippy().hide()
                   }
                 "

--- a/packages/hoppscotch-app/components/collections/teams/Folder.vue
+++ b/packages/hoppscotch-app/components/collections/teams/Folder.vue
@@ -59,12 +59,25 @@
               class="flex flex-col focus:outline-none"
               tabindex="0"
               role="menu"
+              @keyup.r="requestAction.$el.click()"
               @keyup.n="folderAction.$el.click()"
               @keyup.e="edit.$el.click()"
               @keyup.delete="deleteAction.$el.click()"
               @keyup.x="exportAction.$el.click()"
               @keyup.escape="options.tippy().hide()"
             >
+              <SmartItem
+                ref="requestAction"
+                svg="plus"
+                :label="$t('request.new')"
+                :shortcut="['R']"
+                @click.native="
+                  () => {
+                    $emit('add-request', { path: folderPath })
+                    options.tippy().hide()
+                  }
+                "
+              />
               <SmartItem
                 ref="folderAction"
                 svg="folder-plus"
@@ -137,6 +150,7 @@
           :folder-path="`${folderPath}/${subFolderIndex}`"
           :picked="picked"
           :loading-collection-i-ds="loadingCollectionIDs"
+          @add-request="$emit('add-request', $event)"
           @add-folder="$emit('add-folder', $event)"
           @edit-folder="$emit('edit-folder', $event)"
           @edit-request="$emit('edit-request', $event)"
@@ -228,6 +242,7 @@ export default defineComponent({
     return {
       tippyActions: ref<any | null>(null),
       options: ref<any | null>(null),
+      requestAction: ref<any | null>(null),
       folderAction: ref<any | null>(null),
       edit: ref<any | null>(null),
       deleteAction: ref<any | null>(null),

--- a/packages/hoppscotch-app/locales/en.json
+++ b/packages/hoppscotch-app/locales/en.json
@@ -337,6 +337,7 @@
     "invalid_name": "Please provide a name for the request",
     "method": "Method",
     "name": "Request name",
+    "new": "New Request",
     "parameter_list": "Query Parameters",
     "parameters": "Parameters",
     "path": "Path",


### PR DESCRIPTION
### Description

  New Request button is now available in the kabab menu
  for both folders and collections in REST as well as
  GraphQL.
  It creates a new request, saves it to the store and
  points to it.

Closes #2156 