### PR TITLE
fix: unwanted transitions caused pane layout shift

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -459,6 +459,14 @@ pre.ace_editor {
   @apply bg-dividerLight;
 }
 
+.splitpanes--horizontal .splitpanes__pane {
+  @apply transition-none;
+}
+
+.splitpanes--vertical .splitpanes__pane {
+  @apply transition-none;
+}
+
 .cm-focused {
   @apply select-auto;
   @apply outline-none #{!important};


### PR DESCRIPTION
### Description

Whenever you switch tabs, refresh page, or opens up a collapsed pane - you could see the horizontal pane slides up with a 200ms transition. This is causing a layout shift and an unpleasant UX while working with multiple tabs (eg: REST page).

I've turned off this behaviours by setting the transition property to none.

| Before | After |
| --- | --- |
| <video src="https://user-images.githubusercontent.com/10395817/231997245-7736c5e5-6f64-449b-8c28-bd28d1fcda4f.webm"> | <video src="https://user-images.githubusercontent.com/10395817/231999448-8b3362dd-ff23-4d65-980a-23f6e9ad27d8.webm"> |


### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
