### PR TITLE
Feat: Add inline environment variable edit

### DIFF
--- a/packages/hoppscotch-app/assets/scss/styles.scss
+++ b/packages/hoppscotch-app/assets/scss/styles.scss
@@ -169,8 +169,9 @@ a {
   .env-icon {
     @apply inline-flex;
     @apply items-center;
-    @apply mr-1;
     @apply text-accentDark;
+    @apply hover:text-accent;
+    @apply hover:cursor-pointer;
   }
 }
 

--- a/packages/hoppscotch-app/assets/scss/styles.scss
+++ b/packages/hoppscotch-app/assets/scss/styles.scss
@@ -132,6 +132,7 @@ a {
 
 .cm-tooltip {
   .tippy-box {
+    @apply shadow-none;
     @apply fixed;
     @apply inline-flex;
     @apply -mt-6;
@@ -166,11 +167,9 @@ a {
     }
 
     .env-icon {
+      @apply transition;
       @apply inline-flex;
       @apply items-center;
-      @apply text-accentDark;
-      @apply hover:text-accent;
-      @apply hover:cursor-pointer;
     }
   }
 

--- a/packages/hoppscotch-app/src/components/environments/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/index.vue
@@ -155,9 +155,9 @@
         @update-selected-team="updateSelectedTeam"
       />
     </div>
-    <EnvironmentsMy v-if="environmentType.type === 'my-environments'" />
+    <EnvironmentsMy v-show="environmentType.type === 'my-environments'" />
     <EnvironmentsTeams
-      v-else
+      v-show="environmentType.type === 'team-environments'"
       :team="environmentType.selectedTeam"
       :team-environments="teamEnvironmentList"
       :loading="loading"

--- a/packages/hoppscotch-app/src/components/environments/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/index.vue
@@ -155,9 +155,9 @@
         @update-selected-team="updateSelectedTeam"
       />
     </div>
-    <EnvironmentsMy v-show="environmentType.type === 'my-environments'" />
+    <EnvironmentsMy v-if="environmentType.type === 'my-environments'" />
     <EnvironmentsTeams
-      v-show="environmentType.type === 'team-environments'"
+      v-if="environmentType.type === 'team-environments'"
       :team="environmentType.selectedTeam"
       :team-environments="teamEnvironmentList"
       :loading="loading"

--- a/packages/hoppscotch-app/src/components/environments/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/index.vue
@@ -155,9 +155,9 @@
         @update-selected-team="updateSelectedTeam"
       />
     </div>
-    <EnvironmentsMy v-if="environmentType.type === 'my-environments'" />
+    <EnvironmentsMy v-show="environmentType.type === 'my-environments'" />
     <EnvironmentsTeams
-      v-if="environmentType.type === 'team-environments'"
+      v-show="environmentType.type === 'team-environments'"
       :team="environmentType.selectedTeam"
       :team-environments="teamEnvironmentList"
       :loading="loading"

--- a/packages/hoppscotch-app/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/Details.vue
@@ -62,6 +62,7 @@
             />
             <SmartEnvInput
               v-model="env.value"
+              :select-text="env.key === editingVariableName"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               :envs="liveEnvs"
               :name="'value' + index"
@@ -163,6 +164,7 @@ const props = withDefaults(
     show: boolean
     action: "edit" | "new"
     editingEnvironmentIndex: number | "Global" | null
+    editingVariableName: string | null
     envVars?: () => Environment["variables"]
   }>(),
   {

--- a/packages/hoppscotch-app/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/Details.vue
@@ -62,7 +62,7 @@
             />
             <SmartEnvInput
               v-model="env.value"
-              :is-text-selected="env.key === editingVariableName"
+              :select-text-on-mount="env.key === editingVariableName"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               :envs="liveEnvs"
               :name="'value' + index"

--- a/packages/hoppscotch-app/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/Details.vue
@@ -62,7 +62,7 @@
             />
             <SmartEnvInput
               v-model="env.value"
-              :select-text="env.key === editingVariableName"
+              :is-text-selected="env.key === editingVariableName"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               :envs="liveEnvs"
               :name="'value' + index"

--- a/packages/hoppscotch-app/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/index.vue
@@ -135,6 +135,6 @@ defineActionHandler("modals.my.environment.edit", (args?: any[]) => {
       return environment.name === envName
     }
   )
-  editEnvironment(envIndex >= 0 ? envIndex : envName)
+  editEnvironment(envIndex >= 0 ? envIndex : "Global")
 })
 </script>

--- a/packages/hoppscotch-app/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/index.vue
@@ -128,8 +128,7 @@ const resetSelectedData = () => {
 }
 
 defineActionHandler("modals.my.environment.edit", (args?: any[]) => {
-  const envName: any = args?.[0]
-  const variableName: string = args?.[1]
+  const [envName, variableName]: any = args
   editingVariableName.value = variableName
   const envIndex: number = environments.value.findIndex(
     (environment: Environment) => {

--- a/packages/hoppscotch-app/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/index.vue
@@ -64,6 +64,7 @@
       :show="showModalDetails"
       :action="action"
       :editing-environment-index="editingEnvironmentIndex"
+      :editing-variable-name="editingVariableName"
       @hide-modal="displayModalEdit(false)"
     />
     <EnvironmentsImportExport
@@ -83,6 +84,8 @@ import { useI18n } from "~/composables/i18n"
 import IconArchive from "~icons/lucide/archive"
 import IconPlus from "~icons/lucide/plus"
 import IconHelpCircle from "~icons/lucide/help-circle"
+import { Environment } from "@hoppscotch/data"
+import { defineActionHandler } from "~/helpers/actions"
 
 const t = useI18n()
 const colorMode = useColorMode()
@@ -100,6 +103,7 @@ const showModalImportExport = ref(false)
 const showModalDetails = ref(false)
 const action = ref<"new" | "edit">("edit")
 const editingEnvironmentIndex = ref<number | "Global" | null>(null)
+const editingVariableName = ref<string>("")
 
 const displayModalAdd = (shouldDisplay: boolean) => {
   action.value = "new"
@@ -122,4 +126,16 @@ const editEnvironment = (environmentIndex: number | "Global") => {
 const resetSelectedData = () => {
   editingEnvironmentIndex.value = null
 }
+
+defineActionHandler("modals.my.environment.edit", (args?: any[]) => {
+  const envName: any = args?.[0]
+  const variableName: string = args?.[1]
+  editingVariableName.value = variableName
+  const envIndex: number = environments.value.findIndex(
+    (environment: Environment) => {
+      return environment.name === envName
+    }
+  )
+  editEnvironment(envIndex >= 0 ? envIndex : envName)
+})
 </script>

--- a/packages/hoppscotch-app/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/index.vue
@@ -103,7 +103,7 @@ const showModalImportExport = ref(false)
 const showModalDetails = ref(false)
 const action = ref<"new" | "edit">("edit")
 const editingEnvironmentIndex = ref<number | "Global" | null>(null)
-const editingVariableName = ref<string>("")
+const editingVariableName = ref("")
 
 const displayModalAdd = (shouldDisplay: boolean) => {
   action.value = "new"

--- a/packages/hoppscotch-app/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/index.vue
@@ -127,14 +127,16 @@ const resetSelectedData = () => {
   editingEnvironmentIndex.value = null
 }
 
-defineActionHandler("modals.my.environment.edit", (args?: any[]) => {
-  const [envName, variableName]: any = args
-  editingVariableName.value = variableName
-  const envIndex: number = environments.value.findIndex(
-    (environment: Environment) => {
-      return environment.name === envName
-    }
-  )
-  editEnvironment(envIndex >= 0 ? envIndex : "Global")
-})
+defineActionHandler(
+  "modals.my.environment.edit",
+  ({ envName, variableName }) => {
+    editingVariableName.value = variableName
+    const envIndex: number = environments.value.findIndex(
+      (environment: Environment) => {
+        return environment.name === envName
+      }
+    )
+    editEnvironment(envIndex >= 0 ? envIndex : "Global")
+  }
+)
 </script>

--- a/packages/hoppscotch-app/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-app/src/components/environments/teams/Details.vue
@@ -65,6 +65,7 @@
             />
             <SmartEnvInput
               v-model="env.value"
+              :select-text="env.key === editingVariableName"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               :envs="liveEnvs"
               :name="'value' + index"
@@ -173,6 +174,7 @@ const props = withDefaults(
     action: "edit" | "new"
     editingEnvironment: TeamEnvironment | null
     editingTeamId: string | undefined
+    editingVariableName: string | null
     isViewer: boolean
   }>(),
   {

--- a/packages/hoppscotch-app/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-app/src/components/environments/teams/Details.vue
@@ -65,7 +65,7 @@
             />
             <SmartEnvInput
               v-model="env.value"
-              :is-text-selected="env.key === editingVariableName"
+              :select-text-on-mount="env.key === editingVariableName"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               :envs="liveEnvs"
               :name="'value' + index"

--- a/packages/hoppscotch-app/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-app/src/components/environments/teams/Details.vue
@@ -65,7 +65,7 @@
             />
             <SmartEnvInput
               v-model="env.value"
-              :select-text="env.key === editingVariableName"
+              :is-text-selected="env.key === editingVariableName"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               :envs="liveEnvs"
               :name="'value' + index"

--- a/packages/hoppscotch-app/src/components/environments/teams/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/teams/index.vue
@@ -145,7 +145,7 @@ const showModalImportExport = ref(false)
 const showModalDetails = ref(false)
 const action = ref<"new" | "edit">("edit")
 const editingEnvironment = ref<TeamEnvironment | null>(null)
-const editingVariableName = ref<string>("")
+const editingVariableName = ref("")
 
 const displayModalAdd = (shouldDisplay: boolean) => {
   action.value = "new"
@@ -185,10 +185,9 @@ const getErrorMessage = (err: GQLError<string>) => {
 defineActionHandler("modals.team.environment.edit", (args?: any[]) => {
   const [envName, variableName]: any = args
   editingVariableName.value = variableName
-  const teamEnvToEdit: TeamEnvironment | undefined =
-    props.teamEnvironments.find((environment: TeamEnvironment) => {
-      return environment.environment.name === envName
-    })
+  const teamEnvToEdit = props.teamEnvironments.find(
+    (environment) => environment.environment.name === envName
+  )
   if (teamEnvToEdit) editEnvironment(teamEnvToEdit)
 })
 </script>

--- a/packages/hoppscotch-app/src/components/environments/teams/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/teams/index.vue
@@ -182,12 +182,14 @@ const getErrorMessage = (err: GQLError<string>) => {
   }
 }
 
-defineActionHandler("modals.team.environment.edit", (args?: any[]) => {
-  const [envName, variableName]: any = args
-  editingVariableName.value = variableName
-  const teamEnvToEdit = props.teamEnvironments.find(
-    (environment) => environment.environment.name === envName
-  )
-  if (teamEnvToEdit) editEnvironment(teamEnvToEdit)
-})
+defineActionHandler(
+  "modals.team.environment.edit",
+  ({ envName, variableName }) => {
+    editingVariableName.value = variableName
+    const teamEnvToEdit = props.teamEnvironments.find(
+      (environment) => environment.environment.name === envName
+    )
+    if (teamEnvToEdit) editEnvironment(teamEnvToEdit)
+  }
+)
 </script>

--- a/packages/hoppscotch-app/src/components/environments/teams/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/teams/index.vue
@@ -183,8 +183,7 @@ const getErrorMessage = (err: GQLError<string>) => {
 }
 
 defineActionHandler("modals.team.environment.edit", (args?: any[]) => {
-  const envName: any = args?.[0]
-  const variableName: string = args?.[1]
+  const [envName, variableName]: any = args
   editingVariableName.value = variableName
   const teamEnvToEdit: TeamEnvironment | undefined =
     props.teamEnvironments.find((environment: TeamEnvironment) => {

--- a/packages/hoppscotch-app/src/components/environments/teams/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/teams/index.vue
@@ -102,6 +102,7 @@
       :action="action"
       :editing-environment="editingEnvironment"
       :editing-team-id="team?.id"
+      :editing-variable-name="editingVariableName"
       :is-viewer="team?.myRole === 'VIEWER'"
       @hide-modal="displayModalEdit(false)"
     />
@@ -125,6 +126,7 @@ import IconPlus from "~icons/lucide/plus"
 import IconArchive from "~icons/lucide/archive"
 import IconHelpCircle from "~icons/lucide/help-circle"
 import { Team } from "~/helpers/backend/graphql"
+import { defineActionHandler } from "~/helpers/actions"
 
 const t = useI18n()
 
@@ -132,7 +134,7 @@ const colorMode = useColorMode()
 
 type SelectedTeam = Team | undefined
 
-defineProps<{
+const props = defineProps<{
   team: SelectedTeam
   teamEnvironments: TeamEnvironment[]
   adapterError: GQLError<string> | null
@@ -143,6 +145,7 @@ const showModalImportExport = ref(false)
 const showModalDetails = ref(false)
 const action = ref<"new" | "edit">("edit")
 const editingEnvironment = ref<TeamEnvironment | null>(null)
+const editingVariableName = ref<string>("")
 
 const displayModalAdd = (shouldDisplay: boolean) => {
   action.value = "new"
@@ -178,4 +181,15 @@ const getErrorMessage = (err: GQLError<string>) => {
     }
   }
 }
+
+defineActionHandler("modals.team.environment.edit", (args?: any[]) => {
+  const envName: any = args?.[0]
+  const variableName: string = args?.[1]
+  editingVariableName.value = variableName
+  const teamEnvToEdit: TeamEnvironment | undefined =
+    props.teamEnvironments.find((environment: TeamEnvironment) => {
+      return environment.environment.name === envName
+    })
+  if (teamEnvToEdit) editEnvironment(teamEnvToEdit)
+})
 </script>

--- a/packages/hoppscotch-app/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-app/src/components/smart/EnvInput.vue
@@ -42,7 +42,7 @@ const props = withDefaults(
     styles?: string
     envs?: { key: string; value: string; source: string }[] | null
     focus?: boolean
-    selectText?: boolean
+    isTextSelected?: boolean
     readonly?: boolean
   }>(),
   {
@@ -218,14 +218,14 @@ const triggerTextSelection = () => {
 onMounted(() => {
   if (editor.value) {
     if (!view.value) initView(editor.value)
-    if (props.selectText) triggerTextSelection()
+    if (props.isTextSelected) triggerTextSelection()
   }
 })
 
 watch(editor, () => {
   if (editor.value) {
     if (!view.value) initView(editor.value)
-    if (props.selectText) triggerTextSelection()
+    if (props.isTextSelected) triggerTextSelection()
   } else {
     view.value?.destroy()
     view.value = undefined

--- a/packages/hoppscotch-app/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-app/src/components/smart/EnvInput.vue
@@ -42,7 +42,7 @@ const props = withDefaults(
     styles?: string
     envs?: { key: string; value: string; source: string }[] | null
     focus?: boolean
-    isTextSelected?: boolean
+    selectTextOnMount?: boolean
     readonly?: boolean
   }>(),
   {
@@ -218,14 +218,14 @@ const triggerTextSelection = () => {
 onMounted(() => {
   if (editor.value) {
     if (!view.value) initView(editor.value)
-    if (props.isTextSelected) triggerTextSelection()
+    if (props.selectTextOnMount) triggerTextSelection()
   }
 })
 
 watch(editor, () => {
   if (editor.value) {
     if (!view.value) initView(editor.value)
-    if (props.isTextSelected) triggerTextSelection()
+    if (props.selectTextOnMount) triggerTextSelection()
   } else {
     view.value?.destroy()
     view.value = undefined

--- a/packages/hoppscotch-app/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-app/src/components/smart/EnvInput.vue
@@ -27,7 +27,7 @@ import {
   keymap,
   tooltips,
 } from "@codemirror/view"
-import { EditorState, Extension } from "@codemirror/state"
+import { EditorSelection, EditorState, Extension } from "@codemirror/state"
 import { clone } from "lodash-es"
 import { history, historyKeymap } from "@codemirror/commands"
 import { inputTheme } from "~/helpers/editor/themes/baseTheme"
@@ -42,6 +42,7 @@ const props = withDefaults(
     styles?: string
     envs?: { key: string; value: string; source: string }[] | null
     focus?: boolean
+    selectText?: boolean
     readonly?: boolean
   }>(),
   {
@@ -203,15 +204,28 @@ const initView = (el: any) => {
   })
 }
 
+const triggerTextSelection = () => {
+  nextTick(() => {
+    view.value?.focus()
+    view.value?.dispatch({
+      selection: EditorSelection.create([
+        EditorSelection.range(0, props.modelValue.length),
+      ]),
+    })
+  })
+}
+
 onMounted(() => {
   if (editor.value) {
     if (!view.value) initView(editor.value)
+    if (props.selectText) triggerTextSelection()
   }
 })
 
 watch(editor, () => {
   if (editor.value) {
     if (!view.value) initView(editor.value)
+    if (props.selectText) triggerTextSelection()
   } else {
     view.value?.destroy()
     view.value = undefined

--- a/packages/hoppscotch-app/src/helpers/actions.ts
+++ b/packages/hoppscotch-app/src/helpers/actions.ts
@@ -22,8 +22,8 @@ export type HoppAction =
   | "modals.search.toggle" // Shows the search modal
   | "modals.support.toggle" // Shows the support modal
   | "modals.share.toggle" // Shows the share modal
-  | "modals.my.environment.edit" // Edit current environment
-  | "modals.team.environment.edit" // Edit current environment
+  | "modals.my.environment.edit" // Edit current personal environment
+  | "modals.team.environment.edit" // Edit current team environment
   | "navigation.jump.rest" // Jump to REST page
   | "navigation.jump.graphql" // Jump to GraphQL page
   | "navigation.jump.realtime" // Jump to realtime page

--- a/packages/hoppscotch-app/src/helpers/actions.ts
+++ b/packages/hoppscotch-app/src/helpers/actions.ts
@@ -22,6 +22,8 @@ export type HoppAction =
   | "modals.search.toggle" // Shows the search modal
   | "modals.support.toggle" // Shows the support modal
   | "modals.share.toggle" // Shows the share modal
+  | "modals.my.environment.edit" // Edit current environment
+  | "modals.team.environment.edit" // Edit current environment
   | "navigation.jump.rest" // Jump to REST page
   | "navigation.jump.graphql" // Jump to GraphQL page
   | "navigation.jump.realtime" // Jump to realtime page
@@ -38,7 +40,7 @@ export type HoppAction =
 
 type BoundActionList = {
   // eslint-disable-next-line no-unused-vars
-  [_ in HoppAction]?: Array<() => void>
+  [_ in HoppAction]?: Array<(args?: any[]) => void>
 }
 
 const boundActions: BoundActionList = {}
@@ -55,8 +57,8 @@ export function bindAction(action: HoppAction, handler: () => void) {
   activeActions$.next(Object.keys(boundActions) as HoppAction[])
 }
 
-export function invokeAction(action: HoppAction) {
-  boundActions[action]?.forEach((handler) => handler())
+export function invokeAction(action: HoppAction, args?: any[]) {
+  boundActions[action]?.forEach((handler) => handler(args))
 }
 
 export function unbindAction(action: HoppAction, handler: () => void) {
@@ -69,7 +71,10 @@ export function unbindAction(action: HoppAction, handler: () => void) {
   activeActions$.next(Object.keys(boundActions) as HoppAction[])
 }
 
-export function defineActionHandler(action: HoppAction, handler: () => void) {
+export function defineActionHandler(
+  action: HoppAction,
+  handler: (args?: any[]) => void
+) {
   onMounted(() => {
     bindAction(action, handler)
   })

--- a/packages/hoppscotch-app/src/helpers/actions.ts
+++ b/packages/hoppscotch-app/src/helpers/actions.ts
@@ -38,31 +38,101 @@ export type HoppAction =
   | "response.file.download" // Download response as file
   | "response.copy" // Copy response to clipboard
 
+/**
+ * Defines the arguments, if present for a given type that is required to be passed on
+ * invocation and will be passed to action handlers.
+ *
+ * This type is supposed to be an object with the key being one of the actions mentioned above.
+ * The value to the key can be anything.
+ * If an action has no argument, you do not need to add it to this type.
+ *
+ * NOTE: We can't enforce type checks to make sure the key is Action, you
+ * will know if you got something wrong if there is a type error in this file
+ */
+type HoppActionArgs = {
+  "modals.my.environment.edit": {
+    envName: string
+    variableName: string
+  }
+  "modals.team.environment.edit": {
+    envName: string
+    variableName: string
+  }
+}
+
+/**
+ * HoppActions which require arguments for their invocation
+ */
+type HoppActionWithArgs = keyof HoppActionArgs
+
+/**
+ * HoppActions which do not require arguments for their invocation
+ */
+type HoppActionWithNoArgs = Exclude<HoppAction, HoppActionWithArgs>
+
+/**
+ * Resolves the argument type for a given HoppAction
+ */
+type ArgOfHoppAction<A extends HoppAction> = A extends HoppActionWithArgs
+  ? HoppActionArgs[A]
+  : undefined
+
+/**
+ * Resolves the action function for a given HoppAction, used by action handler function defs
+ */
+type ActionFunc<A extends HoppAction> = A extends HoppActionWithArgs
+  ? (arg: ArgOfHoppAction<A>) => void
+  : () => void
+
 type BoundActionList = {
   // eslint-disable-next-line no-unused-vars
-  [_ in HoppAction]?: Array<(args?: any[]) => void>
+  [A in HoppAction]?: Array<ActionFunc<A>>
 }
 
 const boundActions: BoundActionList = {}
 
 export const activeActions$ = new BehaviorSubject<HoppAction[]>([])
 
-export function bindAction(action: HoppAction, handler: () => void) {
+export function bindAction<A extends HoppAction>(
+  action: A,
+  handler: ActionFunc<A>
+) {
   if (boundActions[action]) {
     boundActions[action]?.push(handler)
   } else {
-    boundActions[action] = [handler]
+    // 'any' assertion because TypeScript doesn't seem to be able to figure out the links.
+    boundActions[action] = [handler] as any
   }
 
   activeActions$.next(Object.keys(boundActions) as HoppAction[])
 }
 
-export function invokeAction(action: HoppAction, args?: any[]) {
-  boundActions[action]?.forEach((handler) => handler(args))
+type InvokeActionFunc = {
+  (action: HoppActionWithNoArgs, args?: undefined): void
+  <A extends HoppActionWithArgs>(action: A, args: ArgOfHoppAction<A>): void
 }
 
-export function unbindAction(action: HoppAction, handler: () => void) {
-  boundActions[action] = boundActions[action]?.filter((x) => x !== handler)
+/**
+ * Invokes a action, triggering action handlers if any registered.
+ * The second argument parameter is optional if your action has no args required
+ * @param action The action to fire
+ * @param args The argument passed to the action handler. Optional if action has no args required
+ */
+export const invokeAction: InvokeActionFunc = <A extends HoppAction>(
+  action: A,
+  args: ArgOfHoppAction<A>
+) => {
+  boundActions[action]?.forEach((handler) => handler(args!))
+}
+
+export function unbindAction<A extends HoppAction>(
+  action: A,
+  handler: ActionFunc<A>
+) {
+  // 'any' assertion because TypeScript doesn't seem to be able to figure out the links.
+  boundActions[action] = boundActions[action]?.filter(
+    (x) => x !== handler
+  ) as any
 
   if (boundActions[action]?.length === 0) {
     delete boundActions[action]
@@ -71,9 +141,9 @@ export function unbindAction(action: HoppAction, handler: () => void) {
   activeActions$.next(Object.keys(boundActions) as HoppAction[])
 }
 
-export function defineActionHandler(
-  action: HoppAction,
-  handler: (args?: any[]) => void
+export function defineActionHandler<A extends HoppAction>(
+  action: A,
+  handler: ActionFunc<A>
 ) {
   onMounted(() => {
     bindAction(action, handler)

--- a/packages/hoppscotch-app/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-app/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -76,12 +76,13 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
 
       const selectedEnvType = getSelectedEnvironmentType()
 
-      const envTypeIcon = `<i class="inline-flex items-center pr-2 mr-2 -my-1 text-base border-r material-icons border-secondary">${
+      const envTypeIcon = `<i class="inline-flex items-center px-1 mr-2 -my-1 text-base border-x material-icons border-secondary">${
         selectedEnvType === "TEAM_ENV" ? "people" : "person"
       }</i>`
 
       const appendEditAction = (tooltip: HTMLElement) => {
         const editIcon = document.createElement("span")
+        editIcon.className = "env-icon"
         editIcon.addEventListener("click", () => {
           const isPersonalEnv =
             envName === "Global" || selectedEnvType !== "TEAM_ENV"
@@ -91,7 +92,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
             parsedEnvKey,
           ])
         })
-        editIcon.innerHTML = `<i class="inline-flex material-icons ml-2 -my-1 text-base cursor-pointer">edit</i>`
+        editIcon.innerHTML = `<i class="inline-flex items-center px-1 ml-2 -my-1 text-base border-x material-icons border-secondary">edit</i>`
         tooltip.appendChild(editIcon)
       }
 

--- a/packages/hoppscotch-app/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-app/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -73,13 +73,14 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
 
       const selectedEnvType = getSelectedEnvironmentType()
 
-      const envTypeIcon = `<i class="inline-flex items-center px-1 mr-2 -my-1 text-base border-x material-icons border-secondary">${
+      const envTypeIcon = `<i class="inline-flex -my-1 -mx-0.5 opacity-65 items-center text-base material-icons border-secondary">${
         selectedEnvType === "TEAM_ENV" ? "people" : "person"
       }</i>`
 
       const appendEditAction = (tooltip: HTMLElement) => {
         const editIcon = document.createElement("span")
-        editIcon.className = "env-icon"
+        editIcon.className =
+          "env-icon ml-2 text-accent cursor-pointer hover:text-accentDark"
         editIcon.addEventListener("click", () => {
           const isPersonalEnv =
             envName === "Global" || selectedEnvType !== "TEAM_ENV"
@@ -89,7 +90,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
             variableName: parsedEnvKey,
           })
         })
-        editIcon.innerHTML = `<i class="inline-flex items-center px-1 ml-2 -my-1 text-base border-x material-icons border-secondary">edit</i>`
+        editIcon.innerHTML = `<i class="inline-flex -my-1 -mx-1 items-center px-1 text-base material-icons border-secondary">drive_file_rename_outline</i>`
         tooltip.appendChild(editIcon)
       }
 
@@ -104,8 +105,8 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
           const kbd = document.createElement("kbd")
           const icon = document.createElement("span")
           icon.innerHTML = envTypeIcon
-          icon.className = "env-icon"
-          kbd.textContent = finalEnv          
+          icon.className = "env-icon mr-2"
+          kbd.textContent = finalEnv
           tooltipContainer.appendChild(icon)
           tooltipContainer.appendChild(document.createTextNode(`${envName} `))
           tooltipContainer.appendChild(kbd)

--- a/packages/hoppscotch-app/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-app/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -84,10 +84,10 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
           const isPersonalEnv =
             envName === "Global" || selectedEnvType !== "TEAM_ENV"
           const action = isPersonalEnv ? "my" : "team"
-          invokeAction(`modals.${action}.environment.edit`, [
+          invokeAction(`modals.${action}.environment.edit`, {
             envName,
-            parsedEnvKey,
-          ])
+            variableName: parsedEnvKey,
+          })
         })
         editIcon.innerHTML = `<i class="inline-flex items-center px-1 ml-2 -my-1 text-base border-x material-icons border-secondary">edit</i>`
         tooltip.appendChild(editIcon)

--- a/packages/hoppscotch-app/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-app/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -61,10 +61,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
 
       const parsedEnvKey = text.slice(start - from, end - from)
 
-      const tooltipEnv = aggregateEnvs.find(
-        (env) => env.key === parsedEnvKey
-        // env.key === word.slice(wordSelection.from + 2, wordSelection.to - 2)
-      )
+      const tooltipEnv = aggregateEnvs.find((env) => env.key === parsedEnvKey)
 
       const envName = tooltipEnv?.sourceEnv ?? "Choose an Environment"
 

--- a/packages/hoppscotch-app/src/helpers/editor/themes/baseTheme.ts
+++ b/packages/hoppscotch-app/src/helpers/editor/themes/baseTheme.ts
@@ -102,11 +102,14 @@ export const baseTheme = EditorView.theme({
     border: "none",
     borderRadius: "4px",
   },
+  ".cm-tooltip-arrow": {
+    color: "var(--tooltip-color)",
+  },
   ".cm-tooltip-arrow:after": {
-    borderTopColor: "var(--tooltip-color) !important",
+    borderTopColor: "inherit !important",
   },
   ".cm-tooltip-arrow:before": {
-    borderTopColor: "var(--tooltip-color) !important",
+    borderTopColor: "inherit !important",
   },
   ".cm-tooltip.cm-tooltip-autocomplete > ul": {
     fontFamily: "var(--font-mono)",
@@ -234,11 +237,14 @@ export const inputTheme = EditorView.theme({
     border: "none",
     borderRadius: "4px",
   },
+  ".cm-tooltip-arrow": {
+    color: "var(--tooltip-color)",
+  },
   ".cm-tooltip-arrow:after": {
-    borderTopColor: "var(--tooltip-color) !important",
+    borderTopColor: "currentColor !important",
   },
   ".cm-tooltip-arrow:before": {
-    borderTopColor: "var(--tooltip-color) !important",
+    borderTopColor: "currentColor !important",
   },
   ".cm-tooltip.cm-tooltip-autocomplete > ul": {
     fontFamily: "var(--font-mono)",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2607 

### Description

- Adds edit action on environment variable tooltip:
![image](https://user-images.githubusercontent.com/15387723/197411817-4dd2b6f8-6ba4-4193-80ac-14075690caf2.png)

- When the edit icon is clicked, the environment edit modal is opened with the variable value auto selected
![image](https://user-images.githubusercontent.com/15387723/197411851-20d422b7-8ecb-47c6-8142-b44332300229.png)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
- Implements two new actions handler to invoke the environment edit modals;
- Changes the approach on `environments/index.vue` to conditionally render env components to use v-show instead of v-if, so the modals can be called even when the correspondent tab is not active;
- Adds option to pass parameters to `invokeAction` method
- Adds `selectText` prop to EnvInput so it can auto select the text on the input when it's rendered