### PR TITLE
chore: move collections sync system to platform

### DIFF
--- a/packages/hoppscotch-common/src/helpers/fb/index.ts
+++ b/packages/hoppscotch-common/src/helpers/fb/index.ts
@@ -1,7 +1,6 @@
 import { initializeApp } from "firebase/app"
 import { platform } from "~/platform"
 import { initAnalytics } from "./analytics"
-import { initCollections } from "./collections"
 import { initHistory } from "./history"
 import { initSettings } from "./settings"
 
@@ -25,7 +24,7 @@ export function initializeFirebase() {
 
       platform.auth.performAuthInit()
       initSettings()
-      initCollections()
+      platform.sync.collections.initCollectionsSync()
       initHistory()
       platform.sync.environments.initEnvironmentsSync()
       initAnalytics()

--- a/packages/hoppscotch-common/src/platform/collections.ts
+++ b/packages/hoppscotch-common/src/platform/collections.ts
@@ -1,0 +1,3 @@
+export type CollectionsPlatformDef = {
+  initCollectionsSync: () => void
+}

--- a/packages/hoppscotch-common/src/platform/index.ts
+++ b/packages/hoppscotch-common/src/platform/index.ts
@@ -1,12 +1,14 @@
 import { AuthPlatformDef } from "./auth"
 import { UIPlatformDef } from "./ui"
 import { EnvironmentsPlatformDef } from "./environments"
+import { CollectionsPlatformDef } from "./collections"
 
 export type PlatformDef = {
   ui?: UIPlatformDef
   auth: AuthPlatformDef
   sync: {
     environments: EnvironmentsPlatformDef
+    collections: CollectionsPlatformDef
   }
 }
 

--- a/packages/hoppscotch-web/package.json
+++ b/packages/hoppscotch-web/package.json
@@ -28,7 +28,8 @@
     "stream-browserify": "^3.0.0",
     "util": "^0.12.4",
     "vue": "^3.2.41",
-    "workbox-window": "^6.5.4"
+    "workbox-window": "^6.5.4",
+    "@hoppscotch/data": "workspace:^0.4.4"
   },
   "devDependencies": {
     "@intlify/vite-plugin-vue-i18n": "^6.0.1",

--- a/packages/hoppscotch-web/src/collections.ts
+++ b/packages/hoppscotch-web/src/collections.ts
@@ -9,14 +9,22 @@ import {
   translateToNewRESTCollection,
   translateToNewGQLCollection,
 } from "@hoppscotch/data"
-import { platform } from "~/platform"
+
+import { def as platformAuth } from "./firebase/auth"
+
 import {
   restCollections$,
   graphqlCollections$,
   setRESTCollections,
   setGraphqlCollections,
-} from "~/newstore/collections"
-import { getSettingSubject, settingsStore } from "~/newstore/settings"
+} from "@hoppscotch/common/newstore/collections"
+
+import {
+  getSettingSubject,
+  settingsStore,
+} from "@hoppscotch/common/newstore/settings"
+
+import { CollectionsPlatformDef } from "@hoppscotch/common/platform/collections"
 
 type CollectionFlags = "collectionsGraphql" | "collections"
 
@@ -40,11 +48,8 @@ let loadedRESTCollections = false
  */
 let loadedGraphqlCollections = false
 
-export async function writeCollections(
-  collection: any[],
-  flag: CollectionFlags
-) {
-  const currentUser = platform.auth.getCurrentUser()
+async function writeCollections(collection: any[], flag: CollectionFlags) {
+  const currentUser = platformAuth.getCurrentUser()
 
   if (currentUser === null)
     throw new Error("User not logged in to write collections")
@@ -68,11 +73,11 @@ export async function writeCollections(
   }
 }
 
-export function initCollections() {
-  const currentUser$ = platform.auth.getCurrentUserStream()
+function initCollectionsSync() {
+  const currentUser$ = platformAuth.getCurrentUserStream()
 
   const restCollSub = restCollections$.subscribe((collections) => {
-    const currentUser = platform.auth.getCurrentUser()
+    const currentUser = platformAuth.getCurrentUser()
 
     if (
       loadedRESTCollections &&
@@ -84,7 +89,7 @@ export function initCollections() {
   })
 
   const gqlCollSub = graphqlCollections$.subscribe((collections) => {
-    const currentUser = platform.auth.getCurrentUser()
+    const currentUser = platformAuth.getCurrentUser()
 
     if (
       loadedGraphqlCollections &&
@@ -177,8 +182,12 @@ export function initCollections() {
         gqlCollSub.unsubscribe()
         currentUserSub.unsubscribe()
 
-        initCollections()
+        initCollectionsSync()
       }
     }
   )
+}
+
+export const def: CollectionsPlatformDef = {
+  initCollectionsSync,
 }

--- a/packages/hoppscotch-web/src/main.ts
+++ b/packages/hoppscotch-web/src/main.ts
@@ -1,10 +1,12 @@
 import { createHoppApp } from "@hoppscotch/common"
 import { def as authDef } from "./firebase/auth"
 import { def as envDef } from "./environments"
+import { def as collectionsDef } from "./collections"
 
 createHoppApp("#app", {
   auth: authDef,
   sync: {
     environments: envDef,
+    collections: collectionsDef,
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,7 +345,7 @@ importers:
       vite-plugin-inspect: 0.7.4_vite@3.1.4
       vite-plugin-pages: 0.26.0_vnheu5mvzzbfbuhqo4shkhdhei
       vite-plugin-pages-sitemap: 1.4.0
-      vite-plugin-pwa: 0.13.1_bg4cnt4dy3xq3a47wkujd6ryzq
+      vite-plugin-pwa: 0.13.1_vite@3.1.4
       vite-plugin-vue-layouts: 0.7.0_oewzdqozxqnqgsrjzmwikx34vi
       vite-plugin-windicss: 1.8.8_vite@3.1.4
       vue-tsc: 0.38.2_typescript@4.7.4
@@ -551,6 +551,7 @@ importers:
   packages/hoppscotch-web:
     specifiers:
       '@hoppscotch/common': workspace:^
+      '@hoppscotch/data': workspace:^0.4.4
       '@hoppscotch/ui': workspace:^
       '@intlify/vite-plugin-vue-i18n': ^6.0.1
       '@rushstack/eslint-patch': ^1.1.4
@@ -588,6 +589,7 @@ importers:
       workbox-window: ^6.5.4
     dependencies:
       '@hoppscotch/common': link:../hoppscotch-common
+      '@hoppscotch/data': link:../hoppscotch-data
       '@hoppscotch/ui': link:../hoppscotch-ui
       buffer: 6.0.3
       firebase: 9.8.4
@@ -618,7 +620,7 @@ importers:
       vite-plugin-inspect: 0.7.4_vite@3.2.4
       vite-plugin-pages: 0.26.0_vite@3.2.4
       vite-plugin-pages-sitemap: 1.4.0
-      vite-plugin-pwa: 0.13.1_3kw35epztoiwny7qtfesjexvtu
+      vite-plugin-pwa: 0.13.1_vite@3.2.4
       vite-plugin-static-copy: 0.12.0_vite@3.2.4
       vite-plugin-vue-layouts: 0.7.0_vite@3.2.4+vue@3.2.45
       vite-plugin-windicss: 1.8.8_vite@3.2.4
@@ -5723,7 +5725,7 @@ packages:
     dev: true
 
   /after/0.8.2:
-    resolution: {integrity: sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=}
+    resolution: {integrity: sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA==}
     dev: false
 
   /agent-base/6.0.2:
@@ -6080,7 +6082,7 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   /base64-arraybuffer/0.1.4:
-    resolution: {integrity: sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=}
+    resolution: {integrity: sha512-a1eIFi4R9ySrbiMuyTGx5e92uRH5tQY6kArNcFaKBUleIoLjdjBg7Zxm3Mqm3Kmkf27HLR/1fnxX9q8GQ7Iavg==}
     engines: {node: '>= 0.6.0'}
     dev: false
 
@@ -6542,7 +6544,7 @@ packages:
     dev: true
 
   /component-bind/1.0.0:
-    resolution: {integrity: sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=}
+    resolution: {integrity: sha512-WZveuKPeKAG9qY+FkYDeADzdHyTYdIboXS59ixDeRJL5ZhxpqUnxSOwop4FQjMsiYm3/Or8cegVbpAHNA7pHxw==}
     dev: false
 
   /component-emitter/1.3.0:
@@ -6550,7 +6552,7 @@ packages:
     dev: false
 
   /component-inherit/0.0.3:
-    resolution: {integrity: sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=}
+    resolution: {integrity: sha512-w+LhYREhatpVqTESyGFg3NlP6Iu0kEKUHETY9GoZP/pQyW4mHFZuFWRUCIqVPZ36ueVLtoOEZaAqbCF2RDndaA==}
     dev: false
 
   /concat-map/0.0.1:
@@ -8954,7 +8956,7 @@ packages:
     dev: false
 
   /has-cors/1.1.0:
-    resolution: {integrity: sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=}
+    resolution: {integrity: sha512-g5VNKdkFuUuVCP9gYfDJHjK2nqdQJ7aDLTnycnc2+RvsOQbuLdF5pm7vuE5J76SEBIQjs4kQY/BWq74JUmjbXA==}
     dev: false
 
   /has-flag/3.0.0:
@@ -9258,7 +9260,7 @@ packages:
     engines: {node: '>=8'}
 
   /indexof/0.0.1:
-    resolution: {integrity: sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=}
+    resolution: {integrity: sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==}
     dev: false
 
   /inflight/1.0.6:
@@ -12953,7 +12955,7 @@ packages:
     dev: true
 
   /to-array/0.1.4:
-    resolution: {integrity: sha1-F+bBH3PdTz10zaek/zI46a2b+JA=}
+    resolution: {integrity: sha512-LhVdShQD/4Mk4zXNroIQZJC+Ap3zgLcDuwEdcmLv9CCO73NWockQDwyUnW/m8VX/EElfL6FcYx7EeutN4HJA6A==}
     dev: false
 
   /to-fast-properties/2.0.0:
@@ -14023,29 +14025,10 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-pwa/0.13.1_3kw35epztoiwny7qtfesjexvtu:
+  /vite-plugin-pwa/0.13.1_vite@3.1.4:
     resolution: {integrity: sha512-NR3dIa+o2hzlzo4lF4Gu0cYvoMjSw2DdRc6Epw1yjmCqWaGuN86WK9JqZie4arNlE1ZuWT3CLiMdiX5wcmmUmg==}
     peerDependencies:
       vite: ^3.1.0
-      workbox-window: ^6.5.4
-    dependencies:
-      debug: 4.3.4
-      fast-glob: 3.2.11
-      pretty-bytes: 6.0.0
-      rollup: 2.79.1
-      vite: 3.2.4
-      workbox-build: 6.5.4
-      workbox-window: 6.5.4
-    transitivePeerDependencies:
-      - '@types/babel__core'
-      - supports-color
-    dev: true
-
-  /vite-plugin-pwa/0.13.1_bg4cnt4dy3xq3a47wkujd6ryzq:
-    resolution: {integrity: sha512-NR3dIa+o2hzlzo4lF4Gu0cYvoMjSw2DdRc6Epw1yjmCqWaGuN86WK9JqZie4arNlE1ZuWT3CLiMdiX5wcmmUmg==}
-    peerDependencies:
-      vite: ^3.1.0
-      workbox-window: ^6.5.4
     dependencies:
       debug: 4.3.4
       fast-glob: 3.2.11
@@ -14063,7 +14046,6 @@ packages:
     resolution: {integrity: sha512-NR3dIa+o2hzlzo4lF4Gu0cYvoMjSw2DdRc6Epw1yjmCqWaGuN86WK9JqZie4arNlE1ZuWT3CLiMdiX5wcmmUmg==}
     peerDependencies:
       vite: ^3.1.0
-      workbox-window: ^6.5.4
     dependencies:
       debug: 4.3.4
       fast-glob: 3.2.11
@@ -14071,6 +14053,7 @@ packages:
       rollup: 2.79.1
       vite: 3.2.4_sass@1.53.0
       workbox-build: 6.5.4
+      workbox-window: 6.5.4
     transitivePeerDependencies:
       - '@types/babel__core'
       - supports-color
@@ -15099,7 +15082,7 @@ packages:
     dev: false
 
   /yeast/0.1.2:
-    resolution: {integrity: sha1-AI4G2AlDIMNy28L47XagymyKxBk=}
+    resolution: {integrity: sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg==}
     dev: false
 
   /yn/3.1.1:


### PR DESCRIPTION
This PR extracts out the collections firebase syncing to hoppscotch-web, and defines the common interface to be used with other hoppscotch platforms.