### PR TITLE
refactor: use refAutoReset instead of settimeout

### DIFF
--- a/packages/hoppscotch-app/components/app/DeveloperOptions.vue
+++ b/packages/hoppscotch-app/components/app/DeveloperOptions.vue
@@ -45,7 +45,7 @@ const emit = defineEmits<{
   (e: "hide-modal"): void
 }>()
 
-const copyIcon = refAutoReset("copy", 1000)
+const copyIcon = refAutoReset<"copy" | "check">("copy", 1000)
 
 // Copy user auth token to clipboard
 const copyUserAuthToken = () => {

--- a/packages/hoppscotch-app/components/app/DeveloperOptions.vue
+++ b/packages/hoppscotch-app/components/app/DeveloperOptions.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "@nuxtjs/composition-api"
+import { refAutoReset } from "@vueuse/core"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import {
   useI18n,
@@ -45,7 +45,7 @@ const emit = defineEmits<{
   (e: "hide-modal"): void
 }>()
 
-const copyIcon = ref("copy")
+const copyIcon = refAutoReset("copy", 1000)
 
 // Copy user auth token to clipboard
 const copyUserAuthToken = () => {
@@ -53,7 +53,6 @@ const copyUserAuthToken = () => {
     copyToClipboard(userAuthToken.value)
     copyIcon.value = "check"
     toast.success(`${t("state.copied_to_clipboard")}`)
-    setTimeout(() => (copyIcon.value = "copy"), 1000)
   } else {
     toast.error(`${t("error.something_went_wrong")}`)
   }

--- a/packages/hoppscotch-app/components/app/Share.vue
+++ b/packages/hoppscotch-app/components/app/Share.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "@nuxtjs/composition-api"
+import { refAutoReset } from "@vueuse/core"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import { useI18n, useToast } from "~/helpers/utils/composables"
 
@@ -60,7 +60,8 @@ const subject = "Checkout Hoppscotch - an open source API development ecosystem"
 const summary = `Hi there!%0D%0A%0D%0AI thought you'll like this new platform that I joined called Hoppscotch - https://hoppscotch.io.%0D%0AIt is a simple and intuitive interface for creating and managing your APIs. You can build, test, document, and share your APIs.%0D%0A%0D%0AThe best part about Hoppscotch is that it is open source and free to get started.%0D%0A%0D%0A`
 const twitter = "hoppscotch_io"
 
-const copyIcon = ref("copy")
+const copyIcon = refAutoReset("copy", 1000)
+
 const platforms = [
   {
     name: "Email",
@@ -93,7 +94,6 @@ const copyAppLink = () => {
   copyToClipboard(url)
   copyIcon.value = "check"
   toast.success(`${t("state.copied_to_clipboard")}`)
-  setTimeout(() => (copyIcon.value = "copy"), 1000)
 }
 
 const hideModal = () => {

--- a/packages/hoppscotch-app/components/app/Share.vue
+++ b/packages/hoppscotch-app/components/app/Share.vue
@@ -60,7 +60,7 @@ const subject = "Checkout Hoppscotch - an open source API development ecosystem"
 const summary = `Hi there!%0D%0A%0D%0AI thought you'll like this new platform that I joined called Hoppscotch - https://hoppscotch.io.%0D%0AIt is a simple and intuitive interface for creating and managing your APIs. You can build, test, document, and share your APIs.%0D%0A%0D%0AThe best part about Hoppscotch is that it is open source and free to get started.%0D%0A%0D%0A`
 const twitter = "hoppscotch_io"
 
-const copyIcon = refAutoReset("copy", 1000)
+const copyIcon = refAutoReset<"copy" | "check">("copy", 1000)
 
 const platforms = [
   {

--- a/packages/hoppscotch-app/components/environments/Details.vue
+++ b/packages/hoppscotch-app/components/environments/Details.vue
@@ -120,6 +120,7 @@ import clone from "lodash/clone"
 import { computed, ref, watch } from "@nuxtjs/composition-api"
 import * as E from "fp-ts/Either"
 import { Environment, parseTemplateStringE } from "@hoppscotch/data"
+import { refAutoReset } from "@vueuse/core"
 import {
   createEnvironment,
   environments$,
@@ -160,7 +161,8 @@ const emit = defineEmits<{
 
 const name = ref<string | null>(null)
 const vars = ref([{ key: "", value: "" }])
-const clearIcon = ref("trash-2")
+
+const clearIcon = refAutoReset("trash-2", 1000)
 
 const globalVars = useReadonlyStream(globalEnv$, [])
 
@@ -225,7 +227,6 @@ const clearContent = () => {
   vars.value = []
   clearIcon.value = "check"
   toast.success(`${t("state.cleared")}`)
-  setTimeout(() => (clearIcon.value = "trash-2"), 1000)
 }
 
 const addEnvironmentVariable = () => {

--- a/packages/hoppscotch-app/components/environments/Details.vue
+++ b/packages/hoppscotch-app/components/environments/Details.vue
@@ -162,7 +162,7 @@ const emit = defineEmits<{
 const name = ref<string | null>(null)
 const vars = ref([{ key: "", value: "" }])
 
-const clearIcon = refAutoReset("trash-2", 1000)
+const clearIcon = refAutoReset<"trash-2" | "check">("trash-2", 1000)
 
 const globalVars = useReadonlyStream(globalEnv$, [])
 

--- a/packages/hoppscotch-app/components/graphql/RequestOptions.vue
+++ b/packages/hoppscotch-app/components/graphql/RequestOptions.vue
@@ -312,6 +312,7 @@ import {
 import draggable from "vuedraggable"
 import isEqual from "lodash/isEqual"
 import cloneDeep from "lodash/cloneDeep"
+import { refAutoReset } from "@vueuse/core"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import {
   useNuxt,
@@ -612,10 +613,10 @@ useCodemirror(queryEditor, gqlQueryString, {
   environmentHighlights: false,
 })
 
-const copyQueryIcon = ref("copy")
-const copyVariablesIcon = ref("copy")
-const prettifyQueryIcon = ref("wand")
-const prettifyVariablesIcon = ref("wand")
+const copyQueryIcon = refAutoReset("copy", 1000)
+const copyVariablesIcon = refAutoReset("copy", 1000)
+const prettifyQueryIcon = refAutoReset("wand", 1000)
+const prettifyVariablesIcon = refAutoReset("wand", 1000)
 
 const showSaveRequestModal = ref(false)
 
@@ -623,7 +624,6 @@ const copyQuery = () => {
   copyToClipboard(gqlQueryString.value)
   copyQueryIcon.value = "check"
   toast.success(`${t("state.copied_to_clipboard")}`)
-  setTimeout(() => (copyQueryIcon.value = "copy"), 1000)
 }
 
 const response = useStream(gqlResponse$, "", setGQLResponse)
@@ -699,7 +699,6 @@ const prettifyQuery = () => {
     toast.error(`${t("error.gql_prettify_invalid_query")}`)
     prettifyQueryIcon.value = "info"
   }
-  setTimeout(() => (prettifyQueryIcon.value = "wand"), 1000)
 }
 
 const saveRequest = () => {
@@ -710,7 +709,6 @@ const copyVariables = () => {
   copyToClipboard(variableString.value)
   copyVariablesIcon.value = "check"
   toast.success(`${t("state.copied_to_clipboard")}`)
-  setTimeout(() => (copyVariablesIcon.value = "copy"), 1000)
 }
 
 const prettifyVariableString = () => {
@@ -723,7 +721,6 @@ const prettifyVariableString = () => {
     prettifyVariablesIcon.value = "info"
     toast.error(`${t("error.json_prettify_invalid_body")}`)
   }
-  setTimeout(() => (prettifyVariablesIcon.value = "wand"), 1000)
 }
 
 const clearGQLQuery = () => {

--- a/packages/hoppscotch-app/components/graphql/RequestOptions.vue
+++ b/packages/hoppscotch-app/components/graphql/RequestOptions.vue
@@ -613,10 +613,13 @@ useCodemirror(queryEditor, gqlQueryString, {
   environmentHighlights: false,
 })
 
-const copyQueryIcon = refAutoReset("copy", 1000)
-const copyVariablesIcon = refAutoReset("copy", 1000)
-const prettifyQueryIcon = refAutoReset("wand", 1000)
-const prettifyVariablesIcon = refAutoReset("wand", 1000)
+const copyQueryIcon = refAutoReset<"copy" | "check">("copy", 1000)
+const copyVariablesIcon = refAutoReset<"copy" | "check">("copy", 1000)
+const prettifyQueryIcon = refAutoReset<"wand" | "check" | "info">("wand", 1000)
+const prettifyVariablesIcon = refAutoReset<"wand" | "check" | "info">(
+  "wand",
+  1000
+)
 
 const showSaveRequestModal = ref(false)
 

--- a/packages/hoppscotch-app/components/graphql/Response.vue
+++ b/packages/hoppscotch-app/components/graphql/Response.vue
@@ -112,8 +112,11 @@ useCodemirror(
   })
 )
 
-const downloadResponseIcon = refAutoReset("download", 1000)
-const copyResponseIcon = refAutoReset("copy", 1000)
+const downloadResponseIcon = refAutoReset<"download" | "check">(
+  "download",
+  1000
+)
+const copyResponseIcon = refAutoReset<"copy" | "check">("copy", 1000)
 
 const copyResponse = () => {
   copyToClipboard(responseString.value!)

--- a/packages/hoppscotch-app/components/graphql/Response.vue
+++ b/packages/hoppscotch-app/components/graphql/Response.vue
@@ -78,6 +78,7 @@
 
 <script setup lang="ts">
 import { reactive, ref } from "@nuxtjs/composition-api"
+import { refAutoReset } from "@vueuse/core"
 import { useCodemirror } from "~/helpers/editor/codemirror"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import {
@@ -111,14 +112,13 @@ useCodemirror(
   })
 )
 
-const downloadResponseIcon = ref("download")
-const copyResponseIcon = ref("copy")
+const downloadResponseIcon = refAutoReset("download", 1000)
+const copyResponseIcon = refAutoReset("copy", 1000)
 
 const copyResponse = () => {
   copyToClipboard(responseString.value!)
   copyResponseIcon.value = "check"
   toast.success(`${t("state.copied_to_clipboard")}`)
-  setTimeout(() => (copyResponseIcon.value = "copy"), 1000)
 }
 
 const downloadResponse = () => {
@@ -135,7 +135,6 @@ const downloadResponse = () => {
   setTimeout(() => {
     document.body.removeChild(a)
     URL.revokeObjectURL(url)
-    downloadResponseIcon.value = "download"
   }, 1000)
 }
 </script>

--- a/packages/hoppscotch-app/components/graphql/Sidebar.vue
+++ b/packages/hoppscotch-app/components/graphql/Sidebar.vue
@@ -307,8 +307,8 @@ const graphqlTypes = useReadonlyStream(
   []
 )
 
-const downloadSchemaIcon = refAutoReset("download", 1000)
-const copySchemaIcon = refAutoReset("copy", 1000)
+const downloadSchemaIcon = refAutoReset<"download" | "check">("download", 1000)
+const copySchemaIcon = refAutoReset<"copy" | "check">("copy", 1000)
 
 const graphqlFieldsFilterText = ref("")
 

--- a/packages/hoppscotch-app/components/graphql/Sidebar.vue
+++ b/packages/hoppscotch-app/components/graphql/Sidebar.vue
@@ -193,6 +193,7 @@ import { computed, nextTick, reactive, ref } from "@nuxtjs/composition-api"
 import { GraphQLField, GraphQLType } from "graphql"
 import { map } from "rxjs/operators"
 import { GQLHeader } from "@hoppscotch/data"
+import { refAutoReset } from "@vueuse/core"
 import { useCodemirror } from "~/helpers/editor/codemirror"
 import { GQLConnection } from "~/helpers/GQLConnection"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
@@ -306,8 +307,8 @@ const graphqlTypes = useReadonlyStream(
   []
 )
 
-const downloadSchemaIcon = ref("download")
-const copySchemaIcon = ref("copy")
+const downloadSchemaIcon = refAutoReset("download", 1000)
+const copySchemaIcon = refAutoReset("copy", 1000)
 
 const graphqlFieldsFilterText = ref("")
 
@@ -423,7 +424,6 @@ const downloadSchema = () => {
   setTimeout(() => {
     document.body.removeChild(a)
     URL.revokeObjectURL(url)
-    downloadSchemaIcon.value = "download"
   }, 1000)
 }
 
@@ -432,7 +432,6 @@ const copySchema = () => {
 
   copyToClipboard(schemaString.value)
   copySchemaIcon.value = "check"
-  setTimeout(() => (copySchemaIcon.value = "copy"), 1000)
 }
 
 const handleUseHistory = (entry: GQLHistoryEntry) => {

--- a/packages/hoppscotch-app/components/http/CodegenModal.vue
+++ b/packages/hoppscotch-app/components/http/CodegenModal.vue
@@ -87,6 +87,7 @@
 import { computed, ref, watch } from "@nuxtjs/composition-api"
 import * as O from "fp-ts/Option"
 import { Environment, makeRESTRequest } from "@hoppscotch/data"
+import { refAutoReset } from "@vueuse/core"
 import { useCodemirror } from "~/helpers/editor/codemirror"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import {
@@ -118,8 +119,9 @@ const options = ref<any | null>(null)
 
 const request = ref(getRESTRequest())
 const codegenType = ref<CodegenName>("shell-curl")
-const copyIcon = ref("copy")
 const errorState = ref(false)
+
+const copyIcon = refAutoReset("copy", 1000)
 
 const requestCode = computed(() => {
   const aggregateEnvs = getAggregateEnvs()
@@ -184,7 +186,6 @@ const copyRequestCode = () => {
   copyToClipboard(requestCode.value)
   copyIcon.value = "check"
   toast.success(`${t("state.copied_to_clipboard")}`)
-  setTimeout(() => (copyIcon.value = "copy"), 1000)
 }
 
 const searchQuery = ref("")

--- a/packages/hoppscotch-app/components/http/CodegenModal.vue
+++ b/packages/hoppscotch-app/components/http/CodegenModal.vue
@@ -121,7 +121,7 @@ const request = ref(getRESTRequest())
 const codegenType = ref<CodegenName>("shell-curl")
 const errorState = ref(false)
 
-const copyIcon = refAutoReset("copy", 1000)
+const copyIcon = refAutoReset<"copy" | "check">("copy", 1000)
 
 const requestCode = computed(() => {
   const aggregateEnvs = getAggregateEnvs()

--- a/packages/hoppscotch-app/components/http/ImportCurl.vue
+++ b/packages/hoppscotch-app/components/http/ImportCurl.vue
@@ -39,6 +39,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from "@nuxtjs/composition-api"
+import { refAutoReset } from "@vueuse/core"
 import { useCodemirror } from "~/helpers/editor/codemirror"
 import { setRESTRequest } from "~/newstore/RESTSession"
 import { useI18n, useToast } from "~/helpers/utils/composables"
@@ -95,7 +96,7 @@ const handleImport = () => {
   hideModal()
 }
 
-const pasteIcon = ref("clipboard")
+const pasteIcon = refAutoReset("clipboard", 1000)
 
 const handlePaste = async () => {
   try {
@@ -103,7 +104,6 @@ const handlePaste = async () => {
     if (text) {
       curl.value = text
       pasteIcon.value = "check"
-      setTimeout(() => (pasteIcon.value = "clipboard"), 1000)
     }
   } catch (e) {
     console.error("Failed to copy: ", e)

--- a/packages/hoppscotch-app/components/http/ImportCurl.vue
+++ b/packages/hoppscotch-app/components/http/ImportCurl.vue
@@ -96,7 +96,7 @@ const handleImport = () => {
   hideModal()
 }
 
-const pasteIcon = refAutoReset("clipboard", 1000)
+const pasteIcon = refAutoReset<"clipboard" | "check">("clipboard", 1000)
 
 const handlePaste = async () => {
   try {

--- a/packages/hoppscotch-app/components/http/RawBody.vue
+++ b/packages/hoppscotch-app/components/http/RawBody.vue
@@ -61,6 +61,7 @@ import { computed, reactive, Ref, ref } from "@nuxtjs/composition-api"
 import * as TO from "fp-ts/TaskOption"
 import { pipe } from "fp-ts/function"
 import { HoppRESTReqBody, ValidContentTypes } from "@hoppscotch/data"
+import { refAutoReset } from "@vueuse/core"
 import { useCodemirror } from "~/helpers/editor/codemirror"
 import { getEditorLangForMimeType } from "~/helpers/editorutils"
 import { pluckRef, useI18n, useToast } from "~/helpers/utils/composables"
@@ -91,7 +92,8 @@ const rawParamsBody = pluckRef(
   >,
   "body"
 )
-const prettifyIcon = ref("wand")
+
+const prettifyIcon = refAutoReset("wand", 1000)
 
 const rawInputEditorLang = computed(() =>
   getEditorLangForMimeType(props.contentType)
@@ -148,6 +150,5 @@ const prettifyRequestBody = () => {
     prettifyIcon.value = "info"
     toast.error(`${t("error.json_prettify_invalid_body")}`)
   }
-  setTimeout(() => (prettifyIcon.value = "wand"), 1000)
 }
 </script>

--- a/packages/hoppscotch-app/components/http/RawBody.vue
+++ b/packages/hoppscotch-app/components/http/RawBody.vue
@@ -93,7 +93,7 @@ const rawParamsBody = pluckRef(
   "body"
 )
 
-const prettifyIcon = refAutoReset("wand", 1000)
+const prettifyIcon = refAutoReset<"wand" | "check" | "info">("wand", 1000)
 
 const rawInputEditorLang = computed(() =>
   getEditorLangForMimeType(props.contentType)

--- a/packages/hoppscotch-app/components/http/Request.vue
+++ b/packages/hoppscotch-app/components/http/Request.vue
@@ -215,6 +215,7 @@ import { computed, ref, watch } from "@nuxtjs/composition-api"
 import { isLeft, isRight } from "fp-ts/lib/Either"
 import * as E from "fp-ts/Either"
 import cloneDeep from "lodash/cloneDeep"
+import { refAutoReset } from "@vueuse/core"
 import {
   updateRESTResponse,
   restEndpoint$,
@@ -393,7 +394,10 @@ const clearContent = () => {
   resetRESTRequest()
 }
 
-const copyLinkIcon = hasNavigatorShare ? ref("share-2") : ref("copy")
+const copyLinkIcon = hasNavigatorShare
+  ? refAutoReset("share-2", 1000)
+  : refAutoReset("copy", 1000)
+
 const shareLink = ref<string | null>("")
 const fetchingShareLink = ref(false)
 
@@ -448,7 +452,6 @@ const copyShareLink = (shareLink: string) => {
     copyLinkIcon.value = "check"
     copyToClipboard(`https://hopp.sh/r${shareLink}`)
     toast.success(`${t("state.copied_to_clipboard")}`)
-    setTimeout(() => (copyLinkIcon.value = "copy"), 2000)
   }
 }
 

--- a/packages/hoppscotch-app/components/http/Request.vue
+++ b/packages/hoppscotch-app/components/http/Request.vue
@@ -394,9 +394,10 @@ const clearContent = () => {
   resetRESTRequest()
 }
 
-const copyLinkIcon = hasNavigatorShare
-  ? refAutoReset("share-2", 1000)
-  : refAutoReset("copy", 1000)
+const copyLinkIcon = refAutoReset<"share-2" | "copy" | "check">(
+  hasNavigatorShare ? "share-2" : "copy",
+  1000
+)
 
 const shareLink = ref<string | null>("")
 const fetchingShareLink = ref(false)

--- a/packages/hoppscotch-app/components/lenses/HeadersRenderer.vue
+++ b/packages/hoppscotch-app/components/lenses/HeadersRenderer.vue
@@ -39,7 +39,7 @@ const props = defineProps<{
   headers: Array<HoppRESTHeader>
 }>()
 
-const copyIcon = refAutoReset("copy", 1000)
+const copyIcon = refAutoReset<"copy" | "check">("copy", 1000)
 
 const copyHeaders = () => {
   copyToClipboard(JSON.stringify(props.headers))

--- a/packages/hoppscotch-app/components/lenses/HeadersRenderer.vue
+++ b/packages/hoppscotch-app/components/lenses/HeadersRenderer.vue
@@ -26,8 +26,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "@nuxtjs/composition-api"
 import { HoppRESTHeader } from "@hoppscotch/data"
+import { refAutoReset } from "@vueuse/core"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import { useI18n, useToast } from "~/helpers/utils/composables"
 
@@ -39,12 +39,11 @@ const props = defineProps<{
   headers: Array<HoppRESTHeader>
 }>()
 
-const copyIcon = ref("copy")
+const copyIcon = refAutoReset("copy", 1000)
 
 const copyHeaders = () => {
   copyToClipboard(JSON.stringify(props.headers))
   copyIcon.value = "check"
   toast.success(`${t("state.copied_to_clipboard")}`)
-  setTimeout(() => (copyIcon.value = "copy"), 1000)
 }
 </script>

--- a/packages/hoppscotch-app/components/lenses/HeadersRendererEntry.vue
+++ b/packages/hoppscotch-app/components/lenses/HeadersRendererEntry.vue
@@ -41,7 +41,7 @@ defineProps<{
   header: HoppRESTHeader
 }>()
 
-const copyIcon = refAutoReset("copy", 1000)
+const copyIcon = refAutoReset<"copy" | "check">("copy", 1000)
 
 const copyHeader = (headerValue: string) => {
   copyToClipboard(headerValue)

--- a/packages/hoppscotch-app/components/lenses/HeadersRendererEntry.vue
+++ b/packages/hoppscotch-app/components/lenses/HeadersRendererEntry.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "@nuxtjs/composition-api"
+import { refAutoReset } from "@vueuse/core"
 import { HoppRESTHeader } from "~/../hoppscotch-data/dist"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import { useI18n, useToast } from "~/helpers/utils/composables"
@@ -41,12 +41,11 @@ defineProps<{
   header: HoppRESTHeader
 }>()
 
-const copyIcon = ref("copy")
+const copyIcon = refAutoReset("copy", 1000)
 
 const copyHeader = (headerValue: string) => {
   copyToClipboard(headerValue)
   copyIcon.value = "check"
   toast.success(`${t("state.copied_to_clipboard")}`)
-  setTimeout(() => (copyIcon.value = "copy"), 1000)
 }
 </script>

--- a/packages/hoppscotch-app/components/profile/Shortcode.vue
+++ b/packages/hoppscotch-app/components/profile/Shortcode.vue
@@ -65,6 +65,7 @@ import { pipe } from "fp-ts/function"
 import * as RR from "fp-ts/ReadonlyRecord"
 import * as O from "fp-ts/Option"
 import { translateToNewRequest } from "@hoppscotch/data"
+import { refAutoReset } from "@vueuse/core"
 import { useI18n, useToast } from "~/helpers/utils/composables"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import { Shortcode } from "~/helpers/shortcodes/Shortcode"
@@ -93,7 +94,8 @@ const requestMethodLabels = {
 } as const
 
 const timeStampRef = ref()
-const copyIconRefs = ref<"copy" | "check">("copy")
+
+const copyIconRefs = refAutoReset("copy", 1000)
 
 const parseShortcodeRequest = computed(() =>
   pipe(props.shortcode.request, JSON.parse, translateToNewRequest)
@@ -118,7 +120,6 @@ const copyShortcode = (codeID: string) => {
   copyToClipboard(`https://hopp.sh/r/${codeID}`)
   toast.success(`${t("state.copied_to_clipboard")}`)
   copyIconRefs.value = "check"
-  setTimeout(() => (copyIconRefs.value = "copy"), 1000)
 }
 </script>
 

--- a/packages/hoppscotch-app/components/profile/Shortcode.vue
+++ b/packages/hoppscotch-app/components/profile/Shortcode.vue
@@ -95,7 +95,7 @@ const requestMethodLabels = {
 
 const timeStampRef = ref()
 
-const copyIconRefs = refAutoReset("copy", 1000)
+const copyIconRefs = refAutoReset<"copy" | "check">("copy", 1000)
 
 const parseShortcodeRequest = computed(() =>
   pipe(props.shortcode.request, JSON.parse, translateToNewRequest)

--- a/packages/hoppscotch-app/components/realtime/Communication.vue
+++ b/packages/hoppscotch-app/components/realtime/Communication.vue
@@ -147,7 +147,7 @@ const toast = useToast()
 const linewrapEnabled = ref(true)
 const wsCommunicationBody = ref<HTMLElement>()
 
-const prettifyIcon = refAutoReset("wand", 1000)
+const prettifyIcon = refAutoReset<"wand" | "check" | "info">("wand", 1000)
 
 const knownContentTypes = {
   JSON: "application/ld+json",

--- a/packages/hoppscotch-app/components/realtime/Communication.vue
+++ b/packages/hoppscotch-app/components/realtime/Communication.vue
@@ -113,6 +113,7 @@ import { computed, reactive, ref } from "@nuxtjs/composition-api"
 import { pipe } from "fp-ts/function"
 import * as TO from "fp-ts/TaskOption"
 import * as O from "fp-ts/Option"
+import { refAutoReset } from "@vueuse/core"
 import { useCodemirror } from "~/helpers/editor/codemirror"
 import jsonLinter from "~/helpers/editor/linting/json"
 import { readFileAsText } from "~/helpers/functional/files"
@@ -145,7 +146,8 @@ const toast = useToast()
 
 const linewrapEnabled = ref(true)
 const wsCommunicationBody = ref<HTMLElement>()
-const prettifyIcon = ref<"wand" | "check" | "info">("wand")
+
+const prettifyIcon = refAutoReset("wand", 1000)
 
 const knownContentTypes = {
   JSON: "application/ld+json",
@@ -216,6 +218,5 @@ const prettifyRequestBody = () => {
     prettifyIcon.value = "info"
     toast.error(`${t("error.json_prettify_invalid_body")}`)
   }
-  setTimeout(() => (prettifyIcon.value = "wand"), 1000)
 }
 </script>

--- a/packages/hoppscotch-app/components/realtime/LogEntry.vue
+++ b/packages/hoppscotch-app/components/realtime/LogEntry.vue
@@ -310,7 +310,7 @@ const { downloadIcon, downloadResponse } = useDownloadResponse(
   logPayload
 )
 
-const copyQueryIcon = refAutoReset("copy", 1000)
+const copyQueryIcon = refAutoReset<"copy" | "check">("copy", 1000)
 
 const copyQuery = (entry: string) => {
   copyToClipboard(entry)

--- a/packages/hoppscotch-app/components/realtime/LogEntry.vue
+++ b/packages/hoppscotch-app/components/realtime/LogEntry.vue
@@ -203,7 +203,7 @@ import * as LJSON from "lossless-json"
 import * as O from "fp-ts/Option"
 import { pipe } from "fp-ts/function"
 import { ref, computed, reactive, watch } from "@nuxtjs/composition-api"
-import { useTimeAgo } from "@vueuse/core"
+import { refAutoReset, useTimeAgo } from "@vueuse/core"
 import { LogEntryData } from "./Log.vue"
 import { useI18n } from "~/helpers/utils/composables"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
@@ -310,11 +310,11 @@ const { downloadIcon, downloadResponse } = useDownloadResponse(
   logPayload
 )
 
-const copyQueryIcon = ref("copy")
+const copyQueryIcon = refAutoReset("copy", 1000)
+
 const copyQuery = (entry: string) => {
   copyToClipboard(entry)
   copyQueryIcon.value = "check"
-  setTimeout(() => (copyQueryIcon.value = "copy"), 1000)
 }
 
 // Relative Time

--- a/packages/hoppscotch-app/helpers/lenses/composables/useCopyResponse.ts
+++ b/packages/hoppscotch-app/helpers/lenses/composables/useCopyResponse.ts
@@ -10,7 +10,7 @@ export default function useCopyResponse(responseBodyText: Ref<any>): {
   const toast = useToast()
   const t = useI18n()
 
-  const copyIcon = refAutoReset("copy", 1000)
+  const copyIcon = refAutoReset<"copy" | "check">("copy", 1000)
 
   const copyResponse = () => {
     copyToClipboard(responseBodyText.value)

--- a/packages/hoppscotch-app/helpers/lenses/composables/useCopyResponse.ts
+++ b/packages/hoppscotch-app/helpers/lenses/composables/useCopyResponse.ts
@@ -1,4 +1,5 @@
-import { Ref, ref } from "@nuxtjs/composition-api"
+import { Ref } from "@nuxtjs/composition-api"
+import { refAutoReset } from "@vueuse/core"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import { useI18n, useToast } from "~/helpers/utils/composables"
 
@@ -8,13 +9,13 @@ export default function useCopyResponse(responseBodyText: Ref<any>): {
 } {
   const toast = useToast()
   const t = useI18n()
-  const copyIcon = ref("copy")
+
+  const copyIcon = refAutoReset("copy", 1000)
 
   const copyResponse = () => {
     copyToClipboard(responseBodyText.value)
     copyIcon.value = "check"
     toast.success(`${t("state.copied_to_clipboard")}`)
-    setTimeout(() => (copyIcon.value = "copy"), 1000)
   }
 
   return {

--- a/packages/hoppscotch-app/helpers/lenses/composables/useDownloadResponse.ts
+++ b/packages/hoppscotch-app/helpers/lenses/composables/useDownloadResponse.ts
@@ -1,7 +1,8 @@
 import * as S from "fp-ts/string"
 import * as RNEA from "fp-ts/ReadonlyNonEmptyArray"
 import { pipe } from "fp-ts/function"
-import { Ref, ref } from "@nuxtjs/composition-api"
+import { Ref } from "@nuxtjs/composition-api"
+import { refAutoReset } from "@vueuse/core"
 import { useI18n, useToast } from "~/helpers/utils/composables"
 
 export type downloadResponseReturnType = (() => void) | Ref<any>
@@ -13,7 +14,8 @@ export default function useDownloadResponse(
   downloadIcon: Ref<string>
   downloadResponse: () => void
 } {
-  const downloadIcon = ref("download")
+  const downloadIcon = refAutoReset("download", 1000)
+
   const toast = useToast()
   const t = useI18n()
 
@@ -42,7 +44,6 @@ export default function useDownloadResponse(
     setTimeout(() => {
       document.body.removeChild(a)
       URL.revokeObjectURL(url)
-      downloadIcon.value = "download"
     }, 1000)
   }
   return {

--- a/packages/hoppscotch-app/helpers/lenses/composables/useDownloadResponse.ts
+++ b/packages/hoppscotch-app/helpers/lenses/composables/useDownloadResponse.ts
@@ -14,7 +14,7 @@ export default function useDownloadResponse(
   downloadIcon: Ref<string>
   downloadResponse: () => void
 } {
-  const downloadIcon = refAutoReset("download", 1000)
+  const downloadIcon = refAutoReset<"download" | "check">("download", 1000)
 
   const toast = useToast()
   const t = useI18n()

--- a/packages/hoppscotch-app/pages/settings.vue
+++ b/packages/hoppscotch-app/pages/settings.vue
@@ -277,7 +277,7 @@ const hasFirefoxExtInstalled = computed(
   () => browserIsFirefox() && currentExtensionStatus.value === "available"
 )
 
-const clearIcon = refAutoReset("rotate-ccw", 1000)
+const clearIcon = refAutoReset<"rotate-ccw" | "check">("rotate-ccw", 1000)
 
 const confirmRemove = ref(false)
 

--- a/packages/hoppscotch-app/pages/settings.vue
+++ b/packages/hoppscotch-app/pages/settings.vue
@@ -236,6 +236,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, defineComponent } from "@nuxtjs/composition-api"
+import { refAutoReset } from "@vueuse/core"
 import { applySetting, toggleSetting, useSetting } from "~/newstore/settings"
 import {
   useToast,
@@ -276,7 +277,7 @@ const hasFirefoxExtInstalled = computed(
   () => browserIsFirefox() && currentExtensionStatus.value === "available"
 )
 
-const clearIcon = ref("rotate-ccw")
+const clearIcon = refAutoReset("rotate-ccw", 1000)
 
 const confirmRemove = ref(false)
 
@@ -322,7 +323,6 @@ const resetProxy = () => {
   applySetting("PROXY_URL", `https://proxy.hoppscotch.io/`)
   clearIcon.value = "check"
   toast.success(`${t("state.cleared")}`)
-  setTimeout(() => (clearIcon.value = "rotate-ccw"), 1000)
 }
 
 const getColorModeName = (colorMode: string) => {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes https://github.com/hoppscotch/internal-issues/issues/16 <!-- Issue # here -->

### Description
<!-- Add a brief description of the pull request -->

Use [`refAutoReset`](https://vueuse.org/shared/refautoreset/) instead of `setTimeout()`

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
