### PR TITLE
fix: codemirror field overflow

### DIFF
--- a/packages/hoppscotch-app/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-app/src/components/smart/EnvInput.vue
@@ -1,8 +1,8 @@
 <template>
   <div
-    class="relative py-4 flex items-center flex-1 flex-shrink-0 overflow-auto whitespace-nowrap"
+    class="relative flex items-center flex-1 flex-shrink-0 py-4 overflow-auto whitespace-nowrap"
   >
-    <div class="absolute flex flex-1">
+    <div class="absolute inset-0 flex flex-1">
       <div
         ref="editor"
         :placeholder="placeholder"

--- a/packages/hoppscotch-app/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-app/src/components/smart/EnvInput.vue
@@ -1,17 +1,19 @@
 <template>
   <div
-    class="flex items-center flex-1 flex-shrink-0 overflow-auto whitespace-nowrap"
+    class="relative py-4 flex items-center flex-1 flex-shrink-0 overflow-auto whitespace-nowrap"
   >
-    <div
-      ref="editor"
-      :placeholder="placeholder"
-      class="flex flex-1"
-      :class="styles"
-      @keydown.enter.prevent="emit('enter', $event)"
-      @keyup="emit('keyup', $event)"
-      @click="emit('click', $event)"
-      @keydown="emit('keydown', $event)"
-    ></div>
+    <div class="absolute flex flex-1">
+      <div
+        ref="editor"
+        :placeholder="placeholder"
+        class="flex flex-1"
+        :class="styles"
+        @keydown.enter.prevent="emit('enter', $event)"
+        @keyup="emit('keyup', $event)"
+        @click="emit('click', $event)"
+        @keydown="emit('keydown', $event)"
+      ></div>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
Closes #2823 

### Description
This PR fixes the issue where some codemirror fields doesn't wrap and pushes the UI elements away when overflowing.

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

