### PR TITLE
fix: deps mismatch

### DIFF
--- a/packages/hoppscotch-selfhost-web/package.json
+++ b/packages/hoppscotch-selfhost-web/package.json
@@ -66,7 +66,7 @@
     "vite-plugin-html-config": "^1.0.10",
     "vite-plugin-inspect": "^0.7.4",
     "vite-plugin-pages": "^0.26.0",
-    "vite-plugin-pages-sitemap": "^1.4.0",
+    "vite-plugin-pages-sitemap": "^1.4.5",
     "vite-plugin-pwa": "^0.13.1",
     "vite-plugin-static-copy": "^0.12.0",
     "vite-plugin-vue-layouts": "^0.7.0",

--- a/packages/hoppscotch-selfhost-web/vite.config.ts
+++ b/packages/hoppscotch-selfhost-web/vite.config.ts
@@ -78,15 +78,14 @@ export default defineConfig({
       routeStyle: "nuxt",
       dirs: "../hoppscotch-common/src/pages",
       importMode: "async",
-      onRoutesGenerated(routes) {
-        return generateSitemap({
+      onRoutesGenerated: (routes) =>
+        generateSitemap({
           routes,
           nuxtStyle: true,
           allowRobots: true,
           dest: ".sitemap-gen",
           hostname: ENV.VITE_BASE_URL,
-        })
-      },
+        }),
     }),
     StaticCopy({
       targets: [

--- a/packages/hoppscotch-ui/package.json
+++ b/packages/hoppscotch-ui/package.json
@@ -76,7 +76,7 @@
     "vite-plugin-html-config": "^1.0.10",
     "vite-plugin-inspect": "^0.7.4",
     "vite-plugin-pages": "^0.26.0",
-    "vite-plugin-pages-sitemap": "^1.4.0",
+    "vite-plugin-pages-sitemap": "^1.4.5",
     "vite-plugin-pwa": "^0.13.1",
     "vite-plugin-vue-layouts": "^0.7.0",
     "vite-plugin-windicss": "^1.8.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -749,8 +749,8 @@ importers:
         specifier: ^0.26.0
         version: 0.26.0(@vue/compiler-sfc@3.2.39)(vite@3.1.4)
       vite-plugin-pages-sitemap:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.4.5
+        version: 1.4.5
       vite-plugin-pwa:
         specifier: ^0.13.1
         version: 0.13.1(vite@3.1.4)(workbox-build@6.5.4)(workbox-window@6.5.4)
@@ -986,8 +986,8 @@ importers:
         specifier: ^0.26.0
         version: 0.26.0(vite@3.2.4)
       vite-plugin-pages-sitemap:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.4.5
+        version: 1.4.5
       vite-plugin-pwa:
         specifier: ^0.13.1
         version: 0.13.1(vite@3.2.4)(workbox-build@6.5.4)(workbox-window@6.5.4)
@@ -1327,8 +1327,8 @@ importers:
         specifier: ^0.26.0
         version: 0.26.0(@vue/compiler-sfc@3.2.45)(vite@3.2.4)
       vite-plugin-pages-sitemap:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.4.5
+        version: 1.4.5
       vite-plugin-pwa:
         specifier: ^0.13.1
         version: 0.13.1(vite@3.2.4)(workbox-build@6.5.4)(workbox-window@6.5.4)
@@ -21853,8 +21853,8 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-pages-sitemap@1.4.0:
-    resolution: {integrity: sha512-8GlmNSeObvDVUdmgutfWnGBZGsn3Zb8IXCjRODFB0tOhQqAQPZRwXrFha6ZLjvF4DgVJI3sW2FfiXa1wFxJvmg==}
+  /vite-plugin-pages-sitemap@1.4.5:
+    resolution: {integrity: sha512-AcEoJ+0D0P1CwR1LjzBznHs6yNQVP7ha7l6cl/VHrHFcQXbVyKc+QOmLi1a3eONy+aDA3K01pZVK8TzTIufq/w==}
     dev: true
 
   /vite-plugin-pages@0.26.0(@vue/compiler-sfc@3.2.39)(vite@3.1.4):


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a93d2f5</samp>

### Summary
🐛🎨⬆️

<!--
1.  🐛 - This emoji represents a bug fix, which is the main purpose of updating `vite-plugin-pages-sitemap` to fix the sitemap generation issue.
2.  🎨 - This emoji represents a code style improvement, which is what the refactoring and formatting of the `onRoutesGenerated` option achieved.
3.  ⬆️ - This emoji represents a dependency upgrade, which is what updating `vite-plugin-pages-sitemap` to the latest version did.
-->
Updated `vite-plugin-pages-sitemap` to the latest version and refactored the `onRoutesGenerated` option in `vite.config.ts` to fix a sitemap bug and improve code quality for self-hosted web deployments of hoppscotch.

> _Sing, O Muse, of the valiant hoppscotch team_
> _Who strive to make the web a better place_
> _With tools for testing APIs with grace_
> _And self-hosting options for the supreme._

### Walkthrough
*  Update `vite-plugin-pages-sitemap` version to fix sitemap bug for self-hosted web deployments ([link](https://github.com/hoppscotch/hoppscotch/pull/3191/files?diff=unified&w=0#diff-2605d9082135a4d4f37b7ed2aec77c2060e739dac43563c1a6c4b6f6af8fdc75L69-R69), [link](https://github.com/hoppscotch/hoppscotch/pull/3191/files?diff=unified&w=0#diff-ee4a298dac90032cf9423afdeb697d18f3efb3bb9c43690fb78831a4c1960c94L79-R79), [link](https://github.com/hoppscotch/hoppscotch/pull/3191/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL752-R753), [link](https://github.com/hoppscotch/hoppscotch/pull/3191/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL989-R990), [link](https://github.com/hoppscotch/hoppscotch/pull/3191/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1330-R1331), [link](https://github.com/hoppscotch/hoppscotch/pull/3191/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL21856-R21857))
* Refactor `onRoutesGenerated` option of `vite-plugin-pages` to use arrow function and fix indentation in `packages/hoppscotch-selfhost-web/vite.config.ts` ([link](https://github.com/hoppscotch/hoppscotch/pull/3191/files?diff=unified&w=0#diff-01e9dc9636a2f150ced67c072aa668f1b22ee5ac82f2bd199daf1586e92dcacbL81-R82), [link](https://github.com/hoppscotch/hoppscotch/pull/3191/files?diff=unified&w=0#diff-01e9dc9636a2f150ced67c072aa668f1b22ee5ac82f2bd199daf1586e92dcacbL88-R88))

