### PR TITLE
ci: modify publish-docker workflow to push for ARM platforms

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -14,15 +14,21 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: hoppscotch/hoppscotch
           flavor: |
@@ -31,9 +37,10 @@ jobs:
             suffix=
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2524

### Description
<!-- Add a brief description of the pull request -->
This PR modifies the `publish-docker.yml` workflow in order to publish the docker image for ARM based platforms.
Now it pushes images for the following platforms:
- linux/amd64: already existing, default platform
- linux/arm/v7
- linux/arm64/v8

This will add support for new Apple computers with M-series chips, and newer Raspberry Pi (among other systems as well).

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

As the original base image [`node:lts-slim`](https://hub.docker.com/_/node/tags?page=1&name=lts-slim) supports the platforms linux/amd64, linux/arm/v7 and linux/arm64/v8, we can build for those platforms too without problem.

The workflow modifications are based on the [docker/build-push-action docs for Multi-platform image](https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md). I have added two steps to setup QEMU and buildx as the docs indicate (in order to have support for multiple platforms and be able to build multi-platform images, accordingly).

I have tested and run the [workflow in my fork](https://github.com/piraces/hoppscotch/actions/runs/3164527905) publishing to Docker Hub [here](https://hub.docker.com/r/piraces/hoppscotch/tags). There you can test if you want the current branch (I have been testing with QEMU by myself).

As you can see in Docker Hub multiple platforms are now listed (in my part). This is the expected result when this PR gets merged and then making a release.

The only con of this approach (but inevitable), is that the `Build and push Docker image` takes about 20min instead of 5 minutes as now... but this is due to building for two newer platforms with QEMU.

**Note:** I have also modified the reference for some actions in the workflow to target the latest version of the action, instead of a fixed commit (I see this more stable than a fixed commit that can be older). Nevertheless, if this is a problem I can go back and make a commit reference.
