### PR TITLE
fix: cannot write to body when a request is loaded from history

### DIFF
--- a/packages/hoppscotch-common/src/components/history/index.vue
+++ b/packages/hoppscotch-common/src/components/history/index.vue
@@ -99,7 +99,7 @@
           :show-more="showMore"
           @toggle-star="toggleStar(entry.entry)"
           @delete-entry="deleteHistory(entry.entry)"
-          @use-entry="useHistory(entry.entry)"
+          @use-entry="useHistory(toRaw(entry.entry))"
         />
       </details>
     </div>

--- a/packages/hoppscotch-common/src/components/history/index.vue
+++ b/packages/hoppscotch-common/src/components/history/index.vue
@@ -164,7 +164,7 @@ import IconHelpCircle from "~icons/lucide/help-circle"
 import IconTrash2 from "~icons/lucide/trash-2"
 import IconTrash from "~icons/lucide/trash"
 import IconFilter from "~icons/lucide/filter"
-import { computed, ref, Ref } from "vue"
+import { computed, ref, Ref, toRaw } from "vue"
 import { useColorMode } from "@composables/theming"
 import {
   HoppGQLRequest,


### PR DESCRIPTION
**Before**

After Loading a request from user's hoppscotch history, changes to the request body where not taking effect. this is happening, because we are calling `setRequest` with a computed property, which is readonly.

**After**

We pass the computed property as a normal object to `setRequest` which fixes the issue.