### PR TITLE
fix: shortcode data do not fetch or render

### DIFF
--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -115,6 +115,7 @@ declare module '@vue/runtime-core' {
     HttpTestResultReport: typeof import('./components/http/TestResultReport.vue')['default']
     HttpTests: typeof import('./components/http/Tests.vue')['default']
     HttpURLEncodedParams: typeof import('./components/http/URLEncodedParams.vue')['default']
+    IconLucideAlertTriangle: typeof import('~icons/lucide/alert-triangle')['default']
     IconLucideArrowLeft: typeof import('~icons/lucide/arrow-left')['default']
     IconLucideCheckCircle: typeof import('~icons/lucide/check-circle')['default']
     IconLucideChevronRight: typeof import('~icons/lucide/chevron-right')['default']


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a37b072</samp>

### Summary
🎨🧰🚀

<!--
1.  🎨 - This emoji is often used to indicate code refactoring, improving the structure or design of existing code without changing its functionality. In this case, the component code was refactored to use a different syntax and API, but the behavior and appearance of the page should remain the same.
2.  🧰 - This emoji is often used to indicate adding or updating tools, utilities, or dependencies that help with development or testing. In this case, the common function for adding requests to tabs could be seen as a utility that simplifies the logic and reduces repetition in the component code.
3.  🚀 - This emoji is often used to indicate performance improvements, optimizations, or enhancements that make the code run faster or more efficiently. In this case, the `<script setup>` syntax and the composition API could potentially improve the performance of the component by reducing the overhead of creating and registering options-based components, and by enabling better tree-shaking and code-splitting.
-->
Refactored a component to use the latest Vue features and improved code reuse. Simplified the logic for adding requests to tabs with a common function. Updated `r/_id.vue` to use the new function.

Resolved the issue of shortcode not being fetched and rendered in a tab

> _`<script setup>` used_
> _Refactored component code_
> _Snowflakes of logic_

### Walkthrough
*  Simplify component options using `<script setup>` syntax ([link](https://github.com/hoppscotch/hoppscotch/pull/2972/files?diff=unified&w=0#diff-663554b835991ed51ac33363634cf12dca4c894a3484342260a11f5a8c27fc93L62-R63))
*  Refactor component logic to use reactive refs and `onMounted` function ([link](https://github.com/hoppscotch/hoppscotch/pull/2972/files?diff=unified&w=0#diff-663554b835991ed51ac33363634cf12dca4c894a3484342260a11f5a8c27fc93L80-R130))
*  Extract `addRequestToTab` function to avoid code duplication and improve readability ([link](https://github.com/hoppscotch/hoppscotch/pull/2972/files?diff=unified&w=0#diff-663554b835991ed51ac33363634cf12dca4c894a3484342260a11f5a8c27fc93L80-R130))

