### PR TITLE
fix: stack order of tab inside environment selector

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -49,7 +49,7 @@
         />
         <HoppSmartTabs
           v-model="selectedEnvTab"
-          styles="sticky overflow-x-auto my-2 border border-divider rounded flex-shrink-0 z-0 top-0 bg-primary"
+          styles="sticky overflow-x-auto my-2 border border-divider rounded flex-shrink-0 z-10 top-0 bg-primary"
           render-inactive-tabs
         >
           <HoppSmartTab


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c2bac42</samp>

### Summary
🐛📏🗂️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of the change.
2.  📏 - This emoji represents a layout or style adjustment, which is the effect of changing the z-index value.
3.  🗂️ - This emoji represents a tab or folder, which is the element that was affected by the change.
-->
Increased z-index of environment selector tabs to prevent them from being obscured by request editor. Fixed a UI bug in `Selector.vue`.

> _`z-0` to `z-10`_
> _tabs rise above the editor_
> _autumn bug is fixed_

### Walkthrough
*  Increase the z-index of the environment selector tabs to fix a bug where they would be hidden behind the request editor when scrolling ([link](https://github.com/hoppscotch/hoppscotch/pull/3108/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L52-R52))

