### PR TITLE
fix: delete not working properly on request body

### DIFF
--- a/packages/hoppscotch-app/src/components/http/BodyParameters.vue
+++ b/packages/hoppscotch-app/src/components/http/BodyParameters.vue
@@ -332,7 +332,9 @@ const deleteBodyParam = (index: number) => {
     })
   }
 
-  workingParams.value.splice(index, 1)
+  workingParams.value = workingParams.value.filter(
+    (_, arrIndex) => arrIndex != index
+  )
 }
 
 const clearContent = () => {


### PR DESCRIPTION
fixs #2859

**Before**

See the mentioned issue for more info.

we were using ```Array.splice``` to remove an element from an array. but this was not triggering a watcher on the array.

**After**

we now use ```Array.filter``` to remove an element from an array and the reactivity works