### PR TITLE
fix: wrong tab selected after navigating from different route

### DIFF
--- a/packages/hoppscotch-ui/src/components/smart/Windows.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Windows.vue
@@ -228,9 +228,6 @@ const removeTabEntry = (tabID: string) => {
     O.chain((index) => pipe(tabEntries.value, A.deleteAt(index))),
     O.getOrElseW(() => throwError(`Failed to remove tab entry: ${tabID}`))
   )
-  // If we tried to remove the active tabEntries, switch to first tab entry
-  if (props.modelValue === tabID)
-    if (tabEntries.value.length > 0) selectTab(tabEntries.value[0][0])
 }
 const sortTabs = (e: {
   oldDraggableIndex: number


### PR DESCRIPTION
### Description
Issue: If multiple tabs are opened, and the first tab is selected. after going to another page from the REST page and then coming back to REST, the selection goes to the next tab.

Previously, we were forcefully selecting the first possible `Window` forcefully after removing any active `Window`. And it was happening `onBeforeUnmounted`. But, now it will select the last `Window` automatically.

- [ ] Not Completed
- [x] Completed


### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
