### PR TITLE
fix: errors on opening json outline

### DIFF
--- a/packages/hoppscotch-app/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-app/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -100,7 +100,7 @@
           interactive
           trigger="click"
           theme="popover"
-          :on-shown="() => tippyActions.focus()"
+          :on-shown="() => tippyActions[index].focus()"
         >
           <div v-if="item.kind === 'RootObject'" class="outline-item">{}</div>
           <div v-if="item.kind === 'RootArray'" class="outline-item">[]</div>


### PR DESCRIPTION
**Before**
Calling `tippyActions.focus()` was failing because tippyActions was a ref inside a v-for, and hence an array of tippyActions refs.

**After**
Use indexes to access refs inside a v-for