### PR TITLE
feat: checks only if not default param

### DIFF
--- a/packages/hoppscotch-app/components/collections/my/Request.vue
+++ b/packages/hoppscotch-app/components/collections/my/Request.vue
@@ -322,6 +322,7 @@ const setRestReq = (request: any) => {
   )
 }
 
+/** Loads request from the save once, checks for unsaved changes, but ignores default values */
 const selectRequest = () => {
   if (!active.value) {
     confirmChange.value = true
@@ -362,7 +363,7 @@ const selectRequest = () => {
       setRESTSaveContext(null)
     }
   }
-  if (isEqualHoppRESTRequest(getRESTRequest(), getDefaultRESTRequest()) {
+  if (isEqualHoppRESTRequest(getRESTRequest(), getDefaultRESTRequest())) {
     confirmChange.value = false
   }
 }

--- a/packages/hoppscotch-app/components/collections/my/Request.vue
+++ b/packages/hoppscotch-app/components/collections/my/Request.vue
@@ -323,7 +323,9 @@ const setRestReq = (request: any) => {
 }
 
 const selectRequest = () => {
-  if (!active.value) {
+  if (getRESTRequest().endpoint === getDefaultRESTRequest().endpoint) {
+    confirmChange.value = false
+  } else if (!active.value) {
     confirmChange.value = true
 
     if (props.saveRequest)

--- a/packages/hoppscotch-app/components/collections/my/Request.vue
+++ b/packages/hoppscotch-app/components/collections/my/Request.vue
@@ -323,9 +323,7 @@ const setRestReq = (request: any) => {
 }
 
 const selectRequest = () => {
-  if (getRESTRequest().endpoint === getDefaultRESTRequest().endpoint) {
-    confirmChange.value = false
-  } else if (!active.value) {
+  if (!active.value) {
     confirmChange.value = true
 
     if (props.saveRequest)
@@ -363,6 +361,9 @@ const selectRequest = () => {
     } else {
       setRESTSaveContext(null)
     }
+  }
+  if (getRESTRequest().endpoint === getDefaultRESTRequest().endpoint) {
+    confirmChange.value = false
   }
 }
 

--- a/packages/hoppscotch-app/components/collections/my/Request.vue
+++ b/packages/hoppscotch-app/components/collections/my/Request.vue
@@ -362,7 +362,7 @@ const selectRequest = () => {
       setRESTSaveContext(null)
     }
   }
-  if (getRESTRequest().endpoint === getDefaultRESTRequest().endpoint) {
+  if (isEqualHoppRESTRequest(getRESTRequest(), getDefaultRESTRequest()) {
     confirmChange.value = false
   }
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Related to issue 2207

### Description
<!-- Add a brief description of the pull request -->
The issue 2207 added a warning for "unsaved changes might get lost", however, I found it annoying that the message poped up also at the default value...

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
