### PR TITLE
Fix: Update team invitation link to domain specified in .env [HBE-202]

### DIFF
--- a/packages/hoppscotch-backend/src/team-invitation/team-invitation.service.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invitation.service.ts
@@ -126,7 +126,7 @@ export class TeamInvitationService {
             template: 'team-invitation',
             variables: {
               invitee: creator.displayName ?? 'A Hoppscotch User',
-              action_url: `https://hoppscotch.io/join-team?id=${invitation.id}`,
+              action_url: `${process.env.VITE_BASE_URL}/join-team?id=${invitation.id}`,
               invite_team_name: team.name,
             },
           }),


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # HBE-202 - [Bug] - Incorrect Invite Link in Team invitation

### Description
Currently if we invite a user to join a team through team invitation the invite link generated points to - `https://hoppscotch.io/join-team?id=##` instead it should point to `https://your-domain/join-team?id=##` based on the config in the `.env` file.
As reported in the issue - https://github.com/hoppscotch/hoppscotch/issues/3078

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
##Testing Instructions: 
1. Create a team and then invite a user using their email and role in the team
2. Check the mailbox for the invite link it should be in the format `https://your-domain/join-team?id=##` based on env config
