### PR TITLE
fix: response time for requests via extension has incorrect value

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -274,6 +274,10 @@ import { createShortcode } from "~/helpers/backend/mutations/Shortcode"
 import { runMutation } from "~/helpers/backend/GQLClient"
 import { UpdateRequestDocument } from "~/helpers/backend/graphql"
 import { getPlatformSpecialKey as getSpecialKey } from "~/helpers/platformutils"
+import {
+  cancelRunningExtensionRequest,
+  hasExtensionInstalled,
+} from "~/helpers/strategies/ExtensionStrategy"
 
 const t = useI18n()
 
@@ -403,6 +407,9 @@ function isCURL(curl: string) {
 
 const cancelRequest = () => {
   loading.value = false
+  if (hasExtensionInstalled()) {
+    cancelRunningExtensionRequest()
+  }
   updateRESTResponse(null)
 }
 

--- a/packages/hoppscotch-common/src/helpers/strategies/ExtensionStrategy.ts
+++ b/packages/hoppscotch-common/src/helpers/strategies/ExtensionStrategy.ts
@@ -16,7 +16,7 @@ export const hasFirefoxExtensionInstalled = () =>
   hasExtensionInstalled() && browserIsFirefox()
 
 export const cancelRunningExtensionRequest = () => {
-  window.__POSTWOMAN_EXTENSION_HOOK__?.cancelRunningRequest()
+  window.__POSTWOMAN_EXTENSION_HOOK__?.cancelRequest()
 }
 
 export const defineSubscribableObject = <T extends object>(obj: T) => {

--- a/packages/hoppscotch-common/src/shims.d.ts
+++ b/packages/hoppscotch-common/src/shims.d.ts
@@ -8,7 +8,7 @@ interface PWExtensionHook {
   sendRequest: (
     req: AxiosRequestConfig & { wantsBinary: boolean }
   ) => Promise<NetworkResponse>
-  cancelRunningRequest: () => void
+  cancelRequest: () => void
 }
 
 type HoppExtensionStatusHook = {
@@ -18,7 +18,7 @@ type HoppExtensionStatusHook = {
   }
   subscribe(prop: "status", func: (...args: any[]) => any): void
 }
-declare global {
+export declare global {
   interface Window {
     __POSTWOMAN_EXTENSION_HOOK__: PWExtensionHook | undefined
     __HOPP_EXTENSION_STATUS_PROXY__: HoppExtensionStatusHook | undefined

--- a/packages/hoppscotch-common/src/shims.d.ts
+++ b/packages/hoppscotch-common/src/shims.d.ts
@@ -24,11 +24,3 @@ export declare global {
     __HOPP_EXTENSION_STATUS_PROXY__: HoppExtensionStatusHook | undefined
   }
 }
-
-// Vue builtins
-declare module '*.vue' {
-  import type { DefineComponent } from 'vue'
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
-  const component: DefineComponent<{}, {}, any>
-  export default component
-}


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #2897

### Description
<!-- Add a brief description of the pull request -->
The reported bug was in the extension. If one request had failed to return a response, second request shows a huge response time and threw an error. We guessed some object whose reference was shared between requests. Calling the `cancelRequest()` on the extension fixed the response time problem and the error.

Fixed the typing interface for `window.__POSTWOMAN_EXTENSION_HOOK__` with correct [method name](https://github.com/hoppscotch/hoppscotch-extension/blob/main/src/index.ts#L265) . Exported the `window` typing, seems it wasn't previously doing anything.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
