### PR TITLE
fix: curl parser x-www-form-urlencoded body parsing

### DIFF
--- a/packages/hoppscotch-app/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-app/helpers/curl/__tests__/curlparser.spec.js
@@ -809,6 +809,37 @@ const samples = [
       testScript: "",
     }),
   },
+  {
+    command: `curl https://example.com -d "alpha=beta&request_id=4"`,
+    response: makeRESTRequest({
+      method: "POST",
+      name: "Untitled request",
+      endpoint: "https://example.com/",
+      auth: {
+        authType: "none",
+        authActive: true,
+      },
+      body: {
+        contentType: "application/x-www-form-urlencoded",
+        body: rawKeyValueEntriesToString([
+          {
+            active: true,
+            key: "alpha",
+            value: "beta",
+          },
+          {
+            active: true,
+            key: "request_id",
+            value: "4",
+          },
+        ]),
+      },
+      params: [],
+      headers: [],
+      preRequestScript: "",
+      testScript: "",
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-app/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-app/helpers/curl/curlparser.ts
@@ -93,7 +93,8 @@ export const parseCurlCommand = (curlCommand: string) => {
     hasBodyBeenParsed = true
   } else if (
     rawContentType.includes("application/x-www-form-urlencoded") &&
-    !!pairs
+    !!pairs &&
+    Array.isArray(rawData)
   ) {
     body = pairs.map((p) => p.join(": ")).join("\n") || null
     contentType = "application/x-www-form-urlencoded"


### PR DESCRIPTION
x-www-form-urlencoded body is parsed correctly now with/without content-type header provided.
Solves #2424 
