### PR TITLE
chore: update wss url to ws in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ VITE_ADMIN_URL=http://localhost:3100
 
 # Backend URLs
 VITE_BACKEND_GQL_URL=http://localhost:3170/graphql
-VITE_BACKEND_WS_URL=wss://localhost:3170/graphql
+VITE_BACKEND_WS_URL=ws://localhost:3170/graphql
 VITE_BACKEND_API_URL=http://localhost:3170/v1
 
 # Terms Of Service And Privacy Policy Links (Optional)


### PR DESCRIPTION
Closes hfe-58

**Description**

Our environment file currently includes a WSS URL (WebSockets Sequer URL). However, while testing on localhost, this will fail ( none of our subscriptions will work ) because you need to set up certificates and run a WSS server on your local machine. To prevent this, we recommend that the local server URL in the environment file default to using WebSockets instead of the WSS protocol.