### PR TITLE
Integrate Uffizzi PR Environments

### DIFF
--- a/.github/workflows/uffizzi-deploy-env.yml
+++ b/.github/workflows/uffizzi-deploy-env.yml
@@ -1,0 +1,91 @@
+name: Build Images and Create Uffizzi Environment.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened,reopened,synchronize]
+
+jobs:
+  build-hoppscotch:
+    name: Build and Push `hoppscotch`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Set Build Variables
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/tags/v* ]]; then
+            echo "Using TAG mode: $GITHUB_REF_NAME"
+            echo "REL_VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
+            echo "REL_VERSION_STRICT=${GITHUB_REF_NAME#?}" >> $GITHUB_ENV
+          else
+            echo "Using BRANCH mode: v$BASE_DEV_VERSION-dev.$GITHUB_RUN_NUMBER"
+            echo "REL_VERSION=v$BASE_DEV_VERSION-dev.$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
+            echo "REL_VERSION_STRICT=$BASE_DEV_VERSION-dev.$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
+          fi
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images:  ghcr.io/${{ github.repository_owner }}/hoppscotch${{ env.REL_VERSION_STRICT }}
+      - name: Build and Push Image to GHCR
+        uses: docker/build-push-action@v2.9.0
+        with:
+          context: ./
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+
+  render-compose-file:
+    name: Render Docker Compose File
+    runs-on: ubuntu-latest
+    needs: 
+      - build-hoppscotch
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          HOPPSCOTCH_IMAGE=$(echo ${{ needs.build-hoppscotch.outputs.tags }})
+          export HOPPSCOTCH_IMAGE
+          # Render simple template from environment variables.
+          envsubst < docker-compose.template.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Hash Rendered Compose File
+        id: hash
+        run: echo "::set-output name=hash::$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')"
+      - name: Cache Rendered Compose File
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ steps.hash.outputs.hash }}
+
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    needs: render-compose-file
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@add_credentials
+    if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+    with:
+      compose-file-cache-key: ${{ needs.render-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      username: vibhav.bobade+hoppscotch@uffizzi.com
+      server: https://app.uffizzi.com
+      project: hoppscotch-46my
+    secrets:
+      password: ${{ secrets.UFFIZZI_PASSWORD }}
+    permissions:
+      contents: read
+      pull-requests: write

--- a/docker-compose.template.yml
+++ b/docker-compose.template.yml
@@ -1,0 +1,19 @@
+version: "3.7"
+
+x-uffizzi:
+  ingress:
+    service: web
+    port: 3000
+
+services:
+  web:
+    image:  ${HOPPSCOTCH_IMAGE}
+    ports:
+      - "3000:3000"
+    environment:
+      HOST: 0.0.0.0
+    deploy:
+      resources:
+        limits:
+          memory: 500M
+    


### PR DESCRIPTION
### Description

- [x] Add Github Workflow for uffizzi PR environments
- [x] Add docker compose template compatible with uffizzi PR envs

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

### Additional Information

I want to invite the maintainers of Hoppscotch to the Uffizzi project created for them. The PR setups up PR Environments for Hoppscotch to ease development and reviews. Reviewers should be able to see a preview of the PR as a hosted service. The URL of the service will be provided in a comment on the PR itself. I want to invite the maintainers of Hoppscotch to the uffizzi project to get an idea of what the platform looks like. Uffizzi is free for Hoppscotch.