### PR TITLE
fix: 403 forbidden error when trying to load a Google profile picture

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -481,10 +481,6 @@ pre.ace_editor {
 }
 
 .cm-editor {
-  .cm-content {
-    @apply whitespace-normal;
-  }
-
   .cm-line::selection {
     @apply bg-accentDark #{!important};
     @apply text-accentContrast #{!important};

--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -481,6 +481,10 @@ pre.ace_editor {
 }
 
 .cm-editor {
+  .cm-content {
+    @apply whitespace-normal;
+  }
+
   .cm-line::selection {
     @apply bg-accentDark #{!important};
     @apply text-accentContrast #{!important};

--- a/packages/hoppscotch-ui/src/components/smart/Picture.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Picture.vue
@@ -11,6 +11,7 @@
       :src="url"
       :alt="alt"
       loading="lazy"
+      referrerpolicy="no-referrer"
     />
     <div
       v-else
@@ -21,8 +22,7 @@
       <template v-if="initial && initial.charAt(0).toUpperCase()">
         {{ initial.charAt(0).toUpperCase() }}
       </template>
-
-      <icon-lucide-user v-else></icon-lucide-user>
+      <icon-lucide-user v-else />
     </div>
     <span
       v-if="indicator"


### PR DESCRIPTION
### Description
This PR fixes getting the 403:forbidden error when trying to load a Google profile picture from localhost.


### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
