### PR TITLE
fix: parse env with dash from request body

### DIFF
--- a/packages/hoppscotch-app/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-app/src/helpers/utils/EffectiveURL.ts
@@ -12,7 +12,6 @@ import {
   HoppRESTReqBody,
   HoppRESTRequest,
   parseTemplateString,
-  parseBodyEnvVariables,
   Environment,
   HoppRESTHeader,
   HoppRESTParam,
@@ -280,7 +279,9 @@ function getFinalBodyFromRequest(
       ),
       toFormData
     )
-  } else return parseBodyEnvVariables(request.body.body, envVariables)
+  }
+
+  return parseTemplateString(request.body.body, envVariables)
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2665  <!-- Issue # here -->

### Description

When I use an env variable with a dash in its name in a JSON body, the variable does not become substituted with the actual value. Even though the variable is correctly highlighted green. With this PR this issue get resolved.

<!-- Add a brief description of the pull request -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed