### PR TITLE
chore: changes to support id based syncing for collections

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/graphql/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Collection.vue
@@ -299,7 +299,8 @@ const removeCollection = () => {
   ) {
     emit("select", null)
   }
-  removeGraphqlCollection(props.collectionIndex)
+
+  removeGraphqlCollection(props.collectionIndex, props.collection.id)
   toast.success(`${t("state.deleted")}`)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/graphql/Folder.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Folder.vue
@@ -279,7 +279,7 @@ const removeFolder = () => {
     emit("select", { picked: null })
   }
 
-  removeGraphqlFolder(props.folderPath)
+  removeGraphqlFolder(props.folderPath, props.folder.id)
   toast.success(t("state.deleted"))
 }
 

--- a/packages/hoppscotch-common/src/components/collections/graphql/Request.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Request.vue
@@ -214,7 +214,7 @@ const removeRequest = () => {
     emit("select", null)
   }
 
-  removeGraphqlRequest(props.folderPath, props.requestIndex)
+  removeGraphqlRequest(props.folderPath, props.requestIndex, props.request.id)
   toast.success(`${t("state.deleted")}`)
 }
 </script>

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -183,6 +183,8 @@ import {
   updateRESTRequestOrder,
   updateRESTCollectionOrder,
   moveRESTFolder,
+  navigateToFolderWithIndexPath,
+  restCollectionStore,
 } from "~/newstore/collections"
 import TeamCollectionAdapter from "~/helpers/teams/TeamCollectionAdapter"
 import {
@@ -1014,6 +1016,13 @@ const onRemoveCollection = () => {
   if (collectionsType.value.type === "my-collections") {
     const collectionIndex = editingCollectionIndex.value
 
+    const collectionToRemove =
+      collectionIndex || collectionIndex == 0
+        ? navigateToFolderWithIndexPath(restCollectionStore.value.state, [
+            collectionIndex,
+          ])
+        : undefined
+
     if (collectionIndex === null) return
 
     if (
@@ -1024,7 +1033,10 @@ const onRemoveCollection = () => {
       emit("select", null)
     }
 
-    removeRESTCollection(collectionIndex)
+    removeRESTCollection(
+      collectionIndex,
+      collectionToRemove ? collectionToRemove.id : undefined
+    )
 
     resolveSaveContextOnCollectionReorder({
       lastIndex: collectionIndex,
@@ -1077,7 +1089,14 @@ const onRemoveFolder = () => {
       emit("select", null)
     }
 
-    removeRESTFolder(folderPath)
+    const folderToRemove = folderPath
+      ? navigateToFolderWithIndexPath(
+          restCollectionStore.value.state,
+          folderPath.split("/").map((i) => parseInt(i))
+        )
+      : undefined
+
+    removeRESTFolder(folderPath, folderToRemove ? folderToRemove.id : undefined)
 
     const parentFolder = folderPath.split("/").slice(0, -1).join("/") // remove last folder to get parent folder
     resolveSaveContextOnCollectionReorder({
@@ -1151,7 +1170,12 @@ const onRemoveRequest = () => {
       possibleTab.value.document.isDirty = true
     }
 
-    removeRESTRequest(folderPath, requestIndex)
+    const requestToRemove = navigateToFolderWithIndexPath(
+      restCollectionStore.value.state,
+      folderPath.split("/").map((i) => parseInt(i))
+    )?.requests[requestIndex]
+
+    removeRESTRequest(folderPath, requestIndex, requestToRemove?.id)
 
     // the same function is used to reorder requests since after removing, it's basically doing reorder
     resolveSaveContextOnRequestReorder({

--- a/packages/hoppscotch-data/src/graphql/index.ts
+++ b/packages/hoppscotch-data/src/graphql/index.ts
@@ -11,6 +11,7 @@ export type GQLHeader = {
 }
 
 export type HoppGQLRequest = {
+  id?: string
   v: number
   name: string
   url: string


### PR DESCRIPTION
This PR introduces changes to support ID based syncing for collections.

**Changes**

- `removeGraphqlCollection`, `removeGraphqlFolder`, `removeGraphqlRequest`, `removeRestCollection`, `removeRestFolder`, `removeRestRequest` all accepts an optional id. this id is not used in the store right now. but is used in the syncing system for removing these resources.

- Function for removing duplicates from the collections store

