### PR TITLE
Fix issue with disappearing tab when opening request tabs with long text in body/script

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -481,10 +481,6 @@ pre.ace_editor {
 }
 
 .cm-editor {
-  .cm-content {
-    @apply whitespace-normal;
-  }
-
   .cm-line::selection {
     @apply bg-accentDark #{!important};
     @apply text-accentContrast #{!important};

--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -571,8 +571,3 @@ details[open] summary .indicator {
   @apply rounded;
   @apply border-0;
 }
-
-// it fixes the overflow issue on flex items
-.flex {
-  min-width: 0;
-}

--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -571,3 +571,8 @@ details[open] summary .indicator {
   @apply rounded;
   @apply border-0;
 }
+
+// it fixes the overflow issue on flex items
+.flex {
+  min-width: 0;
+}

--- a/packages/hoppscotch-common/src/layouts/default.vue
+++ b/packages/hoppscotch-common/src/layouts/default.vue
@@ -24,7 +24,10 @@
             >
               <Pane class="flex flex-1 !overflow-auto">
                 <main class="flex flex-1 w-full" role="main">
-                  <RouterView v-slot="{ Component }" class="flex flex-1">
+                  <RouterView
+                    v-slot="{ Component }"
+                    class="flex flex-1 min-w-0"
+                  >
                     <Transition name="fade" mode="out-in" appear>
                       <component :is="Component" />
                     </Transition>


### PR DESCRIPTION
Closes #2994 

### Description
<!-- Add a brief description of the pull request -->

Fixed the disappearing request issue when opening tabs for requests with long text by adding the CSS class 
`.flex{ min-width: 0; }`. 
The fix ensures that the request remains visible and accessible by modifying the layout and styling of the request tabs.


- [ ] Not Completed
- [x] Completed
