### PR TITLE
feat: active tab no longer resets after request

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -12,38 +12,26 @@
   </div>
 </template>
 
-<script lang="ts">
-import { computed, defineComponent, watch, ref } from "vue"
+<script setup lang="ts">
+import { computed, watch, ref } from "vue"
 import { startPageProgress, completePageProgress } from "@modules/loadingbar"
 import { useReadonlyStream } from "@composables/stream"
 import { restResponse$ } from "~/newstore/RESTSession"
 
-export default defineComponent({
-  setup() {
-    const response = useReadonlyStream(restResponse$, null)
+const response = useReadonlyStream(restResponse$, null)
 
-    const savedSelectedLensTab = ref<string | undefined>()
+const savedSelectedLensTab = ref<string | undefined>()
 
-    const hasResponse = computed(
-      () =>
-        response.value?.type === "success" || response.value?.type === "fail"
-    )
+const hasResponse = computed(
+  () => response.value?.type === "success" || response.value?.type === "fail"
+)
 
-    const loading = computed(
-      () => response.value === null || response.value.type === "loading"
-    )
+const loading = computed(
+  () => response.value === null || response.value.type === "loading"
+)
 
-    watch(response, () => {
-      if (response.value?.type === "loading") startPageProgress()
-      else completePageProgress()
-    })
-
-    return {
-      hasResponse,
-      loading,
-      response,
-      savedSelectedLensTab,
-    }
-  },
+watch(response, () => {
+  if (response.value?.type === "loading") startPageProgress()
+  else completePageProgress()
 })
 </script>

--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -3,16 +3,19 @@
     <HttpResponseMeta :response="response" />
     <LensesResponseBodyRenderer
       v-if="!loading && hasResponse"
-      :response="response!"
+      v-model:selected-tab-preference="selectedTabPreference"
+      :response="response"
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from "vue"
+import { ref, computed, watch } from "vue"
 import { startPageProgress, completePageProgress } from "@modules/loadingbar"
 import { useReadonlyStream } from "@composables/stream"
 import { restResponse$ } from "~/newstore/RESTSession"
+
+const selectedTabPreference = ref<string | null>(null)
 
 const response = useReadonlyStream(restResponse$, null)
 

--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -3,13 +3,17 @@
     <HttpResponseMeta :response="response" />
     <LensesResponseBodyRenderer
       v-if="!loading && hasResponse"
-      :response="response"
+      :response="response!"
+      :saved-selected-lens-tab="savedSelectedLensTab"
+      @changeSelectedLensTabPersistedOption="
+        (tab) => (savedSelectedLensTab = tab)
+      "
     />
   </div>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, watch } from "vue"
+import { computed, defineComponent, watch, ref } from "vue"
 import { startPageProgress, completePageProgress } from "@modules/loadingbar"
 import { useReadonlyStream } from "@composables/stream"
 import { restResponse$ } from "~/newstore/RESTSession"
@@ -17,6 +21,8 @@ import { restResponse$ } from "~/newstore/RESTSession"
 export default defineComponent({
   setup() {
     const response = useReadonlyStream(restResponse$, null)
+
+    const savedSelectedLensTab = ref<string | undefined>()
 
     const hasResponse = computed(
       () =>
@@ -34,8 +40,9 @@ export default defineComponent({
 
     return {
       hasResponse,
-      response,
       loading,
+      response,
+      savedSelectedLensTab,
     }
   },
 })

--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -4,23 +4,17 @@
     <LensesResponseBodyRenderer
       v-if="!loading && hasResponse"
       :response="response!"
-      :saved-selected-lens-tab="savedSelectedLensTab"
-      @changeSelectedLensTabPersistedOption="
-        (tab) => (savedSelectedLensTab = tab)
-      "
     />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed, watch, ref } from "vue"
+import { computed, watch } from "vue"
 import { startPageProgress, completePageProgress } from "@modules/loadingbar"
 import { useReadonlyStream } from "@composables/stream"
 import { restResponse$ } from "~/newstore/RESTSession"
 
 const response = useReadonlyStream(restResponse$, null)
-
-const savedSelectedLensTab = ref<string | undefined>()
 
 const hasResponse = computed(
   () => response.value?.type === "success" || response.value?.type === "fail"

--- a/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
+++ b/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
@@ -107,7 +107,7 @@ const t = useI18n()
 const colorMode = useColorMode()
 
 const props = defineProps<{
-  response: HoppRESTResponse
+  response: HoppRESTResponse | null
 }>()
 
 /**
@@ -118,6 +118,8 @@ const props = defineProps<{
  */
 const readableResponseSize = computed(() => {
   if (
+    // This is called only in case response is not null, null checking done for tsc
+    props.response === null ||
     props.response.type === "loading" ||
     props.response.type === "network_fail" ||
     props.response.type === "script_fail" ||
@@ -135,6 +137,8 @@ const readableResponseSize = computed(() => {
 
 const statusCategory = computed(() => {
   if (
+    // This is called only in case response is not null, null checking done for tsc
+    props.response === null ||
     props.response.type === "loading" ||
     props.response.type === "network_fail" ||
     props.response.type === "script_fail" ||

--- a/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
+++ b/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
@@ -118,7 +118,6 @@ const props = defineProps<{
  */
 const readableResponseSize = computed(() => {
   if (
-    // This is called only in case response is not null, null checking done for tsc
     props.response === null ||
     props.response.type === "loading" ||
     props.response.type === "network_fail" ||
@@ -137,7 +136,6 @@ const readableResponseSize = computed(() => {
 
 const statusCategory = computed(() => {
   if (
-    // This is called only in case response is not null, null checking done for tsc
     props.response === null ||
     props.response.type === "loading" ||
     props.response.type === "network_fail" ||

--- a/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
@@ -31,14 +31,14 @@ import { refAutoReset } from "@vueuse/core"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
-import type { HoppRESTResponseHeaderKV } from "~/helpers/types/HoppRESTResponse"
+import type { HoppRESTResponseHeader } from "~/helpers/types/HoppRESTResponse"
 
 const t = useI18n()
 
 const toast = useToast()
 
 const props = defineProps<{
-  headers: HoppRESTResponseHeaderKV[]
+  headers: HoppRESTResponseHeader[]
 }>()
 
 const copyIcon = refAutoReset<typeof IconCopy | typeof IconCheck>(

--- a/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
@@ -27,18 +27,18 @@
 <script setup lang="ts">
 import IconCopy from "~icons/lucide/copy"
 import IconCheck from "~icons/lucide/check"
-import { HoppRESTHeader } from "@hoppscotch/data"
 import { refAutoReset } from "@vueuse/core"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
+import type { HoppRESTResponseHeaderKV } from "~/helpers/types/HoppRESTResponse"
 
 const t = useI18n()
 
 const toast = useToast()
 
 const props = defineProps<{
-  headers: Array<HoppRESTHeader>
+  headers: HoppRESTResponseHeaderKV[]
 }>()
 
 const copyIcon = refAutoReset<typeof IconCopy | typeof IconCheck>(

--- a/packages/hoppscotch-common/src/components/lenses/HeadersRendererEntry.vue
+++ b/packages/hoppscotch-common/src/components/lenses/HeadersRendererEntry.vue
@@ -30,7 +30,7 @@
 import IconCopy from "~icons/lucide/copy"
 import IconCheck from "~icons/lucide/check"
 import { refAutoReset } from "@vueuse/core"
-import type { HoppRESTHeader } from "@hoppscotch/data"
+import type { HoppRESTResponseHeaderKV } from "~/helpers/types/HoppRESTResponse"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
@@ -40,7 +40,7 @@ const t = useI18n()
 const toast = useToast()
 
 defineProps<{
-  header: HoppRESTHeader
+  header: HoppRESTResponseHeaderKV
 }>()
 
 const copyIcon = refAutoReset<typeof IconCopy | typeof IconCheck>(

--- a/packages/hoppscotch-common/src/components/lenses/HeadersRendererEntry.vue
+++ b/packages/hoppscotch-common/src/components/lenses/HeadersRendererEntry.vue
@@ -30,7 +30,7 @@
 import IconCopy from "~icons/lucide/copy"
 import IconCheck from "~icons/lucide/check"
 import { refAutoReset } from "@vueuse/core"
-import type { HoppRESTResponseHeaderKV } from "~/helpers/types/HoppRESTResponse"
+import type { HoppRESTResponseHeader } from "~/helpers/types/HoppRESTResponse"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
@@ -40,7 +40,7 @@ const t = useI18n()
 const toast = useToast()
 
 defineProps<{
-  header: HoppRESTResponseHeaderKV
+  header: HoppRESTResponseHeader
 }>()
 
 const copyIcon = refAutoReset<typeof IconCopy | typeof IconCheck>(

--- a/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
@@ -44,18 +44,22 @@
 
 <script lang="ts">
 import { defineComponent } from "vue"
-import { getSuitableLenses, getLensRenderers } from "~/helpers/lenses/lenses"
+import {
+  getSuitableLenses,
+  getLensRenderers,
+  Lens,
+} from "~/helpers/lenses/lenses"
 import { useReadonlyStream } from "@composables/stream"
 import { useI18n } from "@composables/i18n"
 import { restTestResults$ } from "~/newstore/RESTSession"
 
 export default defineComponent({
   components: {
-    // Lens Renderers
     ...getLensRenderers(),
   },
   props: {
     response: { type: Object, default: () => ({}) },
+    savedSelectedLensTab: { type: String },
   },
   setup() {
     const testResults = useReadonlyStream(restTestResults$, null)
@@ -84,11 +88,28 @@ export default defineComponent({
   },
   watch: {
     validLenses: {
-      handler(newValue) {
+      handler(newValue: Lens[]) {
         if (newValue.length === 0) return
-        this.selectedLensTab = newValue[0].renderer
+        const allRenderers = [
+          ...newValue.map((x) => x.renderer),
+          "headers",
+          "results",
+        ]
+        if (
+          this.savedSelectedLensTab &&
+          allRenderers.includes(this.savedSelectedLensTab)
+        ) {
+          this.selectedLensTab = this.savedSelectedLensTab
+        } else {
+          this.selectedLensTab = newValue[0].renderer
+        }
       },
       immediate: true,
+    },
+    selectedLensTab: {
+      handler(newValue) {
+        this.$emit("changeSelectedLensTabPersistedOption", newValue)
+      },
     },
   },
 })

--- a/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
@@ -90,14 +90,16 @@ watch(
   validLenses,
   (newValue: Lens[]) => {
     if (newValue.length === 0) return
-    const allRenderers = [
+    const validRenderers = [
       ...newValue.map((x) => x.renderer),
       "headers",
       "results",
     ]
-    const savedLensTabPreference =
-      getLocalConfig("response_selected_lens_tab") ?? ""
-    if (allRenderers.includes(savedLensTabPreference)) {
+    const savedLensTabPreference = getLocalConfig("response_selected_lens_tab")
+    if (
+      savedLensTabPreference &&
+      validRenderers.includes(savedLensTabPreference)
+    ) {
       selectedLensTab.value = savedLensTabPreference
     } else {
       selectedLensTab.value = newValue[0].renderer

--- a/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
@@ -52,15 +52,11 @@ import {
 import { useReadonlyStream } from "@composables/stream"
 import { useI18n } from "@composables/i18n"
 import { restTestResults$ } from "~/newstore/RESTSession"
+import { setLocalConfig, getLocalConfig } from "~/newstore/localpersistence"
 
 const props = defineProps({
   response: { type: Object, default: () => ({}) },
-  savedSelectedLensTab: { type: String },
 })
-
-const emit = defineEmits<{
-  (e: "changeSelectedLensTabPersistedOption", val: string): void
-}>()
 
 const allLensRenderers = getLensRenderers()
 
@@ -93,11 +89,10 @@ watch(
       "headers",
       "results",
     ]
-    if (
-      props.savedSelectedLensTab &&
-      allRenderers.includes(props.savedSelectedLensTab)
-    ) {
-      selectedLensTab.value = props.savedSelectedLensTab
+    const savedLensTabPreference =
+      getLocalConfig("response_selected_lens_tab") ?? ""
+    if (allRenderers.includes(savedLensTabPreference)) {
+      selectedLensTab.value = savedLensTabPreference
     } else {
       selectedLensTab.value = newValue[0].renderer
     }
@@ -106,6 +101,6 @@ watch(
 )
 
 watch(selectedLensTab, (newValue) => {
-  emit("changeSelectedLensTabPersistedOption", newValue)
+  setLocalConfig("response_selected_lens_tab", newValue)
 })
 </script>

--- a/packages/hoppscotch-common/src/helpers/types/HoppRESTResponse.ts
+++ b/packages/hoppscotch-common/src/helpers/types/HoppRESTResponse.ts
@@ -1,12 +1,12 @@
 import { HoppRESTRequest } from "@hoppscotch/data"
 
-export type HoppRESTResponseHeaderKV = { key: string; value: string }
+export type HoppRESTResponseHeader = { key: string; value: string }
 
 export type HoppRESTResponse =
   | { type: "loading"; req: HoppRESTRequest }
   | {
       type: "fail"
-      headers: HoppRESTResponseHeaderKV[]
+      headers: HoppRESTResponseHeader[]
       body: ArrayBuffer
       statusCode: number
 
@@ -29,7 +29,7 @@ export type HoppRESTResponse =
     }
   | {
       type: "success"
-      headers: HoppRESTResponseHeaderKV[]
+      headers: HoppRESTResponseHeader[]
       body: ArrayBuffer
       statusCode: number
       meta: {

--- a/packages/hoppscotch-common/src/helpers/types/HoppRESTResponse.ts
+++ b/packages/hoppscotch-common/src/helpers/types/HoppRESTResponse.ts
@@ -1,10 +1,12 @@
 import { HoppRESTRequest } from "@hoppscotch/data"
 
+export type HoppRESTResponseHeaderKV = { key: string; value: string }
+
 export type HoppRESTResponse =
   | { type: "loading"; req: HoppRESTRequest }
   | {
       type: "fail"
-      headers: { key: string; value: string }[]
+      headers: HoppRESTResponseHeaderKV[]
       body: ArrayBuffer
       statusCode: number
 
@@ -27,7 +29,7 @@ export type HoppRESTResponse =
     }
   | {
       type: "success"
-      headers: { key: string; value: string }[]
+      headers: HoppRESTResponseHeaderKV[]
       body: ArrayBuffer
       statusCode: number
       meta: {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2080 

Intended to be follow up of https://github.com/hoppscotch/hoppscotch/pull/2915

### Description
<!-- Add a brief description of the pull request -->
[Excerpt from #2915]
When the ResponseBodyRenderer component renders for each request, the active tab (json, raw etc) is always set to the first one. Users prefer if same tab is persisted. So I moved tab preferences from ResponseBodyRenderer to parent so it loads with previously opened tab.


ResponseBodyRenderer had response props of `{ type: Object, default: () => ({}) }`. Updated to `{ type: Object as PropType<HoppRESTResponse> | null }` instead. 

Which uncovered that `headers` prop in `HeadersRendererEntry.vue` and `header` prop in `HeadersRenderer.vue` were wrongly given as `HoppRESTHeader` (it has key, value, active properties). Updated those to the `HoppRESTResponseHeaderKV` type.

In `ResponseMeta.vue` response prop was updated to `HoppRESTResponse | null`. Updated the code so tsc finds the null checks ok.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
