### PR TITLE
feat: active tab no longer resets after request

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -12,38 +12,26 @@
   </div>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, watch, ref } from "vue"
+<script setup lang="ts">
+import { computed, watch, ref } from "vue"
 import { startPageProgress, completePageProgress } from "@modules/loadingbar"
 import { useReadonlyStream } from "@composables/stream"
 import { restResponse$ } from "~/newstore/RESTSession"
 
-export default defineComponent({
-  setup() {
-    const response = useReadonlyStream(restResponse$, null)
+const response = useReadonlyStream(restResponse$, null)
 
-    const savedSelectedLensTab = ref<string | undefined>()
+const savedSelectedLensTab = ref<string | undefined>()
 
-    const hasResponse = computed(
-      () =>
-        response.value?.type === "success" || response.value?.type === "fail"
-    )
+const hasResponse = computed(
+  () => response.value?.type === "success" || response.value?.type === "fail"
+)
 
-    const loading = computed(
-      () => response.value === null || response.value.type === "loading"
-    )
+const loading = computed(
+  () => response.value === null || response.value.type === "loading"
+)
 
-    watch(response, () => {
-      if (response.value?.type === "loading") startPageProgress()
-      else completePageProgress()
-    })
-
-    return {
-      hasResponse,
-      loading,
-      response,
-      savedSelectedLensTab,
-    }
-  },
+watch(response, () => {
+  if (response.value?.type === "loading") startPageProgress()
+  else completePageProgress()
 })
 </script>

--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -3,13 +3,17 @@
     <HttpResponseMeta :response="response" />
     <LensesResponseBodyRenderer
       v-if="!loading && hasResponse"
-      :response="response"
+      :response="response!"
+      :saved-selected-lens-tab="savedSelectedLensTab"
+      @changeSelectedLensTabPersistedOption="
+        (tab) => (savedSelectedLensTab = tab)
+      "
     />
   </div>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, watch } from "vue"
+import { computed, defineComponent, watch, ref } from "vue"
 import { startPageProgress, completePageProgress } from "@modules/loadingbar"
 import { useReadonlyStream } from "@composables/stream"
 import { restResponse$ } from "~/newstore/RESTSession"
@@ -17,6 +21,8 @@ import { restResponse$ } from "~/newstore/RESTSession"
 export default defineComponent({
   setup() {
     const response = useReadonlyStream(restResponse$, null)
+
+    const savedSelectedLensTab = ref<string | undefined>()
 
     const hasResponse = computed(
       () =>
@@ -34,8 +40,9 @@ export default defineComponent({
 
     return {
       hasResponse,
-      response,
       loading,
+      response,
+      savedSelectedLensTab,
     }
   },
 })

--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -4,23 +4,17 @@
     <LensesResponseBodyRenderer
       v-if="!loading && hasResponse"
       :response="response!"
-      :saved-selected-lens-tab="savedSelectedLensTab"
-      @changeSelectedLensTabPersistedOption="
-        (tab) => (savedSelectedLensTab = tab)
-      "
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, watch, ref } from "vue"
+import { computed, watch } from "vue"
 import { startPageProgress, completePageProgress } from "@modules/loadingbar"
 import { useReadonlyStream } from "@composables/stream"
 import { restResponse$ } from "~/newstore/RESTSession"
 
 const response = useReadonlyStream(restResponse$, null)
-
-const savedSelectedLensTab = ref<string | undefined>()
 
 const hasResponse = computed(
   () => response.value?.type === "success" || response.value?.type === "fail"

--- a/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
@@ -44,18 +44,22 @@
 
 <script lang="ts">
 import { defineComponent } from "vue"
-import { getSuitableLenses, getLensRenderers } from "~/helpers/lenses/lenses"
+import {
+  getSuitableLenses,
+  getLensRenderers,
+  Lens,
+} from "~/helpers/lenses/lenses"
 import { useReadonlyStream } from "@composables/stream"
 import { useI18n } from "@composables/i18n"
 import { restTestResults$ } from "~/newstore/RESTSession"
 
 export default defineComponent({
   components: {
-    // Lens Renderers
     ...getLensRenderers(),
   },
   props: {
     response: { type: Object, default: () => ({}) },
+    savedSelectedLensTab: { type: String },
   },
   setup() {
     const testResults = useReadonlyStream(restTestResults$, null)
@@ -84,11 +88,28 @@ export default defineComponent({
   },
   watch: {
     validLenses: {
-      handler(newValue) {
+      handler(newValue: Lens[]) {
         if (newValue.length === 0) return
-        this.selectedLensTab = newValue[0].renderer
+        const allRenderers = [
+          ...newValue.map((x) => x.renderer),
+          "headers",
+          "results",
+        ]
+        if (
+          this.savedSelectedLensTab &&
+          allRenderers.includes(this.savedSelectedLensTab)
+        ) {
+          this.selectedLensTab = this.savedSelectedLensTab
+        } else {
+          this.selectedLensTab = newValue[0].renderer
+        }
       },
       immediate: true,
+    },
+    selectedLensTab: {
+      handler(newValue) {
+        this.$emit("changeSelectedLensTabPersistedOption", newValue)
+      },
     },
   },
 })

--- a/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
@@ -52,15 +52,11 @@ import {
 import { useReadonlyStream } from "@composables/stream"
 import { useI18n } from "@composables/i18n"
 import { restTestResults$ } from "~/newstore/RESTSession"
+import { setLocalConfig, getLocalConfig } from "~/newstore/localpersistence"
 
 const props = defineProps({
   response: { type: Object, default: () => ({}) },
-  savedSelectedLensTab: { type: String },
 })
-
-const emit = defineEmits<{
-  (e: "changeSelectedLensTabPersistedOption", val: string): void
-}>()
 
 const allLensRenderers = getLensRenderers()
 
@@ -93,11 +89,10 @@ watch(
       "headers",
       "results",
     ]
-    if (
-      props.savedSelectedLensTab &&
-      allRenderers.includes(props.savedSelectedLensTab)
-    ) {
-      selectedLensTab.value = props.savedSelectedLensTab
+    const savedLensTabPreference =
+      getLocalConfig("response_selected_lens_tab") ?? ""
+    if (allRenderers.includes(savedLensTabPreference)) {
+      selectedLensTab.value = savedLensTabPreference
     } else {
       selectedLensTab.value = newValue[0].renderer
     }
@@ -106,6 +101,6 @@ watch(
 )
 
 watch(selectedLensTab, (newValue) => {
-  emit("changeSelectedLensTabPersistedOption", newValue)
+  setLocalConfig("response_selected_lens_tab", newValue)
 })
 </script>


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2080

### Description
<!-- Add a brief description of the pull request -->
When the `ResponseBodyRenderer` component renders for each request, the active tab (json, raw etc) is always set to the first one. Users prefer if same tab is persisted. So I moved tab preferences from `ResponseBodyRenderer` to parent so it loads with previously opened tab.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
