### PR TITLE
chore: improve mobile responsiveness on environment selector

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -11,13 +11,14 @@
       class="bg-transparent border-b border-dividerLight select-wrapper"
     >
       <HoppButtonSecondary
-        v-if="selectedEnv.type !== 'NO_ENV_SELECTED'"
-        :label="selectedEnv.name"
-        class="flex-1 !justify-start pr-8 rounded-none"
-      />
-      <HoppButtonSecondary
-        v-else
-        :label="`${t('environment.select')}`"
+        :icon="IconLayers"
+        :label="
+          mdAndLarger
+            ? selectedEnv.type !== 'NO_ENV_SELECTED'
+              ? selectedEnv.name
+              : `${t('environment.select')}`
+            : ''
+        "
         class="flex-1 !justify-start pr-8 rounded-none"
       />
     </span>
@@ -58,6 +59,7 @@
             <HoppSmartItem
               v-for="(gen, index) in myEnvironments"
               :key="`gen-${index}`"
+              :icon="IconLayers"
               :label="gen.name"
               :info-icon="index === selectedEnv.index ? IconCheck : undefined"
               :active-info-icon="index === selectedEnv.index"
@@ -99,6 +101,7 @@
               <HoppSmartItem
                 v-for="(gen, index) in teamEnvironmentList"
                 :key="`gen-team-${index}`"
+                :icon="IconLayers"
                 :label="gen.environment.name"
                 :info-icon="
                   gen.id === selectedEnv.teamEnvID ? IconCheck : undefined
@@ -148,6 +151,7 @@
 <script lang="ts" setup>
 import { computed, ref, watch } from "vue"
 import IconCheck from "~icons/lucide/check"
+import IconLayers from "~icons/lucide/layers"
 import { TippyComponent } from "vue-tippy"
 import { useI18n } from "~/composables/i18n"
 import { GQLError } from "~/helpers/backend/GQLClient"
@@ -160,6 +164,10 @@ import {
 import { workspaceStatus$ } from "~/newstore/workspace"
 import TeamEnvironmentAdapter from "~/helpers/teams/TeamEnvironmentAdapter"
 import { useColorMode } from "@composables/theming"
+import { breakpointsTailwind, useBreakpoints } from "@vueuse/core"
+
+const breakpoints = useBreakpoints(breakpointsTailwind)
+const mdAndLarger = breakpoints.greater("md")
 
 const t = useI18n()
 

--- a/packages/hoppscotch-ui/src/components/smart/Windows.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Windows.vue
@@ -100,7 +100,7 @@
         </div>
       </div>
 
-      <div v-if="hasActions" class="w-64">
+      <div v-if="hasActions" :class="mdAndLarger ? 'w-64' : 'w-16'">
         <slot name="actions" />
       </div>
 
@@ -115,7 +115,7 @@
         }"
         :style="[
           `--thumb-width: ${scrollThumb.width}px`,
-          `width: calc(100% - ${hasActions ? '19rem' : '3rem'})`,
+          `width: calc(100% - ${hasActions ? mdAndLarger ? '19rem' : '7rem' : '3rem'})`,
         ]"
         id="myRange"
       />
@@ -144,7 +144,7 @@ import {
   nextTick,
   useSlots,
 } from "vue"
-import { useElementSize } from "@vueuse/core"
+import { breakpointsTailwind, useBreakpoints, useElementSize } from "@vueuse/core"
 import type { Slot } from "vue"
 import draggable from "vuedraggable-es"
 import { HoppUIPluginOptions, HOPP_UI_OPTIONS } from "./../../index"
@@ -166,6 +166,9 @@ export type TabProvider = {
   updateTabEntry: (tabID: string, newMeta: TabMeta) => void
   removeTabEntry: (tabID: string) => void
 }
+
+const breakpoints = useBreakpoints(breakpointsTailwind)
+const mdAndLarger = breakpoints.greater("md")
 
 const { t } = inject<HoppUIPluginOptions>(HOPP_UI_OPTIONS) ?? {}
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at db09898</samp>

### Summary
🎨📱📦

<!--
1.  🎨 - This emoji is often used to indicate changes or improvements to the UI or design of a project. Adding an icon and hiding the environment label on smaller screens are examples of UI changes that could be represented by this emoji.
2.  📱 - This emoji is often used to indicate changes or improvements to the responsiveness or compatibility of a project on different devices or screen sizes. Improving the layout of the `Windows.vue` component to handle different screen sizes and avoid layout issues is an example of a responsiveness change that could be represented by this emoji.
3.  📦 - This emoji is often used to indicate changes or additions to the dependencies or modules of a project. Using the `@vueuse/core` module to access the Tailwind CSS breakpoints and handle breakpoints is an example of a dependency change that could be represented by this emoji.
-->
Improved the UI and responsiveness of the environment selector and the windows components. Added an icon to indicate the environment list and hid the label on smaller screens. Used `@vueuse/core` to handle breakpoints and layout adjustments.

> _`@vueuse/core` helps_
> _Responsive UI for screens_
> _Layers icon in fall_

### Walkthrough
*  Add an icon of layers to the environment selector and hide the label on smaller screens ([link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L14-R23), [link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664R62), [link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664R104), [link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664R154), [link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L163-R171))
*  Import `IconLayers`, `breakpointsTailwind`, and `useBreakpoints` from external modules to use them in the `Selector.vue` component ([link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664R154), [link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L163-R171))
*  Define a reactive value `mdAndLarger` that returns true if the screen size is greater than or equal to the medium breakpoint defined by Tailwind CSS in the `Selector.vue` and `Windows.vue` components ([link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L163-R171), [link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L147-R147), [link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5R170-R172))
*  Adjust the width of the actions slot and the scrollable area in the `Windows.vue` component depending on the screen size and the presence of actions ([link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L103-R103), [link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L118-R118))
*  Import `breakpointsTailwind` and `useBreakpoints` from external modules to use them in the `Windows.vue` component ([link](https://github.com/hoppscotch/hoppscotch/pull/3100/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L147-R147))

