### PR TITLE
fix: graphql save request emit payload

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/graphql/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Collection.vue
@@ -225,6 +225,7 @@ import {
   removeGraphqlCollection,
   moveGraphqlRequest,
 } from "~/newstore/collections"
+import { Picked } from "~/helpers/types/HoppPicked"
 
 const props = defineProps({
   picked: { type: Object, default: null },
@@ -241,7 +242,7 @@ const t = useI18n()
 
 // TODO: improve types plz
 const emit = defineEmits<{
-  (e: "select", i: { picked: any }): void
+  (e: "select", i: Picked | null): void
   (e: "edit-request", i: any): void
   (e: "duplicate-request", i: any): void
   (e: "add-request", i: any): void
@@ -277,10 +278,8 @@ const collectionIcon = computed(() => {
 
 const pick = () => {
   emit("select", {
-    picked: {
-      pickedType: "gql-my-collection",
-      collectionIndex: props.collectionIndex,
-    },
+    pickedType: "gql-my-collection",
+    collectionIndex: props.collectionIndex,
   })
 }
 
@@ -298,7 +297,7 @@ const removeCollection = () => {
     props.picked?.pickedType === "gql-my-collection" &&
     props.picked?.collectionIndex === props.collectionIndex
   ) {
-    emit("select", { picked: null })
+    emit("select", null)
   }
   removeGraphqlCollection(props.collectionIndex)
   toast.success(`${t("state.deleted")}`)

--- a/packages/hoppscotch-common/src/components/collections/graphql/Request.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Request.vue
@@ -169,11 +169,9 @@ const isSelected = computed(
 
 const pick = () => {
   emit("select", {
-    picked: {
-      pickedType: "gql-my-request",
-      folderPath: props.folderPath,
-      requestIndex: props.requestIndex,
-    },
+    pickedType: "gql-my-request",
+    folderPath: props.folderPath,
+    requestIndex: props.requestIndex,
   })
 }
 
@@ -213,7 +211,7 @@ const removeRequest = () => {
     props.picked.folderPath === props.folderPath &&
     props.picked.requestIndex === props.requestIndex
   ) {
-    emit("select", { picked: null })
+    emit("select", null)
   }
 
   removeGraphqlRequest(props.folderPath, props.requestIndex)


### PR DESCRIPTION
### Description
This PR fixes the bug in graphQl save request modal which the emitted payload was sent incorrectly, the type was changed in #2865.

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
