### PR TITLE
chore: move environments firebase things to hoppscotch-web

### DIFF
--- a/packages/hoppscotch-common/src/helpers/fb/index.ts
+++ b/packages/hoppscotch-common/src/helpers/fb/index.ts
@@ -27,7 +27,7 @@ export function initializeFirebase() {
       initSettings()
       initCollections()
       initHistory()
-      platform.environments.initEnvironments()
+      platform.sync.environments.initEnvironmentsSync()
       initAnalytics()
 
       initialized = true

--- a/packages/hoppscotch-common/src/helpers/fb/index.ts
+++ b/packages/hoppscotch-common/src/helpers/fb/index.ts
@@ -2,7 +2,6 @@ import { initializeApp } from "firebase/app"
 import { platform } from "~/platform"
 import { initAnalytics } from "./analytics"
 import { initCollections } from "./collections"
-import { initEnvironments } from "./environments"
 import { initHistory } from "./history"
 import { initSettings } from "./settings"
 
@@ -28,7 +27,7 @@ export function initializeFirebase() {
       initSettings()
       initCollections()
       initHistory()
-      initEnvironments()
+      platform.environments.initEnvironments()
       initAnalytics()
 
       initialized = true

--- a/packages/hoppscotch-common/src/platform/environments.ts
+++ b/packages/hoppscotch-common/src/platform/environments.ts
@@ -1,3 +1,3 @@
 export type EnvironmentsPlatformDef = {
-  initEnvironments: () => void
+  initEnvironmentsSync: () => void
 }

--- a/packages/hoppscotch-common/src/platform/environments.ts
+++ b/packages/hoppscotch-common/src/platform/environments.ts
@@ -1,0 +1,3 @@
+export type EnvironmentsPlatformDef = {
+  initEnvironments: () => void
+}

--- a/packages/hoppscotch-common/src/platform/index.ts
+++ b/packages/hoppscotch-common/src/platform/index.ts
@@ -1,9 +1,11 @@
 import { AuthPlatformDef } from "./auth"
 import { UIPlatformDef } from "./ui"
+import { EnvironmentsPlatformDef } from "./environments"
 
 export type PlatformDef = {
   ui?: UIPlatformDef
   auth: AuthPlatformDef
+  environments: EnvironmentsPlatformDef
 }
 
 export let platform: PlatformDef

--- a/packages/hoppscotch-common/src/platform/index.ts
+++ b/packages/hoppscotch-common/src/platform/index.ts
@@ -5,7 +5,9 @@ import { EnvironmentsPlatformDef } from "./environments"
 export type PlatformDef = {
   ui?: UIPlatformDef
   auth: AuthPlatformDef
-  environments: EnvironmentsPlatformDef
+  sync: {
+    environments: EnvironmentsPlatformDef
+  }
 }
 
 export let platform: PlatformDef

--- a/packages/hoppscotch-web/src/environments.ts
+++ b/packages/hoppscotch-web/src/environments.ts
@@ -6,14 +6,18 @@ import {
   onSnapshot,
   setDoc,
 } from "firebase/firestore"
-import { platform } from "~/platform"
+import { def as platformAuth } from "./firebase/auth"
 import {
   environments$,
   globalEnv$,
   replaceEnvironments,
   setGlobalEnvVariables,
-} from "~/newstore/environments"
-import { getSettingSubject, settingsStore } from "~/newstore/settings"
+} from "@hoppscotch/common/newstore/environments"
+import {
+  getSettingSubject,
+  settingsStore,
+} from "@hoppscotch/common/newstore/settings"
+import { EnvironmentsPlatformDef } from "@hoppscotch/common/platform/environments"
 
 /**
  * Used locally to prevent infinite loop when environment sync update
@@ -32,7 +36,7 @@ let loadedEnvironments = false
 let loadedGlobals = true
 
 async function writeEnvironments(environment: Environment[]) {
-  const currentUser = platform.auth.getCurrentUser()
+  const currentUser = platformAuth.getCurrentUser()
 
   if (currentUser === null)
     throw new Error("Cannot write environments when signed out")
@@ -57,7 +61,7 @@ async function writeEnvironments(environment: Environment[]) {
 }
 
 async function writeGlobalEnvironment(variables: Environment["variables"]) {
-  const currentUser = platform.auth.getCurrentUser()
+  const currentUser = platformAuth.getCurrentUser()
 
   if (currentUser === null)
     throw new Error("Cannot write global environment when signed out")
@@ -82,10 +86,10 @@ async function writeGlobalEnvironment(variables: Environment["variables"]) {
 }
 
 export function initEnvironments() {
-  const currentUser$ = platform.auth.getCurrentUserStream()
+  const currentUser$ = platformAuth.getCurrentUserStream()
 
   const envListenSub = environments$.subscribe((envs) => {
-    const currentUser = platform.auth.getCurrentUser()
+    const currentUser = platformAuth.getCurrentUser()
 
     if (
       currentUser &&
@@ -97,7 +101,7 @@ export function initEnvironments() {
   })
 
   const globalListenSub = globalEnv$.subscribe((vars) => {
-    const currentUser = platform.auth.getCurrentUser()
+    const currentUser = platformAuth.getCurrentUser()
 
     if (currentUser && settingsStore.value.syncEnvironments && loadedGlobals) {
       writeGlobalEnvironment(vars)
@@ -175,4 +179,8 @@ export function initEnvironments() {
       }
     }
   )
+}
+
+export const def: EnvironmentsPlatformDef = {
+  initEnvironments,
 }

--- a/packages/hoppscotch-web/src/environments.ts
+++ b/packages/hoppscotch-web/src/environments.ts
@@ -85,7 +85,7 @@ async function writeGlobalEnvironment(variables: Environment["variables"]) {
   }
 }
 
-export function initEnvironments() {
+export function initEnvironmentsSync() {
   const currentUser$ = platformAuth.getCurrentUserStream()
 
   const envListenSub = environments$.subscribe((envs) => {
@@ -175,12 +175,12 @@ export function initEnvironments() {
         globalListenSub.unsubscribe()
         currentUserSub.unsubscribe()
 
-        initEnvironments()
+        initEnvironmentsSync()
       }
     }
   )
 }
 
 export const def: EnvironmentsPlatformDef = {
-  initEnvironments,
+  initEnvironmentsSync,
 }

--- a/packages/hoppscotch-web/src/main.ts
+++ b/packages/hoppscotch-web/src/main.ts
@@ -4,5 +4,7 @@ import { def as envDef } from "./environments"
 
 createHoppApp("#app", {
   auth: authDef,
-  environments: envDef,
+  sync: {
+    environments: envDef,
+  },
 })

--- a/packages/hoppscotch-web/src/main.ts
+++ b/packages/hoppscotch-web/src/main.ts
@@ -1,6 +1,8 @@
 import { createHoppApp } from "@hoppscotch/common"
 import { def as authDef } from "./firebase/auth"
+import { def as envDef } from "./environments"
 
 createHoppApp("#app", {
   auth: authDef,
+  environments: envDef,
 })


### PR DESCRIPTION
This PR extracts out the environments firebase syncing to hoppscotch-web, and defines the common interface to be used with other hoppscotch platforms.