### PR TITLE
fix: sync popup firing multiple times

### DIFF
--- a/packages/hoppscotch-common/src/newstore/syncing.ts
+++ b/packages/hoppscotch-common/src/newstore/syncing.ts
@@ -1,0 +1,40 @@
+import { distinctUntilChanged, pluck } from "rxjs"
+import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
+
+type SyncState = {
+  initialSync: boolean
+  sync: boolean
+}
+
+type CurrentSyncingState = {
+  currentSyncingItem: SyncState
+}
+
+const initialState: CurrentSyncingState = {
+  currentSyncingItem: {
+    initialSync: false,
+    sync: false,
+  },
+}
+
+const dispatchers = defineDispatchers({
+  changeCurrentSyncStatus(_, { syncItem }: { syncItem: SyncState }) {
+    return {
+      currentSyncingItem: syncItem,
+    }
+  },
+})
+
+export const currentSyncStore = new DispatchingStore(initialState, dispatchers)
+
+export const currentSyncingStatus$ = currentSyncStore.subject$.pipe(
+  pluck("currentSyncingItem"),
+  distinctUntilChanged()
+)
+
+export function changeCurrentSyncStatus(syncItem: SyncState) {
+  currentSyncStore.dispatch({
+    dispatcher: "changeCurrentSyncStatus",
+    payload: { syncItem },
+  })
+}

--- a/packages/hoppscotch-common/src/newstore/syncing.ts
+++ b/packages/hoppscotch-common/src/newstore/syncing.ts
@@ -2,8 +2,8 @@ import { distinctUntilChanged, pluck } from "rxjs"
 import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
 
 type SyncState = {
-  initialSync: boolean
-  sync: boolean
+  isInitialSync: boolean
+  shouldSync: boolean
 }
 
 type CurrentSyncingState = {
@@ -12,8 +12,8 @@ type CurrentSyncingState = {
 
 const initialState: CurrentSyncingState = {
   currentSyncingItem: {
-    initialSync: false,
-    sync: false,
+    isInitialSync: false,
+    shouldSync: false,
   },
 }
 

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -87,7 +87,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, onMounted, onBeforeUnmount, watch, onBeforeMount } from "vue"
+import { ref, onMounted, onBeforeUnmount, onBeforeMount } from "vue"
 import { safelyExtractRESTRequest } from "@hoppscotch/data"
 import { translateExtURLParams } from "~/helpers/RESTExtURLParams"
 import { useRoute } from "vue-router"
@@ -140,8 +140,8 @@ const toast = useToast()
 const tabs = getActiveTabs()
 
 const confirmSync = useReadonlyStream(currentSyncingStatus$, {
-  initialSync: false,
-  sync: true,
+  isInitialSync: false,
+  shouldSync: true,
 })
 const tabStateForSync = ref<PersistableRESTTabState | null>(null)
 
@@ -237,40 +237,6 @@ const onSaveModalClose = () => {
   }
 }
 
-watch(
-  () => confirmSync.value.initialSync,
-  (newValue) => {
-    if (newValue) {
-      toast.show(t("confirm.sync"), {
-        duration: 0,
-        action: [
-          {
-            text: `${t("action.yes")}`,
-            onClick: (_, toastObject) => {
-              syncTabState()
-              changeCurrentSyncStatus({
-                initialSync: true,
-                sync: true,
-              })
-              toastObject.goAway(0)
-            },
-          },
-          {
-            text: `${t("action.no")}`,
-            onClick: (_, toastObject) => {
-              changeCurrentSyncStatus({
-                initialSync: true,
-                sync: false,
-              })
-              toastObject.goAway(0)
-            },
-          },
-        ],
-      })
-    }
-  }
-)
-
 const syncTabState = () => {
   if (tabStateForSync.value) loadTabsFromPersistedState(tabStateForSync.value)
 }
@@ -309,6 +275,35 @@ function startTabStateSync(): Subscription {
   return sub
 }
 
+const showSyncToast = () => {
+  toast.show(t("confirm.sync"), {
+    duration: 0,
+    action: [
+      {
+        text: `${t("action.yes")}`,
+        onClick: (_, toastObject) => {
+          syncTabState()
+          changeCurrentSyncStatus({
+            isInitialSync: true,
+            shouldSync: true,
+          })
+          toastObject.goAway(0)
+        },
+      },
+      {
+        text: `${t("action.no")}`,
+        onClick: (_, toastObject) => {
+          changeCurrentSyncStatus({
+            isInitialSync: true,
+            shouldSync: false,
+          })
+          toastObject.goAway(0)
+        },
+      },
+    ],
+  })
+}
+
 function setupTabStateSync() {
   const route = useRoute()
 
@@ -324,11 +319,14 @@ function setupTabStateSync() {
       const tabStateFromSync =
         await platform.sync.tabState.loadTabStateFromSync()
 
-      if (tabStateFromSync && !confirmSync.value.initialSync) {
+      if (tabStateFromSync && !confirmSync.value.isInitialSync) {
         tabStateForSync.value = tabStateFromSync
+        showSyncToast()
+        // Have to set isInitialSync to true here because the toast is shown
+        // and the user does not click on any of the actions
         changeCurrentSyncStatus({
-          initialSync: true,
-          sync: false,
+          isInitialSync: true,
+          shouldSync: false,
         })
       }
     }


### PR DESCRIPTION
Closes HFE-46

### Description
This PR fixes the issue where popup for workspace restoration was firing multiple times when navigating from other pages and returning back to the REST page and on some other occasions.

### Checks
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed

