### PR TITLE
feat: display response size with a bigger unit in tooltip

### DIFF
--- a/packages/hoppscotch-app/components/http/ResponseMeta.vue
+++ b/packages/hoppscotch-app/components/http/ResponseMeta.vue
@@ -117,7 +117,11 @@
             <span class="text-secondary"> {{ t("response.time") }}: </span>
             {{ `${response.meta.responseDuration} ms` }}
           </span>
-          <span v-if="response.meta && response.meta.responseSize">
+          <span
+            v-if="response.meta && response.meta.responseSize"
+            v-tippy="responseSizeTippy"
+            :title="responseSizeHint"
+          >
             <span class="text-secondary"> {{ t("response.size") }}: </span>
             {{ `${response.meta.responseSize} B` }}
           </span>
@@ -140,6 +144,36 @@ const t = useI18n()
 const props = defineProps<{
   response: HoppRESTResponse
 }>()
+
+const responseSizeTippy = computed(() => {
+  if (
+    props.response.type === "loading" ||
+    props.response.type === "network_fail" ||
+    props.response.type === "script_fail" ||
+    props.response.type === "fail"
+  )
+    return
+  if (Number(props.response.meta.responseSize) <= 1000)
+    return {
+      onShow: () => {
+        return false
+      },
+    }
+  else return { theme: "tooltip", allowHTML: true }
+})
+
+const responseSizeHint = computed(() => {
+  if (
+    props.response.type === "loading" ||
+    props.response.type === "network_fail" ||
+    props.response.type === "script_fail" ||
+    props.response.type === "fail"
+  )
+    return
+  const size = Number(props.response.meta.responseSize)
+  if (size >= 100000) return (size / 1000000).toFixed(2) + " MB"
+  if (size >= 1000) return (size / 1000).toFixed(2) + " KB"
+})
 
 const statusCategory = computed(() => {
   if (

--- a/packages/hoppscotch-app/components/http/ResponseMeta.vue
+++ b/packages/hoppscotch-app/components/http/ResponseMeta.vue
@@ -120,7 +120,7 @@
           <span
             v-if="response.meta && response.meta.responseSize"
             v-tippy="
-              responseSizeReadable
+              readableResponseSize
                 ? { theme: 'tooltip' }
                 : { onShow: () => false }
             "
@@ -128,8 +128,8 @@
           >
             <span class="text-secondary"> {{ t("response.size") }}: </span>
             {{
-              responseSizeReadable
-                ? responseSizeReadable
+              readableResponseSize
+                ? readableResponseSize
                 : `${response.meta.responseSize} B`
             }}
           </span>
@@ -153,7 +153,13 @@ const props = defineProps<{
   response: HoppRESTResponse
 }>()
 
-const responseSizeReadable = computed(() => {
+/**
+ * Gives the response size in a human readable format
+ * (changes unit from B to MB/KB depending on the size)
+ * If no changes (error res state) or value can be made (size < 1KB ?),
+ * it returns undefined
+ */
+const readableResponseSize = computed(() => {
   if (
     props.response.type === "loading" ||
     props.response.type === "network_fail" ||
@@ -161,9 +167,12 @@ const responseSizeReadable = computed(() => {
     props.response.type === "fail"
   )
     return undefined
+
   const size = props.response.meta.responseSize
+
   if (size >= 100000) return (size / 1000000).toFixed(2) + " MB"
   if (size >= 1000) return (size / 1000).toFixed(2) + " KB"
+
   return undefined
 })
 

--- a/packages/hoppscotch-app/components/http/ResponseMeta.vue
+++ b/packages/hoppscotch-app/components/http/ResponseMeta.vue
@@ -119,7 +119,9 @@
           </span>
           <span
             v-if="response.meta && response.meta.responseSize"
-            v-tippy="responseSizeTippy"
+            v-tippy="
+              responseSizeHint ? { theme: 'tooltip' } : { onShow: () => false }
+            "
             :title="responseSizeHint"
           >
             <span class="text-secondary"> {{ t("response.size") }}: </span>
@@ -145,23 +147,6 @@ const props = defineProps<{
   response: HoppRESTResponse
 }>()
 
-const responseSizeTippy = computed(() => {
-  if (
-    props.response.type === "loading" ||
-    props.response.type === "network_fail" ||
-    props.response.type === "script_fail" ||
-    props.response.type === "fail"
-  )
-    return
-  if (Number(props.response.meta.responseSize) <= 1000)
-    return {
-      onShow: () => {
-        return false
-      },
-    }
-  else return { theme: "tooltip", allowHTML: true }
-})
-
 const responseSizeHint = computed(() => {
   if (
     props.response.type === "loading" ||
@@ -169,10 +154,11 @@ const responseSizeHint = computed(() => {
     props.response.type === "script_fail" ||
     props.response.type === "fail"
   )
-    return
-  const size = Number(props.response.meta.responseSize)
+    return undefined
+  const size = props.response.meta.responseSize
   if (size >= 100000) return (size / 1000000).toFixed(2) + " MB"
   if (size >= 1000) return (size / 1000).toFixed(2) + " KB"
+  return undefined
 })
 
 const statusCategory = computed(() => {

--- a/packages/hoppscotch-app/components/http/ResponseMeta.vue
+++ b/packages/hoppscotch-app/components/http/ResponseMeta.vue
@@ -120,12 +120,18 @@
           <span
             v-if="response.meta && response.meta.responseSize"
             v-tippy="
-              responseSizeHint ? { theme: 'tooltip' } : { onShow: () => false }
+              responseSizeReadable
+                ? { theme: 'tooltip' }
+                : { onShow: () => false }
             "
-            :title="responseSizeHint"
+            :title="`${response.meta.responseSize} B`"
           >
             <span class="text-secondary"> {{ t("response.size") }}: </span>
-            {{ `${response.meta.responseSize} B` }}
+            {{
+              responseSizeReadable
+                ? responseSizeReadable
+                : `${response.meta.responseSize} B`
+            }}
           </span>
         </div>
       </div>
@@ -147,7 +153,7 @@ const props = defineProps<{
   response: HoppRESTResponse
 }>()
 
-const responseSizeHint = computed(() => {
+const responseSizeReadable = computed(() => {
   if (
     props.response.type === "loading" ||
     props.response.type === "network_fail" ||


### PR DESCRIPTION
### Description

The response size is always displayed using larger units like KB or MB in other API testing tools I've used. But hoppscotch shows them up with only a B. I added a tooltip to display the response size in reasonable units.

For responses with a size of 0b to 1000b, the tooltip won't show up. For those with a size of 1000b to 1000000b, kB will be shown. For those larger than 1000000b, mb will be shown. 

I am no expert on the front-end technologies, so I just imitated the current codes. If you don't like these codes, please keep the idea even if you close the pr.
