### PR TITLE
refactor: store changes for collections

### DIFF
--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -31,7 +31,7 @@ const defaultGraphqlCollectionState = {
 type RESTCollectionStoreType = typeof defaultRESTCollectionState
 type GraphqlCollectionStoreType = typeof defaultGraphqlCollectionState
 
-function navigateToFolderWithIndexPath(
+export function navigateToFolderWithIndexPath(
   collections: HoppCollection<HoppRESTRequest | HoppGQLRequest>[],
   indexPaths: number[]
 ) {
@@ -97,12 +97,15 @@ const restCollectionDispatchers = defineDispatchers({
     { state }: RESTCollectionStoreType,
     {
       collectionIndex,
-      collection,
-    }: { collectionIndex: number; collection: HoppCollection<any> }
+      partialCollection,
+    }: {
+      collectionIndex: number
+      partialCollection: Partial<HoppCollection<any>>
+    }
   ) {
     return {
       state: state.map((col, index) =>
-        index === collectionIndex ? collection : col
+        index === collectionIndex ? { ...col, ...partialCollection } : col
       ),
     }
   },
@@ -824,13 +827,13 @@ export function getRESTCollection(collectionIndex: number) {
 
 export function editRESTCollection(
   collectionIndex: number,
-  collection: HoppCollection<HoppRESTRequest>
+  partialCollection: Partial<HoppCollection<HoppRESTRequest>>
 ) {
   restCollectionStore.dispatch({
     dispatcher: "editCollection",
     payload: {
       collectionIndex,
-      collection,
+      partialCollection: partialCollection,
     },
   })
 }


### PR DESCRIPTION
**Before**

1. You needed the entire collection to call `editCollection`. This was a limitation when handling `UserCollectionEdited` subscription, because we don't have access to the entire collection. Also the only thing we updated was the collection name.

2. `navigateToFolderWithIndexPath` was not exported, but were required in the sync layer

**After**

1. `editCollection` store dispatcher takes a partial collection as an argument, instead of an entire collection
2. `navigateToFolderWithIndexPath` is exported


