### PR TITLE
chore: update generateSitemap usage

### DIFF
--- a/packages/hoppscotch-common/package.json
+++ b/packages/hoppscotch-common/package.json
@@ -148,7 +148,7 @@
     "vite-plugin-html-config": "^1.0.10",
     "vite-plugin-inspect": "^0.7.4",
     "vite-plugin-pages": "^0.26.0",
-    "vite-plugin-pages-sitemap": "^1.4.0",
+    "vite-plugin-pages-sitemap": "^1.4.5",
     "vite-plugin-pwa": "^0.13.1",
     "vite-plugin-vue-layouts": "^0.7.0",
     "vite-plugin-windicss": "^1.8.8",

--- a/packages/hoppscotch-selfhost-web/vite.config.ts
+++ b/packages/hoppscotch-selfhost-web/vite.config.ts
@@ -79,8 +79,7 @@ export default defineConfig({
       dirs: "../hoppscotch-common/src/pages",
       importMode: "async",
       onRoutesGenerated(routes) {
-        // HACK: See: https://github.com/jbaubree/vite-plugin-pages-sitemap/issues/173
-        return ((generateSitemap as any).default as typeof generateSitemap)({
+        return generateSitemap({
           routes,
           nuxtStyle: true,
           allowRobots: true,


### PR DESCRIPTION
**Before**

We were using an workaround with the generateSitemap plugin.
see https://github.com/jbaubree/vite-plugin-pages-sitemap/issues/173 for context.

**After**

thanks to the package authors fixing the need for the workaround in v1.4.5, we have removed the workaround

