### PR TITLE
Add drag and drop support for folders

### DIFF
--- a/packages/hoppscotch-app/components/collections/my/Collection.vue
+++ b/packages/hoppscotch-app/components/collections/my/Collection.vue
@@ -239,7 +239,7 @@
 
 <script lang="ts">
 import { defineComponent, ref } from "@nuxtjs/composition-api"
-import { moveRESTRequest } from "~/newstore/collections"
+import { moveRESTRequest, moveRESTFolder } from "~/newstore/collections"
 
 export default defineComponent({
   props: {
@@ -324,11 +324,21 @@ export default defineComponent({
         collectionID: this.collection.id,
       })
     },
-    dropEvent({ dataTransfer }: any) {
+    dropEvent({ dataTransfer }: DragEvent) {
+      if (!dataTransfer) return
+
       this.dragging = !this.dragging
       const folderPath = dataTransfer.getData("folderPath")
       const requestIndex = dataTransfer.getData("requestIndex")
-      moveRESTRequest(folderPath, requestIndex, `${this.collectionIndex}`)
+
+      if (requestIndex)
+        moveRESTRequest(
+          folderPath,
+          parseInt(requestIndex),
+          `${this.collectionIndex}`
+        )
+      else if (folderPath && `${folderPath}` !== `${this.collectionIndex}`)
+        moveRESTFolder(folderPath, `${this.collectionIndex}`)
     },
   },
 })

--- a/packages/hoppscotch-app/components/collections/my/Folder.vue
+++ b/packages/hoppscotch-app/components/collections/my/Folder.vue
@@ -2,6 +2,8 @@
   <div class="flex flex-col" :class="[{ 'bg-primaryLight': dragging }]">
     <div
       class="flex items-stretch group"
+      draggable="true"
+      @dragstart="dragStart"
       @dragover.prevent
       @drop.prevent="dropEvent"
       @dragover="dragging = true"
@@ -213,7 +215,7 @@
 <script lang="ts">
 import { defineComponent, ref } from "@nuxtjs/composition-api"
 import { useI18n } from "~/helpers/utils/composables"
-import { moveRESTRequest } from "~/newstore/collections"
+import { moveRESTFolder, moveRESTRequest } from "~/newstore/collections"
 
 export default defineComponent({
   name: "Folder",
@@ -301,11 +303,23 @@ export default defineComponent({
         folderPath: this.folderPath,
       })
     },
-    dropEvent({ dataTransfer }) {
+    dragStart({ dataTransfer }: DragEvent) {
+      if (dataTransfer) {
+        this.dragging = !this.dragging
+        dataTransfer.setData("folderPath", this.folderPath)
+      }
+    },
+    dropEvent({ dataTransfer }: DragEvent) {
+      if (!dataTransfer) return
+
       this.dragging = !this.dragging
       const folderPath = dataTransfer.getData("folderPath")
       const requestIndex = dataTransfer.getData("requestIndex")
-      moveRESTRequest(folderPath, requestIndex, this.folderPath)
+
+      if (requestIndex)
+        moveRESTRequest(folderPath, parseInt(requestIndex), this.folderPath)
+      else if (folderPath && folderPath !== this.folderPath)
+        moveRESTFolder(folderPath, this.folderPath)
     },
   },
 })

--- a/packages/hoppscotch-app/newstore/collections.ts
+++ b/packages/hoppscotch-app/newstore/collections.ts
@@ -180,6 +180,49 @@ const restCollectionDispatchers = defineDispatchers({
     }
   },
 
+  moveFolder(
+    { state }: RESTCollectionStoreType,
+    { path, destinationPath }: { path: string; destinationPath: string }
+  ) {
+    const newState = state
+
+    const indexPaths = path.split("/").map((x) => parseInt(x))
+    const destinationIndexPaths = destinationPath
+      .split("/")
+      .map((x) => parseInt(x))
+    if (indexPaths.length === 0 || destinationIndexPaths.length === 0) {
+      console.error(
+        `Given path is too short. Skipping request to move folder '${path}' to destination '${destinationPath}'.`
+      )
+      return {}
+    }
+
+    const folderIndex = indexPaths.pop() as number
+    const containingFolder = navigateToFolderWithIndexPath(newState, indexPaths)
+    if (containingFolder === null) {
+      console.error(
+        `Could not resolve path '${path}'. Skipping moveFolder dispatch.`
+      )
+      return {}
+    }
+
+    const target = navigateToFolderWithIndexPath(
+      newState,
+      destinationIndexPaths
+    )
+    if (target === null) {
+      console.error(
+        `Could not resolve destination path '${destinationPath}'. Skipping moveFolder dispatch.`
+      )
+      return {}
+    }
+
+    const theFolder = containingFolder.folders.splice(folderIndex, 1)
+    target.folders.push(theFolder[0])
+
+    return { state }
+  },
+
   editRequest(
     { state }: RESTCollectionStoreType,
     {
@@ -681,6 +724,16 @@ export function removeRESTFolder(path: string) {
     dispatcher: "removeFolder",
     payload: {
       path,
+    },
+  })
+}
+
+export function moveRESTFolder(path: string, destinationPath: string) {
+  restCollectionStore.dispatch({
+    dispatcher: "moveFolder",
+    payload: {
+      path,
+      destinationPath,
     },
   })
 }


### PR DESCRIPTION
  Folders can be dragged and dropped in other folders
  (up or down in hirarchy) and also inside collections
  as direct their children.

Solves #2220 #2393 