### PR TITLE
feat: update keyboard shortcut to navigate to profile page

### DIFF
--- a/packages/hoppscotch-app/helpers/keybindings.ts
+++ b/packages/hoppscotch-app/helpers/keybindings.ts
@@ -56,6 +56,7 @@ export const bindings: {
   "alt-q": "navigation.jump.graphql",
   "alt-w": "navigation.jump.realtime",
   "alt-d": "navigation.jump.documentation",
+  "alt-m": "navigation.jump.profile",
   "alt-s": "navigation.jump.settings",
 }
 

--- a/packages/hoppscotch-app/helpers/shortcuts.js
+++ b/packages/hoppscotch-app/helpers/shortcuts.js
@@ -103,7 +103,7 @@ export default [
         label: "shortcut.navigation.settings",
       },
       {
-        keys: [getPlatformAlternateKey(), "P"],
+        keys: [getPlatformAlternateKey(), "M"],
         label: "shortcut.navigation.profile",
       },
     ],
@@ -171,7 +171,7 @@ export const spotlight = [
         icon: "arrow-right",
       },
       {
-        keys: [getPlatformAlternateKey(), "P"],
+        keys: [getPlatformAlternateKey(), "M"],
         label: "shortcut.navigation.profile",
         action: "navigation.jump.profile",
         icon: "arrow-right",
@@ -267,7 +267,7 @@ export const fuse = [
     tags: ["settings", "jump", "page", "navigation", "account", "theme", "go"],
   },
   {
-    keys: [getPlatformAlternateKey(), "P"],
+    keys: [getPlatformAlternateKey(), "M"],
     label: "shortcut.navigation.profile",
     action: "navigation.jump.profile",
     icon: "arrow-right",


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2543 <!-- Issue # here -->

### Description
Updating the command for Go to Profile page. Previously `Alt+P` command was bound to two different commands. In this PR we changed the command for Navigate to Profile page from `Alt+P` to `Alt+M`

<!-- Add a brief description of the pull request -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
