### PR TITLE
fix: magic link URL

### DIFF
--- a/packages/hoppscotch-backend/src/auth/auth.service.ts
+++ b/packages/hoppscotch-backend/src/auth/auth.service.ts
@@ -232,7 +232,7 @@ export class AuthService {
       template: 'code-your-own',
       variables: {
         inviteeEmail: email,
-        magicLink: `${url}/magic-link?token=${generatedTokens.token}`,
+        magicLink: `${url}/enter?token=${generatedTokens.token}`,
       },
     });
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
### Issue Number
Fixes #3016 
Closes HBE-195

### Description
<!-- Add a brief description of the pull request -->

#### Background Information of Issue

During the *Sign In* with the magic-link option, the user gets an email with a link (embedded with a token).
The path/route of the magic link was mismatched with the front-end application. For that reason, users are getting 404 error in the front-end application and are unable to sign in to the application successfully.

<img width="1438" alt="Screenshot 2023-05-04 at 2 06 37 PM" src="https://user-images.githubusercontent.com/30154643/236146155-d81d1f8a-2c98-4ca9-9789-a8904928e5bb.png">

#### Proposed Solution

In this PR, we fixed the magic link (path/route), which was sent through email. After this fix, the user will be able to sign in to the application successfully.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
Nil