### PR TITLE
fix: text overflow on spotlight search results

### DIFF
--- a/packages/hoppscotch-common/src/components/app/spotlight/Entry.vue
+++ b/packages/hoppscotch-common/src/components/app/spotlight/Entry.vue
@@ -12,37 +12,37 @@
       class="opacity-50 svg-icons"
       :class="{ 'opacity-100': active }"
     />
-    <span
+    <template
       v-if="entry.text.type === 'text' && typeof entry.text.text === 'string'"
-      class="block truncate"
     >
-      {{ entry.text.text }}
-    </span>
-    <span
+      <span class="block truncate">
+        {{ entry.text.text }}
+      </span>
+    </template>
+    <template
       v-else-if="entry.text.type === 'text' && Array.isArray(entry.text.text)"
-      class="flex items-center flex-1"
     >
-      <span
+      <template
         v-for="(labelPart, labelPartIndex) in entry.text.text"
         :key="`label-${labelPart}-${labelPartIndex}`"
-        class="flex items-center space-x-2"
       >
-        {{ labelPart }}
+        <span class="block truncate">
+          {{ labelPart }}
+        </span>
         <icon-lucide-chevron-right
           v-if="labelPartIndex < entry.text.text.length - 1"
-          class="block truncate"
+          class="flex flex-shrink-0"
+        />
+      </template>
+    </template>
+    <template v-else-if="entry.text.type === 'custom'">
+      <span class="block truncate">
+        <component
+          :is="entry.text.component"
+          v-bind="entry.text.componentProps"
         />
       </span>
-    </span>
-    <span
-      v-else-if="entry.text.type === 'custom'"
-      class="block truncate w-full"
-    >
-      <component
-        :is="entry.text.component"
-        v-bind="entry.text.componentProps"
-      />
-    </span>
+    </template>
     <span v-if="formattedShortcutKeys" class="block truncate">
       <kbd
         v-for="(key, keyIndex) in formattedShortcutKeys"


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 323312b</samp>

### Summary
🚀🎨♿

<!--
1.  🚀 - This emoji can be used to indicate a performance improvement or a speed boost, as well as a general sense of progress or innovation. It could also suggest that the changes are part of a larger feature or enhancement that is being launched or deployed.
2.  🎨 - This emoji can be used to indicate a design or UI improvement, a visual refactor, or a style change. It could also suggest that the changes are part of a creative or artistic process or outcome.
3.  ♿ - This emoji can be used to indicate an accessibility improvement, a compliance with standards or guidelines, or a support for users with disabilities or special needs. It could also suggest that the changes are part of a social or ethical responsibility or commitment.
-->
Refactor spotlight entry component to use `<template>` elements instead of `<span>` and prevent icon shrinking. This improves performance and responsiveness.

> _`<template>` tags cut_
> _Unneeded `<span>`s for speed_
> _Winter pruning done_

### Walkthrough
* Replace `<span>` elements with `<template>` elements to avoid rendering unnecessary DOM nodes and improve performance in the spotlight entry component ([link](https://github.com/hoppscotch/hoppscotch/pull/3181/files?diff=unified&w=0#diff-300593efc11f61fbf739d35fd3e25d679f6c00ac17cb44f4d1297f6aa524fb3bL15-R45))
* Prevent the chevron icon from shrinking when the entry text is truncated by adding a `flex-shrink-0` class ([link](https://github.com/hoppscotch/hoppscotch/pull/3181/files?diff=unified&w=0#diff-300593efc11f61fbf739d35fd3e25d679f6c00ac17cb44f4d1297f6aa524fb3bL15-R45))

