### PR TITLE
fix: failed to execute 'observe' on 'IntersectionObserver'

### DIFF
--- a/packages/hoppscotch-ui/src/components/smart/Windows.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Windows.vue
@@ -115,7 +115,9 @@
         }"
         :style="[
           `--thumb-width: ${scrollThumb.width}px`,
-          `width: calc(100% - ${hasActions ? mdAndLarger ? '19rem' : '7rem' : '3rem'})`,
+          `width: calc(100% - ${
+            hasActions ? (mdAndLarger ? '19rem' : '7rem') : '3rem'
+          })`,
         ]"
         id="myRange"
       />
@@ -144,7 +146,11 @@ import {
   nextTick,
   useSlots,
 } from "vue"
-import { breakpointsTailwind, useBreakpoints, useElementSize } from "@vueuse/core"
+import {
+  breakpointsTailwind,
+  useBreakpoints,
+  useElementSize,
+} from "@vueuse/core"
 import type { Slot } from "vue"
 import draggable from "vuedraggable-es"
 import { HoppUIPluginOptions, HOPP_UI_OPTIONS } from "./../../index"
@@ -350,8 +356,8 @@ watch(
         rootMargin: "0px",
         threshold: 1.0,
       })
-      observer.observe(element!)
 
+      if (element) observer.observe(element)
       element?.scrollIntoView({ behavior: "smooth", inline: "center" })
     })
   },


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9f6dae4</samp>

### Summary
🎨🧹🚧

<!--
1.  🎨 - This emoji is used to indicate that the code has been improved in terms of style or formatting, such as indentation, spacing, alignment, or consistency.
2.  🧹 - This emoji is used to indicate that the code has been cleaned up or refactored, such as removing unused or redundant code, simplifying logic, or renaming variables.
3.  🚧 - This emoji is used to indicate that the code has been made more robust or resilient, such as adding error handling, validation, or null checks, or fixing bugs or edge cases.
-->
Improve Windows component code quality and functionality. Format style and import statements and add a null check for `useScrollIntoView` in `Windows.vue`.

> _Oh we're the Windows crew and we know what to do_
> _We format and import with style and grace_
> _We check for nulls and bugs, we don't need any hugs_
> _We useScrollIntoView to put things in place_

### Walkthrough
* Improve readability of style binding and import statements in `Windows.vue` ([link](https://github.com/hoppscotch/hoppscotch/pull/3122/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L118-R120), [link](https://github.com/hoppscotch/hoppscotch/pull/3122/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L147-R153))
* Prevent error when element is null or undefined in useScrollIntoView function in `Windows.vue` ([link](https://github.com/hoppscotch/hoppscotch/pull/3122/files?diff=unified&w=0#diff-052acc17f6ece720f660d3841f7e49f0a3a1d6ad68dc973819e3d758e45141d5L353-R360))


Closes HFE-72
