### PR TITLE
fix: curl parser url sanitisation

### DIFF
--- a/packages/hoppscotch-app/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-app/helpers/curl/__tests__/curlparser.spec.js
@@ -768,11 +768,52 @@ const samples = [
       testScript: "",
     }),
   },
+  {
+    command: `curl \`
+  google.com -H "content-type: application/json"`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled request",
+      endpoint: "https://google.com/",
+      auth: {
+        authType: "none",
+        authActive: true,
+      },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      params: [],
+      headers: [],
+      preRequestScript: "",
+      testScript: "",
+    }),
+  },
+  {
+    command: `curl 192.168.0.24:8080/ping`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled request",
+      endpoint: "http://192.168.0.24:8080/ping",
+      auth: {
+        authType: "none",
+        authActive: true,
+      },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      params: [],
+      headers: [],
+      preRequestScript: "",
+      testScript: "",
+    }),
+  },
 ]
 
-describe("parseCurlToHoppRESTReq", () => {
+describe("Parse curl command to Hopp REST Request", () => {
   for (const [i, { command, response }] of samples.entries()) {
-    test(`matches expectation for sample #${i + 1}`, () => {
+    test(`for sample #${i + 1}:\n\n${command}`, () => {
       expect(parseCurlToHoppRESTReq(command)).toEqual(response)
     })
   }

--- a/packages/hoppscotch-app/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-app/helpers/curl/curlparser.ts
@@ -12,7 +12,7 @@ import { getHeaders, recordToHoppHeaders } from "./sub_helpers/headers"
 // import { getCookies } from "./sub_helpers/cookies"
 import { getQueries } from "./sub_helpers/queries"
 import { getMethod } from "./sub_helpers/method"
-import { concatParams, parseURL } from "./sub_helpers/url"
+import { concatParams, getURLObject } from "./sub_helpers/url"
 import { preProcessCurlCommand } from "./sub_helpers/preproc"
 import { getBody, getFArgumentMultipartData } from "./sub_helpers/body"
 import { getDefaultRESTRequest } from "~/newstore/RESTSession"
@@ -42,7 +42,7 @@ export const parseCurlCommand = (curlCommand: string) => {
 
   const method = getMethod(parsedArguments)
   // const cookies = getCookies(parsedArguments)
-  const urlObject = parseURL(parsedArguments)
+  const urlObject = getURLObject(parsedArguments)
   const auth = getAuthObject(parsedArguments, headers, urlObject)
 
   let rawData: string | string[] = pipe(

--- a/packages/hoppscotch-app/helpers/curl/sub_helpers/contentParser.ts
+++ b/packages/hoppscotch-app/helpers/curl/sub_helpers/contentParser.ts
@@ -158,12 +158,14 @@ const getXMLBody = (rawData: string) =>
     O.alt(() => O.some(rawData))
   )
 
-const getFormattedJSON = flow(
-  safeParseJSON,
-  O.map((parsedJSON) => JSON.stringify(parsedJSON, null, 2)),
-  O.getOrElse(() => "{}"),
-  O.of
-)
+const getFormattedJSON = (jsonString: string) =>
+  pipe(
+    jsonString.replaceAll("\\", ""),
+    safeParseJSON,
+    O.map((parsedJSON) => JSON.stringify(parsedJSON, null, 2)),
+    O.getOrElse(() => "{ }"),
+    O.of
+  )
 
 const getXWWWFormUrlEncodedBody = flow(
   decodeURIComponent,

--- a/packages/hoppscotch-app/helpers/curl/sub_helpers/contentParser.ts
+++ b/packages/hoppscotch-app/helpers/curl/sub_helpers/contentParser.ts
@@ -160,7 +160,7 @@ const getXMLBody = (rawData: string) =>
 
 const getFormattedJSON = (jsonString: string) =>
   pipe(
-    jsonString.replaceAll("\\", ""),
+    jsonString.replaceAll('\\"', '"'),
     safeParseJSON,
     O.map((parsedJSON) => JSON.stringify(parsedJSON, null, 2)),
     O.getOrElse(() => "{ }"),

--- a/packages/hoppscotch-app/helpers/curl/sub_helpers/preproc.ts
+++ b/packages/hoppscotch-app/helpers/curl/sub_helpers/preproc.ts
@@ -19,10 +19,11 @@ const replaceables: { [key: string]: string } = {
 const paperCuts = flow(
   // remove '\' and newlines
   S.replace(/ ?\\ ?$/gm, " "),
-  S.replace(/\n/g, ""),
+  S.replace(/\n/g, " "),
   // remove all $ symbols from start of argument values
   S.replace(/\$'/g, "'"),
-  S.replace(/\$"/g, '"')
+  S.replace(/\$"/g, '"'),
+  S.trim
 )
 
 // replace --zargs option with -Z

--- a/packages/hoppscotch-app/helpers/functional/debug.ts
+++ b/packages/hoppscotch-app/helpers/functional/debug.ts
@@ -17,6 +17,6 @@ export const trace = <T>(x: T) => {
 export const namedTrace =
   (name: string) =>
   <T>(x: T) => {
-    console.log(`${name}: `, x)
+    console.log(`${name}:`, x)
     return x
   }


### PR DESCRIPTION
- All Unsafe characters are removed from the url string following RFC 1738
- All the non-tagged arguments are checked for possible presence of url
- Some more local url checks were added.

Reference: [RFC 1738](http://www.faqs.org/rfcs/rfc1738.html)