### PR TITLE
feat: introduce more events into the analytics pipeline

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -284,6 +284,14 @@ const importerAction = async (stepResults: StepReturnValue[]) => {
           emit("import-to-teams", result)
         } else {
           appendRESTCollections(result)
+
+          platform.analytics?.logEvent({
+            type: "HOPP_IMPORT_COLLECTION",
+            importer: importerModule.value!.name,
+            platform: "rest",
+            workspaceType: "personal",
+          })
+
           fileImported()
         }
       }

--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -89,6 +89,7 @@ import {
 import { GQLError } from "~/helpers/backend/GQLClient"
 import { computedWithControl } from "@vueuse/core"
 import { currentActiveTab } from "~/helpers/rest/tab"
+import { platform } from "~/platform"
 
 const t = useI18n()
 const toast = useToast()
@@ -223,6 +224,13 @@ const saveRequestAs = async () => {
       },
     }
 
+    platform.analytics?.logEvent({
+      type: "HOPP_SAVE_REQUEST",
+      createdNow: true,
+      platform: "rest",
+      workspaceType: "personal",
+    })
+
     requestSaved()
   } else if (picked.value.pickedType === "my-folder") {
     if (!isHoppRESTRequest(requestUpdated))
@@ -242,6 +250,13 @@ const saveRequestAs = async () => {
         requestIndex: insertionIndex,
       },
     }
+
+    platform.analytics?.logEvent({
+      type: "HOPP_SAVE_REQUEST",
+      createdNow: true,
+      platform: "rest",
+      workspaceType: "personal",
+    })
 
     requestSaved()
   } else if (picked.value.pickedType === "my-request") {
@@ -264,17 +279,38 @@ const saveRequestAs = async () => {
       },
     }
 
+    platform.analytics?.logEvent({
+      type: "HOPP_SAVE_REQUEST",
+      createdNow: false,
+      platform: "rest",
+      workspaceType: "personal",
+    })
+
     requestSaved()
   } else if (picked.value.pickedType === "teams-collection") {
     if (!isHoppRESTRequest(requestUpdated))
       throw new Error("requestUpdated is not a REST Request")
 
     updateTeamCollectionOrFolder(picked.value.collectionID, requestUpdated)
+
+    platform.analytics?.logEvent({
+      type: "HOPP_SAVE_REQUEST",
+      createdNow: true,
+      platform: "rest",
+      workspaceType: "team",
+    })
   } else if (picked.value.pickedType === "teams-folder") {
     if (!isHoppRESTRequest(requestUpdated))
       throw new Error("requestUpdated is not a REST Request")
 
     updateTeamCollectionOrFolder(picked.value.folderID, requestUpdated)
+
+    platform.analytics?.logEvent({
+      type: "HOPP_SAVE_REQUEST",
+      createdNow: true,
+      platform: "rest",
+      workspaceType: "team",
+    })
   } else if (picked.value.pickedType === "teams-request") {
     if (!isHoppRESTRequest(requestUpdated))
       throw new Error("requestUpdated is not a REST Request")
@@ -291,6 +327,13 @@ const saveRequestAs = async () => {
       request: JSON.stringify(requestUpdated),
       title: requestUpdated.name,
     }
+
+    platform.analytics?.logEvent({
+      type: "HOPP_SAVE_REQUEST",
+      createdNow: false,
+      platform: "rest",
+      workspaceType: "team",
+    })
 
     pipe(
       updateTeamRequest(picked.value.requestID, data),
@@ -313,6 +356,13 @@ const saveRequestAs = async () => {
       requestUpdated as HoppGQLRequest
     )
 
+    platform.analytics?.logEvent({
+      type: "HOPP_SAVE_REQUEST",
+      createdNow: false,
+      platform: "gql",
+      workspaceType: "team",
+    })
+
     requestSaved()
   } else if (picked.value.pickedType === "gql-my-folder") {
     // TODO: Check for GQL request ?
@@ -321,6 +371,13 @@ const saveRequestAs = async () => {
       requestUpdated as HoppGQLRequest
     )
 
+    platform.analytics?.logEvent({
+      type: "HOPP_SAVE_REQUEST",
+      createdNow: true,
+      platform: "gql",
+      workspaceType: "team",
+    })
+
     requestSaved()
   } else if (picked.value.pickedType === "gql-my-collection") {
     // TODO: Check for GQL request ?
@@ -328,6 +385,13 @@ const saveRequestAs = async () => {
       `${picked.value.collectionIndex}`,
       requestUpdated as HoppGQLRequest
     )
+
+    platform.analytics?.logEvent({
+      type: "HOPP_SAVE_REQUEST",
+      createdNow: true,
+      platform: "gql",
+      workspaceType: "team",
+    })
 
     requestSaved()
   }

--- a/packages/hoppscotch-common/src/components/collections/graphql/Add.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Add.vue
@@ -46,6 +46,7 @@ import { useToast } from "@composables/toast"
 import { useI18n } from "@composables/i18n"
 import { HoppGQLRequest, makeCollection } from "@hoppscotch/data"
 import { addGraphqlCollection } from "~/newstore/collections"
+import { platform } from "~/platform"
 
 export default defineComponent({
   props: {
@@ -79,6 +80,13 @@ export default defineComponent({
       )
 
       this.hideModal()
+
+      platform.analytics?.logEvent({
+        type: "HOPP_CREATE_COLLECTION",
+        isRootCollection: true,
+        platform: "gql",
+        workspaceType: "personal",
+      })
     },
     hideModal() {
       this.name = null

--- a/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
@@ -244,6 +244,14 @@ const importFromJSON = () => {
       return
     }
     appendGraphqlCollections(collections)
+
+    platform.analytics?.logEvent({
+      type: "HOPP_IMPORT_COLLECTION",
+      importer: "json",
+      workspaceType: "personal",
+      platform: "gql",
+    })
+
     fileImported()
   }
   reader.readAsText(inputChooseFileToImportFrom.value.files[0])
@@ -256,6 +264,12 @@ const exportJSON = () => {
   const a = document.createElement("a")
   const url = URL.createObjectURL(file)
   a.href = url
+
+  platform?.analytics?.logEvent({
+    type: "HOPP_EXPORT_COLLECTION",
+    exporter: "json",
+    platform: "gql",
+  })
 
   // TODO: get uri from meta
   a.download = `${url.split("/").pop()!.split("#")[0].split("?")[0]}.json`

--- a/packages/hoppscotch-common/src/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/index.vue
@@ -153,6 +153,7 @@ import IconArchive from "~icons/lucide/archive"
 import { useI18n } from "@composables/i18n"
 import { useReadonlyStream } from "@composables/stream"
 import { useColorMode } from "@composables/theming"
+import { platform } from "~/platform"
 
 export default defineComponent({
   props: {
@@ -285,6 +286,13 @@ export default defineComponent({
         response: "",
       })
 
+      platform.analytics?.logEvent({
+        type: "HOPP_SAVE_REQUEST",
+        platform: "gql",
+        createdNow: true,
+        workspaceType: "personal",
+      })
+
       this.displayModalAddRequest(false)
     },
     addRequest(payload) {
@@ -294,6 +302,14 @@ export default defineComponent({
     },
     onAddFolder({ name, path }) {
       addGraphqlFolder(name, path)
+
+      platform.analytics?.logEvent({
+        type: "HOPP_CREATE_COLLECTION",
+        isRootCollection: false,
+        platform: "gql",
+        workspaceType: "personal",
+      })
+
       this.displayModalAddFolder(false)
     },
     addFolder(payload) {

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -599,10 +599,24 @@ const addNewRootCollection = (name: string) => {
       })
     )
 
+    platform.analytics?.logEvent({
+      type: "HOPP_CREATE_COLLECTION",
+      platform: "rest",
+      workspaceType: "personal",
+      isRootCollection: true,
+    })
+
     displayModalAdd(false)
   } else if (hasTeamWriteAccess.value) {
     if (!collectionsType.value.selectedTeam) return
     modalLoadingState.value = true
+
+    platform.analytics?.logEvent({
+      type: "HOPP_CREATE_COLLECTION",
+      platform: "rest",
+      workspaceType: "team",
+      isRootCollection: true,
+    })
 
     pipe(
       createNewRootCollection(name, collectionsType.value.selectedTeam.id),
@@ -652,6 +666,13 @@ const onAddRequest = (requestName: string) => {
       },
     })
 
+    platform.analytics?.logEvent({
+      type: "HOPP_SAVE_REQUEST",
+      workspaceType: "personal",
+      createdNow: true,
+      platform: "rest",
+    })
+
     displayModalAddRequest(false)
   } else if (hasTeamWriteAccess.value) {
     const folder = editingFolder.value
@@ -666,6 +687,13 @@ const onAddRequest = (requestName: string) => {
       teamID: collectionsType.value.selectedTeam.id,
       title: requestName,
     }
+
+    platform.analytics?.logEvent({
+      type: "HOPP_SAVE_REQUEST",
+      workspaceType: "team",
+      platform: "rest",
+      createdNow: true,
+    })
 
     pipe(
       createRequestInCollection(folder.id, data),
@@ -712,12 +740,27 @@ const onAddFolder = (folderName: string) => {
   if (collectionsType.value.type === "my-collections") {
     if (!path) return
     addRESTFolder(folderName, path)
+
+    platform.analytics?.logEvent({
+      type: "HOPP_CREATE_COLLECTION",
+      workspaceType: "personal",
+      isRootCollection: false,
+      platform: "rest",
+    })
+
     displayModalAddFolder(false)
   } else if (hasTeamWriteAccess.value) {
     const folder = editingFolder.value
     if (!folder || !folder.id) return
 
     modalLoadingState.value = true
+
+    platform.analytics?.logEvent({
+      type: "HOPP_CREATE_COLLECTION",
+      workspaceType: "personal",
+      isRootCollection: false,
+      platform: "rest",
+    })
 
     pipe(
       createChildCollection(folderName, folder.id),
@@ -1884,6 +1927,12 @@ const exportData = async (
 }
 
 const exportJSONCollection = async () => {
+  platform.analytics?.logEvent({
+    type: "HOPP_EXPORT_COLLECTION",
+    exporter: "json",
+    platform: "rest",
+  })
+
   await getJSONCollection()
 
   initializeDownloadCollection(collectionJSON.value, null)
@@ -1894,6 +1943,12 @@ const createCollectionGist = async () => {
     toast.error(t("profile.no_permission").toString())
     return
   }
+
+  platform.analytics?.logEvent({
+    type: "HOPP_EXPORT_COLLECTION",
+    exporter: "gist",
+    platform: "rest",
+  })
 
   creatingGistCollection.value = true
   await getJSONCollection()
@@ -1924,6 +1979,12 @@ const importToTeams = async (collection: HoppCollection<HoppRESTRequest>[]) => {
   if (!collectionsType.value.selectedTeam) return
 
   importingMyCollections.value = true
+
+  platform.analytics?.logEvent({
+    type: "HOPP_EXPORT_COLLECTION",
+    exporter: "import-to-teams",
+    platform: "rest",
+  })
 
   pipe(
     importJSONToTeam(

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -190,6 +190,12 @@ const createEnvironmentGist = async () => {
     )
 
     toast.success(t("export.gist_created").toString())
+
+    platform.analytics?.logEvent({
+      type: "HOPP_EXPORT_ENVIRONMENT",
+      platform: "rest",
+    })
+
     window.open(res.data.html_url)
   } catch (e) {
     toast.error(t("error.something_went_wrong").toString())
@@ -249,6 +255,13 @@ const openDialogChooseFileToImportFrom = () => {
 
 const importToTeams = async (content: Environment[]) => {
   loading.value = true
+
+  platform.analytics?.logEvent({
+    type: "HOPP_IMPORT_ENVIRONMENT",
+    platform: "rest",
+    workspaceType: "team",
+  })
+
   for (const [i, env] of content.entries()) {
     if (i === content.length - 1) {
       await pipe(
@@ -301,6 +314,12 @@ const importFromJSON = () => {
     return
   }
 
+  platform.analytics?.logEvent({
+    type: "HOPP_IMPORT_ENVIRONMENT",
+    platform: "rest",
+    workspaceType: "personal",
+  })
+
   const reader = new FileReader()
 
   reader.onload = ({ target }) => {
@@ -352,6 +371,7 @@ const importFromPostman = ({
   const environment: Environment = { name, variables: [] }
   values.forEach(({ key, value }) => environment.variables.push({ key, value }))
   const environments = [environment]
+
   importFromHoppscotch(environments)
 }
 

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -148,6 +148,7 @@ import { useToast } from "@composables/toast"
 import { useReadonlyStream } from "@composables/stream"
 import { useColorMode } from "@composables/theming"
 import { environmentsStore } from "~/newstore/environments"
+import { platform } from "~/platform"
 
 type EnvironmentVariable = {
   id: number
@@ -311,6 +312,11 @@ const saveEnvironment = () => {
       index: envList.value.length - 1,
     })
     toast.success(`${t("environment.created")}`)
+
+    platform.analytics?.logEvent({
+      type: "HOPP_CREATE_ENVIRONMENT",
+      workspaceType: "personal",
+    })
   } else if (props.editingEnvironmentIndex === "Global") {
     // Editing the Global environment
     setGlobalEnvVariables(environmentUpdated.variables)

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -156,6 +156,7 @@ import IconTrash from "~icons/lucide/trash"
 import IconTrash2 from "~icons/lucide/trash-2"
 import IconDone from "~icons/lucide/check"
 import IconPlus from "~icons/lucide/plus"
+import { platform } from "~/platform"
 
 type EnvironmentVariable = {
   id: number
@@ -294,6 +295,11 @@ const saveEnvironment = async () => {
   )
 
   if (props.action === "new") {
+    platform.analytics?.logEvent({
+      type: "HOPP_CREATE_ENVIRONMENT",
+      workspaceType: "team",
+    })
+
     await pipe(
       createTeamEnvironment(
         JSON.stringify(filterdVariables),

--- a/packages/hoppscotch-common/src/components/graphql/Request.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Request.vue
@@ -48,7 +48,8 @@ const onConnectClick = () => {
   if (!connected.value) {
     props.conn.connect(url.value, headers.value as any)
 
-    platform.analytics?.logHoppRequestRunToAnalytics({
+    platform.analytics?.logEvent({
+      type: "HOPP_REQUEST_RUN",
       platform: "graphql-schema",
       strategy: getCurrentStrategyID(),
     })

--- a/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
@@ -748,7 +748,8 @@ const runQuery = async () => {
     console.error(e)
   }
 
-  platform.analytics?.logHoppRequestRunToAnalytics({
+  platform.analytics?.logEvent({
+    type: "HOPP_REQUEST_RUN",
     platform: "graphql-query",
     strategy: getCurrentStrategyID(),
   })

--- a/packages/hoppscotch-common/src/components/http/CodegenModal.vue
+++ b/packages/hoppscotch-common/src/components/http/CodegenModal.vue
@@ -165,6 +165,7 @@ import IconCheck from "~icons/lucide/check"
 import IconWrapText from "~icons/lucide/wrap-text"
 import { currentActiveTab } from "~/helpers/rest/tab"
 import cloneDeep from "lodash-es/cloneDeep"
+import { platform } from "~/platform"
 
 const t = useI18n()
 
@@ -248,6 +249,10 @@ watch(
   (goingToShow) => {
     if (goingToShow) {
       request.value = cloneDeep(currentActiveTab.value.document.request)
+
+      platform.analytics?.logEvent({
+        type: "HOPP_REST_CODEGEN_OPENED",
+      })
     }
   }
 )

--- a/packages/hoppscotch-common/src/components/http/ImportCurl.vue
+++ b/packages/hoppscotch-common/src/components/http/ImportCurl.vue
@@ -94,6 +94,7 @@ import IconClipboard from "~icons/lucide/clipboard"
 import IconCheck from "~icons/lucide/check"
 import IconTrash2 from "~icons/lucide/trash-2"
 import { currentActiveTab } from "~/helpers/rest/tab"
+import { platform } from "~/platform"
 
 const t = useI18n()
 
@@ -143,6 +144,10 @@ const handleImport = () => {
   const text = curl.value
   try {
     const req = parseCurlToHoppRESTReq(text)
+
+    platform.analytics?.logEvent({
+      type: "HOPP_REST_IMPORT_CURL",
+    })
 
     currentActiveTab.value.document.request = req
   } catch (e) {

--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -446,6 +446,11 @@ const copyRequest = async () => {
     shareLink.value = ""
     fetchingShareLink.value = true
     const shortcodeResult = await createShortcode(tab.value.document.request)()
+
+    platform.analytics?.logEvent({
+      type: "HOPP_SHORTCODE_CREATED",
+    })
+
     if (E.isLeft(shortcodeResult)) {
       toast.error(`${shortcodeResult.left.error}`)
       shareLink.value = `${t("error.something_went_wrong")}`
@@ -516,6 +521,14 @@ const saveRequest = () => {
       editRESTRequest(saveCtx.folderPath, saveCtx.requestIndex, req)
 
       tab.value.document.isDirty = false
+
+      platform.analytics?.logEvent({
+        type: "HOPP_SAVE_REQUEST",
+        platform: "rest",
+        createdNow: false,
+        workspaceType: "personal",
+      })
+
       toast.success(`${t("request.saved")}`)
     } catch (e) {
       tab.value.document.saveContext = undefined
@@ -526,6 +539,13 @@ const saveRequest = () => {
 
     // TODO: handle error case (NOTE: overwriteRequestTeams is async)
     try {
+      platform.analytics?.logEvent({
+        type: "HOPP_SAVE_REQUEST",
+        platform: "rest",
+        createdNow: false,
+        workspaceType: "team",
+      })
+
       runMutation(UpdateRequestDocument, {
         requestID: saveCtx.requestID,
         data: {

--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -324,7 +324,8 @@ const newSendRequest = async () => {
   loading.value = true
 
   // Log the request run into analytics
-  platform.analytics?.logHoppRequestRunToAnalytics({
+  platform.analytics?.logEvent({
+    type: "HOPP_REQUEST_RUN",
     platform: "rest",
     strategy: getCurrentStrategyID(),
   })

--- a/packages/hoppscotch-common/src/components/teams/Add.vue
+++ b/packages/hoppscotch-common/src/components/teams/Add.vue
@@ -44,6 +44,7 @@ import { createTeam } from "~/helpers/backend/mutations/Team"
 import { TeamNameCodec } from "~/helpers/backend/types/TeamName"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
+import { platform } from "~/platform"
 
 const t = useI18n()
 
@@ -68,6 +69,12 @@ const addNewTeam = async () => {
     TE.fromEither,
     TE.mapLeft(() => "invalid_name" as const),
     TE.chainW(createTeam),
+    TE.chainFirstIOK(
+      () => () =>
+        platform.analytics?.logEvent({
+          type: "HOPP_CREATE_TEAM",
+        })
+    ),
     TE.match(
       (err) => {
         // err is of type "invalid_name" | GQLError<Err>

--- a/packages/hoppscotch-common/src/helpers/realtime/MQTTConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/MQTTConnection.ts
@@ -105,7 +105,8 @@ export class MQTTConnection {
       this.handleError(e)
     }
 
-    platform.analytics?.logHoppRequestRunToAnalytics({
+    platform.analytics?.logEvent({
+      type: "HOPP_REQUEST_RUN",
       platform: "mqtt",
     })
   }

--- a/packages/hoppscotch-common/src/helpers/realtime/SIOConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/SIOConnection.ts
@@ -113,7 +113,8 @@ export class SIOConnection {
       this.handleError(error, "CONNECTION")
     }
 
-    platform.analytics?.logHoppRequestRunToAnalytics({
+    platform.analytics?.logEvent({
+      type: "HOPP_REQUEST_RUN",
       platform: "socketio",
     })
   }

--- a/packages/hoppscotch-common/src/helpers/realtime/SSEConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/SSEConnection.ts
@@ -63,7 +63,8 @@ export class SSEConnection {
       })
     }
 
-    platform.analytics?.logHoppRequestRunToAnalytics({
+    platform.analytics?.logEvent({
+      type: "HOPP_REQUEST_RUN",
       platform: "sse",
     })
   }

--- a/packages/hoppscotch-common/src/helpers/realtime/WSConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/WSConnection.ts
@@ -71,7 +71,8 @@ export class WSConnection {
       this.handleError(error as SyntaxError)
     }
 
-    platform.analytics?.logHoppRequestRunToAnalytics({
+    platform.analytics?.logEvent({
+      type: "HOPP_REQUEST_RUN",
       platform: "wss",
     })
   }

--- a/packages/hoppscotch-common/src/helpers/rest/tab.ts
+++ b/packages/hoppscotch-common/src/helpers/rest/tab.ts
@@ -6,6 +6,7 @@ import { refWithControl } from "@vueuse/core"
 import { HoppRESTResponse } from "../types/HoppRESTResponse"
 import { getDefaultRESTRequest } from "./default"
 import { HoppTestResult } from "../types/HoppTestResult"
+import { platform } from "~/platform"
 
 export type HoppRESTTab = {
   id: string
@@ -146,6 +147,10 @@ export function createNewTab(document: HoppRESTDocument, switchToIt = true) {
   if (switchToIt) {
     currentTabID.value = id
   }
+
+  platform.analytics?.logEvent({
+    type: "HOPP_REST_NEW_TAB_OPENED",
+  })
 
   return tab
 }

--- a/packages/hoppscotch-common/src/pages/r/_id.vue
+++ b/packages/hoppscotch-common/src/pages/r/_id.vue
@@ -84,6 +84,7 @@ import IconHome from "~icons/lucide/home"
 import IconRefreshCW from "~icons/lucide/refresh-cw"
 import { createNewTab } from "~/helpers/rest/tab"
 import { getDefaultRESTRequest } from "~/helpers/rest/default"
+import { platform } from "~/platform"
 
 const route = useRoute()
 const router = useRouter()
@@ -119,6 +120,10 @@ const addRequestToTab = () => {
       invalidLink.value = true
       return
     }
+
+    platform.analytics?.logEvent({
+      type: "HOPP_SHORTCODE_RESOLVED",
+    })
 
     const request: unknown = JSON.parse(data.right.shortcode?.request as string)
 

--- a/packages/hoppscotch-common/src/platform/analytics.ts
+++ b/packages/hoppscotch-common/src/platform/analytics.ts
@@ -5,8 +5,51 @@ export type HoppRequestEvent =
     }
   | { platform: "wss" | "sse" | "socketio" | "mqtt" }
 
+export type AnalyticsEvent =
+  | ({ type: "HOPP_REQUEST_RUN" } & HoppRequestEvent)
+  | {
+      type: "HOPP_CREATE_ENVIRONMENT"
+      workspaceType: "personal" | "team"
+    }
+  | {
+      type: "HOPP_CREATE_COLLECTION"
+      platform: "rest" | "gql"
+      isRootCollection: boolean
+      workspaceType: "personal" | "team"
+    }
+  | { type: "HOPP_CREATE_TEAM" }
+  | {
+      type: "HOPP_SAVE_REQUEST"
+      createdNow: boolean
+      workspaceType: "personal" | "team"
+      platform: "rest" | "gql"
+    }
+  | { type: "HOPP_SHORTCODE_CREATED" }
+  | { type: "HOPP_SHORTCODE_RESOLVED" }
+  | { type: "HOPP_REST_NEW_TAB_OPENED" }
+  | {
+      type: "HOPP_IMPORT_COLLECTION"
+      importer: string
+      workspaceType: "personal" | "team"
+      platform: "rest" | "gql"
+    }
+  | {
+      type: "HOPP_IMPORT_ENVIRONMENT"
+      workspaceType: "personal" | "team"
+      platform: "rest" | "gql"
+    }
+  | {
+      type: "HOPP_EXPORT_COLLECTION"
+      exporter: string
+      platform: "rest" | "gql"
+    }
+  | { type: "HOPP_EXPORT_ENVIRONMENT"; platform: "rest" | "gql" }
+  | { type: "HOPP_REST_CODEGEN_OPENED" }
+  | { type: "HOPP_REST_IMPORT_CURL" }
+
 export type AnalyticsPlatformDef = {
   initAnalytics: () => void
+  logEvent: (ev: AnalyticsEvent) => void
   logHoppRequestRunToAnalytics: (ev: HoppRequestEvent) => void
   logPageView: (pagePath: string) => void
 }

--- a/packages/hoppscotch-common/src/platform/analytics.ts
+++ b/packages/hoppscotch-common/src/platform/analytics.ts
@@ -50,6 +50,5 @@ export type AnalyticsEvent =
 export type AnalyticsPlatformDef = {
   initAnalytics: () => void
   logEvent: (ev: AnalyticsEvent) => void
-  logHoppRequestRunToAnalytics: (ev: HoppRequestEvent) => void
   logPageView: (pagePath: string) => void
 }


### PR DESCRIPTION
Closes HFE-112

### Description
This PR introduces more events into the analytics pipeline as outlined by the `analytics.ts` definition.
This PR drops `logHoppRequestRunToAnalytics` in favor of a general `logEvent` function that can accept analytics data.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
N/A