### PR TITLE
fix: Self-host unable to use Azure oauth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ MICROSOFT_CLIENT_ID="************************************************"
 MICROSOFT_CLIENT_SECRET="************************************************"
 MICROSOFT_CALLBACK_URL="http://localhost:3170/v1/auth/microsoft/callback"
 MICROSOFT_SCOPE="user.read"
+MICROSOFT_TENANT="common"
 
 # Mailer config
 MAILER_SMTP_URL="smtps://user@domain.com:pass@smtp.domain.com"

--- a/packages/hoppscotch-backend/src/auth/strategies/microsoft.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/microsoft.strategy.ts
@@ -17,6 +17,7 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy) {
       clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
       callbackURL: process.env.MICROSOFT_CALLBACK_URL,
       scope: [process.env.MICROSOFT_SCOPE],
+      tenant: process.env.MICROSOFT_TENANT,
       store: true,
     });
   }

--- a/packages/hoppscotch-backend/src/auth/strategies/microsoft.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/microsoft.strategy.ts
@@ -17,7 +17,6 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy) {
       clientSecret: process.env.MICROSOFT_CLIENT_SECRET,
       callbackURL: process.env.MICROSOFT_CALLBACK_URL,
       scope: [process.env.MICROSOFT_SCOPE],
-      passReqToCallback: true,
       store: true,
     });
   }


### PR DESCRIPTION
Closes #3050 #3139 

### Description (bugfix)
The `passReqToCallback=true` alters the arguments passed to `MicrosoftStrategy.validate` such that first argument is a `request` object and other arguments are shifted across one. This meant that actual values for `accessToken` and critically `profile` weren't in the expected arguments and therefore the rest of the method would break. I believe `passReqToCallback` was added in error in 81cb0d43d78e41a3ce1e82260a10fa9baedfbc64. This method could never work in it's current form with this option set to true.

This has been tested (and previously debugged) on a private instance of hopscotch so I can confirm that this method does now indeed work in "production"

###  Description (feature)

Many orgs using Azure AD will be running on their own "tenants" rather than the "common" tenant, and therefore need to be able to specify a tenant ID to allow oauth2 url's to be correctly generated by passport-microsoft. This change allows setting the tenant ID as the `MICROSOFT_TENANT` env var.

See passportjs.org/packages/passport-microsoft for more detail.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
none
