### PR TITLE
fix: fixed incorrect GOOGLE_SCOPE env value in .env.example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ WHITELISTED_ORIGINS = "http://localhost:3170,http://localhost:3000,http://localh
 GOOGLE_CLIENT_ID="************************************************"
 GOOGLE_CLIENT_SECRET="************************************************"
 GOOGLE_CALLBACK_URL="http://localhost:3170/v1/auth/google/callback"
-GOOGLE_SCOPE="['email', 'profile'],"
+GOOGLE_SCOPE="email,profile"
 
 # Github Auth Config
 GITHUB_CLIENT_ID="************************************************"


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

### Description
<!-- Add a brief description of the pull request -->

This PR introduces the fix to change the value of the `GOOGLE_SCOPE` env variable from its previously incorrect value to the right value now.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
