### PR TITLE
fix: set team environment from test

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -165,8 +165,8 @@ const props = withDefaults(
   defineProps<{
     show: boolean
     action: "edit" | "new"
-    editingEnvironmentIndex: number | "Global" | null
-    editingVariableName: string | null
+    editingEnvironmentIndex?: number | "Global" | null
+    editingVariableName?: string | null
     envVars?: () => Environment["variables"]
   }>(),
   {

--- a/packages/hoppscotch-common/src/components/http/TestResult.vue
+++ b/packages/hoppscotch-common/src/components/http/TestResult.vue
@@ -197,9 +197,16 @@
       />
     </div>
     <EnvironmentsMyDetails
-      :show="showModalDetails"
+      :show="showMyEnvironmentDetailsModal"
       action="new"
       :env-vars="getAdditionVars"
+      @hide-modal="displayModalAdd(false)"
+    />
+    <EnvironmentsTeamsDetails
+      :show="showTeamEnvironmentDetailsModal"
+      action="new"
+      :env-vars="getAdditionVars"
+      :editing-team-id="workspace.type === 'team' ? workspace.teamID : null"
       @hide-modal="displayModalAdd(false)"
     />
   </div>
@@ -225,6 +232,7 @@ import IconClose from "~icons/lucide/x"
 
 import { useColorMode } from "~/composables/theming"
 import { useVModel } from "@vueuse/core"
+import { workspaceStatus$ } from "~/newstore/workspace"
 
 const props = defineProps<{
   modelValue: HoppTestResult | null | undefined
@@ -239,10 +247,15 @@ const testResults = useVModel(props, "modelValue", emit)
 const t = useI18n()
 const colorMode = useColorMode()
 
-const showModalDetails = ref(false)
+const workspace = useReadonlyStream(workspaceStatus$, { type: "personal" })
+
+const showMyEnvironmentDetailsModal = ref(false)
+const showTeamEnvironmentDetailsModal = ref(false)
 
 const displayModalAdd = (shouldDisplay: boolean) => {
-  showModalDetails.value = shouldDisplay
+  if (workspace.value.type === "personal")
+    showMyEnvironmentDetailsModal.value = shouldDisplay
+  else showTeamEnvironmentDetailsModal.value = shouldDisplay
 }
 
 /**

--- a/packages/hoppscotch-common/src/components/http/TestResult.vue
+++ b/packages/hoppscotch-common/src/components/http/TestResult.vue
@@ -206,7 +206,9 @@
       :show="showTeamEnvironmentDetailsModal"
       action="new"
       :env-vars="getAdditionVars"
-      :editing-team-id="workspace.type === 'team' ? workspace.teamID : null"
+      :editing-team-id="
+        workspace.type === 'team' ? workspace.teamID : undefined
+      "
       @hide-modal="displayModalAdd(false)"
     />
   </div>


### PR DESCRIPTION
Closes HFE-54

### Description
This PR adds the option to set an environment from the test and save it as a team environment if the team workspace is selected.

#### Before
When using the test `pw.env.set("variable", "value");` saves the environment to the 'My Environments' or to the 'Global' even the current workspace is selected as team.

#### After
Now when using the `pw.env.set("variable", "value");` sets the environment automatically to the selected team environment and personal environments respectively checking the current workspace status.


### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed
