### PR TITLE
Test Results: Environment variables overflow issue fix

### DIFF
--- a/packages/hoppscotch-app/components/http/TestResultEnv.vue
+++ b/packages/hoppscotch-app/components/http/TestResultEnv.vue
@@ -12,10 +12,10 @@
       <span class="text-secondaryDark">
         {{ env.key }}
       </span>
-      <span class="text-secondaryDark">
+      <span class="text-secondaryDark pl-4 break-all">
         {{ ` \xA0 — \xA0 ${env.value}` }}
       </span>
-      <span v-if="status === 'updations'" class="text-secondaryLight">
+      <span v-if="status === 'updations'" class="text-secondaryLight px-4 break-all">
         {{ ` \xA0 ← \xA0 ${env.previousValue}` }}
       </span>
     </div>

--- a/packages/hoppscotch-app/components/http/TestResultEnv.vue
+++ b/packages/hoppscotch-app/components/http/TestResultEnv.vue
@@ -12,10 +12,10 @@
       <span class="text-secondaryDark">
         {{ env.key }}
       </span>
-      <span class="text-secondaryDark pl-4 break-all">
+      <span class="text-secondaryDark pl-2 break-all">
         {{ ` \xA0 — \xA0 ${env.value}` }}
       </span>
-      <span v-if="status === 'updations'" class="text-secondaryLight px-4 break-all">
+      <span v-if="status === 'updations'" class="text-secondaryLight px-2 break-all">
         {{ ` \xA0 ← \xA0 ${env.previousValue}` }}
       </span>
     </div>


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2472 

### Description
If we set environment variables in Test, The Test Results section shows the environment variable change,
But if the value of the variable is too long it breaks the UI, I have added a fix that will break the word in multiple lines if it's too long.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

### Additional Information
Screenshot of the **Test Results** section after changes(for large, overflowing values)

<img width="1044" alt="Screen Shot 2022-06-27 at 2 08 19 PM" src="https://user-images.githubusercontent.com/14347543/175900393-82a95128-c6d5-49fd-9af1-5fa6cabd141d.png">
