### PR TITLE
fix: link github and google

### DIFF
--- a/packages/hoppscotch-app/components/firebase/Login.vue
+++ b/packages/hoppscotch-app/components/firebase/Login.vue
@@ -128,6 +128,7 @@ import {
   currentUser$,
   signInWithEmail,
   linkWithFBCredential,
+  linkWithFBCredentialFromAuthError,
   getGithubCredentialFromResult,
 } from "~/helpers/fb/auth"
 import { setLocalConfig } from "~/newstore/localpersistence"
@@ -218,8 +219,6 @@ export default defineComponent({
         if (e.code === "auth/account-exists-with-different-credential") {
           // Step 2.
           // User's email already exists.
-          // The pending Google credential.
-          const pendingCred = e.credential
           this.$toast.info(`${this.$t("auth.account_exists")}`, {
             duration: 0,
             closeOnSwipe: false,
@@ -227,7 +226,7 @@ export default defineComponent({
               text: `${this.$t("action.yes")}`,
               onClick: async (_, toastObject) => {
                 const { user } = await signInUserWithGoogle()
-                await linkWithFBCredential(user, pendingCred)
+                await linkWithFBCredentialFromAuthError(user, e)
 
                 this.showLoginSuccess()
 

--- a/packages/hoppscotch-app/helpers/fb/auth.ts
+++ b/packages/hoppscotch-app/helpers/fb/auth.ts
@@ -16,6 +16,7 @@ import {
   signOut,
   linkWithCredential,
   AuthCredential,
+  AuthError,
   UserCredential,
   updateProfile,
   updateEmail,
@@ -237,6 +238,24 @@ export async function linkWithFBCredential(
   credential: AuthCredential
 ) {
   return await linkWithCredential(user, credential)
+}
+
+/**
+ * Links account with another account given in a auth/account-exists-with-different-credential error
+ *
+ * @param user - User who has the errors
+ *
+ * @param error - Error caught after trying to login
+ *
+ * @returns Promise of UserCredential
+ */
+export async function linkWithFBCredentialFromAuthError(
+  user: User,
+  error: unknown
+) {
+  // Marked as not null since this function is supposed to be called after an auth/account-exists-with-different-credential error, ie credentials actually exist
+  const credentials = OAuthProvider.credentialFromError(error as AuthError)!
+  return await linkWithCredential(user, credentials)
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2610

### Description
This fixes the original bug report in #2610 about having a Github and Google account. They were not getting linked previously. This is a draft PR to request inputs about how to handle multiple combinations of accounts.

For example sign in with Google assumes linked account is always Github. Sign in with Github assumes linked account is Google. Sign in with Microsoft assumes linked account is Github. We should allow any combination of linked accounts and our code should reflect that.

Don't know about Github/MS/Google to email behavior.

This could be an opportunity to DRY some duplicate code.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
