### PR TITLE
fix: timing dependency on test case

### DIFF
--- a/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
@@ -360,13 +360,15 @@ describe('UserHistoryService', () => {
   });
   describe('removeRequestFromHistory', () => {
     test('Should resolve right and delete request from users history', async () => {
+      const executedOn = new Date();
+
       mockPrisma.userHistory.delete.mockResolvedValueOnce({
         userUid: 'abc',
         id: '1',
         request: [{}],
         responseMetadata: [{}],
         reqType: ReqType.REST,
-        executedOn: new Date(),
+        executedOn: executedOn,
         isStarred: false,
       });
 
@@ -376,7 +378,7 @@ describe('UserHistoryService', () => {
         request: JSON.stringify([{}]),
         responseMetadata: JSON.stringify([{}]),
         reqType: ReqType.REST,
-        executedOn: new Date(),
+        executedOn: executedOn,
         isStarred: false,
       };
 
@@ -384,7 +386,7 @@ describe('UserHistoryService', () => {
         await userHistoryService.removeRequestFromHistory('abc', '1'),
       ).toEqualRight(userHistory);
     });
-    test('Should resolve left and error out when req id is invalid ', async () => {
+    test('Should resolve left and error out when req id is invalid', async () => {
       mockPrisma.userHistory.delete.mockResolvedValueOnce(null);
 
       return expect(


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HBE-194

### Description
<!-- Add a brief description of the pull request -->
In this PR, we fix a unit test issue for the backend by which the build was being failed.

```
packages/hoppscotch-backend do-test:     - Expected Right  - 1
packages/hoppscotch-backend do-test:     + Received Right  + 1
packages/hoppscotch-backend do-test:       Object {
packages/hoppscotch-backend do-test:     -   "executedOn": 2023-04-23T10:19:35.258Z,
packages/hoppscotch-backend do-test:     +   "executedOn": 2023-04-23T10:19:35.257Z,
packages/hoppscotch-backend do-test:         "id": "1",
packages/hoppscotch-backend do-test:         "isStarred": false,
packages/hoppscotch-backend do-test:         "reqType": "REST",
packages/hoppscotch-backend do-test:         "request": "[{}]",
packages/hoppscotch-backend do-test:         "responseMetadata": "[{}]",
packages/hoppscotch-backend do-test:         "userUid": "abc",
packages/hoppscotch-backend do-test:       }
```
Here if you see, you will notice that the `executedOn` value is mismatched by a millisecond.  This occurred because of we had written `new Date()` twice instead of using the same reference.

[https://github.com/hoppscotch/hoppscotch/actions/runs/4777765956/jobs/8493727095](https://github.com/hoppscotch/hoppscotch/actions/runs/4777765956/jobs/8493727095)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### How to Reproduce Issue
Just run the backend test cases, sometime you will get this issue.
```
pnpm run test
```

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
Nil


