### PR TITLE
fix: use --location param for url when parsing curl

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -338,7 +338,7 @@ watch(workingHeaders, (headersList) => {
 
 // Sync logic between headers and working/bulk headers
 watch(
-  request.value.headers,
+  () => request.value.headers,
   (newHeadersList) => {
     // Sync should overwrite working headers
     const filteredWorkingHeaders = pipe(

--- a/packages/hoppscotch-common/src/components/http/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestOptions.vue
@@ -72,6 +72,10 @@ const emit = defineEmits<{
 
 const request = ref(props.modelValue)
 
+watch(props, (updatedProps) => {
+  request.value = updatedProps.modelValue
+})
+
 watch(
   () => request.value,
   (newVal) => {

--- a/packages/hoppscotch-common/src/components/http/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestOptions.vue
@@ -54,7 +54,8 @@
 <script setup lang="ts">
 import { useI18n } from "@composables/i18n"
 import { HoppRESTRequest } from "@hoppscotch/data"
-import { computed, ref, watch } from "vue"
+import { useVModel } from "@vueuse/core"
+import { computed, ref } from "vue"
 
 export type RequestOptionTabs =
   | "params"
@@ -70,19 +71,7 @@ const emit = defineEmits<{
   (e: "update:modelValue", value: HoppRESTRequest): void
 }>()
 
-const request = ref(props.modelValue)
-
-watch(props, (updatedProps) => {
-  request.value = updatedProps.modelValue
-})
-
-watch(
-  () => request.value,
-  (newVal) => {
-    emit("update:modelValue", newVal)
-  },
-  { deep: true }
-)
+const request = useVModel(props, "modelValue", emit)
 
 const selectedRealtimeTab = ref<RequestOptionTabs>("params")
 

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
@@ -71,9 +71,11 @@ const parseURL = (urlText: string | number) =>
  * @returns URL object
  */
 export function getURLObject(parsedArguments: parser.Arguments) {
+  const location = parsedArguments.location ?? undefined
+
   return pipe(
     // contains raw url strings
-    parsedArguments._.slice(1),
+    [...parsedArguments._.slice(1), location],
     A.findFirstMap(parseURL),
     // no url found
     O.getOrElse(() => new URL(defaultRESTReq.endpoint))


### PR DESCRIPTION
Fixes #3109 

### Url is not properly parsed when importing using curl 

**Before**

We were not respecting the `--location` parameter when parsing the curl request.

**After** 

Respect the `--location` parameter when parsing the curl request.

### Body And Headers are not loaded properly

**Before**

In component `RequestOptions.vue`, we have a ref `request` which is set to `props.modelValue` in the setup function. but when the component updates with new props, this is not updated. this caused child components that uses this `request` ref to not get updated reactively.

**After**

Added a watcher that updates the `request` ref, when the props change. 