### PR TITLE
fix: Add healthcheck for hoppscotch-db in docker-compose, and more

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,11 +67,13 @@ services:
       - "5432:5432"
     user: postgres
     environment:
+      # The default user defined by the docker image
+      POSTGRES_USER: postgres
       # NOTE: Please UPDATE THIS PASSWORD!
       POSTGRES_PASSWORD: testpass
       POSTGRES_DB: hoppscotch
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
+      test: ["CMD-SHELL", "sh -c 'pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}'"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,8 +78,8 @@ services:
       POSTGRES_DB: hoppscotch
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready" ]
-      interval: 10s
+      interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,12 +27,6 @@ services:
         condition: service_healthy
     ports:
       - "3170:3000"
-    command:
-      - /bin/sh
-      - -c
-      - |
-        pnpm exec prisma migrate deploy
-        pnpm run start:prod
 
   # The main hoppscotch app. This will be hosted at port 3000
   # NOTE: To do TLS or play around with how the app is hosted, you can look into the Caddyfile for

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch?connect_timeout=300
       - PORT=3000
     volumes:
+      # Uncomment the line below when modifying code. Only applicable when using the "dev" target.
+      # - ./packages/hoppscotch-backend/:/usr/src/app
       - /usr/src/app/node_modules/
     depends_on:
       hoppscotch-db:
@@ -66,7 +68,7 @@ services:
   # you are using an external postgres instance
   # This will be exposed at port 5432
   hoppscotch-db:
-    image: postgres:15.3-alpine3.18
+    image: postgres:15
     ports:
       - "5432:5432"
     user: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,12 +19,18 @@ services:
       - DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch?connect_timeout=300
       - PORT=3000
     volumes:
-      - ./packages/hoppscotch-backend/:/usr/src/app
       - /usr/src/app/node_modules/
     depends_on:
-      - hoppscotch-db
+      hoppscotch-db:
+        condition: service_healthy
     ports:
       - "3170:3000"
+    command:
+      - /bin/sh
+      - -c
+      - |
+        pnpm exec prisma migrate deploy
+        pnpm run start:prod
 
   # The main hoppscotch app. This will be hosted at port 3000
   # NOTE: To do TLS or play around with how the app is hosted, you can look into the Caddyfile for
@@ -60,12 +66,18 @@ services:
   # you are using an external postgres instance
   # This will be exposed at port 5432
   hoppscotch-db:
-    image: postgres
+    image: postgres:15.3-alpine3.18
     ports:
       - "5432:5432"
+    user: postgres
     environment:
       # NOTE: Please UPDATE THIS PASSWORD!
       POSTGRES_PASSWORD: testpass
       POSTGRES_DB: hoppscotch
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 


### PR DESCRIPTION
Run database migration on docker-compose up.
Add docker-compose healthcheck for hoppscotch-backend. 
Remove volume to fix `MODULE_NOT_FOUND` error.

Closes #2999

### Description
1. Applies the database migration after the database is ready, and before the `hoppscotch-backend` application starts. 
2. Removes unnecessary volumes which results in `MODULE_NOT_FOUND` and/or permission errors.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed