### PR TITLE
fix: find linked account from authentication error and link it

### DIFF
--- a/packages/hoppscotch-app/src/helpers/fb/auth.ts
+++ b/packages/hoppscotch-app/src/helpers/fb/auth.ts
@@ -244,10 +244,13 @@ export async function linkWithFBCredential(
 export async function linkWithFBCredentialFromAuthError(error: unknown) {
   // credential is not null since this function is called after an auth/account-exists-with-different-credential error, ie credentials actually exist
   const credentials = OAuthProvider.credentialFromError(error as AuthError)!
+
   const otherLinkedProviders = (
     await getSignInMethodsForEmail((error as AuthError).customData.email!)
   ).filter((providerId) => credentials.providerId !== providerId)
+
   let user: User | null = null
+
   if (otherLinkedProviders.indexOf("google.com") >= -1) {
     user = (await signInUserWithGoogle()).user
   } else if (otherLinkedProviders.indexOf("github.com") >= -1) {
@@ -255,6 +258,7 @@ export async function linkWithFBCredentialFromAuthError(error: unknown) {
   } else if (otherLinkedProviders.indexOf("microsoft.com") >= -1) {
     user = (await signInUserWithMicrosoft()).user
   }
+
   // user is not null since going through each provider will return a user
   return await linkWithCredential(user!, credentials)
 }

--- a/packages/hoppscotch-app/src/helpers/fb/auth.ts
+++ b/packages/hoppscotch-app/src/helpers/fb/auth.ts
@@ -237,19 +237,26 @@ export async function linkWithFBCredential(
 /**
  * Links account with another account given in a auth/account-exists-with-different-credential error
  *
- * @param user - User who has the errors
- *
  * @param error - Error caught after trying to login
  *
  * @returns Promise of UserCredential
  */
-export async function linkWithFBCredentialFromAuthError(
-  user: User,
-  error: unknown
-) {
-  // Marked as not null since this function is supposed to be called after an auth/account-exists-with-different-credential error, ie credentials actually exist
+export async function linkWithFBCredentialFromAuthError(error: unknown) {
+  // credential is not null since this function is called after an auth/account-exists-with-different-credential error, ie credentials actually exist
   const credentials = OAuthProvider.credentialFromError(error as AuthError)!
-  return await linkWithCredential(user, credentials)
+  const otherLinkedProviders = (
+    await getSignInMethodsForEmail((error as AuthError).customData.email!)
+  ).filter((providerId) => credentials.providerId !== providerId)
+  let user: User | null = null
+  if (otherLinkedProviders.indexOf("google.com") >= -1) {
+    user = (await signInUserWithGoogle()).user
+  } else if (otherLinkedProviders.indexOf("github.com") >= -1) {
+    user = (await signInUserWithGithub()).user
+  } else if (otherLinkedProviders.indexOf("microsoft.com") >= -1) {
+    user = (await signInUserWithMicrosoft()).user
+  }
+  // user is not null since going through each provider will return a user
+  return await linkWithCredential(user!, credentials)
 }
 
 /**


### PR DESCRIPTION

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

### Description
<!-- Add a brief description of the pull request -->
If an account linking error happens, new logic finds out the account and links it. Dead code related to linking accounts have been deleted.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
