### PR TITLE
feat: add toggle preview key binding

### DIFF
--- a/packages/hoppscotch-app/components/lenses/renderers/HTMLLensRenderer.vue
+++ b/packages/hoppscotch-app/components/lenses/renderers/HTMLLensRenderer.vue
@@ -67,6 +67,7 @@ import useCopyResponse from "~/helpers/lenses/composables/useCopyResponse"
 import { useCodemirror } from "~/helpers/editor/codemirror"
 import { HoppRESTResponse } from "~/helpers/types/HoppRESTResponse"
 import { useI18n } from "~/helpers/utils/composables"
+import { defineActionHandler } from "~/helpers/actions"
 
 const t = useI18n()
 
@@ -102,6 +103,12 @@ useCodemirror(
     environmentHighlights: true,
   })
 )
+
+defineActionHandler("response.preview.toggle", () => {
+  if (previewEnabled) {
+    togglePreview()
+  }
+})
 </script>
 
 <style lang="scss" scoped>

--- a/packages/hoppscotch-app/helpers/actions.ts
+++ b/packages/hoppscotch-app/helpers/actions.ts
@@ -32,6 +32,7 @@ export type HoppAction =
   | "settings.theme.light" // Use light theme
   | "settings.theme.dark" // Use dark theme
   | "settings.theme.black" // Use black theme
+  | "response.preview.toggle" // Toggle preview mode on and off on response
 
 type BoundActionList = {
   // eslint-disable-next-line no-unused-vars

--- a/packages/hoppscotch-app/helpers/keybindings.ts
+++ b/packages/hoppscotch-app/helpers/keybindings.ts
@@ -58,6 +58,7 @@ export const bindings: {
   "alt-d": "navigation.jump.documentation",
   "alt-m": "navigation.jump.profile",
   "alt-s": "navigation.jump.settings",
+  "alt-shift-p": "response.preview.toggle",
 }
 
 /**

--- a/packages/hoppscotch-app/helpers/shortcuts.js
+++ b/packages/hoppscotch-app/helpers/shortcuts.js
@@ -117,6 +117,15 @@ export default [
       },
     ],
   },
+  {
+    section: "shortcut.response.title",
+    shortcuts: [
+      {
+        keys: [getPlatformAlternateKey(), "Shift", "P"],
+        label: "shortcut.response.preview",
+      },
+    ],
+  },
 ]
 
 export const spotlight = [

--- a/packages/hoppscotch-app/locales/en.json
+++ b/packages/hoppscotch-app/locales/en.json
@@ -495,6 +495,10 @@
       "light": "Switch  theme to light mode",
       "system": "Switch  theme to system mode",
       "title": "Theme"
+    },
+    "response": {
+      "title": "Response",
+      "preview": "Toggle response preview"
     }
   },
   "shortcodes":{


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2682

### Description
<!-- Add a brief description of the pull request -->
This PR adds a new key binding "alt+shift+p" to toggle preview mode on a response to make developer workflow easier and more efficient.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ x] I have updated the documentation as required
- [ x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
