### PR TITLE
feat: auto-complete recent history entries in URL bar

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -173,6 +173,7 @@
     "folder": "Folder is empty",
     "headers": "This request does not have any headers",
     "history": "History is empty",
+    "history_suggestions": "History does not have any matching entries",
     "invites": "Invite list is empty",
     "members": "Team is empty",
     "parameters": "This request does not have any parameters",

--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -26,7 +26,6 @@ declare module '@vue/runtime-core' {
     AppShortcutsPrompt: typeof import('./components/app/ShortcutsPrompt.vue')['default']
     AppSidenav: typeof import('./components/app/Sidenav.vue')['default']
     AppSupport: typeof import('./components/app/Support.vue')['default']
-    AppURLAutocomplete: typeof import('./components/app/URLAutocomplete.vue')['default']
     ButtonPrimary: typeof import('./../../hoppscotch-ui/src/components/button/Primary.vue')['default']
     ButtonSecondary: typeof import('./../../hoppscotch-ui/src/components/button/Secondary.vue')['default']
     Collections: typeof import('./components/collections/index.vue')['default']

--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -26,6 +26,7 @@ declare module '@vue/runtime-core' {
     AppShortcutsPrompt: typeof import('./components/app/ShortcutsPrompt.vue')['default']
     AppSidenav: typeof import('./components/app/Sidenav.vue')['default']
     AppSupport: typeof import('./components/app/Support.vue')['default']
+    AppURLAutocomplete: typeof import('./components/app/URLAutocomplete.vue')['default']
     ButtonPrimary: typeof import('./../../hoppscotch-ui/src/components/button/Primary.vue')['default']
     ButtonSecondary: typeof import('./../../hoppscotch-ui/src/components/button/Secondary.vue')['default']
     Collections: typeof import('./components/collections/index.vue')['default']

--- a/packages/hoppscotch-common/src/components/app/Shortcuts.vue
+++ b/packages/hoppscotch-common/src/components/app/Shortcuts.vue
@@ -44,11 +44,7 @@
           :text="`${t('state.nothing_found')} ‟${filterText}”`"
         >
           <icon-lucide-search class="pb-2 opacity-75 svg-icons" />
-          <span class="my-2 text-center flex flex-col">
-            {{ t("state.nothing_found") }}
-            <span class="break-all">"{{ filterText }}"</span>
-          </span>
-        </div>
+        </HoppSmartPlaceholder>
       </div>
       <div v-else class="flex flex-col divide-y divide-dividerLight">
         <details

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -28,7 +28,7 @@
         </span>
         <div
           v-if="currentSuggestionIndex === index"
-          class="flex text-secondary items-center"
+          class="hidden md:flex text-secondary items-center"
         >
           <kbd class="shortcut-key">TAB</kbd>
           <span class="ml-2 truncate">to select</span>

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -4,7 +4,7 @@
       <div
         ref="editor"
         :placeholder="placeholder"
-        class="flex flex-1"
+        class="flex flex-1 overflow-x-hidden"
         :class="styles"
         @click="emit('click', $event)"
         @keydown="handleKeystroke"
@@ -138,7 +138,7 @@ const handleFocusOut = () => {
   // wait for click event to be handled before hiding the popover
   setTimeout(() => {
     showSuggestionPopover.value = false
-  }, 100)
+  }, 75)
 }
 
 const updateModelValue = (value: string) => {

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="autocomplete-wrapper">
-    <div class="absolute inset-0 flex flex-1">
+    <div class="absolute inset-0 flex flex-1 overflow-x-hidden">
       <div
         ref="editor"
         :placeholder="placeholder"
-        class="flex flex-1 overflow-x-hidden"
+        class="flex flex-1"
         :class="styles"
         @click="emit('click', $event)"
         @keydown="handleKeystroke"
@@ -138,7 +138,7 @@ const handleFocusOut = () => {
   // wait for click event to be handled before hiding the popover
   setTimeout(() => {
     showSuggestionPopover.value = false
-  }, 75)
+  }, 80)
 }
 
 const updateModelValue = (value: string) => {
@@ -200,22 +200,6 @@ const handleKeystroke = (ev: KeyboardEvent) => {
 
   if (ev.key === "Escape") {
     showSuggestionPopover.value = false
-  }
-
-  // used to set codemirror cursor at the end of the line when ctrl+right arrow is pressed
-  if (ev.key === "ArrowRight" && ev.ctrlKey) {
-    view.value?.dispatch({
-      selection: EditorSelection.create([
-        EditorSelection.range(props.modelValue.length, props.modelValue.length),
-      ]),
-    })
-  }
-
-  // used to set codemirror cursor at the start of the line when ctrl+left arrow is pressed
-  if (ev.key === "ArrowLeft" && ev.ctrlKey) {
-    view.value?.dispatch({
-      selection: EditorSelection.create([EditorSelection.range(0, 0)]),
-    })
   }
 
   // used to scroll to the first suggestion when right arrow is pressed

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -8,6 +8,8 @@
         :class="styles"
         @click="emit('click', $event)"
         @keydown="handleKeystroke"
+        @focusin="showSuggestionPopover = true"
+        @focusout="showSuggestionPopover = false"
       ></div>
     </div>
     <ul v-if="showSuggestionPopover" ref="suggestionsMenu" class="suggestions">
@@ -55,7 +57,6 @@ import { HoppReactiveEnvPlugin } from "~/helpers/editor/extensions/HoppEnvironme
 import { useReadonlyStream } from "@composables/stream"
 import { AggregateEnvironment, aggregateEnvs$ } from "~/newstore/environments"
 import { platform } from "~/platform"
-import { onClickOutside } from "@vueuse/core"
 import { useI18n } from "~/composables/i18n"
 
 const props = withDefaults(
@@ -105,10 +106,6 @@ const showSuggestionPopover = ref(false)
 
 const suggestionsMenu = ref<HTMLElement | null>(null)
 
-onClickOutside(suggestionsMenu, () => {
-  showSuggestionPopover.value = false
-})
-
 const suggestions = computed(() => {
   if (
     props.modelValue &&
@@ -123,21 +120,6 @@ const suggestions = computed(() => {
     return props.autoCompleteSource ?? []
   }
 })
-
-watch(
-  () => suggestions.value,
-  (newValue) => {
-    if (
-      newValue.length > 0 &&
-      props.modelValue.length > 0 &&
-      props.modelValue !== newValue[0]
-    ) {
-      showSuggestionPopover.value = true
-    } else {
-      showSuggestionPopover.value = false
-    }
-  }
-)
 
 const updateModelValue = (value: string) => {
   emit("update:modelValue", value)

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -108,7 +108,7 @@ const editor = ref<any | null>(null)
 const currentSuggestionIndex = ref(-1)
 const showSuggestionPopover = ref(false)
 
-const suggestionsMenu = ref<HTMLElement | null>(null)
+const suggestionsMenu = ref<any | null>(null)
 
 onClickOutside(suggestionsMenu, () => {
   showSuggestionPopover.value = false

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -28,6 +28,11 @@
           <span class="ml-2 truncate">to select</span>
         </div>
       </li>
+      <li v-if="suggestions.length === 0" class="pointer-events-none">
+        <span class="truncate py-0.5">
+          {{ t("empty.history_suggestions") }}
+        </span>
+      </li>
     </ul>
   </div>
 </template>
@@ -51,6 +56,7 @@ import { useReadonlyStream } from "@composables/stream"
 import { AggregateEnvironment, aggregateEnvs$ } from "~/newstore/environments"
 import { platform } from "~/platform"
 import { onClickOutside } from "@vueuse/core"
+import { useI18n } from "~/composables/i18n"
 
 const props = withDefaults(
   defineProps<{
@@ -85,6 +91,8 @@ const emit = defineEmits<{
   (e: "keydown", ev: any): void
   (e: "click", ev: any): void
 }>()
+
+const t = useI18n()
 
 const cachedValue = ref(props.modelValue)
 

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -132,7 +132,6 @@ const updateModelValue = (value: string) => {
 }
 
 const handleKeystroke = (ev: KeyboardEvent) => {
-  // emit("keydown", ev)
   if (["ArrowDown", "ArrowUp", "Enter", "Tab", "Escape"].includes(ev.key)) {
     ev.preventDefault()
   }
@@ -140,7 +139,7 @@ const handleKeystroke = (ev: KeyboardEvent) => {
     showSuggestionPopover.value = true
   }
   if (ev.key === "ArrowDown") {
-    fixScrolling()
+    scrollActiveElIntoView()
 
     currentSuggestionIndex.value =
       currentSuggestionIndex.value < suggestions.value.length - 1
@@ -150,7 +149,7 @@ const handleKeystroke = (ev: KeyboardEvent) => {
     emit("keydown", ev)
   }
   if (ev.key === "ArrowUp") {
-    fixScrolling()
+    scrollActiveElIntoView()
 
     currentSuggestionIndex.value =
       currentSuggestionIndex.value - 1 >= 0
@@ -181,7 +180,7 @@ const handleKeystroke = (ev: KeyboardEvent) => {
 /**
  * Used to scroll the active suggestion into view
  */
-const fixScrolling = () => {
+const scrollActiveElIntoView = () => {
   const suggestionsMenuEl = suggestionsMenu.value
   if (suggestionsMenuEl) {
     const activeSuggestionEl = suggestionsMenuEl.querySelector(".active")

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="autocomplete-wrapper relative flex items-center flex-1 flex-shrink-0 py-4 whitespace-nowrap"
-  >
+  <div class="autocomplete-wrapper">
     <div class="absolute inset-0 flex flex-1">
       <div
         ref="editor"
@@ -406,6 +404,12 @@ watch(editor, () => {
 <style lang="scss" scoped>
 .autocomplete-wrapper {
   @apply relative;
+  @apply flex;
+  @apply items-center;
+  @apply flex-1;
+  @apply flex-shrink-0;
+  @apply py-4;
+  @apply whitespace-nowrap;
 
   .suggestions {
     @apply absolute;

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="autocomplete-wrapper">
-    <div class="absolute inset-0 flex flex-1 overflow-x-hidden">
+    <div class="absolute inset-0 flex flex-1 overflow-x-auto">
       <div
         ref="editor"
         :placeholder="placeholder"
@@ -21,7 +21,7 @@
         v-for="(suggestion, index) in suggestions"
         :key="`suggestion-${index}`"
         :class="{ active: currentSuggestionIndex === index }"
-        @click.prevent="updateModelValue(suggestion)"
+        @click="updateModelValue(suggestion)"
       >
         <span class="truncate py-0.5">
           {{ suggestion }}
@@ -151,9 +151,9 @@ const handleKeystroke = (ev: KeyboardEvent) => {
   if (["ArrowDown", "ArrowUp", "Enter", "Tab", "Escape"].includes(ev.key)) {
     ev.preventDefault()
   }
-  if (["ArrowDown"].includes(ev.key) && suggestions.value.length > 0) {
-    showSuggestionPopover.value = true
-  }
+
+  showSuggestionPopover.value = true
+
   if (
     ["Enter", "Tab"].includes(ev.key) &&
     suggestions.value.length > 0 &&
@@ -174,6 +174,7 @@ const handleKeystroke = (ev: KeyboardEvent) => {
       })
     })
   }
+
   if (ev.key === "ArrowDown") {
     scrollActiveElIntoView()
 
@@ -184,6 +185,7 @@ const handleKeystroke = (ev: KeyboardEvent) => {
 
     emit("keydown", ev)
   }
+
   if (ev.key === "ArrowUp") {
     scrollActiveElIntoView()
 
@@ -194,17 +196,19 @@ const handleKeystroke = (ev: KeyboardEvent) => {
 
     emit("keyup", ev)
   }
+
   if (ev.key === "Enter") {
     emit("enter", ev)
+    showSuggestionPopover.value = false
   }
 
   if (ev.key === "Escape") {
     showSuggestionPopover.value = false
   }
 
-  // used to scroll to the first suggestion when right arrow is pressed
-  if (ev.key === "ArrowRight") {
-    if (suggestions.value.length > 0 && showSuggestionPopover.value) {
+  // used to scroll to the first suggestion when left arrow is pressed
+  if (ev.key === "ArrowLeft") {
+    if (suggestions.value.length > 0) {
       currentSuggestionIndex.value = 0
       nextTick(() => {
         scrollActiveElIntoView()
@@ -212,9 +216,9 @@ const handleKeystroke = (ev: KeyboardEvent) => {
     }
   }
 
-  // used to scroll to the last suggestion when left arrow is pressed
-  if (ev.key === "ArrowLeft") {
-    if (suggestions.value.length > 0 && showSuggestionPopover.value) {
+  // used to scroll to the last suggestion when right arrow is pressed
+  if (ev.key === "ArrowRight") {
+    if (suggestions.value.length > 0) {
       currentSuggestionIndex.value = suggestions.value.length - 1
       nextTick(() => {
         scrollActiveElIntoView()
@@ -222,6 +226,16 @@ const handleKeystroke = (ev: KeyboardEvent) => {
     }
   }
 }
+
+// reset currentSuggestionIndex showSuggestionPopover is false
+watch(
+  () => showSuggestionPopover.value,
+  (newVal) => {
+    if (!newVal) {
+      currentSuggestionIndex.value = -1
+    }
+  }
+)
 
 /**
  * Used to scroll the active suggestion into view

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -14,11 +14,7 @@
         @keydown="handleKeystroke"
       ></div>
     </div>
-    <ul
-      v-if="showSuggestionPopover"
-      class="suggestions"
-      @click-outside="showSuggestionPopover = false"
-    >
+    <ul v-if="showSuggestionPopover" ref="suggestionsMenu" class="suggestions">
       <li
         v-for="(suggestion, index) in suggestions"
         :key="`suggestion-${index}`"
@@ -50,6 +46,7 @@ import { HoppReactiveEnvPlugin } from "~/helpers/editor/extensions/HoppEnvironme
 import { useReadonlyStream } from "@composables/stream"
 import { AggregateEnvironment, aggregateEnvs$ } from "~/newstore/environments"
 import { platform } from "~/platform"
+import { onClickOutside } from "@vueuse/core"
 
 const props = withDefaults(
   defineProps<{
@@ -93,6 +90,12 @@ const editor = ref<any | null>(null)
 
 const currentSuggestionIndex = ref(-1)
 const showSuggestionPopover = ref(false)
+
+const suggestionsMenu = ref(null)
+
+onClickOutside(suggestionsMenu, () => {
+  showSuggestionPopover.value = false
+})
 
 const suggestions = computed(() => {
   if (

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -12,7 +12,11 @@
         @focusout="showSuggestionPopover = false"
       ></div>
     </div>
-    <ul v-if="showSuggestionPopover" ref="suggestionsMenu" class="suggestions">
+    <ul
+      v-if="showSuggestionPopover && autoCompleteSource"
+      ref="suggestionsMenu"
+      class="suggestions"
+    >
       <li
         v-for="(suggestion, index) in suggestions"
         :key="`suggestion-${index}`"
@@ -106,18 +110,27 @@ const showSuggestionPopover = ref(false)
 
 const suggestionsMenu = ref<HTMLElement | null>(null)
 
+//filter autocompleteSource with unique values
+const uniqueAutoCompleteSource = computed(() => {
+  if (props.autoCompleteSource) {
+    return [...new Set(props.autoCompleteSource)]
+  } else {
+    return []
+  }
+})
+
 const suggestions = computed(() => {
   if (
     props.modelValue &&
     props.modelValue.length > 0 &&
-    props.autoCompleteSource &&
-    props.autoCompleteSource.length > 0
+    uniqueAutoCompleteSource.value &&
+    uniqueAutoCompleteSource.value.length > 0
   ) {
-    return props.autoCompleteSource.filter((suggestion) =>
+    return uniqueAutoCompleteSource.value.filter((suggestion) =>
       suggestion.toLowerCase().includes(props.modelValue.toLowerCase())
     )
   } else {
-    return props.autoCompleteSource ?? []
+    return uniqueAutoCompleteSource.value ?? []
   }
 })
 

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -14,7 +14,6 @@
       <li
         v-for="(suggestion, index) in suggestions"
         :key="`suggestion-${index}`"
-        class="py-1 px-2 cursor-pointer"
         :class="{ active: currentSuggestionIndex === index }"
         @click.prevent="updateModelValue(suggestion)"
       >
@@ -429,6 +428,7 @@ watch(editor, () => {
       @apply py-2 px-2;
       @apply text-secondary;
       @apply font-semibold;
+      @apply cursor-pointer;
 
       &:last-child {
         border-radius: 0 0 0 8px;

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -143,8 +143,7 @@ const handleKeystroke = (ev: KeyboardEvent) => {
     suggestions.value.length > 0 &&
     currentSuggestionIndex.value > -1
   ) {
-    emit("update:modelValue", suggestions.value[currentSuggestionIndex.value])
-    showSuggestionPopover.value = false
+    updateModelValue(suggestions.value[currentSuggestionIndex.value])
     currentSuggestionIndex.value = -1
 
     //used to set codemirror cursor at the end of the line after selecting a suggestion

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -17,7 +17,16 @@
         :class="{ active: currentSuggestionIndex === index }"
         @click.prevent="updateModelValue(suggestion)"
       >
-        {{ suggestion }}
+        <span class="truncate py-0.5">
+          {{ suggestion }}
+        </span>
+        <div
+          v-if="currentSuggestionIndex === index"
+          class="flex text-secondary items-center"
+        >
+          <kbd class="shortcut-key">TAB</kbd>
+          <span class="ml-2 truncate">to select</span>
+        </div>
       </li>
     </ul>
   </div>
@@ -404,10 +413,8 @@ watch(editor, () => {
 .autocomplete-wrapper {
   @apply relative;
   @apply flex;
-  @apply items-center;
   @apply flex-1;
   @apply flex-shrink-0;
-  @apply py-4;
   @apply whitespace-nowrap;
 
   .suggestions {
@@ -417,17 +424,20 @@ watch(editor, () => {
     @apply shadow-lg;
     @apply max-h-46;
     @apply border-b border-x border-divider;
-    @apply p-2;
     @apply overflow-y-auto;
-    @apply top-[calc(100%+2px)];
-    @apply left-0;
+    @apply -left-[1px];
     @apply right-0;
+
+    top: calc(100% + 1px);
     border-radius: 0 0 8px 8px;
+
     li {
+      @apply flex;
+      @apply items-center;
+      @apply justify-between;
       @apply w-full;
-      @apply py-2 px-2;
+      @apply py-2 px-4;
       @apply text-secondary;
-      @apply font-semibold;
       @apply cursor-pointer;
 
       &:last-child {

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -9,7 +9,6 @@
         @click="emit('click', $event)"
         @keydown="handleKeystroke"
         @focusin="showSuggestionPopover = true"
-        @focusout="handleFocusOut"
       ></div>
     </div>
     <ul
@@ -62,6 +61,7 @@ import { useReadonlyStream } from "@composables/stream"
 import { AggregateEnvironment, aggregateEnvs$ } from "~/newstore/environments"
 import { platform } from "~/platform"
 import { useI18n } from "~/composables/i18n"
+import { onClickOutside } from "@vueuse/core"
 
 const props = withDefaults(
   defineProps<{
@@ -110,6 +110,10 @@ const showSuggestionPopover = ref(false)
 
 const suggestionsMenu = ref<HTMLElement | null>(null)
 
+onClickOutside(suggestionsMenu, () => {
+  showSuggestionPopover.value = false
+})
+
 //filter autocompleteSource with unique values
 const uniqueAutoCompleteSource = computed(() => {
   if (props.autoCompleteSource) {
@@ -133,13 +137,6 @@ const suggestions = computed(() => {
     return uniqueAutoCompleteSource.value ?? []
   }
 })
-
-const handleFocusOut = () => {
-  // wait for click event to be handled before hiding the popover
-  setTimeout(() => {
-    showSuggestionPopover.value = false
-  }, 80)
-}
 
 const updateModelValue = (value: string) => {
   emit("update:modelValue", value)

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -152,9 +152,11 @@ const handleKeystroke = (ev: KeyboardEvent) => {
   } else if (ev.key === "Enter") {
     ev.preventDefault()
     console.log("enter", currentSuggestionIndex.value, suggestions.value)
-    if (currentSuggestionIndex.value >= -1 && suggestions.value.length > 0) {
+    if (currentSuggestionIndex.value > -1 && suggestions.value.length > 0) {
       emit("update:modelValue", suggestions.value[currentSuggestionIndex.value])
       currentSuggestionIndex.value = -1
+    } else {
+      emit("enter", ev)
     }
   } else if (ev.key === "Tab") {
     ev.preventDefault()

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -9,7 +9,7 @@
         @click="emit('click', $event)"
         @keydown="handleKeystroke"
         @focusin="showSuggestionPopover = true"
-        @focusout="showSuggestionPopover = false"
+        @focusout="handleFocusOut"
       ></div>
     </div>
     <ul
@@ -133,6 +133,13 @@ const suggestions = computed(() => {
     return uniqueAutoCompleteSource.value ?? []
   }
 })
+
+const handleFocusOut = () => {
+  // wait for click event to be handled before hiding the popover
+  setTimeout(() => {
+    showSuggestionPopover.value = false
+  }, 100)
+}
 
 const updateModelValue = (value: string) => {
   emit("update:modelValue", value)

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -14,23 +14,21 @@
         @keydown="handleKeystroke"
       ></div>
     </div>
-    <div
+    <ul
       v-if="showSuggestionPopover"
-      class="suggestions left-0 right-0"
+      class="suggestions"
       @click-outside="showSuggestionPopover = false"
     >
-      <ul class="overlow-y-auto">
-        <li
-          v-for="(suggestion, index) in suggestions"
-          :key="`suggestion-${index}`"
-          class="py-1 px-2 cursor-pointer"
-          :class="{ active: currentSuggestionIndex === index }"
-          @click.prevent="updateModelValue(suggestion)"
-        >
-          {{ suggestion }}
-        </li>
-      </ul>
-    </div>
+      <li
+        v-for="(suggestion, index) in suggestions"
+        :key="`suggestion-${index}`"
+        class="py-1 px-2 cursor-pointer"
+        :class="{ active: currentSuggestionIndex === index }"
+        @click.prevent="updateModelValue(suggestion)"
+      >
+        {{ suggestion }}
+      </li>
+    </ul>
   </div>
 </template>
 
@@ -332,11 +330,6 @@ watch(editor, () => {
 .autocomplete-wrapper {
   @apply relative;
 
-  input:focus + ul.suggestions,
-  .suggestions:hover {
-    @apply block;
-  }
-
   .suggestions {
     @apply absolute;
     @apply bg-popover;
@@ -345,29 +338,26 @@ watch(editor, () => {
     @apply max-h-46;
     @apply border-b border-x border-divider;
     @apply p-2;
-    @apply overflow-hidden;
+    @apply overflow-y-auto;
     @apply top-[calc(100%+2px)];
     @apply left-0;
     @apply right-0;
+    border-radius: 0 0 8px 8px;
+    li {
+      @apply w-full;
+      @apply py-2 px-2;
+      @apply text-secondary;
+      @apply font-semibold;
 
-    ul {
-      border-radius: 0 0 8px 8px;
-      li {
-        @apply w-full;
-        @apply py-2 px-2;
-        @apply text-secondary;
-        @apply font-semibold;
+      &:last-child {
+        border-radius: 0 0 0 8px;
+      }
 
-        &:last-child {
-          border-radius: 0 0 0 8px;
-        }
-
-        &:hover,
-        &.active {
-          @apply bg-primaryDark;
-          @apply text-secondaryDark;
-          @apply cursor-pointer;
-        }
+      &:hover,
+      &.active {
+        @apply bg-primaryDark;
+        @apply text-secondaryDark;
+        @apply cursor-pointer;
       }
     }
   }


### PR DESCRIPTION
Closes #3087 
Closes HFE-66

![auto-complete-url](https://github.com/hoppscotch/hoppscotch/assets/10395817/6270a8ce-e561-47ff-91db-9bae11f99c28)

### Description
This PR adds the autocomplete feature to the SmartEnv component which helps in adding a autocomplete to the URL input bar where the latest 10 history entries are shown.


### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
