### PR TITLE
fix: fixed issue with team-invitations and new user accounts

### DIFF
--- a/packages/hoppscotch-backend/src/team-invitation/team-invite-viewer.guard.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invite-viewer.guard.ts
@@ -32,7 +32,7 @@ export class TeamInviteViewerGuard implements CanActivate {
       // Get user
       TE.bindW('user', ({ gqlCtx }) =>
         pipe(
-          O.fromNullable(gqlCtx.getContext<{ user?: User }>().user),
+          O.fromNullable(gqlCtx.getContext().req.user),
           TE.fromOption(() => BUG_AUTH_NO_USER_CTX),
         ),
       ),

--- a/packages/hoppscotch-backend/src/team-invitation/team-invitee.guard.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invitee.guard.ts
@@ -33,7 +33,7 @@ export class TeamInviteeGuard implements CanActivate {
       // Get user
       TE.bindW('user', ({ gqlCtx }) =>
         pipe(
-          O.fromNullable(gqlCtx.getContext<{ user?: User }>().user),
+          O.fromNullable(gqlCtx.getContext().req.user),
           TE.fromOption(() => BUG_AUTH_NO_USER_CTX),
         ),
       ),


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes issue #3090

### Description
<!-- Add a brief description of the pull request -->
This PR fixes a bug with the auth guards present in the TeamInvitation module where new users trying to join a team with a valid invitation could not do so and be presented with the *BUG_AUTH_NO_USER_CTX* error instead.

### How to reproduce bug for testing
Have a normal running instance of SH running with one valid user account then:

- Create a new team and Invite a new user whose account does not exist in the DB into the team.
- Create the account for the user to whom you sent the invite link in the earlier step.
- Make sure to be logged in as the newly created user click on the button in the email you received before to join the team.
- You should see the error being thrown.

### Issue Number
HBE-227

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
Nil
