### PR TITLE
Fixed team invite case sensitive and admin can't delete invites

### DIFF
--- a/packages/hoppscotch-backend/src/team-invitation/team-invitation.service.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invitation.service.ts
@@ -256,7 +256,7 @@ export class TeamInvitationService {
           pipe(
             undefined,
             TE.fromPredicate(
-              (a) => acceptedBy.email === invitation.inviteeEmail,
+              (a) => acceptedBy.email.toLowerCase() === invitation.inviteeEmail.toLowerCase(),
               () => TEAM_INVITE_EMAIL_DO_NOT_MATCH,
             ),
           ),

--- a/packages/hoppscotch-backend/src/team-invitation/team-invite-team-owner.guard.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invite-team-owner.guard.ts
@@ -57,7 +57,7 @@ export class TeamInviteTeamOwnerGuard implements CanActivate {
 
       TE.chainW(
         TE.fromPredicate(
-          ({ userMember }) => userMember.role === TeamMemberRole.OWNER,
+          ({ userMember, user }) => (userMember.role === TeamMemberRole.OWNER || user.isAdmin),
           () => TEAM_NOT_REQUIRED_ROLE,
         ),
       ),

--- a/packages/hoppscotch-backend/src/team-invitation/team-invitee.guard.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invitee.guard.ts
@@ -55,7 +55,7 @@ export class TeamInviteeGuard implements CanActivate {
       // Check if the emails match
       TE.chainW(
         TE.fromPredicate(
-          ({ user, invite }) => user.email === invite.inviteeEmail,
+          ({ user, invite }) => user.email.toLowerCase() === invite.inviteeEmail.toLowerCase(),
           () => TEAM_INVITE_EMAIL_DO_NOT_MATCH,
         ),
       ),


### PR DESCRIPTION
I had the problem that by using MS as an authentication provider, users ended up in the database with email addresses in which the first letter of the first and last name was capitalized, which is basically not a problem. However, this meant that if the team invite was not spelled exactly the same way, it was not possible to accept it.

The second problem was that if I hadn't created the invite or the team, as an admin I couldn't delete the broken invite because it only checked whether I had the necessary role in the team.


