### PR TITLE
fix: unified bg color in collection tree

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/MyCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/MyCollections.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col flex-1 bg-primary">
+  <div class="flex flex-col flex-1 bg-primaryContrast">
     <div
       class="sticky z-10 flex justify-between flex-1 border-b bg-primary border-dividerLight"
       :style="

--- a/packages/hoppscotch-common/src/components/collections/TeamCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/TeamCollections.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col flex-1 bg-primary">
+  <div class="flex flex-col flex-1 bg-primaryContrast">
     <div
       class="sticky z-10 flex justify-between flex-1 border-b bg-primary border-dividerLight"
       :style="


### PR DESCRIPTION
Closes HFE-109

### Description
There was a small background color mismatch in the collection tree, this PR fixes this issue.
![Screenshot 2023-06-21 at 10 23 14 AM](https://github.com/hoppscotch/hoppscotch/assets/53208152/735bf519-8949-40a1-b1ae-95c23d4348ae)

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
