### PR TITLE
feat: Ability to test headers in test request

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,10 @@
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:18",
   "forwardPorts": [3000],
 	"features": {
-		"ghcr.io/NicoVIII/devcontainer-features/pnpm:1": {}
+		"ghcr.io/NicoVIII/devcontainer-features/pnpm:1": {},
+			"ghcr.io/devcontainers/features/sshd:1": {
+        "version": "latest"
+    }
 	},
 	"postCreateCommand": "cp packages/hoppscotch-app/.env.example packages/hoppscotch-app/.env && pnpm i"
 }

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ _Add-ons are developed and maintained under **[Hoppscotch Organization](https://
 - [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript)
 - [TypeScript](https://www.typescriptlang.org)
 - [Vue](https://vuejs.org)
-- [Nuxt](https://nuxtjs.org)
+- [Vite](https://vitejs.dev)
 
 ## **Developing**
 

--- a/packages/hoppscotch-app/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-app/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -80,7 +80,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
       const appendEditAction = (tooltip: HTMLElement) => {
         const editIcon = document.createElement("span")
         editIcon.className =
-          "env-icon ml-2 text-accent cursor-pointer hover:text-accentDark"
+          "ml-2 cursor-pointer env-icon text-accent hover:text-accentDark"
         editIcon.addEventListener("click", () => {
           const isPersonalEnv =
             envName === "Global" || selectedEnvType !== "TEAM_ENV"
@@ -90,7 +90,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
             variableName: parsedEnvKey,
           })
         })
-        editIcon.innerHTML = `<i class="inline-flex -my-1 -mx-1 items-center px-1 text-base material-icons border-secondary">drive_file_rename_outline</i>`
+        editIcon.innerHTML = `<i class="inline-flex items-center px-1 -mx-1 -my-1 text-base material-icons border-secondary">drive_file_rename_outline</i>`
         tooltip.appendChild(editIcon)
       }
 
@@ -105,7 +105,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
           const kbd = document.createElement("kbd")
           const icon = document.createElement("span")
           icon.innerHTML = envTypeIcon
-          icon.className = "env-icon mr-2"
+          icon.className = "mr-2 env-icon"
           kbd.textContent = finalEnv
           tooltipContainer.appendChild(icon)
           tooltipContainer.appendChild(document.createTextNode(`${envName} `))

--- a/packages/hoppscotch-app/src/helpers/terndoc/pw-test.json
+++ b/packages/hoppscotch-app/src/helpers/terndoc/pw-test.json
@@ -10,7 +10,8 @@
       "toBeLevel5xx": "fn()",
       "toBeType": "fn(type: string)",
       "toHaveLength": "fn(length: number)",
-      "toInclude": "fn(value: ?)"
+      "toInclude": "fn(value: ?)",
+      "toHaveHeaderValue": "fn(header_value_tuple: string)"
     }
   },
   "pw": {

--- a/packages/hoppscotch-js-sandbox/src/__tests__/testing/expect/toHaveHeaderValue.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/testing/expect/toHaveHeaderValue.spec.ts
@@ -1,0 +1,93 @@
+import * as TE from "fp-ts/TaskEither"
+import { pipe } from "fp-ts/function"
+import { execTestScript, TestResponse } from "../../../test-runner"
+import "@relmify/jest-fp-ts"
+
+const fakeResponse: TestResponse = {
+  status: 200,
+  body: "hoi",
+  headers: [
+    { key: "content-type", value: "application/text" },
+    { key: "content-length", value: "20030519" },
+  ],
+}
+
+const func = (script: string, res: TestResponse) =>
+  pipe(
+    execTestScript(script, { global: [], selected: [] }, res),
+    TE.map((x) => x.tests)
+  )
+
+describe("toHaveHeaderValue", () => {
+  test("assertion passes for valid header and value", async () => {
+    expect(
+      func(
+        `pw.expect(pw.response.headers).toHaveHeaderValue("content-length:20030519")`,
+        fakeResponse
+      )()
+    ).resolves.toEqualRight([
+      expect.objectContaining({
+        expectResults: [
+          {
+            status: "pass",
+            message: `Header, content-length is 20030519`,
+          },
+        ],
+      }),
+    ])
+  })
+
+  test("assertion passes for valid header but wrong value", async () => {
+    expect(
+      func(
+        `pw.expect(pw.response.headers).toHaveHeaderValue("content-length:200314010404")`,
+        fakeResponse
+      )()
+    ).resolves.toEqualRight([
+      expect.objectContaining({
+        expectResults: [
+          {
+            status: "fail",
+            message: `Header, content-length is 20030519, expected 200314010404`,
+          },
+        ],
+      }),
+    ])
+  })
+
+  test("assertion passes for not-clause valid header and value", async () => {
+    expect(
+      func(
+        `pw.expect(pw.response.headers).not.toHaveHeaderValue("content-length:200314010404")`,
+        fakeResponse
+      )()
+    ).resolves.toEqualRight([
+      expect.objectContaining({
+        expectResults: [
+          {
+            status: "pass",
+            message: `Header, content-length is not 200314010404`,
+          },
+        ],
+      }),
+    ])
+  })
+
+  test("assertion fails for absence of header", async () => {
+    expect(
+      func(
+        `pw.expect(pw.response.headers).toHaveHeaderValue("access-control-allow-origin:hoppscotch.io")`,
+        fakeResponse
+      )()
+    ).resolves.toEqualRight([
+      expect.objectContaining({
+        expectResults: [
+          {
+            status: "fail",
+            message: `Header, access-control-allow-origin is missing to test`,
+          },
+        ],
+      }),
+    ])
+  })
+})


### PR DESCRIPTION
Closes #2852 

### Description
This PR includes commit to add shortcut method to test for headers and their value from the response in test scripts. This function also supports negation with `not`

### Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
Now, a test to the header can be done as followed...
![hoppscotch_toHaveHeaderValue](https://user-images.githubusercontent.com/45619033/201560485-0f188d3f-fe98-40d1-a953-0f4dbee8f16b.PNG)
