### PR TITLE
fix: request name not updating in the save request modal

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -135,6 +135,15 @@ const requestName = ref(
   props.mode === "rest" ? restRequestName.value : gqlRequestName.value
 )
 
+watch(
+  () => [currentActiveTab.value.document.request.name, gqlRequestName.value],
+  () => {
+    if (props.mode === "rest")
+      requestName.value = currentActiveTab.value.document.request.name
+    else requestName.value = gqlRequestName.value
+  }
+)
+
 const requestData = reactive({
   name: requestName,
   collectionIndex: undefined as number | undefined,

--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, ref, watch } from "vue"
+import { nextTick, reactive, ref, watch } from "vue"
 import { cloneDeep } from "lodash-es"
 import {
   HoppGQLRequest,
@@ -126,12 +126,13 @@ const emit = defineEmits<{
 }>()
 
 const gqlRequestName = useGQLRequestName()
-const requestName = computedWithControl(
-  () => [currentActiveTab.value, gqlRequestName.value],
-  () =>
-    props.mode === "rest"
-      ? currentActiveTab.value.document.request.name
-      : gqlRequestName.value
+const restRequestName = computedWithControl(
+  () => currentActiveTab.value,
+  () => currentActiveTab.value.document.request.name
+)
+
+const requestName = ref(
+  props.mode === "rest" ? restRequestName.value : gqlRequestName.value
 )
 
 const requestData = reactive({
@@ -191,6 +192,8 @@ const saveRequestAs = async () => {
     props.mode === "rest"
       ? cloneDeep(currentActiveTab.value.document.request)
       : cloneDeep(getGQLSession().request)
+
+  requestUpdated.name = requestName.value
 
   if (picked.value.pickedType === "my-collection") {
     if (!isHoppRESTRequest(requestUpdated))
@@ -373,6 +376,9 @@ const updateTeamCollectionOrFolder = (
 
 const requestSaved = () => {
   toast.success(`${t("request.added")}`)
+  nextTick(() => {
+    currentActiveTab.value.document.isDirty = false
+  })
   hideModal()
 }
 


### PR DESCRIPTION
### Description
This fixes the issue in the save request modal where the request name was not being updated while saving the current active tab request.

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
