### PR TITLE
chore: type and UX improvement for SmartTree

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/Collection.vue
@@ -193,7 +193,7 @@ import IconTrash2 from "~icons/lucide/trash-2"
 import IconEdit from "~icons/lucide/edit"
 import IconFolder from "~icons/lucide/folder"
 import IconFolderOpen from "~icons/lucide/folder-open"
-import { PropType, ref, computed, watch } from "vue"
+import { ref, computed, watch } from "vue"
 import { HoppCollection, HoppRESTRequest } from "@hoppscotch/data"
 import { useI18n } from "@composables/i18n"
 import { TippyComponent } from "vue-tippy"
@@ -209,67 +209,36 @@ type FolderType = "collection" | "folder"
 
 const t = useI18n()
 
-const props = defineProps({
-  id: {
-    type: String,
-    default: "",
-    required: true,
-  },
-  parentID: {
-    type: String as PropType<string | null>,
-    default: null,
-    required: false,
-  },
-  data: {
-    type: Object as PropType<HoppCollection<HoppRESTRequest> | TeamCollection>,
-    default: () => ({}),
-    required: true,
-  },
-  collectionsType: {
-    type: String as PropType<CollectionType>,
-    default: "my-collections",
-    required: true,
-  },
-  /**
-   * Collection component can be used for both collections and folders.
-   * folderType is used to determine which one it is.
-   */
-  folderType: {
-    type: String as PropType<FolderType>,
-    default: "collection",
-    required: true,
-  },
-  isOpen: {
-    type: Boolean,
-    default: false,
-    required: true,
-  },
-  isSelected: {
-    type: Boolean as PropType<boolean | null>,
-    default: false,
-    required: false,
-  },
-  exportLoading: {
-    type: Boolean,
-    default: false,
-    required: false,
-  },
-  hasNoTeamAccess: {
-    type: Boolean,
-    default: false,
-    required: false,
-  },
-  collectionMoveLoading: {
-    type: Array as PropType<string[]>,
-    default: () => [],
-    required: false,
-  },
-  isLastItem: {
-    type: Boolean,
-    default: false,
-    required: false,
-  },
-})
+const props = withDefaults(
+  defineProps<{
+    id: string
+    parentID?: string | null
+    data: HoppCollection<HoppRESTRequest> | TeamCollection
+    /**
+     * Collection component can be used for both collections and folders.
+     * folderType is used to determine which one it is.
+     */
+    collectionsType: CollectionType
+    folderType: FolderType
+    isOpen: boolean
+    isSelected?: boolean | null
+    exportLoading?: boolean
+    hasNoTeamAccess?: boolean
+    collectionMoveLoading?: string[]
+    isLastItem?: boolean
+  }>(),
+  {
+    id: "",
+    parentID: null,
+    collectionsType: "my-collections",
+    folderType: "collection",
+    isOpen: false,
+    isSelected: false,
+    exportLoading: false,
+    hasNoTeamAccess: false,
+    isLastItem: false,
+  }
+)
 
 const emit = defineEmits<{
   (event: "toggle-children"): void
@@ -448,8 +417,13 @@ const notSameDestination = computed(() => {
 })
 
 const isCollLoading = computed(() => {
-  if (props.collectionMoveLoading.length > 0 && props.data.id) {
-    return props.collectionMoveLoading.includes(props.data.id)
+  const { collectionMoveLoading } = props
+  if (
+    collectionMoveLoading &&
+    collectionMoveLoading.length > 0 &&
+    props.data.id
+  ) {
+    return collectionMoveLoading.includes(props.data.id)
   } else {
     return false
   }

--- a/packages/hoppscotch-common/src/components/smart/Tree.vue
+++ b/packages/hoppscotch-common/src/components/smart/Tree.vue
@@ -10,7 +10,7 @@
         class="flex flex-col flex-1"
       >
         <SmartTreeBranch
-          :root-node-length="rootNodes.data.length"
+          :root-nodes-length="rootNodes.data.length"
           :node-item="rootNode"
           :adapter="adapter as SmartTreeAdapter<T>"
         >

--- a/packages/hoppscotch-common/src/components/smart/Tree.vue
+++ b/packages/hoppscotch-common/src/components/smart/Tree.vue
@@ -10,6 +10,7 @@
         class="flex flex-col flex-1"
       >
         <SmartTreeBranch
+          :root-node-length="rootNodes.data.length"
           :node-item="rootNode"
           :adapter="adapter as SmartTreeAdapter<T>"
         >

--- a/packages/hoppscotch-common/src/components/smart/TreeBranch.vue
+++ b/packages/hoppscotch-common/src/components/smart/TreeBranch.vue
@@ -88,7 +88,7 @@ const props = defineProps<{
   /**
    *  Total number of rootNode
    */
-  rootNodeLength: number
+  rootNodesLength?: number
 }>()
 
 const CHILD_SLOT_NAME = "default"
@@ -98,10 +98,10 @@ const t = useI18n()
  * Marks whether the children on this branch were ever rendered
  * See the usage inside '<template>' for more info
  */
-const childrenRendered = ref(props.rootNodeLength === 1 ? true : false)
+const childrenRendered = ref(props.rootNodesLength === 1 ? true : false)
 
-const showChildren = ref(props.rootNodeLength === 1 ? true : false)
-const isNodeOpen = ref(props.rootNodeLength === 1 ? true : false)
+const showChildren = ref(props.rootNodesLength === 1 ? true : false)
+const isNodeOpen = ref(props.rootNodesLength === 1 ? true : false)
 
 const highlightNode = ref(false)
 

--- a/packages/hoppscotch-common/src/components/smart/TreeBranch.vue
+++ b/packages/hoppscotch-common/src/components/smart/TreeBranch.vue
@@ -85,6 +85,10 @@ const props = defineProps<{
    *  The node item that will be used to render the tree branch content
    */
   nodeItem: TreeNode<T>
+  /**
+   *  Total number of rootNode
+   */
+  rootNodeLength: number
 }>()
 
 const CHILD_SLOT_NAME = "default"
@@ -94,10 +98,10 @@ const t = useI18n()
  * Marks whether the children on this branch were ever rendered
  * See the usage inside '<template>' for more info
  */
-const childrenRendered = ref(false)
+const childrenRendered = ref(props.rootNodeLength === 1 ? true : false)
 
-const showChildren = ref(false)
-const isNodeOpen = ref(false)
+const showChildren = ref(props.rootNodeLength === 1 ? true : false)
+const isNodeOpen = ref(props.rootNodeLength === 1 ? true : false)
 
 const highlightNode = ref(false)
 

--- a/packages/hoppscotch-common/src/components/smart/TreeBranch.vue
+++ b/packages/hoppscotch-common/src/components/smart/TreeBranch.vue
@@ -94,14 +94,16 @@ const props = defineProps<{
 const CHILD_SLOT_NAME = "default"
 const t = useI18n()
 
+const isOnlyRootChild = computed(() => props.rootNodesLength === 1)
+
 /**
  * Marks whether the children on this branch were ever rendered
  * See the usage inside '<template>' for more info
  */
-const childrenRendered = ref(props.rootNodesLength === 1 ? true : false)
+const childrenRendered = ref(isOnlyRootChild.value)
 
-const showChildren = ref(props.rootNodesLength === 1 ? true : false)
-const isNodeOpen = ref(props.rootNodesLength === 1 ? true : false)
+const showChildren = ref(isOnlyRootChild.value)
+const isNodeOpen = ref(isOnlyRootChild.value)
 
 const highlightNode = ref(false)
 


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at ef9bd74</samp>

### Summary
:sparkles::hammer_and_wrench::art:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement, which is the case for the `root-node-length` prop that allows the user to pass the number of root nodes in the tree data and control the default expansion state of the tree.
2. :hammer_and_wrench: - This emoji represents a bug fix or improvement of existing code, which is the case for the refactoring of props definition and error handling in `Collection.vue`. This also implies some code maintenance and cleanup, which is also appropriate for this emoji.
3. :art: - This emoji represents an improvement of the UI or UX, which is the case for the prop added to `TreeBranch` component that makes the single root node case more user-friendly by rendering and expanding it by default. This also implies some aesthetic or design changes, which is also suitable for this emoji.
-->
Improved the UX of the `Collection` and `Tree` components. Refactored some props and collapse/expand logic. Removed unnecessary code.

Previous: By default, we keep all collections collapsed.

Now: If there is only one single collection we will expand it by default.


### Walkthrough
*  Add `root-node-length` prop to `Tree` component to control default expansion of root nodes ([link](https://github.com/hoppscotch/hoppscotch/pull/3126/files?diff=unified&w=0#diff-37f31bd418fb2714f7b03adc41f442e4d5f238e514f6f7686d3e36f9822eb3eeR13))
*  Pass `root-node-length` prop from `Tree` to `TreeBranch` component ([link](https://github.com/hoppscotch/hoppscotch/pull/3126/files?diff=unified&w=0#diff-c610c01d2842bcdf7e4e76738ea233b1b93966c00c4bfe8350f76b01df6bf25dR88-R91))
*  Initialize `childrenRendered`, `showChildren`, and `isNodeOpen` refs in `TreeBranch` component based on `root-node-length` prop value ([link](https://github.com/hoppscotch/hoppscotch/pull/3126/files?diff=unified&w=0#diff-c610c01d2842bcdf7e4e76738ea233b1b93966c00c4bfe8350f76b01df6bf25dL97-R104))
*  Refactor `props` definition in `Collection` component to use `withDefaults` helper function ([link](https://github.com/hoppscotch/hoppscotch/pull/3126/files?diff=unified&w=0#diff-05cb9071e28b438c122f532071b3d08014b8e25633418ca0ae71615d8ad2b283L212-R241))
*  Remove unused `PropType` import from `Collection` component ([link](https://github.com/hoppscotch/hoppscotch/pull/3126/files?diff=unified&w=0#diff-05cb9071e28b438c122f532071b3d08014b8e25633418ca0ae71615d8ad2b283L196-R196))
*  Add null check for `collectionMoveLoading` prop in `isCollLoading` computed property in `Collection` component ([link](https://github.com/hoppscotch/hoppscotch/pull/3126/files?diff=unified&w=0#diff-05cb9071e28b438c122f532071b3d08014b8e25633418ca0ae71615d8ad2b283L451-R426))



Closes HFE-94
