### PR TITLE
refactor: move global env to top in UI

### DIFF
--- a/packages/hoppscotch-app/src/components.d.ts
+++ b/packages/hoppscotch-app/src/components.d.ts
@@ -109,7 +109,6 @@ declare module '@vue/runtime-core' {
     IconLucideSearch: typeof import('~icons/lucide/search')['default']
     IconLucideUser: typeof import('~icons/lucide/user')['default']
     IconLucideUsers: typeof import('~icons/lucide/users')['default']
-    IconLucideVerified: typeof import('~icons/lucide/verified')['default']
     LensesHeadersRenderer: typeof import('./components/lenses/HeadersRenderer.vue')['default']
     LensesHeadersRendererEntry: typeof import('./components/lenses/HeadersRendererEntry.vue')['default']
     LensesRenderersHTMLLensRenderer: typeof import('./components/lenses/renderers/HTMLLensRenderer.vue')['default']

--- a/packages/hoppscotch-app/src/components.d.ts
+++ b/packages/hoppscotch-app/src/components.d.ts
@@ -55,6 +55,7 @@ declare module '@vue/runtime-core' {
     CollectionsTeamsRequest: typeof import('./components/collections/teams/Request.vue')['default']
     Environments: typeof import('./components/environments/index.vue')['default']
     EnvironmentsChooseType: typeof import('./components/environments/ChooseType.vue')['default']
+    EnvironmentsDetail: typeof import('./components/environments/Detail.vue')['default']
     EnvironmentsImportExport: typeof import('./components/environments/ImportExport.vue')['default']
     EnvironmentsMy: typeof import('./components/environments/my/index.vue')['default']
     EnvironmentsMyDetails: typeof import('./components/environments/my/Details.vue')['default']

--- a/packages/hoppscotch-app/src/components.d.ts
+++ b/packages/hoppscotch-app/src/components.d.ts
@@ -100,6 +100,7 @@ declare module '@vue/runtime-core' {
     IconLucideArrowLeft: typeof import('~icons/lucide/arrow-left')['default']
     IconLucideCheckCircle: typeof import('~icons/lucide/check-circle')['default']
     IconLucideChevronRight: typeof import('~icons/lucide/chevron-right')['default']
+    IconLucideGlobe: typeof import('~icons/lucide/globe')['default']
     IconLucideInbox: typeof import('~icons/lucide/inbox')['default']
     IconLucideInfo: typeof import('~icons/lucide/info')['default']
     IconLucideLayers: typeof import('~icons/lucide/layers')['default']

--- a/packages/hoppscotch-app/src/components/collections/ChooseType.vue
+++ b/packages/hoppscotch-app/src/components/collections/ChooseType.vue
@@ -130,6 +130,15 @@ onLoggedIn(() => {
   adapter.initialize()
 })
 
+watch(
+  () => currentUser.value,
+  (user) => {
+    if (!user) {
+      selectedCollectionTab.value = "my-collections"
+    }
+  }
+)
+
 const onTeamSelectIntersect = () => {
   // Load team data as soon as intersection
   adapter.fetchList()

--- a/packages/hoppscotch-app/src/components/environments/ChooseType.vue
+++ b/packages/hoppscotch-app/src/components/environments/ChooseType.vue
@@ -77,7 +77,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from "vue"
-import { Team } from "~/helpers/backend/graphql"
+import { GetMyTeamsQuery } from "~/helpers/backend/graphql"
 import { onLoggedIn } from "@composables/auth"
 import { currentUserInfo$ } from "~/helpers/teams/BackendUserInfo"
 import TeamListAdapter from "~/helpers/teams/TeamListAdapter"
@@ -89,7 +89,9 @@ import IconUsers from "~icons/lucide/users"
 
 const t = useI18n()
 
-type SelectedTeam = Team | undefined
+type TeamData = GetMyTeamsQuery["myTeams"][number]
+
+type SelectedTeam = TeamData | undefined
 
 type EnvironmentTabs = "my-environments" | "team-environments"
 
@@ -125,6 +127,15 @@ watch(myTeams, (teams) => {
     }
   }
 })
+
+watch(
+  () => currentUser.value,
+  (user) => {
+    if (!user) {
+      selectedEnvironmentTab.value = "my-environments"
+    }
+  }
+)
 
 onLoggedIn(() => {
   adapter.initialize()

--- a/packages/hoppscotch-app/src/components/environments/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/index.vue
@@ -152,7 +152,7 @@
       <EnvironmentsMyEnvironment
         environment-index="Global"
         :environment="globalEnvironment"
-        class="border-b border-dividerLight py-1"
+        class="border-b border-dividerLight"
         @edit-environment="editEnvironment('Global')"
       />
       <EnvironmentsChooseType

--- a/packages/hoppscotch-app/src/components/environments/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/index.vue
@@ -149,6 +149,12 @@
           </div>
         </template>
       </tippy>
+      <EnvironmentsMyEnvironment
+        environment-index="Global"
+        :environment="globalEnvironment"
+        class="border-b border-dividerLight py-1"
+        @edit-environment="editEnvironment('Global')"
+      />
       <EnvironmentsChooseType
         :environment-type="environmentType"
         @update-environment-type="updateEnvironmentType"
@@ -163,6 +169,12 @@
       :loading="loading"
       :adapter-error="adapterError"
     />
+    <EnvironmentsMyDetails
+      :show="showModalDetails"
+      :action="action"
+      :editing-environment-index="editingEnvironmentIndex"
+      @hide-modal="displayModalEdit(false)"
+    />
   </div>
 </template>
 
@@ -175,6 +187,7 @@ import { useReadonlyStream, useStream } from "@composables/stream"
 import { useI18n } from "~/composables/i18n"
 import {
   environments$,
+  globalEnv$,
   selectedEnvironmentIndex$,
   setSelectedEnvironmentIndex,
 } from "~/newstore/environments"
@@ -198,6 +211,13 @@ const environmentType = ref<EnvironmentsChooseType>({
   type: "my-environments",
   selectedTeam: undefined,
 })
+
+const globalEnv = useReadonlyStream(globalEnv$, [])
+
+const globalEnvironment = computed(() => ({
+  name: "Global",
+  variables: globalEnv.value,
+}))
 
 const currentUser = useReadonlyStream(currentUser$, null)
 
@@ -232,6 +252,27 @@ watch(
     }
   }
 )
+
+const showModalDetails = ref(false)
+const action = ref<"new" | "edit">("edit")
+const editingEnvironmentIndex = ref<"Global" | null>(null)
+
+const displayModalEdit = (shouldDisplay: boolean) => {
+  action.value = "edit"
+  showModalDetails.value = shouldDisplay
+
+  if (!shouldDisplay) resetSelectedData()
+}
+
+const editEnvironment = (environmentIndex: "Global") => {
+  editingEnvironmentIndex.value = environmentIndex
+  action.value = "edit"
+  displayModalEdit(true)
+}
+
+const resetSelectedData = () => {
+  editingEnvironmentIndex.value = null
+}
 
 const myEnvironments = useReadonlyStream(environments$, [])
 

--- a/packages/hoppscotch-app/src/components/environments/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/index.vue
@@ -161,9 +161,9 @@
         @update-selected-team="updateSelectedTeam"
       />
     </div>
-    <EnvironmentsMy v-show="environmentType.type === 'my-environments'" />
+    <EnvironmentsMy v-if="environmentType.type === 'my-environments'" />
     <EnvironmentsTeams
-      v-show="environmentType.type === 'team-environments'"
+      v-if="environmentType.type === 'team-environments'"
       :team="environmentType.selectedTeam"
       :team-environments="teamEnvironmentList"
       :loading="loading"
@@ -195,6 +195,7 @@ import TeamEnvironmentAdapter from "~/helpers/teams/TeamEnvironmentAdapter"
 import { GQLError } from "~/helpers/backend/GQLClient"
 import IconCheck from "~icons/lucide/check"
 import { TippyComponent } from "vue-tippy"
+import { defineActionHandler } from "~/helpers/actions"
 
 const t = useI18n()
 
@@ -256,6 +257,7 @@ watch(
 const showModalDetails = ref(false)
 const action = ref<"new" | "edit">("edit")
 const editingEnvironmentIndex = ref<"Global" | null>(null)
+const editingVariableName = ref("")
 
 const displayModalEdit = (shouldDisplay: boolean) => {
   action.value = "edit"
@@ -273,6 +275,14 @@ const editEnvironment = (environmentIndex: "Global") => {
 const resetSelectedData = () => {
   editingEnvironmentIndex.value = null
 }
+
+defineActionHandler(
+  "modals.my.environment.edit",
+  ({ envName, variableName }) => {
+    editingVariableName.value = variableName
+    envName === "Global" && editEnvironment("Global")
+  }
+)
 
 const myEnvironments = useReadonlyStream(environments$, [])
 

--- a/packages/hoppscotch-app/src/components/environments/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/index.vue
@@ -173,6 +173,7 @@
       :show="showModalDetails"
       :action="action"
       :editing-environment-index="editingEnvironmentIndex"
+      :editing-variable-name="editingVariableName"
       @hide-modal="displayModalEdit(false)"
     />
   </div>

--- a/packages/hoppscotch-app/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/Details.vue
@@ -165,7 +165,7 @@ const props = withDefaults(
     show: boolean
     action: "edit" | "new"
     editingEnvironmentIndex: number | "Global" | null
-    editingVariableName?: string | null
+    editingVariableName: string | null
     envVars?: () => Environment["variables"]
   }>(),
   {

--- a/packages/hoppscotch-app/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/Details.vue
@@ -165,13 +165,14 @@ const props = withDefaults(
     show: boolean
     action: "edit" | "new"
     editingEnvironmentIndex: number | "Global" | null
-    editingVariableName: string | null
+    editingVariableName?: string | null
     envVars?: () => Environment["variables"]
   }>(),
   {
     show: false,
     action: "edit",
     editingEnvironmentIndex: null,
+    editingVariableName: null,
     envVars: () => [],
   }
 )

--- a/packages/hoppscotch-app/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/Environment.vue
@@ -4,6 +4,14 @@
     @contextmenu.prevent="options!.tippy.show()"
   >
     <span
+      v-if="environmentIndex === 'Global'"
+      class="flex items-center justify-center px-4 cursor-pointer"
+      @click="emit('edit-environment')"
+    >
+      <icon-lucide-globe class="svg-icons" />
+    </span>
+    <span
+      v-else
       class="flex items-center justify-center px-4 cursor-pointer"
       @click="emit('edit-environment')"
     >
@@ -70,7 +78,7 @@
               "
             />
             <SmartItem
-              v-if="!(environmentIndex === 'Global')"
+              v-if="environmentIndex !== 'Global'"
               ref="deleteAction"
               :icon="IconTrash2"
               :label="`${t('action.delete')}`"

--- a/packages/hoppscotch-app/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/index.vue
@@ -123,7 +123,7 @@ defineActionHandler(
         return environment.name === envName
       }
     )
-    envName !== "Global" && editEnvironment(envIndex)
+    if (envName !== "Global") editEnvironment(envIndex)
   }
 )
 </script>

--- a/packages/hoppscotch-app/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/index.vue
@@ -89,7 +89,7 @@ const environments = useReadonlyStream(environments$, [])
 const showModalImportExport = ref(false)
 const showModalDetails = ref(false)
 const action = ref<"new" | "edit">("edit")
-const editingEnvironmentIndex = ref<number | "Global" | null>(null)
+const editingEnvironmentIndex = ref<number | null>(null)
 const editingVariableName = ref("")
 
 const displayModalAdd = (shouldDisplay: boolean) => {
@@ -105,7 +105,7 @@ const displayModalEdit = (shouldDisplay: boolean) => {
 const displayModalImportExport = (shouldDisplay: boolean) => {
   showModalImportExport.value = shouldDisplay
 }
-const editEnvironment = (environmentIndex: number | "Global") => {
+const editEnvironment = (environmentIndex: number) => {
   editingEnvironmentIndex.value = environmentIndex
   action.value = "edit"
   displayModalEdit(true)
@@ -123,7 +123,7 @@ defineActionHandler(
         return environment.name === envName
       }
     )
-    editEnvironment(envIndex >= 0 ? envIndex : "Global")
+    envName !== "Global" && editEnvironment(envIndex)
   }
 )
 </script>

--- a/packages/hoppscotch-app/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/index.vue
@@ -89,7 +89,7 @@ const environments = useReadonlyStream(environments$, [])
 const showModalImportExport = ref(false)
 const showModalDetails = ref(false)
 const action = ref<"new" | "edit">("edit")
-const editingEnvironmentIndex = ref<number | null>(null)
+const editingEnvironmentIndex = ref<number | "Global" | null>(null)
 const editingVariableName = ref("")
 
 const displayModalAdd = (shouldDisplay: boolean) => {
@@ -105,7 +105,7 @@ const displayModalEdit = (shouldDisplay: boolean) => {
 const displayModalImportExport = (shouldDisplay: boolean) => {
   showModalImportExport.value = shouldDisplay
 }
-const editEnvironment = (environmentIndex: number) => {
+const editEnvironment = (environmentIndex: number | "Global") => {
   editingEnvironmentIndex.value = environmentIndex
   action.value = "edit"
   displayModalEdit(true)

--- a/packages/hoppscotch-app/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/index.vue
@@ -26,12 +26,6 @@
       </div>
     </div>
     <EnvironmentsMyEnvironment
-      environment-index="Global"
-      :environment="globalEnvironment"
-      class="border-b border-dashed border-dividerLight"
-      @edit-environment="editEnvironment('Global')"
-    />
-    <EnvironmentsMyEnvironment
       v-for="(environment, index) in environments"
       :key="`environment-${index}`"
       :environment-index="index"
@@ -76,8 +70,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue"
-import { environments$, globalEnv$ } from "~/newstore/environments"
+import { ref } from "vue"
+import { environments$ } from "~/newstore/environments"
 import { useColorMode } from "~/composables/theming"
 import { useReadonlyStream } from "@composables/stream"
 import { useI18n } from "~/composables/i18n"
@@ -90,19 +84,12 @@ import { defineActionHandler } from "~/helpers/actions"
 const t = useI18n()
 const colorMode = useColorMode()
 
-const globalEnv = useReadonlyStream(globalEnv$, [])
-
-const globalEnvironment = computed(() => ({
-  name: "Global",
-  variables: globalEnv.value,
-}))
-
 const environments = useReadonlyStream(environments$, [])
 
 const showModalImportExport = ref(false)
 const showModalDetails = ref(false)
 const action = ref<"new" | "edit">("edit")
-const editingEnvironmentIndex = ref<number | "Global" | null>(null)
+const editingEnvironmentIndex = ref<number | null>(null)
 const editingVariableName = ref("")
 
 const displayModalAdd = (shouldDisplay: boolean) => {
@@ -118,7 +105,7 @@ const displayModalEdit = (shouldDisplay: boolean) => {
 const displayModalImportExport = (shouldDisplay: boolean) => {
   showModalImportExport.value = shouldDisplay
 }
-const editEnvironment = (environmentIndex: number | "Global") => {
+const editEnvironment = (environmentIndex: number) => {
   editingEnvironmentIndex.value = environmentIndex
   action.value = "edit"
   displayModalEdit(true)

--- a/packages/hoppscotch-app/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-app/src/components/environments/my/index.vue
@@ -32,7 +32,6 @@
       :environment="environment"
       @edit-environment="editEnvironment(index)"
     />
-
     <div
       v-if="environments.length === 0"
       class="flex flex-col items-center justify-center p-4 text-secondaryLight"


### PR DESCRIPTION
### Description
This PR moves the global environment above the environment type selection toggle so that it's visible in both my and team's environment state. It also fixes an issue where the environment state does not revert back to my environment when the user logs out.

**Before**

![image](https://user-images.githubusercontent.com/53208152/199581455-a93097b7-378e-4709-957f-642bf5688da4.png)


**After**

![image](https://user-images.githubusercontent.com/53208152/199581374-56182c9f-c663-45fa-92d1-7fc907cf1c0f.png)


### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

