### PR TITLE
fix: invalid environment index can break the app

### DIFF
--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -42,21 +42,18 @@ const dispatchers = defineDispatchers({
       selectedEnvironmentIndex,
     }: { selectedEnvironmentIndex: SelectedEnvironmentIndex }
   ) {
-    let isValidIndex = true
-
-    if (selectedEnvironmentIndex.type == "MY_ENV") {
-      isValidIndex =
-        selectedEnvironmentIndex.type == "MY_ENV" &&
-        !!store.environments[selectedEnvironmentIndex.index]
+    if (
+      selectedEnvironmentIndex.type === "MY_ENV" &&
+      !!store.environments[selectedEnvironmentIndex.index]
+    ) {
+      return {
+        selectedEnvironmentIndex,
+      }
+    } else {
+      return {
+        type: "NO_ENV_SELECTED",
+      }
     }
-
-    return isValidIndex
-      ? {
-          selectedEnvironmentIndex,
-        }
-      : {
-          type: "NO_ENV_SELECTED",
-        }
   },
   appendEnvironments(
     { environments }: EnvironmentStore,

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -37,14 +37,26 @@ type EnvironmentStore = typeof defaultEnvironmentsState
 
 const dispatchers = defineDispatchers({
   setSelectedEnvironmentIndex(
-    _: EnvironmentStore,
+    store: EnvironmentStore,
     {
       selectedEnvironmentIndex,
     }: { selectedEnvironmentIndex: SelectedEnvironmentIndex }
   ) {
-    return {
-      selectedEnvironmentIndex,
+    let isValidIndex = true
+
+    if (selectedEnvironmentIndex.type == "MY_ENV") {
+      isValidIndex =
+        selectedEnvironmentIndex.type == "MY_ENV" &&
+        !!store.environments[selectedEnvironmentIndex.index]
     }
+
+    return isValidIndex
+      ? {
+          selectedEnvironmentIndex,
+        }
+      : {
+          type: "NO_ENV_SELECTED",
+        }
   },
   appendEnvironments(
     { environments }: EnvironmentStore,
@@ -358,7 +370,7 @@ export const aggregateEnvs$: Observable<AggregateEnvironment[]> = combineLatest(
   map(([selectedEnv, globalVars]) => {
     const results: AggregateEnvironment[] = []
 
-    selectedEnv.variables.forEach(({ key, value }) =>
+    selectedEnv?.variables.forEach(({ key, value }) =>
       results.push({ key, value, sourceEnv: selectedEnv.name })
     )
     globalVars.forEach(({ key, value }) =>

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -337,21 +337,22 @@ export const selectedEnvironmentIndex$ = environmentsStore.subject$.pipe(
   distinctUntilChanged()
 )
 
-export const currentEnvironment$ = environmentsStore.subject$.pipe(
-  map(({ environments, selectedEnvironmentIndex }) => {
-    if (selectedEnvironmentIndex.type === "NO_ENV_SELECTED") {
-      const env: Environment = {
-        name: "No environment",
-        variables: [],
+export const currentEnvironment$: Observable<Environment | undefined> =
+  environmentsStore.subject$.pipe(
+    map(({ environments, selectedEnvironmentIndex }) => {
+      if (selectedEnvironmentIndex.type === "NO_ENV_SELECTED") {
+        const env: Environment = {
+          name: "No environment",
+          variables: [],
+        }
+        return env
+      } else if (selectedEnvironmentIndex.type === "MY_ENV") {
+        return environments[selectedEnvironmentIndex.index]
+      } else {
+        return selectedEnvironmentIndex.environment
       }
-      return env
-    } else if (selectedEnvironmentIndex.type === "MY_ENV") {
-      return environments[selectedEnvironmentIndex.index]
-    } else {
-      return selectedEnvironmentIndex.environment
-    }
-  })
-)
+    })
+  )
 
 export type AggregateEnvironment = {
   key: string


### PR DESCRIPTION
Closes HFE-40

**Before**

If we're loading an environment index that doesnt exist from the localstorage, it could lead to unwanted behaviours.
the type for `currentEnvironment$` was not considering the enviornment could be undefined.

**After**

When setting the selectedEnvironmentIndex, we verify if the environment corresponding to the index exist in the store. Otherwise we set selectedEnvironmentIndex for 'NO_ENV_SELECTED'

Also we update the type of currentEnvironment$ to include a possible undefined

