### PR TITLE
fix: graphql authorization headers

### DIFF
--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -86,6 +86,7 @@ declare module '@vue/runtime-core' {
     HoppSmartLink: typeof import('@hoppscotch/ui')['HoppSmartLink']
     HoppSmartModal: typeof import('@hoppscotch/ui')['HoppSmartModal']
     HoppSmartPicture: typeof import('@hoppscotch/ui')['HoppSmartPicture']
+    HoppSmartPlaceholder: typeof import('@hoppscotch/ui')['HoppSmartPlaceholder']
     HoppSmartProgressRing: typeof import('@hoppscotch/ui')['HoppSmartProgressRing']
     HoppSmartRadioGroup: typeof import('@hoppscotch/ui')['HoppSmartRadioGroup']
     HoppSmartSlideOver: typeof import('@hoppscotch/ui')['HoppSmartSlideOver']

--- a/packages/hoppscotch-common/src/components/graphql/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Authorization.vue
@@ -142,12 +142,14 @@
         <div v-if="authType === 'basic'">
           <div class="flex flex-1 border-b border-dividerLight">
             <SmartEnvInput
+              :environmentHighlights="false"
               v-model="basicUsername"
               :placeholder="t('authorization.username')"
             />
           </div>
           <div class="flex flex-1 border-b border-dividerLight">
             <SmartEnvInput
+              :environmentHighlights="false"
               v-model="basicPassword"
               :placeholder="t('authorization.password')"
             />
@@ -155,21 +157,37 @@
         </div>
         <div v-if="authType === 'bearer'">
           <div class="flex flex-1 border-b border-dividerLight">
-            <SmartEnvInput v-model="bearerToken" placeholder="Token" />
+            <SmartEnvInput
+              :environmentHighlights="false"
+              v-model="bearerToken"
+              placeholder="Token"
+            />
           </div>
         </div>
         <div v-if="authType === 'oauth-2'">
           <div class="flex flex-1 border-b border-dividerLight">
-            <SmartEnvInput v-model="oauth2Token" placeholder="Token" />
+            <SmartEnvInput
+              :environmentHighlights="false"
+              v-model="oauth2Token"
+              placeholder="Token"
+            />
           </div>
           <HttpOAuth2Authorization />
         </div>
         <div v-if="authType === 'api-key'">
           <div class="flex flex-1 border-b border-dividerLight">
-            <SmartEnvInput v-model="apiKey" placeholder="Key" />
+            <SmartEnvInput
+              :environmentHighlights="false"
+              v-model="apiKey"
+              placeholder="Key"
+            />
           </div>
           <div class="flex flex-1 border-b border-dividerLight">
-            <SmartEnvInput v-model="apiValue" placeholder="Value" />
+            <SmartEnvInput
+              :environmentHighlights="false"
+              v-model="apiValue"
+              placeholder="Value"
+            />
           </div>
           <div class="flex items-center border-b border-dividerLight">
             <span class="flex items-center">

--- a/packages/hoppscotch-common/src/components/graphql/Request.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Request.vue
@@ -31,7 +31,12 @@ import { GQLConnection } from "~/helpers/GQLConnection"
 import { getCurrentStrategyID } from "~/helpers/network"
 import { useReadonlyStream, useStream } from "@composables/stream"
 import { useI18n } from "@composables/i18n"
-import { gqlHeaders$, gqlURL$, setGQLURL } from "~/newstore/GQLSession"
+import {
+  gqlAuth$,
+  gqlHeaders$,
+  gqlURL$,
+  setGQLURL,
+} from "~/newstore/GQLSession"
 
 const t = useI18n()
 
@@ -41,12 +46,16 @@ const props = defineProps<{
 
 const connected = useReadonlyStream(props.conn.connected$, false)
 const headers = useReadonlyStream(gqlHeaders$, [])
+const auth = useReadonlyStream(gqlAuth$, {
+  authType: "none",
+  authActive: true,
+})
 
 const url = useStream(gqlURL$, "", setGQLURL)
 
 const onConnectClick = () => {
   if (!connected.value) {
-    props.conn.connect(url.value, headers.value as any)
+    props.conn.connect(url.value, headers.value as any, auth.value)
 
     platform.analytics?.logHoppRequestRunToAnalytics({
       platform: "graphql-schema",

--- a/packages/hoppscotch-common/src/components/graphql/Request.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Request.vue
@@ -17,6 +17,7 @@
       <HoppButtonPrimary
         id="get"
         name="get"
+        :loading="isLoading"
         :label="!connected ? t('action.connect') : t('action.disconnect')"
         class="w-32"
         @click="onConnectClick"
@@ -45,6 +46,7 @@ const props = defineProps<{
 }>()
 
 const connected = useReadonlyStream(props.conn.connected$, false)
+const isLoading = useReadonlyStream(props.conn.isLoading$, false)
 const headers = useReadonlyStream(gqlHeaders$, [])
 const auth = useReadonlyStream(gqlAuth$, {
   authType: "none",

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -44,6 +44,7 @@ const props = withDefaults(
     envs?: { key: string; value: string; source: string }[] | null
     focus?: boolean
     selectTextOnMount?: boolean
+    environmentHighlights?: boolean
     readonly?: boolean
   }>(),
   {
@@ -53,6 +54,7 @@ const props = withDefaults(
     envs: null,
     focus: false,
     readonly: false,
+    environmentHighlights: true,
   }
 )
 
@@ -142,7 +144,7 @@ const initView = (el: any) => {
     tooltips({
       position: "absolute",
     }),
-    envTooltipPlugin,
+    props.environmentHighlights ? envTooltipPlugin : [],
     placeholderExt(props.placeholder),
     EditorView.domEventHandlers({
       paste(ev) {

--- a/packages/hoppscotch-common/src/helpers/GQLConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/GQLConnection.ts
@@ -99,7 +99,7 @@ export class GQLConnection {
 
   private timeoutSubscription: any
 
-  public connect(url: string, headers: GQLHeader[]) {
+  public connect(url: string, headers: GQLHeader[], auth: HoppGQLAuth) {
     if (this.connected$.value) {
       throw new Error(
         "A connection is already running. Close it before starting another."
@@ -110,7 +110,7 @@ export class GQLConnection {
     this.connected$.next(true)
 
     const poll = async () => {
-      await this.getSchema(url, headers)
+      await this.getSchema(url, headers, auth)
       this.timeoutSubscription = setTimeout(() => {
         poll()
       }, GQL_SCHEMA_POLL_INTERVAL)
@@ -135,7 +135,11 @@ export class GQLConnection {
     this.schema$.next(null)
   }
 
-  private async getSchema(url: string, headers: GQLHeader[]) {
+  private async getSchema(
+    url: string,
+    reqHeaders: GQLHeader[],
+    auth: HoppGQLAuth
+  ) {
     try {
       this.isLoading$.next(true)
 
@@ -143,10 +147,38 @@ export class GQLConnection {
         query: getIntrospectionQuery(),
       })
 
+      const headers = reqHeaders.filter((x) => x.active && x.key !== "")
+
+      // TODO: Support a better b64 implementation than btoa ?
+      if (auth.authType === "basic") {
+        const username = auth.username
+        const password = auth.password
+
+        headers.push({
+          active: true,
+          key: "Authorization",
+          value: `Basic ${btoa(`${username}:${password}`)}`,
+        })
+      } else if (auth.authType === "bearer" || auth.authType === "oauth-2") {
+        headers.push({
+          active: true,
+          key: "Authorization",
+          value: `Bearer ${auth.token}`,
+        })
+      } else if (auth.authType === "api-key") {
+        const { key, value, addTo } = auth
+
+        if (addTo === "Headers") {
+          headers.push({
+            active: true,
+            key,
+            value,
+          })
+        }
+      }
+
       const finalHeaders: Record<string, string> = {}
-      headers
-        .filter((x) => x.active && x.key !== "")
-        .forEach((x) => (finalHeaders[x.key] = x.value))
+      headers.forEach((x) => (finalHeaders[x.key] = x.value))
 
       const reqOptions = {
         method: "POST",

--- a/packages/hoppscotch-common/src/newstore/GQLSession.ts
+++ b/packages/hoppscotch-common/src/newstore/GQLSession.ts
@@ -275,7 +275,4 @@ export const gqlResponse$ = gqlSessionStore.subject$.pipe(
   distinctUntilChanged()
 )
 
-export const gqlAuth$ = gqlSessionStore.subject$.pipe(
-  pluck("request", "auth"),
-  distinctUntilChanged()
-)
+export const gqlAuth$ = gqlSessionStore.subject$.pipe(pluck("request", "auth"))

--- a/packages/hoppscotch-common/src/pages/graphql.vue
+++ b/packages/hoppscotch-common/src/pages/graphql.vue
@@ -14,12 +14,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, watch } from "vue"
-import { useReadonlyStream } from "@composables/stream"
-import { useI18n } from "@composables/i18n"
 import { usePageHead } from "@composables/head"
-import { startPageProgress, completePageProgress } from "@modules/loadingbar"
+import { useI18n } from "@composables/i18n"
 import { GQLConnection } from "@helpers/GQLConnection"
+import { computed, onBeforeUnmount } from "vue"
 
 const t = useI18n()
 
@@ -28,16 +26,10 @@ usePageHead({
 })
 
 const gqlConn = new GQLConnection()
-const isLoading = useReadonlyStream(gqlConn.isLoading$, false)
 
 onBeforeUnmount(() => {
   if (gqlConn.connected$.value) {
     gqlConn.disconnect()
   }
-})
-
-watch(isLoading, () => {
-  if (isLoading.value) startPageProgress()
-  else completePageProgress()
 })
 </script>


### PR DESCRIPTION
Closes #3135 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 2091437</samp>

### Summary

This pull request fixes the Authorization config not being added to headers in GraphQL. And it removes environment highlights on Authorization field on GraphQL as env support doesn't yet have in GQL

> _`GQLConnection`_
> _Authenticates requests now_
> _Winter of secrets_

### Walkthrough
*  Add `environmentHighlights` prop to `SmartEnvInput` component to control environment variable highlighting ([link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-ff8bedda71a90ead557a88ca19c335becf4d9bf0328f8add3a32ebbaf7e12b40R145), [link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-ff8bedda71a90ead557a88ca19c335becf4d9bf0328f8add3a32ebbaf7e12b40R152), [link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-ff8bedda71a90ead557a88ca19c335becf4d9bf0328f8add3a32ebbaf7e12b40L158-R173), [link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-ff8bedda71a90ead557a88ca19c335becf4d9bf0328f8add3a32ebbaf7e12b40L169-R190), [link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-77b8f4b02b324137697f8b9f9666a4109da9f05ffca983065e49f7ff302de548R47), [link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-77b8f4b02b324137697f8b9f9666a4109da9f05ffca983065e49f7ff302de548R57), [link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-77b8f4b02b324137697f8b9f9666a4109da9f05ffca983065e49f7ff302de548L145-R147))
*  Import and use `gqlAuth$` stream from `GQLSession` store to get authentication information for GraphQL request in `Request.vue` ([link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-21140ccefcd7ad2a17c48a1f2af4f1d738e073d434fbbc5d4a30eb17579b6c6cL34-R39), [link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-21140ccefcd7ad2a17c48a1f2af4f1d738e073d434fbbc5d4a30eb17579b6c6cR49-R52))
*  Pass `auth` variable to `connect` and `getSchema` methods of `GQLConnection` class in `Request.vue` and `GQLConnection.ts` to send authentication information along with URL and headers when connecting to GraphQL endpoint ([link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-21140ccefcd7ad2a17c48a1f2af4f1d738e073d434fbbc5d4a30eb17579b6c6cL49-R58), [link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-f683d1d71a52fb88829fa4213632f582fefcbd731887006523bc98c050cab8c8L102-R102), [link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-f683d1d71a52fb88829fa4213632f582fefcbd731887006523bc98c050cab8c8L113-R113), [link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-f683d1d71a52fb88829fa4213632f582fefcbd731887006523bc98c050cab8c8L138-R142))
*  Handle different authentication types and add corresponding headers to request in `getSchema` method of `GQLConnection` class in `GQLConnection.ts` ([link](https://github.com/hoppscotch/hoppscotch/pull/3136/files?diff=unified&w=0#diff-f683d1d71a52fb88829fa4213632f582fefcbd731887006523bc98c050cab8c8L146-R181))

