### PR TITLE
fix: Copy and download filtered response body

### DIFF
--- a/packages/hoppscotch-app/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-app/components/lenses/renderers/JSONLensRenderer.vue
@@ -218,8 +218,6 @@ const props = defineProps<{
 
 const { responseBodyText } = useResponseBody(props.response)
 
-const { copyIcon, copyResponse } = useCopyResponse(responseBodyText)
-
 const { downloadIcon, downloadResponse } = useDownloadResponse(
   "application/json",
   responseBodyText
@@ -309,6 +307,8 @@ const filterResponseError = computed(() =>
     )
   )
 )
+
+const { copyIcon, copyResponse } = useCopyResponse(jsonBodyText)
 
 const outlineOptions = ref<any | null>(null)
 const jsonResponse = ref<any | null>(null)

--- a/packages/hoppscotch-app/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-app/components/lenses/renderers/JSONLensRenderer.vue
@@ -218,11 +218,6 @@ const props = defineProps<{
 
 const { responseBodyText } = useResponseBody(props.response)
 
-const { downloadIcon, downloadResponse } = useDownloadResponse(
-  "application/json",
-  responseBodyText
-)
-
 const toggleFilter = ref(false)
 const filterQueryText = ref("")
 
@@ -309,6 +304,10 @@ const filterResponseError = computed(() =>
 )
 
 const { copyIcon, copyResponse } = useCopyResponse(jsonBodyText)
+const { downloadIcon, downloadResponse } = useDownloadResponse(
+  "application/json",
+  jsonBodyText
+)
 
 const outlineOptions = ref<any | null>(null)
 const jsonResponse = ref<any | null>(null)


### PR DESCRIPTION
### Description
Currently, the initial response body gets copied and downloaded after filtering, this PR fixes this bug.

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
