### PR TITLE
docs: fixed shortcut keys for spotlight and shortcuts menu

### DIFF
--- a/packages/hoppscotch-common/src/components/app/ShortcutsPrompt.vue
+++ b/packages/hoppscotch-common/src/components/app/ShortcutsPrompt.vue
@@ -22,10 +22,11 @@
         </div>
         <div class="flex">
           <kbd class="shortcut-key">{{ getSpecialKey() }}</kbd>
-          <kbd class="shortcut-key">K</kbd>
+          <kbd class="shortcut-key">/</kbd>
         </div>
         <div class="flex">
-          <kbd class="shortcut-key">/</kbd>
+          <kbd class="shortcut-key">{{ getSpecialKey() }}</kbd>
+          <kbd class="shortcut-key">K</kbd>
         </div>
         <div class="flex">
           <kbd class="shortcut-key">?</kbd>

--- a/packages/hoppscotch-common/src/helpers/shortcuts.ts
+++ b/packages/hoppscotch-common/src/helpers/shortcuts.ts
@@ -16,12 +16,12 @@ export function getShortcuts(t: (x: string) => string): ShortcutDef[] {
     },
     {
       label: t("shortcut.general.command_menu"),
-      keys: ["/"],
+      keys: [getPlatformSpecialKey(), "K"],
       section: t("shortcut.general.title"),
     },
     {
       label: t("shortcut.general.show_all"),
-      keys: [getPlatformSpecialKey(), "K"],
+      keys: [getPlatformSpecialKey(), "/"],
       section: t("shortcut.general.title"),
     },
     {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7a1d1e1</samp>

### Summary
🔀🎛️📑

<!--
1.  🔀 - This emoji represents the swapping or switching of the shortcut keys, which is the main action of these changes.
2.  🎛️ - This emoji represents the command menu or the settings, which is the feature that these changes affect.
3.  📑 - This emoji represents the shortcuts or the documentation, which is the information that these changes update.
-->
This pull request fixes shortcut keys for the command menu and the show all shortcuts in the `ShortcutsPrompt.vue` component and the `getShortcuts` helper function. This makes the shortcut keys consistent and less confusing for the users.

> _`ShortcutsPrompt` changed_
> _Swap keys for command and show_
> _Autumn of confusion_

### Walkthrough
*  Swap the shortcut keys for the command menu and the show all shortcuts in the `ShortcutsPrompt.vue` component and the `getShortcuts` helper function to make them consistent and less confusing for the users ([link](https://github.com/hoppscotch/hoppscotch/pull/3192/files?diff=unified&w=0#diff-f8bd7cb85f1791c09751fb79b298916a921400887d095aeb8df31651eb9a33cdL25-R29), [link](https://github.com/hoppscotch/hoppscotch/pull/3192/files?diff=unified&w=0#diff-89bb51d435834bebbdb4715ee6705ab1641254ae50ecf170d98dbd1baa96e531L19-R24))

