### PR TITLE
fix: collection request name edit issue

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -147,6 +147,7 @@
     "remove_team": "Are you sure you want to delete this team?",
     "remove_telemetry": "Are you sure you want to opt-out of Telemetry?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
+    "request_save": "You have changed request name. Do you want to save it?",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
     "sync": "Would you like to restore your workspace from cloud? This will discard your local progress."
   },

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -147,7 +147,6 @@
     "remove_team": "Are you sure you want to delete this team?",
     "remove_telemetry": "Are you sure you want to opt-out of Telemetry?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
-    "request_save": "You have changed request name. Do you want to save it?",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
     "sync": "Would you like to restore your workspace from cloud? This will discard your local progress."
   },

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -861,7 +861,7 @@ const editRequest = (payload: {
 }) => {
   const { folderPath, requestIndex, request } = payload
   editingRequest.value = request
-  editingRequestName.value = request.name || ""
+  editingRequestName.value = request.name ?? ""
   if (collectionsType.value.type === "my-collections" && folderPath) {
     editingFolderPath.value = folderPath
     editingRequestIndex.value = parseInt(requestIndex)

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -126,7 +126,7 @@
     />
     <CollectionsEditRequest
       :show="showModalEditRequest"
-      :model-value="editingRequest ? editingRequest.name : ''"
+      v-model="editingRequestName"
       :loading-state="modalLoadingState"
       @submit="updateEditingRequest"
       @hide-modal="displayModalEditRequest(false)"
@@ -288,6 +288,7 @@ const editingFolder = ref<
 const editingFolderName = ref<string | null>(null)
 const editingFolderPath = ref<string | null>(null)
 const editingRequest = ref<HoppRESTRequest | null>(null)
+const editingRequestName = ref("")
 const editingRequestIndex = ref<number | null>(null)
 const editingRequestID = ref<string | null>(null)
 
@@ -860,6 +861,7 @@ const editRequest = (payload: {
 }) => {
   const { folderPath, requestIndex, request } = payload
   editingRequest.value = request
+  editingRequestName.value = request.name || ""
   if (collectionsType.value.type === "my-collections" && folderPath) {
     editingFolderPath.value = folderPath
     editingRequestIndex.value = parseInt(requestIndex)
@@ -877,6 +879,7 @@ const updateEditingRequest = (newName: string) => {
     ...request,
     name: newName || request.name,
   }
+  editingRequestName.value = ""
   if (collectionsType.value.type === "my-collections") {
     const folderPath = editingFolderPath.value
     const requestIndex = editingRequestIndex.value

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -125,8 +125,8 @@
       @hide-modal="displayModalEditFolder(false)"
     />
     <CollectionsEditRequest
-      :show="showModalEditRequest"
       v-model="editingRequestName"
+      :show="showModalEditRequest"
       :loading-state="modalLoadingState"
       @submit="updateEditingRequest"
       @hide-modal="displayModalEditRequest(false)"
@@ -879,7 +879,6 @@ const updateEditingRequest = (newName: string) => {
     ...request,
     name: newName || request.name,
   }
-  editingRequestName.value = ""
   if (collectionsType.value.type === "my-collections") {
     const folderPath = editingFolderPath.value
     const requestIndex = editingRequestIndex.value

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -157,7 +157,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, PropType, ref, watch } from "vue"
+import { computed, nextTick, PropType, ref, watch } from "vue"
 import { useToast } from "@composables/toast"
 import { useI18n } from "@composables/i18n"
 import { Picked } from "~/helpers/types/HoppPicked"
@@ -895,6 +895,9 @@ const updateEditingRequest = (newName: string) => {
 
     if (possibleActiveTab) {
       possibleActiveTab.value.document.request.name = requestUpdated.name
+      nextTick(() => {
+        possibleActiveTab.value.document.isDirty = false
+      })
     }
 
     displayModalEditRequest(false)
@@ -933,6 +936,9 @@ const updateEditingRequest = (newName: string) => {
 
     if (possibleTab) {
       possibleTab.value.document.request.name = requestName
+      nextTick(() => {
+        possibleTab.value.document.isDirty = false
+      })
     }
   }
 }

--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -217,6 +217,7 @@
       @hide-modal="showCodegenModal = false"
     />
     <CollectionsSaveRequest
+      v-if="showSaveRequestModal"
       mode="rest"
       :show="showSaveRequestModal"
       @hide-modal="showSaveRequestModal = false"

--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -217,7 +217,6 @@
       @hide-modal="showCodegenModal = false"
     />
     <CollectionsSaveRequest
-      v-if="showSaveRequestModal"
       mode="rest"
       :show="showSaveRequestModal"
       @hide-modal="showSaveRequestModal = false"

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -196,6 +196,7 @@ const renameReqName = () => {
   if (tab.value) {
     tab.value.document.request.name = reqName.value
     updateTab(tab.value)
+    invokeAction("request.save")
   }
   showRenamingReqNameModal.value = false
 }

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -79,6 +79,7 @@
       @resolve="onResolveConfirmSaveTab"
     />
     <CollectionsSaveRequest
+      v-if="savingRequest"
       mode="rest"
       :show="savingRequest"
       @hide-modal="onSaveModalClose"

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -79,8 +79,8 @@
       @resolve="onResolveConfirmSaveTab"
     />
     <CollectionsSaveRequest
+      mode="rest"
       :show="savingRequest"
-      :mode="'rest'"
       @hide-modal="onSaveModalClose"
     />
   </div>

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -196,7 +196,9 @@ const renameReqName = () => {
   if (tab.value) {
     tab.value.document.request.name = reqName.value
     updateTab(tab.value)
-    invokeAction("request.save")
+    if (tab.value.document.saveContext) {
+      invokeAction("request.save")
+    }
   }
   showRenamingReqNameModal.value = false
 }

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -197,11 +197,30 @@ const renameReqName = () => {
   if (tab.value) {
     tab.value.document.request.name = reqName.value
     updateTab(tab.value)
-    if (tab.value.document.saveContext) {
-      invokeAction("request.save")
-    }
+    showSaveToast()
   }
   showRenamingReqNameModal.value = false
+}
+
+const showSaveToast = () => {
+  toast.show(t("confirm.request_save"), {
+    duration: 0,
+    action: [
+      {
+        text: `${t("action.yes")}`,
+        onClick: (_, toastObject) => {
+          invokeAction("request.save")
+          toastObject.goAway(0)
+        },
+      },
+      {
+        text: `${t("action.no")}`,
+        onClick: (_, toastObject) => {
+          toastObject.goAway(0)
+        },
+      },
+    ],
+  })
 }
 
 /**

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -197,30 +197,8 @@ const renameReqName = () => {
   if (tab.value) {
     tab.value.document.request.name = reqName.value
     updateTab(tab.value)
-    showSaveToast()
   }
   showRenamingReqNameModal.value = false
-}
-
-const showSaveToast = () => {
-  toast.show(t("confirm.request_save"), {
-    duration: 0,
-    action: [
-      {
-        text: `${t("action.yes")}`,
-        onClick: (_, toastObject) => {
-          invokeAction("request.save")
-          toastObject.goAway(0)
-        },
-      },
-      {
-        text: `${t("action.no")}`,
-        onClick: (_, toastObject) => {
-          toastObject.goAway(0)
-        },
-      },
-    ],
-  })
 }
 
 /**


### PR DESCRIPTION
### Tests

**Personal workspace**

- [x] Editing and saving requests from personal workspace > collection section - **changes should be directly saved, no dirty indicator**
- [x] Editing and saving request from personal workspace > double click the tab name - **request should be dirty with unsaved changes indicator**
- [x] Editing and saving new requests from personal workspace > new request (click on the new tab +)" - **request should be dirty with unsaved changes indicator**

**Team workspace**

- [x] Editing and saving requests from team workspace > collection section - **changes should be directly saved, no dirty indicator**
- [x] Editing and saving request from team workspace > double click the tab name - **request should be dirty with unsaved changes indicator**
- [x] Editing and saving new requests from team workspace > new request (click on the new tab +)" - **request should be dirty with unsaved changes indicator**

**Behaviours**

- [x] Dirty indicator behavior on all above cases
- [x] Manual save action behavior on all above cases

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c343374</samp>

### Summary
✨🐛♻️

<!--
1.  ✨ - This emoji represents the addition of a new feature or enhancement, which is the simplification of the editing process and the improved user experience.
2.  🐛 - This emoji represents the fixing of a bug or an issue, which is the removal of the unnecessary `updateRequestName` method and the `requestName` data property that caused errors and inconsistencies in the data flow.
3.  ♻️ - This emoji represents the refactoring or improvement of the code quality, which is the use of the `v-model` directive and the `editingRequestName` ref to make the code more concise, readable, and reactive.
-->
Simplify request name editing in collections modal. Use `v-model` and `editingRequestName` ref to bind data and UI elements in `collections/index.vue`.

> _We're editing request names with ease_
> _Using `v-model` and a `ref`_
> _No more messy data flow to tease_
> _Just a modal dialog that's smooth and def_

### Walkthrough
*  Simplify data binding for editing request name in modal dialog ([link](https://github.com/hoppscotch/hoppscotch/pull/3115/files?diff=unified&w=0#diff-bea4d3e00e3d1167aa2228f3ce3d9a582dc3a006e0753c3806c6e8f1ec0d4080L129-R129), [link](https://github.com/hoppscotch/hoppscotch/pull/3115/files?diff=unified&w=0#diff-bea4d3e00e3d1167aa2228f3ce3d9a582dc3a006e0753c3806c6e8f1ec0d4080R291), [link](https://github.com/hoppscotch/hoppscotch/pull/3115/files?diff=unified&w=0#diff-bea4d3e00e3d1167aa2228f3ce3d9a582dc3a006e0753c3806c6e8f1ec0d4080R864), [link](https://github.com/hoppscotch/hoppscotch/pull/3115/files?diff=unified&w=0#diff-bea4d3e00e3d1167aa2228f3ce3d9a582dc3a006e0753c3806c6e8f1ec0d4080R882))

Closes HFE-75
Closes #3114 
