### PR TITLE
chore: move history firebase things to hoppscotch-web

### DIFF
--- a/packages/hoppscotch-common/src/helpers/fb/index.ts
+++ b/packages/hoppscotch-common/src/helpers/fb/index.ts
@@ -1,7 +1,6 @@
 import { initializeApp } from "firebase/app"
 import { platform } from "~/platform"
 import { initAnalytics } from "./analytics"
-import { initHistory } from "./history"
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_API_KEY,
@@ -24,7 +23,7 @@ export function initializeFirebase() {
       platform.auth.performAuthInit()
       platform.sync.settings.initSettingsSync()
       platform.sync.collections.initCollectionsSync()
-      initHistory()
+      platform.sync.history.initHistorySync()
       platform.sync.environments.initEnvironmentsSync()
       initAnalytics()
 

--- a/packages/hoppscotch-common/src/platform/history.ts
+++ b/packages/hoppscotch-common/src/platform/history.ts
@@ -1,0 +1,3 @@
+export type HistoryPlatformDef = {
+  initHistorySync: () => void
+}

--- a/packages/hoppscotch-common/src/platform/index.ts
+++ b/packages/hoppscotch-common/src/platform/index.ts
@@ -3,6 +3,7 @@ import { UIPlatformDef } from "./ui"
 import { EnvironmentsPlatformDef } from "./environments"
 import { CollectionsPlatformDef } from "./collections"
 import { SettingsPlatformDef } from "./settings"
+import { HistoryPlatformDef } from "./history"
 
 export type PlatformDef = {
   ui?: UIPlatformDef
@@ -11,6 +12,7 @@ export type PlatformDef = {
     environments: EnvironmentsPlatformDef
     collections: CollectionsPlatformDef
     settings: SettingsPlatformDef
+    history: HistoryPlatformDef
   }
 }
 

--- a/packages/hoppscotch-web/src/history.ts
+++ b/packages/hoppscotch-web/src/history.ts
@@ -12,8 +12,11 @@ import {
   updateDoc,
 } from "firebase/firestore"
 import { FormDataKeyValue } from "@hoppscotch/data"
-import { platform } from "~/platform"
-import { getSettingSubject, settingsStore } from "~/newstore/settings"
+import { def as platformAuth } from "./firebase/auth"
+import {
+  getSettingSubject,
+  settingsStore,
+} from "@hoppscotch/common/newstore/settings"
 import {
   GQLHistoryEntry,
   graphqlHistoryStore,
@@ -24,7 +27,8 @@ import {
   setRESTHistoryEntries,
   translateToNewGQLHistory,
   translateToNewRESTHistory,
-} from "~/newstore/history"
+} from "@hoppscotch/common/newstore/history"
+import { HistoryPlatformDef } from "@hoppscotch/common/platform/history"
 
 type HistoryFBCollections = "history" | "graphqlHistory"
 
@@ -76,7 +80,7 @@ async function writeHistory(
       ? purgeFormDataFromRequest(entry as RESTHistoryEntry)
       : entry
 
-  const currentUser = platform.auth.getCurrentUser()
+  const currentUser = platformAuth.getCurrentUser()
 
   if (currentUser === null)
     throw new Error("User not logged in to sync history")
@@ -98,7 +102,7 @@ async function deleteHistory(
   entry: (RESTHistoryEntry | GQLHistoryEntry) & { id: string },
   col: HistoryFBCollections
 ) {
-  const currentUser = platform.auth.getCurrentUser()
+  const currentUser = platformAuth.getCurrentUser()
 
   if (currentUser === null)
     throw new Error("User not logged in to delete history")
@@ -114,7 +118,7 @@ async function deleteHistory(
 }
 
 async function clearHistory(col: HistoryFBCollections) {
-  const currentUser = platform.auth.getCurrentUser()
+  const currentUser = platformAuth.getCurrentUser()
 
   if (currentUser === null)
     throw new Error("User not logged in to clear history")
@@ -130,7 +134,7 @@ async function toggleStar(
   entry: (RESTHistoryEntry | GQLHistoryEntry) & { id: string },
   col: HistoryFBCollections
 ) {
-  const currentUser = platform.auth.getCurrentUser()
+  const currentUser = platformAuth.getCurrentUser()
 
   if (currentUser === null) throw new Error("User not logged in to toggle star")
 
@@ -145,11 +149,11 @@ async function toggleStar(
   }
 }
 
-export function initHistory() {
-  const currentUser$ = platform.auth.getCurrentUserStream()
+export function initHistorySync() {
+  const currentUser$ = platformAuth.getCurrentUserStream()
 
   const restHistorySub = restHistoryStore.dispatches$.subscribe((dispatch) => {
-    const currentUser = platform.auth.getCurrentUser()
+    const currentUser = platformAuth.getCurrentUser()
 
     if (loadedRESTHistory && currentUser && settingsStore.value.syncHistory) {
       if (dispatch.dispatcher === "addEntry") {
@@ -166,7 +170,7 @@ export function initHistory() {
 
   const gqlHistorySub = graphqlHistoryStore.dispatches$.subscribe(
     (dispatch) => {
-      const currentUser = platform.auth.getCurrentUser()
+      const currentUser = platformAuth.getCurrentUser()
 
       if (
         loadedGraphqlHistory &&
@@ -262,7 +266,11 @@ export function initHistory() {
       gqlHistorySub.unsubscribe()
       currentUserSub.unsubscribe()
 
-      initHistory()
+      initHistorySync()
     }
   })
+}
+
+export const def: HistoryPlatformDef = {
+  initHistorySync,
 }

--- a/packages/hoppscotch-web/src/main.ts
+++ b/packages/hoppscotch-web/src/main.ts
@@ -3,6 +3,7 @@ import { def as authDef } from "./firebase/auth"
 import { def as envDef } from "./environments"
 import { def as collectionsDef } from "./collections"
 import { def as settingsDef } from "./settings"
+import { def as historyDef } from "./history"
 
 createHoppApp("#app", {
   auth: authDef,
@@ -10,5 +11,6 @@ createHoppApp("#app", {
     environments: envDef,
     collections: collectionsDef,
     settings: settingsDef,
+    history: historyDef,
   },
 })


### PR DESCRIPTION
This PR extracts out the history firebase syncing to hoppscotch-web, and defines the common interface to be used with other hoppscotch platforms.