### PR TITLE
feat: rename request by double clicking its name on tabs

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -25,6 +25,7 @@
     "learn_more": "Learn more",
     "less": "Less",
     "more": "More",
+    "name": "Name",
     "new": "New",
     "no": "No",
     "open_workspace": "Open workspace",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -25,7 +25,6 @@
     "learn_more": "Learn more",
     "less": "Less",
     "more": "More",
-    "name": "Name",
     "new": "New",
     "no": "No",
     "open_workspace": "Open workspace",

--- a/packages/hoppscotch-common/src/components/collections/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/EditRequest.vue
@@ -42,9 +42,9 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
+import { useVModel } from "@vueuse/core"
 
 const toast = useToast()
 const t = useI18n()
@@ -53,28 +53,22 @@ const props = withDefaults(
   defineProps<{
     show: boolean
     loadingState: boolean
-    editingRequestName: string
+    modelValue?: string
   }>(),
   {
     show: false,
     loadingState: false,
-    editingRequestName: "",
+    modelValue: "",
   }
 )
 
 const emit = defineEmits<{
   (e: "submit", name: string): void
   (e: "hide-modal"): void
+  (e: "update:modelValue", value: string): void
 }>()
 
-const name = ref("")
-
-watch(
-  () => props.editingRequestName,
-  (newName) => {
-    name.value = newName
-  }
-)
+const name = useVModel(props, "modelValue")
 
 const editRequest = () => {
   if (name.value.trim() === "") {

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -126,7 +126,7 @@
     />
     <CollectionsEditRequest
       :show="showModalEditRequest"
-      :editing-request-name="editingRequest ? editingRequest.name : ''"
+      v-bind:model-value="editingRequest ? editingRequest.name : ''"
       :loading-state="modalLoadingState"
       @submit="updateEditingRequest"
       @hide-modal="displayModalEditRequest(false)"

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -64,7 +64,7 @@
     </AppPaneLayout>
     <CollectionsEditRequest
       :show="showRenamingReqNameModal"
-      :editing-request-name="reqName"
+      v-model="reqName"
       @submit="renameReqName"
       @hide-modal="showRenamingReqNameModal = false"
     />
@@ -180,10 +180,10 @@ const openReqRenameModal = () => {
   reqName.value = currentActiveTab.value.document.request.name
 }
 
-const renameReqName = (name: string) => {
+const renameReqName = () => {
   const tab = getTabRef(currentTabID.value)
   if (tab.value) {
-    tab.value.document.request.name = name
+    tab.value.document.request.name = reqName.value
     updateTab(tab.value)
   }
   showRenamingReqNameModal.value = false

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -23,6 +23,7 @@
                 v-tippy="{ theme: 'tooltip', delay: [500, 20] }"
                 :title="tab.document.request.name"
                 class="truncate px-2"
+                @dblclick="openReqRenameModal()"
               >
                 <span
                   class="font-semibold text-tiny"
@@ -61,6 +62,45 @@
         <HttpSidebar />
       </template>
     </AppPaneLayout>
+    <HoppSmartModal
+      v-if="renamingReqName"
+      dialog
+      :title="t('team.new')"
+      @close="renamingReqName = false"
+    >
+      <template #body>
+        <div class="flex flex-col">
+          <input
+            id="selectLabelTeamAdd"
+            v-model="reqName"
+            v-focus
+            class="input floating-input"
+            placeholder=" "
+            type="text"
+            autocomplete="off"
+            @keyup.enter="renameReqName"
+          />
+          <label for="selectLabelTeamAdd">
+            {{ t("action.label") }}
+          </label>
+        </div>
+      </template>
+      <template #footer>
+        <span class="flex space-x-2">
+          <HoppButtonPrimary
+            :label="t('action.save')"
+            outline
+            @click="renameReqName"
+          />
+          <HoppButtonSecondary
+            :label="t('action.cancel')"
+            outline
+            filled
+            @click="renamingReqName = false"
+          />
+        </span>
+      </template>
+    </HoppSmartModal>
     <HoppSmartConfirmModal
       :show="confirmingCloseForTabID !== null"
       :confirm="t('modal.close_unsaved_tab')"
@@ -116,6 +156,8 @@ import { oauthRedirect } from "~/helpers/oauth"
 
 const savingRequest = ref(false)
 const confirmingCloseForTabID = ref<string | null>(null)
+const renamingReqName = ref(false)
+const reqName = ref<string>("")
 
 const t = useI18n()
 const toast = useToast()
@@ -164,6 +206,20 @@ const removeTab = (tabID: string) => {
   } else {
     closeTab(tab.value.id)
   }
+}
+
+const openReqRenameModal = () => {
+  renamingReqName.value = true
+  reqName.value = currentActiveTab.value.document.request.name
+}
+
+const renameReqName = () => {
+  const tab = getTabRef(currentTabID.value)
+  if (tab.value) {
+    tab.value.document.request.name = reqName.value
+    updateTab(tab.value)
+  }
+  renamingReqName.value = false
 }
 
 /**

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -62,45 +62,12 @@
         <HttpSidebar />
       </template>
     </AppPaneLayout>
-    <HoppSmartModal
-      v-if="renamingReqName"
-      dialog
-      :title="t('request.name')"
-      @close="renamingReqName = false"
-    >
-      <template #body>
-        <div class="flex flex-col">
-          <input
-            id="reqName"
-            v-model="reqName"
-            v-focus
-            class="input floating-input"
-            placeholder=" "
-            type="text"
-            autocomplete="off"
-            @keyup.enter="renameReqName"
-          />
-          <label for="reqName">
-            {{ t("action.name") }}
-          </label>
-        </div>
-      </template>
-      <template #footer>
-        <span class="flex space-x-2">
-          <HoppButtonPrimary
-            :label="t('action.save')"
-            outline
-            @click="renameReqName"
-          />
-          <HoppButtonSecondary
-            :label="t('action.cancel')"
-            outline
-            filled
-            @click="renamingReqName = false"
-          />
-        </span>
-      </template>
-    </HoppSmartModal>
+    <CollectionsEditRequest
+      :show="showRenamingReqNameModal"
+      :editing-request-name="reqName"
+      @submit="renameReqName"
+      @hide-modal="showRenamingReqNameModal = false"
+    />
     <HoppSmartConfirmModal
       :show="confirmingCloseForTabID !== null"
       :confirm="t('modal.close_unsaved_tab')"
@@ -156,7 +123,7 @@ import { oauthRedirect } from "~/helpers/oauth"
 
 const savingRequest = ref(false)
 const confirmingCloseForTabID = ref<string | null>(null)
-const renamingReqName = ref(false)
+const showRenamingReqNameModal = ref(false)
 const reqName = ref<string>("")
 
 const t = useI18n()
@@ -209,17 +176,17 @@ const removeTab = (tabID: string) => {
 }
 
 const openReqRenameModal = () => {
-  renamingReqName.value = true
+  showRenamingReqNameModal.value = true
   reqName.value = currentActiveTab.value.document.request.name
 }
 
-const renameReqName = () => {
+const renameReqName = (name: string) => {
   const tab = getTabRef(currentTabID.value)
   if (tab.value) {
-    tab.value.document.request.name = reqName.value
+    tab.value.document.request.name = name
     updateTab(tab.value)
   }
-  renamingReqName.value = false
+  showRenamingReqNameModal.value = false
 }
 
 /**

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -65,13 +65,13 @@
     <HoppSmartModal
       v-if="renamingReqName"
       dialog
-      :title="t('team.new')"
+      :title="t('request.name')"
       @close="renamingReqName = false"
     >
       <template #body>
         <div class="flex flex-col">
           <input
-            id="selectLabelTeamAdd"
+            id="reqName"
             v-model="reqName"
             v-focus
             class="input floating-input"
@@ -80,8 +80,8 @@
             autocomplete="off"
             @keyup.enter="renameReqName"
           />
-          <label for="selectLabelTeamAdd">
-            {{ t("action.label") }}
+          <label for="reqName">
+            {{ t("action.name") }}
           </label>
         </div>
       </template>


### PR DESCRIPTION
### Summary
🖊️🚀🎨

<!--
1.  🖊️ - This emoji represents the act of renaming or editing something, which is the main functionality of this feature.
2.  🚀 - This emoji represents the improvement or enhancement of the user experience and the speed of the workflow, as the user can now quickly and easily rename their requests without having to open the settings menu or navigate to another page.
3.  🎨 - This emoji represents the design or aesthetic aspect of this feature, as it adds a new modal dialog with a simple and clean UI that matches the rest of the app.
-->
Added a feature to rename requests in `index.vue`. Users can double-click on a request name and enter a new name in a modal dialog.

### Walkthrough
*  Add a feature to rename the request name by double-clicking on it ([link](https://github.com/hoppscotch/hoppscotch/pull/3057/files?diff=unified&w=0#diff-fad0a5fd18efa5e20c31a16edf95ad374d774283c5e75a09e7e35fbd7906ea08R26), [link](https://github.com/hoppscotch/hoppscotch/pull/3057/files?diff=unified&w=0#diff-fad0a5fd18efa5e20c31a16edf95ad374d774283c5e75a09e7e35fbd7906ea08R65-R103), [link](https://github.com/hoppscotch/hoppscotch/pull/3057/files?diff=unified&w=0#diff-fad0a5fd18efa5e20c31a16edf95ad374d774283c5e75a09e7e35fbd7906ea08R159-R160), [link](https://github.com/hoppscotch/hoppscotch/pull/3057/files?diff=unified&w=0#diff-fad0a5fd18efa5e20c31a16edf95ad374d774283c5e75a09e7e35fbd7906ea08R211-R224))
  - Declare two reactive variables, `renamingReqName` and `reqName`, to control the modal dialog and the input value (`packages/hoppscotch-common/src/pages/index.vue` [link](https://github.com/hoppscotch/hoppscotch/pull/3057/files?diff=unified&w=0#diff-fad0a5fd18efa5e20c31a16edf95ad374d774283c5e75a09e7e35fbd7906ea08R159-R160))
  - Define two functions, `openReqRenameModal` and `renameReqName`, to open the modal and update the request name (`packages/hoppscotch-common/src/pages/index.vue` [link](https://github.com/hoppscotch/hoppscotch/pull/3057/files?diff=unified&w=0#diff-fad0a5fd18efa5e20c31a16edf95ad374d774283c5e75a09e7e35fbd7906ea08R211-R224))
  - Add a double-click event listener to the request name element that calls `openReqRenameModal` (`packages/hoppscotch-common/src/pages/index.vue` [link](https://github.com/hoppscotch/hoppscotch/pull/3057/files?diff=unified&w=0#diff-fad0a5fd18efa5e20c31a16edf95ad374d774283c5e75a09e7e35fbd7906ea08R26))
  - Add a template for the modal dialog that uses `renamingReqName` and `reqName` and emits a `close` event (`packages/hoppscotch-common/src/pages/index.vue` [link](https://github.com/hoppscotch/hoppscotch/pull/3057/files?diff=unified&w=0#diff-fad0a5fd18efa5e20c31a16edf95ad374d774283c5e75a09e7e35fbd7906ea08R65-R103))
  - Add a `keyup.enter` event listener to the input field that calls `renameReqName` (`packages/hoppscotch-common/src/pages/index.vue` [link](https://github.com/hoppscotch/hoppscotch/pull/3057/files?diff=unified&w=0#diff-fad0a5fd18efa5e20c31a16edf95ad374d774283c5e75a09e7e35fbd7906ea08R65-R103))


Closes HFE-53