### PR TITLE
fix: pane layout broken when wrap line is off

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -481,6 +481,9 @@ pre.ace_editor {
 }
 
 .cm-editor {
+  .cm-content {
+    @apply whitespace-normal;
+  }
   .cm-line::selection {
     @apply bg-accentDark #{!important};
     @apply text-accentContrast #{!important};


### PR DESCRIPTION
### Issue number
 HFE-42
 
### Description
This pull request fixes an issue where the Pane layout in the REST Response section was not working properly when the "Wrap Lines" option was turned off in the response editor.

### Checks
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed

