### PR TITLE
chore: remove unwanted debug info

### DIFF
--- a/packages/hoppscotch-app/src/composables/codemirror.ts
+++ b/packages/hoppscotch-app/src/composables/codemirror.ts
@@ -40,8 +40,6 @@ import {
 import { HoppEnvironmentPlugin } from "@helpers/editor/extensions/HoppEnvironment"
 // TODO: Migrate from legacy mode
 
-import { captureException } from "@sentry/vue"
-
 type ExtendedEditorConfig = {
   mode: string
   placeholder: string
@@ -286,7 +284,7 @@ export function useCodemirror(
     view.value?.destroy()
   })
 
-  watch(value, (newVal, oldVal) => {
+  watch(value, (newVal) => {
     if (newVal === undefined) {
       view.value?.destroy()
       view.value = undefined
@@ -297,29 +295,14 @@ export function useCodemirror(
       initView(el.value)
     }
     if (cachedValue.value !== newVal) {
-      try {
-        view.value?.dispatch({
-          filter: false,
-          changes: {
-            from: 0,
-            to: view.value.state.doc.length,
-            insert: newVal,
-          },
-        })
-      } catch (e) {
-        captureException(e, {
-          extra: {
-            newVal,
-            oldVal,
-            changes: {
-              from: 0,
-              to: view.value?.state.doc.length,
-              insert: newVal,
-              cachedValue,
-            },
-          },
-        })
-      }
+      view.value?.dispatch({
+        filter: false,
+        changes: {
+          from: 0,
+          to: view.value.state.doc.length,
+          insert: newVal,
+        },
+      })
     }
     cachedValue.value = newVal
   })


### PR DESCRIPTION
**Before**

We added some sentry debug info, to figure out an edge case bug

**After**

This PR removes those info, since the bug is found and fixed

