### PR TITLE
fix: dead key issue in mac

### DIFF
--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -121,8 +121,8 @@ function getPressedKey(ev: KeyboardEvent): Key | null {
   else if (val === "arrowright") return "right"
 
   // Check letter keys
-  if (val.length === 1 && val.toUpperCase() !== val.toLowerCase())
-    return val as Key
+  const isLetter = ev.code.toLowerCase().startsWith("key")
+  if (isLetter) return ev.code.toLowerCase().substring(3) as Key
 
   // Check if number keys
   if (val.length === 1 && !isNaN(val as any)) return val as Key


### PR DESCRIPTION
### Summary
🐛🌐⌨️

<!--
1.  🐛 - This emoji represents a bug or an error that was fixed by the change.
2.  🌐 - This emoji represents a change related to internationalization, localization, or keyboard layouts.
3.  ⌨️ - This emoji represents a change related to keyboard input or interaction.
-->
Fixed a keybinding bug for different keyboard layouts by using `ev.code` instead of `ev.key` in `getPressedKey` function. This affects the file `packages/hoppscotch-common/src/helpers/keybindings.ts`.

Keyboard event for any letters starts with `Key` in `code` property. And after `Key` it contains original letter. eg: if we press `Option+Q` the mac default key would be `Option+œ` but inside code property it would be `Option+KeyQ`. So, only for letters we are checking from `code` instead of `key`

> _`ev.code` not `key`_
> _Fixes keyboard layout bug_
> _Autumn leaves falling_

### Walkthrough
* Fix keybinding bug for different keyboard layouts by using `ev.code` instead of `ev.key` to check for letter keys ([link](https://github.com/hoppscotch/hoppscotch/pull/3058/files?diff=unified&w=0#diff-1739024c7f2b818baf3371ad86dfd3f41e18acfc2da76778f3d545832beb4de6L124-R125))

