### PR TITLE
fix: add aria labels to forms

### DIFF
--- a/packages/hoppscotch-app/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-app/components/smart/EnvInput.vue
@@ -123,6 +123,7 @@ const envTooltipPlugin = new HoppReactiveEnvPlugin(envVars, view)
 
 const initView = (el: any) => {
   const extensions: Extension = [
+    EditorView.contentAttributes.of({ "aria-label": props.placeholder }),
     inputTheme,
     tooltips({
       position: "absolute",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2137 

### Description
Add code to make all forms on page have an aria label equivelent to their placeholder text. This fix works as long as forms have descriptive placeholder text. There may still be more screen reader accessibility improvements to make in the future, but it looks like every component is properly labeled for screen reader use at the moment. 

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
#### Google Lighthouse accessibility rating before change
![Lighthouse pre](https://user-images.githubusercontent.com/71854758/163727212-4113141b-d312-4d5e-bee0-0f4aa7236554.png)
#### Google Lighthouse accessibility rating after change
![Lighthouse post](https://user-images.githubusercontent.com/71854758/163727210-06496ca7-97cb-4130-958d-76abde41195a.png)

