### PR TITLE
fix: keybinding modifier issue

### DIFF
--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -14,7 +14,13 @@ let keybindingsEnabled = true
  * Alt is also regarded as macOS OPTION (⌥) key
  * Ctrl is also regarded as macOS COMMAND (⌘) key (NOTE: this differs from HTML Keyboard spec where COMMAND is Meta key!)
  */
-type ModifierKeys = "ctrl" | "alt" | "ctrl-shift" | "alt-shift"
+type ModifierKeys =
+  | "ctrl"
+  | "alt"
+  | "ctrl-shift"
+  | "alt-shift"
+  | "ctrl-alt"
+  | "ctrl-alt-shift"
 
 /* eslint-disable prettier/prettier */
 // prettier-ignore
@@ -143,18 +149,20 @@ function getPressedKey(ev: KeyboardEvent): Key | null {
 }
 
 function getActiveModifier(ev: KeyboardEvent): ModifierKeys | null {
-  const isShiftKey = ev.shiftKey
+  const modifierKeys = {
+    ctrl: isAppleDevice() ? ev.metaKey : ev.ctrlKey,
+    alt: ev.altKey,
+    shift: ev.shiftKey,
+  }
 
-  // We only allow one modifier key to be pressed (for now)
-  // Control key (+ Command) gets priority and if Alt is also pressed, it is ignored
-  if (isAppleDevice() && ev.metaKey) return isShiftKey ? "ctrl-shift" : "ctrl"
-  else if (!isAppleDevice() && ev.ctrlKey)
-    return isShiftKey ? "ctrl-shift" : "ctrl"
+  // active modifier: ctrl | alt | ctrl-alt | ctrl-shift | ctrl-alt-shift | alt-shift
+  // modiferKeys object's keys are sorted to match the above order
+  const activeModifier = Object.keys(modifierKeys)
+    .filter((key) => modifierKeys[key as keyof typeof modifierKeys])
+    .join("-") as ModifierKeys
 
-  // Test for Alt key
-  if (ev.altKey) return isShiftKey ? "alt-shift" : "alt"
-
-  return null
+  // activeModifier can be empty string which is falsy. other we could have used nullish coalescing
+  return activeModifier || null
 }
 
 /**

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -161,7 +161,7 @@ function getActiveModifier(ev: KeyboardEvent): ModifierKeys | null {
     .filter((key) => modifierKeys[key as keyof typeof modifierKeys])
     .join("-") as ModifierKeys
 
-  // activeModifier can be empty string which is falsy. other we could have used nullish coalescing
+  // activeModifier can be empty string which is falsy. otherwise we could have used nullish coalescing
   return activeModifier || null
 }
 

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -159,10 +159,9 @@ function getActiveModifier(ev: KeyboardEvent): ModifierKeys | null {
   // modiferKeys object's keys are sorted to match the above order
   const activeModifier = Object.keys(modifierKeys)
     .filter((key) => modifierKeys[key as keyof typeof modifierKeys])
-    .join("-") as ModifierKeys
+    .join("-")
 
-  // activeModifier can be empty string which is falsy. otherwise we could have used nullish coalescing
-  return activeModifier || null
+  return activeModifier === "" ? null : (activeModifier as ModifierKeys)
 }
 
 /**


### PR DESCRIPTION
## Before
- Prioritization of key bindings was preventing to run browser's default shortcuts
- Only available modifier was  `type ModifierKeys = "ctrl" | "alt" | "ctrl-shift" | "alt-shift"`

## After
- Running browser's default shortcuts issue fixed
- Extended modifier to `type ModifierKeys = "ctrl" | "alt" | "ctrl-shift" | "alt-shift" | "ctrl-alt" | "ctrl-alt-shift"`


### Walkthrough
* Extend `ModifierKeys` type to support more keybindings ([link](https://github.com/hoppscotch/hoppscotch/pull/3163/files?diff=unified&w=0#diff-1739024c7f2b818baf3371ad86dfd3f41e18acfc2da76778f3d545832beb4de6L17-R23))
* Refactor `getActiveModifier` function to use object and filter ([link](https://github.com/hoppscotch/hoppscotch/pull/3163/files?diff=unified&w=0#diff-1739024c7f2b818baf3371ad86dfd3f41e18acfc2da76778f3d545832beb4de6L146-R165))




Closes HFE-116