### PR TITLE
fix: linting erroring out on graphql queries

### DIFF
--- a/packages/hoppscotch-app/src/helpers/editor/linting/gqlQuery.ts
+++ b/packages/hoppscotch-app/src/helpers/editor/linting/gqlQuery.ts
@@ -28,8 +28,8 @@ export const createGQLQueryLinter: (
             ch: locations![0].column - 1,
           },
           to: {
-            line: locations![0].line - 1,
-            ch: locations![0].column,
+            line: locations![0].line,
+            ch: locations![0].column - 1,
           },
           message,
           severity: "error",


### PR DESCRIPTION
fixes HOPPSCOTCH-APP-33

**Before**

1. Go to the graphql page
2. Connect
3. Send a valid request
4. Make some spelling errors
5. Send the request
6. We get a `Mark decorations may not be empty` error

**After**

This PR fixes it