### PR TITLE
fix: fix url getting overridden when query params are present

### DIFF
--- a/packages/hoppscotch-common/src/helpers/RESTExtURLParams.ts
+++ b/packages/hoppscotch-common/src/helpers/RESTExtURLParams.ts
@@ -6,14 +6,18 @@ import { isJSONContentType } from "./utils/contenttypes"
  * Handles translations for all the hopp.io REST Shareable URL params
  */
 export function translateExtURLParams(
-  urlParams: Record<string, any>
+  urlParams: Record<string, any>,
+  initialReq?: HoppRESTRequest
 ): HoppRESTRequest {
-  if (urlParams.v) return parseV1ExtURL(urlParams)
-  else return parseV0ExtURL(urlParams)
+  if (urlParams.v) return parseV1ExtURL(urlParams, initialReq)
+  else return parseV0ExtURL(urlParams, initialReq)
 }
 
-function parseV0ExtURL(urlParams: Record<string, any>): HoppRESTRequest {
-  const resolvedReq = getDefaultRESTRequest()
+function parseV0ExtURL(
+  urlParams: Record<string, any>,
+  initialReq?: HoppRESTRequest
+): HoppRESTRequest {
+  const resolvedReq = initialReq ?? getDefaultRESTRequest()
 
   if (urlParams.method && typeof urlParams.method === "string") {
     resolvedReq.method = urlParams.method
@@ -89,8 +93,11 @@ function parseV0ExtURL(urlParams: Record<string, any>): HoppRESTRequest {
   return resolvedReq
 }
 
-function parseV1ExtURL(urlParams: Record<string, any>): HoppRESTRequest {
-  const resolvedReq = getDefaultRESTRequest()
+function parseV1ExtURL(
+  urlParams: Record<string, any>,
+  initialReq?: HoppRESTRequest
+): HoppRESTRequest {
+  const resolvedReq = initialReq ?? getDefaultRESTRequest()
 
   if (urlParams.headers && typeof urlParams.headers === "string") {
     resolvedReq.headers = JSON.parse(urlParams.headers)

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -154,8 +154,11 @@ function bindRequestToURLParams() {
     // If query params are empty, or contains code or error param (these are from Oauth Redirect)
     // We skip URL params parsing
     if (Object.keys(query).length === 0 || query.code || query.error) return
+
+    const request = currentActiveTab.value.document.request
+
     currentActiveTab.value.document.request = safelyExtractRESTRequest(
-      translateExtURLParams(query),
+      translateExtURLParams(query, request),
       getDefaultRESTRequest()
     )
   })


### PR DESCRIPTION
fixes #3098
fixes HFE-71

**Before**

We support loading request properties from URL query params. we have a function `translateExtURLParams` that takes query params and converts it into Hoppscotch request properties, but this function was always adding these properties to the default request. so whenever a query param is present, this function is running, and it overwrites the existing request.

**After**

This function takes an optional `initialRequest` parameter that will be used instead of the defaultRequest if passed.