### PR TITLE
fix: firefox browser scrollbar issue

### DIFF
--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -133,7 +133,10 @@ declare module '@vue/runtime-core' {
     IconLucideLayers: typeof import('~icons/lucide/layers')['default']
     IconLucideListEnd: typeof import('~icons/lucide/list-end')['default']
     IconLucideMinus: typeof import('~icons/lucide/minus')['default']
+<<<<<<< HEAD
     IconLucideRss: typeof import('~icons/lucide/rss')['default']
+=======
+>>>>>>> 6db825779 (fix: firefox browser scrollbar issue)
     IconLucideSearch: typeof import('~icons/lucide/search')['default']
     IconLucideUsers: typeof import('~icons/lucide/users')['default']
     LensesHeadersRenderer: typeof import('./components/lenses/HeadersRenderer.vue')['default']

--- a/packages/hoppscotch-ui/src/components/smart/Windows.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Windows.vue
@@ -6,7 +6,7 @@
       class="relative sticky top-0 z-10 flex-shrink-0 overflow-x-auto divide-x divide-dividerLight bg-primaryLight tabs group-tabs"
     >
       <div
-        class="flex flex-1 flex-shrink-0 w-0 scroll-container"
+        class="flex flex-1 flex-shrink-0 w-0 scroll-container overflow-hidden"
         ref="scrollContainer"
       >
         <div
@@ -368,12 +368,6 @@ watch(
 </script>
 
 <style scoped lang="scss">
-.hopp-windows {
-  .scroll-container {
-    overflow: hidden;
-  }
-}
-
 .tabs {
   @apply flex;
   @apply whitespace-nowrap;

--- a/packages/hoppscotch-ui/src/components/smart/Windows.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Windows.vue
@@ -1,10 +1,12 @@
 <template>
-  <div class="flex flex-col flex-1 h-auto overflow-y-hidden flex-nowrap">
+  <div
+    class="flex flex-col flex-1 h-auto overflow-y-hidden flex-nowrap hopp-windows"
+  >
     <div
       class="relative sticky top-0 z-10 flex-shrink-0 overflow-x-auto divide-x divide-dividerLight bg-primaryLight tabs group-tabs"
     >
       <div
-        class="flex flex-1 flex-shrink-0 w-0 overflow-x-auto"
+        class="flex flex-1 flex-shrink-0 w-0 scroll-container"
         ref="scrollContainer"
       >
         <div
@@ -366,6 +368,12 @@ watch(
 </script>
 
 <style scoped lang="scss">
+.hopp-windows {
+  .scroll-container {
+    overflow: hidden;
+  }
+}
+
 .tabs {
   @apply flex;
   @apply whitespace-nowrap;
@@ -455,6 +463,7 @@ $slider-height: 4px;
     @apply min-w-0;
     @apply bg-dividerDark;
     @apply hover:bg-secondaryLight;
+    @apply active:bg-secondaryLight;
 
     width: var(--thumb-width);
     height: $slider-height;
@@ -465,6 +474,7 @@ $slider-height: 4px;
     @apply min-w-0;
     @apply bg-dividerDark;
     @apply hover:bg-secondaryLight;
+    @apply active:bg-secondaryLight;
 
     width: var(--thumb-width);
     height: $slider-height;

--- a/packages/hoppscotch-ui/src/components/smart/Windows.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Windows.vue
@@ -1,12 +1,10 @@
 <template>
-  <div
-    class="flex flex-col flex-1 h-auto overflow-y-hidden flex-nowrap hopp-windows"
-  >
+  <div class="flex flex-col flex-1 h-auto overflow-y-hidden flex-nowrap">
     <div
       class="relative sticky top-0 z-10 flex-shrink-0 overflow-x-auto divide-x divide-dividerLight bg-primaryLight tabs group-tabs"
     >
       <div
-        class="flex flex-1 flex-shrink-0 w-0 scroll-container overflow-hidden"
+        class="flex flex-1 flex-shrink-0 w-0 overflow-hidden"
         ref="scrollContainer"
       >
         <div


### PR DESCRIPTION
Closes HFE-74

### Description

This PR fixes the issue of showing the default `scrollbar-thumb` instead of the custom one on Firefox for HoppUI Windows Scrollbar.