### PR TITLE
docs: fixed broken documentation links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,5 +55,5 @@ VITE_BACKEND_WS_URL=wss://localhost:3170/graphql
 VITE_BACKEND_API_URL=http://localhost:3170/v1
 
 # Terms Of Service And Privacy Policy Links (Optional)
-VITE_APP_TOS_LINK=https://docs.hoppscotch.io/terms
-VITE_APP_PRIVACY_POLICY_LINK=https://docs.hoppscotch.io/privacy
+VITE_APP_TOS_LINK=https://docs.hoppscotch.io/support/terms
+VITE_APP_PRIVACY_POLICY_LINK=https://docs.hoppscotch.io/support/privacy

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ _Collections are synced with cloud / local session storage_
 - Access APIs served in non-HTTPS (`http://`) endpoints
 - Use your Proxy URL
 
-_Official proxy server is hosted by Hoppscotch - **[GitHub](https://github.com/hoppscotch/proxyscotch)** - **[Privacy Policy](https://docs.hoppscotch.io/privacy)**_
+_Official proxy server is hosted by Hoppscotch - **[GitHub](https://github.com/hoppscotch/proxyscotch)** - **[Privacy Policy](https://docs.hoppscotch.io/support/privacy)**_
 
 📜 **Pre-Request Scripts β:** Snippets of code associated with a request that is executed before the request is sent.
 
@@ -178,7 +178,7 @@ _Official proxy server is hosted by Hoppscotch - **[GitHub](https://github.com/h
 
 ⌨️ **Keyboard Shortcuts:** Optimized for efficiency.
 
-> **[Read our documentation on Keyboard Shortcuts](https://docs.hoppscotch.io/features/shortcuts)**
+> **[Read our documentation on Keyboard Shortcuts](https://docs.hoppscotch.io/documentation/features/shortcuts)**
 
 🌎 **i18n:** Experience the app in your language.
 
@@ -278,7 +278,8 @@ _Add-ons are developed and maintained under **[Hoppscotch Organization](https://
 - [Vite](https://vitejs.dev)
 
 ## **Developing**
-Follow the guide in the [Self Hosted Docs](https://docs.hoppscotch.io/documentation/self-host/getting-started).
+
+Follow our [self-hosting guide](https://docs.hoppscotch.io/documentation/self-host/getting-started) to get started with the development environment.
 
 ## **Contributing**
 

--- a/packages/hoppscotch-cli/src/index.ts
+++ b/packages/hoppscotch-cli/src/index.ts
@@ -17,7 +17,7 @@ const CLI_BEFORE_ALL_TXT = `hopp: The ${accent(
 )}) ${chalk.black.bold.bgYellowBright(" ALPHA ")} \n`;
 
 const CLI_AFTER_ALL_TXT = `\nFor more help, head on to ${accent(
-  "https://docs.hoppscotch.io/cli"
+  "https://docs.hoppscotch.io/documentation/clients/cli"
 )}`;
 
 program
@@ -59,7 +59,9 @@ program
   .description("running hoppscotch collection.json file")
   .addHelpText(
     "after",
-    `\nFor help, head on to ${accent("https://docs.hoppscotch.io/cli#test")}`
+    `\nFor help, head on to ${accent(
+      "https://docs.hoppscotch.io/documentation/clients/cli#commands"
+    )}`
   )
   .action(async (path, options) => await test(path, options)());
 

--- a/packages/hoppscotch-common/src/components/app/Footer.vue
+++ b/packages/hoppscotch-common/src/components/app/Footer.vue
@@ -91,7 +91,7 @@
               <HoppSmartItem
                 :icon="IconGift"
                 :label="`${t('app.whats_new')}`"
-                to="https://docs.hoppscotch.io/changelog"
+                to="https://docs.hoppscotch.io/documentation/changelog"
                 blank
                 @click="hide()"
               />
@@ -130,7 +130,7 @@
               <HoppSmartItem
                 :icon="IconLock"
                 :label="`${t('app.terms_and_privacy')}`"
-                to="https://docs.hoppscotch.io/privacy"
+                to="https://docs.hoppscotch.io/support/privacy"
                 blank
                 @click="hide()"
               />

--- a/packages/hoppscotch-common/src/components/app/Options.vue
+++ b/packages/hoppscotch-common/src/components/app/Options.vue
@@ -43,7 +43,7 @@
         <HoppSmartItem
           :icon="IconGift"
           :label="t('app.whats_new')"
-          to="https://docs.hoppscotch.io/changelog"
+          to="https://docs.hoppscotch.io/documentation/changelog"
           :description="t('support.changelog')"
           :info-icon="IconChevronRight"
           active
@@ -63,7 +63,7 @@
         <HoppSmartItem
           :icon="IconLock"
           :label="`${t('app.terms_and_privacy')}`"
-          to="https://docs.hoppscotch.io/privacy"
+          to="https://docs.hoppscotch.io/support/privacy"
           blank
           :description="t('app.terms_and_privacy')"
           :info-icon="IconChevronRight"

--- a/packages/hoppscotch-common/src/components/app/ShortcutsPrompt.vue
+++ b/packages/hoppscotch-common/src/components/app/ShortcutsPrompt.vue
@@ -34,7 +34,7 @@
     </div>
     <HoppButtonSecondary
       :label="`${t('app.documentation')}`"
-      to="https://docs.hoppscotch.io/features/response"
+      to="https://docs.hoppscotch.io/documentation/features/rest-api-testing#response"
       :icon="IconExternalLink"
       blank
       outline

--- a/packages/hoppscotch-common/src/components/app/Support.vue
+++ b/packages/hoppscotch-common/src/components/app/Support.vue
@@ -29,7 +29,7 @@
         <HoppSmartItem
           :icon="IconGift"
           :label="t('app.whats_new')"
-          to="https://docs.hoppscotch.io/changelog"
+          to="https://docs.hoppscotch.io/documentation/changelog"
           :description="t('support.changelog')"
           :info-icon="IconChevronRight"
           active

--- a/packages/hoppscotch-common/src/components/collections/MyCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/MyCollections.vue
@@ -17,7 +17,7 @@
       <span class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/collections"
+          to="https://docs.hoppscotch.io/documentation/features/collections"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/collections/TeamCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/TeamCollections.vue
@@ -27,7 +27,7 @@
       <span class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/collections"
+          to="https://docs.hoppscotch.io/documentation/features/collections"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/index.vue
@@ -25,7 +25,7 @@
         <div class="flex">
           <HoppButtonSecondary
             v-tippy="{ theme: 'tooltip' }"
-            to="https://docs.hoppscotch.io/features/collections"
+            to="https://docs.hoppscotch.io/documentation/features/collections"
             blank
             :title="t('app.wiki')"
             :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/index.vue
@@ -12,7 +12,7 @@
       <div class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/environments"
+          to="https://docs.hoppscotch.io/documentation/features/environments"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/environments/teams/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/index.vue
@@ -22,7 +22,7 @@
       <div class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/environments"
+          to="https://docs.hoppscotch.io/documentation/features/environments"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/graphql/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Authorization.vue
@@ -101,7 +101,7 @@
         </HoppSmartCheckbox>
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/authorization"
+          to="https://docs.hoppscotch.io/documentation/features/authorization"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"
@@ -130,7 +130,7 @@
       <HoppButtonSecondary
         outline
         :label="t('app.documentation')"
-        to="https://docs.hoppscotch.io/features/authorization"
+        to="https://docs.hoppscotch.io/documentation/features/authorization"
         blank
         :icon="IconExternalLink"
         reverse
@@ -236,7 +236,7 @@
           class="link"
           :label="t('authorization.learn')"
           :icon="IconExternalLink"
-          to="https://docs.hoppscotch.io/features/authorization"
+          to="https://docs.hoppscotch.io/documentation/features/authorization"
           blank
           reverse
         />

--- a/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
@@ -39,7 +39,7 @@
             />
             <HoppButtonSecondary
               v-tippy="{ theme: 'tooltip' }"
-              to="https://docs.hoppscotch.io/graphql"
+              to="https://docs.hoppscotch.io/documentation/features/graphql-api-testing"
               blank
               :title="t('app.wiki')"
               :icon="IconHelpCircle"
@@ -87,7 +87,7 @@
           <div class="flex">
             <HoppButtonSecondary
               v-tippy="{ theme: 'tooltip' }"
-              to="https://docs.hoppscotch.io/graphql"
+              to="https://docs.hoppscotch.io/documentation/features/graphql-api-testing"
               blank
               :title="t('app.wiki')"
               :icon="IconHelpCircle"
@@ -137,7 +137,7 @@
           <div class="flex">
             <HoppButtonSecondary
               v-tippy="{ theme: 'tooltip' }"
-              to="https://docs.hoppscotch.io/graphql"
+              to="https://docs.hoppscotch.io/documentation/features/graphql-api-testing"
               blank
               :title="t('app.wiki')"
               :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/graphql/Sidebar.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Sidebar.vue
@@ -57,7 +57,7 @@
           <div class="flex">
             <HoppButtonSecondary
               v-tippy="{ theme: 'tooltip' }"
-              to="https://docs.hoppscotch.io/quickstart/graphql"
+              to="https://docs.hoppscotch.io/documentation/protocols/graphql"
               blank
               :title="t('app.wiki')"
               :icon="IconHelpCircle"
@@ -141,7 +141,7 @@
         <div class="flex">
           <HoppButtonSecondary
             v-tippy="{ theme: 'tooltip' }"
-            to="https://docs.hoppscotch.io/quickstart/graphql"
+            to="https://docs.hoppscotch.io/documentation/protocols/graphql"
             blank
             :title="t('app.wiki')"
             :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/history/index.vue
+++ b/packages/hoppscotch-common/src/components/history/index.vue
@@ -15,7 +15,7 @@
         <div class="flex">
           <HoppButtonSecondary
             v-tippy="{ theme: 'tooltip' }"
-            to="https://docs.hoppscotch.io/features/history"
+            to="https://docs.hoppscotch.io/documentation/features/history"
             blank
             :title="t('app.wiki')"
             :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/http/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/http/Authorization.vue
@@ -100,7 +100,7 @@
         >
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/authorization"
+          to="https://docs.hoppscotch.io/documentation/features/authorization"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"
@@ -127,7 +127,7 @@
       <HoppButtonSecondary
         outline
         :label="t('app.documentation')"
-        to="https://docs.hoppscotch.io/features/authorization"
+        to="https://docs.hoppscotch.io/documentation/features/authorization"
         blank
         :icon="IconExternalLink"
         reverse
@@ -164,7 +164,7 @@
           class="link"
           :label="t('authorization.learn')"
           :icon="IconExternalLink"
-          to="https://docs.hoppscotch.io/features/authorization"
+          to="https://docs.hoppscotch.io/documentation/features/authorization"
           blank
           reverse
         />

--- a/packages/hoppscotch-common/src/components/http/Body.vue
+++ b/packages/hoppscotch-common/src/components/http/Body.vue
@@ -116,7 +116,7 @@
       <HoppButtonSecondary
         outline
         :label="`${t('app.documentation')}`"
-        to="https://docs.hoppscotch.io/features/body"
+        to="https://docs.hoppscotch.io/documentation/getting-started/rest/uploading-data"
         blank
         :icon="IconExternalLink"
         reverse

--- a/packages/hoppscotch-common/src/components/http/BodyParameters.vue
+++ b/packages/hoppscotch-common/src/components/http/BodyParameters.vue
@@ -9,7 +9,7 @@
       <div class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/body"
+          to="https://docs.hoppscotch.io/documentation/getting-started/rest/uploading-data"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -9,7 +9,7 @@
       <div class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/headers"
+          to="https://docs.hoppscotch.io/documentation/features/rest-api-testing"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/http/Parameters.vue
+++ b/packages/hoppscotch-common/src/components/http/Parameters.vue
@@ -9,7 +9,7 @@
       <div class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/parameters"
+          to="https://docs.hoppscotch.io/documentation/getting-started/rest/using-parameters"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/http/PreRequestScript.vue
+++ b/packages/hoppscotch-common/src/components/http/PreRequestScript.vue
@@ -9,7 +9,7 @@
       <div class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/pre-request-script"
+          to="https://docs.hoppscotch.io/documentation/getting-started/rest/pre-request-scripts"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"
@@ -41,7 +41,7 @@
         </div>
         <HoppSmartAnchor
           :label="`${t('preRequest.learn')}`"
-          to="https://docs.hoppscotch.io/features/pre-request-script"
+          to="https://docs.hoppscotch.io/documentation/getting-started/rest/pre-request-scripts"
           blank
         />
         <h4 class="pt-6 font-bold text-secondaryLight">

--- a/packages/hoppscotch-common/src/components/http/RawBody.vue
+++ b/packages/hoppscotch-common/src/components/http/RawBody.vue
@@ -9,7 +9,7 @@
       <div class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/body"
+          to="https://docs.hoppscotch.io/documentation/getting-started/rest/uploading-data"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/http/TestResult.vue
+++ b/packages/hoppscotch-common/src/components/http/TestResult.vue
@@ -189,7 +189,7 @@
       <HoppButtonSecondary
         outline
         :label="`${t('action.learn_more')}`"
-        to="https://docs.hoppscotch.io/features/tests"
+        to="https://docs.hoppscotch.io/documentation/getting-started/rest/tests"
         blank
         :icon="IconExternalLink"
         reverse

--- a/packages/hoppscotch-common/src/components/http/Tests.vue
+++ b/packages/hoppscotch-common/src/components/http/Tests.vue
@@ -9,7 +9,7 @@
       <div class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/tests"
+          to="https://docs.hoppscotch.io/documentation/getting-started/rest/tests"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"
@@ -41,7 +41,7 @@
         </div>
         <HoppSmartAnchor
           :label="`${t('test.learn')}`"
-          to="https://docs.hoppscotch.io/features/tests"
+          to="https://docs.hoppscotch.io/documentation/getting-started/rest/tests"
           blank
         />
         <h4 class="pt-6 font-bold text-secondaryLight">

--- a/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
+++ b/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
@@ -9,7 +9,7 @@
       <div class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/features/body"
+          to="https://docs.hoppscotch.io/documentation/getting-started/rest/uploading-data"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/realtime/Communication.vue
+++ b/packages/hoppscotch-common/src/components/realtime/Communication.vue
@@ -85,7 +85,7 @@
         </HoppSmartCheckbox>
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/realtime"
+          to="https://docs.hoppscotch.io/documentation/features/realtime-api-testing"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/layouts/default.vue
+++ b/packages/hoppscotch-common/src/layouts/default.vue
@@ -106,7 +106,9 @@ onMounted(() => {
           onClick: (_, toastObject) => {
             setLocalConfig("cookiesAllowed", "yes")
             toastObject.goAway(0)
-            window.open("https://docs.hoppscotch.io/privacy", "_blank")?.focus()
+            window
+              .open("https://docs.hoppscotch.io/support/privacy", "_blank")
+              ?.focus()
           },
         },
         {

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -37,8 +37,8 @@
             </template>
             <template #suffix>
               <span
-                class="text-green-600 text-[8px] group-hover:hidden w-4"
                 v-if="tab.document.isDirty"
+                class="text-green-600 text-[8px] group-hover:hidden w-4"
               >
                 <svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
                   <circle cx="12" cy="12" r="10" fill="currentColor"></circle>

--- a/packages/hoppscotch-common/src/pages/realtime/mqtt.vue
+++ b/packages/hoppscotch-common/src/pages/realtime/mqtt.vue
@@ -128,7 +128,7 @@
           <span class="flex">
             <HoppButtonSecondary
               v-tippy="{ theme: 'tooltip' }"
-              to="https://docs.hoppscotch.io/features/mqtt"
+              to="https://docs.hoppscotch.io/documentation/getting-started/realtime/mqtt"
               blank
               :title="t('app.wiki')"
               :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/pages/realtime/socketio.vue
+++ b/packages/hoppscotch-common/src/pages/realtime/socketio.vue
@@ -177,7 +177,7 @@
               </HoppSmartCheckbox>
               <HoppButtonSecondary
                 v-tippy="{ theme: 'tooltip' }"
-                to="https://docs.hoppscotch.io/features/authorization"
+                to="https://docs.hoppscotch.io/documentation/features/authorization"
                 blank
                 :title="t('app.wiki')"
                 :icon="IconHelpCircle"
@@ -206,7 +206,7 @@
             <HoppButtonSecondary
               outline
               :label="t('app.documentation')"
-              to="https://docs.hoppscotch.io/features/authorization"
+              to="https://docs.hoppscotch.io/documentation/features/authorization"
               blank
               :icon="IconExternalLink"
               reverse
@@ -233,7 +233,7 @@
                   class="link"
                   :label="t('authorization.learn')"
                   :icon="IconExternalLink"
-                  to="https://docs.hoppscotch.io/features/authorization"
+                  to="https://docs.hoppscotch.io/documentation/features/authorization"
                   blank
                   reverse
                 />

--- a/packages/hoppscotch-common/src/pages/settings.vue
+++ b/packages/hoppscotch-common/src/pages/settings.vue
@@ -177,7 +177,7 @@
               }}
               <HoppSmartAnchor
                 class="link"
-                to="https://docs.hoppscotch.io/privacy"
+                to="https://docs.hoppscotch.io/support/privacy"
                 blank
                 :label="t('app.proxy_privacy_policy')"
               />.

--- a/packages/hoppscotch-ui/src/stories/Anchor.story.vue
+++ b/packages/hoppscotch-ui/src/stories/Anchor.story.vue
@@ -2,9 +2,19 @@
   <Story title="Anchor">
     <div class="text-secondaryLight text-tiny">
       By signing in, you are agreeing to our
-      <HoppSmartAnchor class="text-red-800 link" to="https://docs.hoppscotch.io/terms" blank label="Terms of Service" />
+      <HoppSmartAnchor
+        class="text-red-800 link"
+        to="https://docs.hoppscotch.io/support/terms"
+        blank
+        label="Terms of Service"
+      />
       and
-      <HoppSmartAnchor class="text-red-600 link" to="https://docs.hoppscotch.io/privacy" blank label="Privacy Policy" />
+      <HoppSmartAnchor
+        class="text-red-600 link"
+        to="https://docs.hoppscotch.io/support/privacy"
+        blank
+        label="Privacy Policy"
+      />
     </div>
   </Story>
 </template>
@@ -12,4 +22,3 @@
 <script setup lang="ts">
 import { HoppSmartAnchor } from "../components/smart"
 </script>
-


### PR DESCRIPTION
Closes #2957, #2981.
Suppressed #2992.

### Description
Routes in the latest documentation have been changed - this went unnoticed in the latest release. This PR updates all the old documentation and wiki URLs with it's latest URLs.

### Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed