### PR TITLE
refactor: optional variables to createEnvironment and fixing the order of initializing GqlClient

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -304,8 +304,7 @@ const saveEnvironment = () => {
 
   if (props.action === "new") {
     // Creating a new environment
-    createEnvironment(name.value)
-    updateEnvironment(envList.value.length - 1, environmentUpdated)
+    createEnvironment(name.value, environmentUpdated.variables)
     setSelectedEnvironmentIndex({
       type: "MY_ENV",
       index: envList.value.length - 1,

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -115,9 +115,7 @@ import {
   deleteEnvironment,
   duplicateEnvironment,
   createEnvironment,
-  setEnvironmentVariables,
   getGlobalVariables,
-  environmentsStore,
 } from "~/newstore/environments"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
@@ -154,9 +152,8 @@ const removeEnvironment = () => {
 const duplicateEnvironments = () => {
   if (props.environmentIndex === null) return
   if (props.environmentIndex === "Global") {
-    createEnvironment(`Global - ${t("action.duplicate")}`)
-    setEnvironmentVariables(
-      environmentsStore.value.environments.length - 1,
+    createEnvironment(
+      `Global - ${t("action.duplicate")}`,
       cloneDeep(getGlobalVariables())
     )
   } else duplicateEnvironment(props.environmentIndex)

--- a/packages/hoppscotch-common/src/index.ts
+++ b/packages/hoppscotch-common/src/index.ts
@@ -19,8 +19,8 @@ export function createHoppApp(el: string | Element, platformDef: PlatformDef) {
   const app = createApp(App)
 
   // Some basic work that needs to be done before module inits even
-  initializeFirebase()
   initBackendGQLClient()
+  initializeFirebase()
   setupLocalPersistence()
   performMigrations()
 

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -62,14 +62,14 @@ const dispatchers = defineDispatchers({
   },
   createEnvironment(
     { environments }: EnvironmentStore,
-    { name }: { name: string }
+    { name, variables }: { name: string; variables: Environment["variables"] }
   ) {
     return {
       environments: [
         ...environments,
         {
           name,
-          variables: [],
+          variables: variables,
         },
       ],
     }
@@ -469,11 +469,15 @@ export function appendEnvironments(envs: Environment[]) {
   })
 }
 
-export function createEnvironment(envName: string) {
+export function createEnvironment(
+  envName: string,
+  variables?: Environment["variables"]
+) {
   environmentsStore.dispatch({
     dispatcher: "createEnvironment",
     payload: {
       name: envName,
+      variables: variables ?? [],
     },
   })
 }


### PR DESCRIPTION
**Before**

1. the `createEnvironment` store action did not support variables as parameters, we were using two actions `createEnvironment` and `updateEnvironment` just for creation.

2. there existed an edge case where the GQLClient was not initialized when `runGqlSubscription` was called, which caused the subscription to not run 

**After**

1. `createEnvironment` store action accepts optional variables parameter.

2. Updated the order of initializing GQLClient to prevent `runGqlSubscription` from not running subscription