### PR TITLE
vi fix typo in translation of clear_all

### DIFF
--- a/packages/hoppscotch-common/locales/vi.json
+++ b/packages/hoppscotch-common/locales/vi.json
@@ -4,7 +4,7 @@
     "cancel": "Hủy bỏ",
     "choose_file": "Chọn một tệp",
     "clear": "Thông thoáng",
-    "clear_all": "Quet sạch tât cả",
+    "clear_all": "Quet sạch tất cả",
     "close": "Close",
     "connect": "Liên kết",
     "connecting": "Connecting",


### PR DESCRIPTION
### Description
all in vietnamese should be translated to "tất cả", I fix the typo of this.

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

### Additional Information
