### PR TITLE
chore: use IDs instead of Strings in graphql queries

### DIFF
--- a/packages/hoppscotch-common/src/helpers/backend/gql/queries/GetCollectionChildren.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/queries/GetCollectionChildren.graphql
@@ -1,4 +1,4 @@
-query GetCollectionChildren($collectionID: ID!, $cursor: String) {
+query GetCollectionChildren($collectionID: ID!, $cursor: ID) {
   collection(collectionID: $collectionID) {
     children(cursor: $cursor) {
       id

--- a/packages/hoppscotch-common/src/helpers/backend/gql/queries/GetCollectionChildrenIDs.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/queries/GetCollectionChildrenIDs.graphql
@@ -1,4 +1,4 @@
-query GetCollectionChildrenIDs($collectionID: ID!, $cursor: String)  {
+query GetCollectionChildrenIDs($collectionID: ID!, $cursor: ID) {
   collection(collectionID: $collectionID) {
     children(cursor: $cursor) {
       id

--- a/packages/hoppscotch-web/src/firebase/init.ts
+++ b/packages/hoppscotch-web/src/firebase/init.ts
@@ -1,0 +1,26 @@
+import { initializeApp } from "firebase/app"
+
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_API_KEY,
+  authDomain: import.meta.env.VITE_AUTH_DOMAIN,
+  databaseURL: import.meta.env.VITE_DATABASE_URL,
+  projectId: import.meta.env.VITE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_APP_ID,
+  measurementId: import.meta.env.VITE_MEASUREMENT_ID,
+}
+
+let initialized = false
+
+export function initializeFirebase() {
+  if (!initialized) {
+    try {
+      initializeApp(firebaseConfig)
+      initialized = true
+    } catch (e) {
+      // initializeApp throws exception if we reinitialize
+      initialized = true
+    }
+  }
+}

--- a/packages/hoppscotch-web/src/main.ts
+++ b/packages/hoppscotch-web/src/main.ts
@@ -1,4 +1,5 @@
 import { createHoppApp } from "@hoppscotch/common"
+import { initializeFirebase } from "./firebase/init"
 import { def as authDef } from "./firebase/auth"
 import { def as envDef } from "./environments"
 import { def as collectionsDef } from "./collections"
@@ -6,6 +7,8 @@ import { def as settingsDef } from "./settings"
 import { def as historyDef } from "./history"
 import { def as tabStateDef } from "./tab"
 import { def as analyticsDef } from "./analytics"
+
+initializeFirebase()
 
 createHoppApp("#app", {
   auth: authDef,


### PR DESCRIPTION
This PR fixes queries `GetCollectionChildren` and `GetCollectionChildrenIDs` to use IDs instead of Strings for cursor