### PR TITLE
fix: returning response from authCookieHandler

### DIFF
--- a/packages/hoppscotch-backend/src/auth/helper.ts
+++ b/packages/hoppscotch-backend/src/auth/helper.ts
@@ -63,7 +63,7 @@ export const authCookieHandler = (
   });
 
   if (!redirect) {
-    res.status(HttpStatus.OK).send();
+    return res.status(HttpStatus.OK).send();
   }
 
   // check to see if redirectUrl is a whitelisted url
@@ -72,7 +72,7 @@ export const authCookieHandler = (
     // if it is not redirect by default to REDIRECT_URL
     redirectUrl = process.env.REDIRECT_URL;
 
-  res.status(HttpStatus.OK).redirect(redirectUrl);
+  return res.status(HttpStatus.OK).redirect(redirectUrl);
 };
 
 /**


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
### Issue number
Fixes #3024 
Close HBE-191

### Description
<!-- Add a brief description of the pull request -->

#### Background Information of Issue

So, whenever the `{BASE_URL}/v1/auth/verify` API was called, the `response` object was written with cookies. Afterward, the server sends a response to the client with conditional redirection. During sending the response, the backend service encounters the following error.

```
[Nest] 123  - 04/28/2023, 10:12:23 AM   ERROR [ExceptionsHandler] Cannot set headers after they are sent to the client
Error: Cannot set headers after they are sent to the client
    at new NodeError (node:internal/errors:393:5)
    at ServerResponse.setHeader (node:_http_outgoing:607:11)
    at ServerResponse.header (/usr/src/app/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/response.js:794:10)
    at ServerResponse.location (/usr/src/app/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/response.js:915:15)
    at ServerResponse.redirect (/usr/src/app/node_modules/.pnpm/express@4.18.2/node_modules/express/lib/response.js:953:18)
    at authCookieHandler (/usr/src/app/src/auth/helper.ts:75:29)
    at AuthController.verify (/usr/src/app/src/auth/auth.controller.ts:57:22)
    at /usr/src/app/node_modules/.pnpm/@nestjs+core@9.2.1_@nestjs+common@9.2.1_@nestjs+platform-express@9.2.1_reflect-metadata@0.1.13_rxjs@7.6.0/node_modules/@nestjs/core/router/router-execution-context.js:46:28
    at /usr/src/app/node_modules/.pnpm/@nestjs+core@9.2.1_@nestjs+common@9.2.1_@nestjs+platform-express@9.2.1_reflect-metadata@0.1.13_rxjs@7.6.0/node_modules/@nestjs/core/router/router-proxy.js:9:17
```

#### Proposed Solution

In the backend service, there were two statements for sending a response to the client (under conditional statement).
In the first statement, there were missed `return` keywords. For that reason, the response was sent to the client but further code execution is ongoing. 
In the following code execution, there was another statement for sending the response to the client. As previously the response already sent to the client, the following one encountered the error.
Simply I added the `return` keyword to fix the issue.

```
return res.status(HttpStatus.OK).send();
```


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
Nil