### PR TITLE
refactor: make editFolder, editCollection take Partial collection as parameter

### DIFF
--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -7,6 +7,7 @@ import {
 } from "@hoppscotch/data"
 import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
 import { getRESTSaveContext, setRESTSaveContext } from "./RESTSession"
+import { cloneDeep } from "lodash-es"
 
 const defaultRESTCollectionState = {
   state: [
@@ -105,7 +106,9 @@ const restCollectionDispatchers = defineDispatchers({
   ) {
     return {
       state: state.map((col, index) =>
-        index === collectionIndex ? { ...col, ...partialCollection } : col
+        index === collectionIndex
+          ? { ...col, ...cloneDeep(partialCollection) }
+          : col
       ),
     }
   },
@@ -162,7 +165,7 @@ const restCollectionDispatchers = defineDispatchers({
 
     Object.assign(target, {
       ...target,
-      ...folder,
+      ...cloneDeep(folder),
     })
 
     return {
@@ -547,7 +550,7 @@ const gqlCollectionDispatchers = defineDispatchers({
   ) {
     return {
       state: state.map((col, index) =>
-        index === collectionIndex ? { ...col, ...collection } : col
+        index === collectionIndex ? { ...col, ...cloneDeep(collection) } : col
       ),
     }
   },
@@ -601,7 +604,7 @@ const gqlCollectionDispatchers = defineDispatchers({
 
     Object.assign(target, {
       ...target,
-      ...folder,
+      ...cloneDeep(folder),
     })
 
     return {

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -144,7 +144,7 @@ const restCollectionDispatchers = defineDispatchers({
       folder,
     }: {
       path: string
-      folder: HoppCollection<HoppRESTRequest>
+      folder: Partial<HoppCollection<HoppRESTRequest>>
     }
   ) {
     const newState = state
@@ -160,7 +160,10 @@ const restCollectionDispatchers = defineDispatchers({
       return {}
     }
 
-    Object.assign(target, folder)
+    Object.assign(target, {
+      ...target,
+      ...folder,
+    })
 
     return {
       state: newState,
@@ -540,11 +543,11 @@ const gqlCollectionDispatchers = defineDispatchers({
     {
       collectionIndex,
       collection,
-    }: { collectionIndex: number; collection: HoppCollection<any> }
+    }: { collectionIndex: number; collection: Partial<HoppCollection<any>> }
   ) {
     return {
       state: state.map((col, index) =>
-        index === collectionIndex ? collection : col
+        index === collectionIndex ? { ...col, ...collection } : col
       ),
     }
   },
@@ -578,7 +581,10 @@ const gqlCollectionDispatchers = defineDispatchers({
 
   editFolder(
     { state }: GraphqlCollectionStoreType,
-    { path, folder }: { path: string; folder: HoppCollection<HoppGQLRequest> }
+    {
+      path,
+      folder,
+    }: { path: string; folder: Partial<HoppCollection<HoppGQLRequest>> }
   ) {
     const newState = state
 
@@ -593,7 +599,10 @@ const gqlCollectionDispatchers = defineDispatchers({
       return {}
     }
 
-    Object.assign(target, folder)
+    Object.assign(target, {
+      ...target,
+      ...folder,
+    })
 
     return {
       state: newState,
@@ -850,7 +859,7 @@ export function addRESTFolder(name: string, path: string) {
 
 export function editRESTFolder(
   path: string,
-  folder: HoppCollection<HoppRESTRequest>
+  folder: Partial<HoppCollection<HoppRESTRequest>>
 ) {
   restCollectionStore.dispatch({
     dispatcher: "editFolder",
@@ -1018,7 +1027,7 @@ export function removeGraphqlCollection(collectionIndex: number) {
 
 export function editGraphqlCollection(
   collectionIndex: number,
-  collection: HoppCollection<HoppGQLRequest>
+  collection: Partial<HoppCollection<HoppGQLRequest>>
 ) {
   graphqlCollectionStore.dispatch({
     dispatcher: "editCollection",
@@ -1041,7 +1050,7 @@ export function addGraphqlFolder(name: string, path: string) {
 
 export function editGraphqlFolder(
   path: string,
-  folder: HoppCollection<HoppGQLRequest>
+  folder: Partial<HoppCollection<HoppGQLRequest>>
 ) {
   graphqlCollectionStore.dispatch({
     dispatcher: "editFolder",


### PR DESCRIPTION
before:

editCollection, editFolder dispatchers needed the entire collection to make an edit. this was not ideal when we want to update small part of the collection.

after:

now editFolder and editCollection accepts a partial collection and folder object and merges it with the collection. this is also backward compatible, so no code changes to existing system are needed. 