### PR TITLE
fix: my collection search filter empty state UI

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/MyCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/MyCollections.vue
@@ -188,7 +188,16 @@
           />
         </template>
         <template #emptyNode="{ node }">
-          <div v-if="node === null">
+          <div
+            v-if="filterText.length !== 0 && filteredCollections.length === 0"
+            class="flex flex-col items-center justify-center p-4 text-secondaryLight"
+          >
+            <icon-lucide-search class="pb-2 opacity-75 svg-icons" />
+            <span class="my-2 text-center">
+              {{ t("state.nothing_found") }} "{{ filterText }}"
+            </span>
+          </div>
+          <div v-else-if="node === null">
             <div
               class="flex flex-col items-center justify-center p-4 text-secondaryLight"
             >
@@ -249,19 +258,6 @@
             />
             <span class="text-center">
               {{ t("empty.folder") }}
-            </span>
-          </div>
-          <div
-            v-if="
-              filterText.length !== 0 &&
-              filteredCollections.length === 0 &&
-              node === null
-            "
-            class="flex flex-col items-center justify-center p-4 text-secondaryLight"
-          >
-            <icon-lucide-search class="pb-2 opacity-75 svg-icons" />
-            <span class="my-2 text-center">
-              {{ t("state.nothing_found") }} "{{ filterText }}"
             </span>
           </div>
         </template>

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -437,6 +437,7 @@ const filteredCollections = computed(() => {
       if (isMatch(request.name)) filteredRequests.push(request)
     }
     for (const folder of collection.folders) {
+      if (isMatch(folder.name)) filteredFolders.push(folder)
       const filteredFolderRequests = []
       for (const request of folder.requests) {
         if (isMatch(request.name)) filteredFolderRequests.push(request)


### PR DESCRIPTION
### Description
This PR fixes the my-collection search filter empty state UI and improves the search feature.

#### Before

![image](https://user-images.githubusercontent.com/53208152/215789590-dfe0c445-f695-4796-8cbe-52368f1b39f2.png)

#### After

![image](https://user-images.githubusercontent.com/53208152/215789900-9c9eb14e-48c0-40e0-904d-cf42e57a9964.png)



### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
