### PR TITLE
feat: added scrollbar for tabs

### DIFF
--- a/packages/hoppscotch-ui/src/components/smart/Windows.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Windows.vue
@@ -101,13 +101,14 @@
         min="1"
         :max="MAX_SCROLL_VALUE"
         v-model="thumbPosition"
-        class="slider absolute inset-x-0 bottom-0 hidden"
+        class="slider absolute bottom-0 hidden left-0"
         :class="{
           '!block': scrollThumb.show,
         }"
         :style="{
           '--thumb-width': scrollThumb.width + 'px',
         }"
+        style="width: calc(100% - 3rem)"
         id="myRange"
       />
     </div>
@@ -126,6 +127,7 @@ import { not } from "fp-ts/Predicate"
 import * as A from "fp-ts/Array"
 import * as O from "fp-ts/Option"
 import { ref, ComputedRef, computed, provide, inject, watch } from "vue"
+import { useElementSize } from "@vueuse/core"
 import type { Slot } from "vue"
 import draggable from "vuedraggable-es"
 import { HoppUIPluginOptions, HOPP_UI_OPTIONS } from "./../../index"
@@ -253,11 +255,12 @@ const addTab = () => {
  */
 
 const MAX_SCROLL_VALUE = 500
-const scrollContainer = ref<HTMLElement | null>(null)
+const scrollContainer = ref<HTMLElement>()
+const { width: scrollContainerWidth } = useElementSize(scrollContainer)
 const thumbPosition = ref(0)
 
 const scrollThumb = computed(() => {
-  const clientWidth = scrollContainer.value?.clientWidth ?? 0
+  const clientWidth = scrollContainerWidth.value ?? 0
   const scrollWidth = tabEntries.value.length * 184
 
   return {

--- a/packages/hoppscotch-ui/src/components/smart/Windows.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Windows.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col flex-1 h-auto overflow-y-hidden flex-nowrap">
     <div
-      class="relative sticky top-0 z-10 flex-shrink-0 overflow-x-auto tabs bg-primaryLight"
+      class="relative sticky top-0 z-10 flex-shrink-0 overflow-x-auto tabs bg-primaryLight group-tabs"
     >
       <div
         class="flex flex-1 flex-shrink-0 w-0 overflow-x-auto"
@@ -95,6 +95,21 @@
           </div>
         </div>
       </div>
+
+      <input
+        type="range"
+        min="1"
+        :max="MAX_SCROLL_VALUE"
+        v-model="thumbPosition"
+        class="slider absolute inset-x-0 bottom-0 hidden"
+        :class="{
+          '!block': scrollThumb.show,
+        }"
+        :style="{
+          '--thumb-width': scrollThumb.width + 'px',
+        }"
+        id="myRange"
+      />
     </div>
     <div class="w-full h-full contents">
       <slot></slot>
@@ -110,7 +125,7 @@ import { pipe } from "fp-ts/function"
 import { not } from "fp-ts/Predicate"
 import * as A from "fp-ts/Array"
 import * as O from "fp-ts/Option"
-import { ref, ComputedRef, computed, provide, inject } from "vue"
+import { ref, ComputedRef, computed, provide, inject, watch } from "vue"
 import type { Slot } from "vue"
 import draggable from "vuedraggable-es"
 import { HoppUIPluginOptions, HOPP_UI_OPTIONS } from "./../../index"
@@ -135,32 +150,24 @@ export type TabProvider = {
 
 const { t } = inject<HoppUIPluginOptions>(HOPP_UI_OPTIONS) ?? {}
 
-const props = defineProps({
-  styles: {
-    type: String,
-    default: "",
-  },
-  modelValue: {
-    type: String,
-    required: true,
-  },
-  renderInactiveTabs: {
-    type: Boolean,
-    default: false,
-  },
-  canAddNewTab: {
-    type: Boolean,
-    default: true,
-  },
-  newText: {
-    type: String,
-    default: null,
-  },
-  closeText: {
-    type: String,
-    default: null,
-  },
-})
+const props = withDefaults(
+  defineProps<{
+    styles: string
+    modelValue: string
+    renderInactiveTabs: boolean
+    canAddNewTab: boolean
+    newText: string | null
+    closeText: string | null
+  }>(),
+  {
+    styles: "",
+    renderInactiveTabs: false,
+    canAddNewTab: true,
+    newText: null,
+    closeText: null,
+  }
+)
+
 const emit = defineEmits<{
   (e: "update:modelValue", newTabID: string): void
   (e: "sort", body: { oldIndex: number; newIndex: number }): void
@@ -241,12 +248,45 @@ const addTab = () => {
   emit("addTab")
 }
 
-const scrollContainer = ref<HTMLElement | null>(null)
+/**
+ * Scroll related properties
+ */
 
+const MAX_SCROLL_VALUE = 500
+const scrollContainer = ref<HTMLElement | null>(null)
+const thumbPosition = ref(0)
+
+const scrollThumb = computed(() => {
+  const clientWidth = scrollContainer.value?.clientWidth ?? 0
+  const scrollWidth = tabEntries.value.length * 184
+
+  return {
+    width: (clientWidth / scrollWidth) * clientWidth || 300,
+    show: clientWidth ? scrollWidth > clientWidth : false,
+  }
+})
+
+/*
+ * Scroll with mouse wheel
+ */
 const scroll = (e: WheelEvent) => {
   scrollContainer.value!.scrollLeft += e.deltaY
   scrollContainer.value!.scrollLeft += e.deltaX
+
+  const { scrollWidth, clientWidth, scrollLeft } = scrollContainer.value!
+  const maxScroll = scrollWidth - clientWidth
+  thumbPosition.value = (scrollLeft / maxScroll) * MAX_SCROLL_VALUE
 }
+
+/*
+ * Scroll with scrollbar/slider
+ * when scroll thumb is dragged or clicked on the scrollbar
+ */
+watch(thumbPosition, (newVal) => {
+  const { scrollWidth, clientWidth } = scrollContainer.value!
+  const maxScroll = scrollWidth - clientWidth
+  scrollContainer.value!.scrollLeft = maxScroll * (newVal / MAX_SCROLL_VALUE)
+})
 </script>
 
 <style scoped lang="scss">
@@ -301,5 +341,39 @@ const scroll = (e: WheelEvent) => {
       }
     }
   }
+}
+
+$slider-height: 4px;
+.slider {
+  --thumb-width: 300px;
+  -webkit-appearance: none;
+  width: 100%;
+  height: $slider-height;
+  background: transparent;
+  outline: none;
+  opacity: 0;
+  -webkit-transition: 0.2s;
+  transition: opacity 0.2s;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    min-width: 300px;
+    width: var(--thumb-width);
+    height: $slider-height;
+    background: gray;
+    cursor: pointer;
+  }
+  &::-moz-range-thumb {
+    min-width: 300px;
+    width: var(--thumb-width);
+    height: $slider-height;
+    background: gray;
+    cursor: pointer;
+  }
+}
+
+.group-tabs:hover .slider {
+  opacity: 0.8;
 }
 </style>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 06590dd</samp>

### Summary
:sparkles::lipstick::wrench:

<!--
1.  :sparkles: - This emoji can be used to indicate a new feature or enhancement, such as adding a custom scrollbar/slider for the tabs.
2.  :lipstick: - This emoji can be used to indicate a cosmetic or UI improvement, such as making the tabs more accessible and user-friendly with a scrollbar/slider.
3.  :wrench: - This emoji can be used to indicate a tooling or configuration change, such as using a range input and a reactive variable to implement the scrollbar/slider functionality.
-->
Added a custom scrollbar/slider for the tabs in the Windows component. This improves the user experience and usability of the `hoppscotch-ui` package by allowing the user to navigate through multiple tabs more easily. The scrollbar/slider is a range input that controls the scroll position of the `Windows.vue` file.

> _Oh, we're the coders of the Windows component_
> _And we've added a scrollbar/slider so fine_
> _It hides away until you hover over it_
> _And it scrolls the tabs with a range input and a `scrollPos` var_

### Walkthrough
*  Add a custom scrollbar/slider for the tabs in `Windows.vue` ([link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L4-R4), [link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5R98-R112), [link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L138-R170), [link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L244-R289), [link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5R345-R378))
  - Use the `group-tabs` class to show or hide the slider on hover ([link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L4-R4), [link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5R345-R378))
  - Use the `input` element of type `range` as the slider ([link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5R98-R112))
  - Bind the slider to the `thumbPosition` reactive variable and the `scrollThumb.width` computed property ([link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5R98-R112), [link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L138-R170))
  - Set the `max` attribute of the slider to the `MAX_SCROLL_VALUE` constant ([link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5R98-R112), [link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L244-R289))
  - Watch the `thumbPosition` and `tabEntries` values and update the scroll position accordingly ([link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L244-R289))
* Refactor the `props` definition to use the `withDefaults` function ([link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L113-R128))
  - Import the `watch` function from `vue` ([link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L113-R128))
  - Specify the default values of the props in a type-safe way ([link](https://github.com/hoppscotch/hoppscotch/pull/2969/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L113-R128))

