### PR TITLE
fix: elastic overscroll on safari

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -4,6 +4,7 @@
   @apply after:backface-hidden;
   @apply selection:bg-accentDark;
   @apply selection:text-accentContrast;
+  @apply overscroll-none;
 }
 
 :root {

--- a/packages/hoppscotch-sh-admin/assets/scss/styles.scss
+++ b/packages/hoppscotch-sh-admin/assets/scss/styles.scss
@@ -4,6 +4,7 @@
   @apply after:backface-hidden;
   @apply selection:bg-accentDark;
   @apply selection:text-accentContrast;
+  @apply overscroll-none;
 }
 
 :root {

--- a/packages/hoppscotch-ui/src/assets/scss/styles.scss
+++ b/packages/hoppscotch-ui/src/assets/scss/styles.scss
@@ -4,6 +4,7 @@
   @apply after:backface-hidden;
   @apply selection:bg-accentDark;
   @apply selection:text-accentContrast;
+  @apply overscroll-none;
 }
 
 :root {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b330203</samp>

| Before | After |
| --- | --- |
| <video src="https://github.com/hoppscotch/hoppscotch/assets/10395817/80109e5c-3f1e-421d-af21-6c65ef965247" /> | <video src="https://github.com/hoppscotch/hoppscotch/assets/10395817/80473ee4-1274-42f3-836d-9794d835052d" /> |

### Summary
🚫🛠️🖥️

<!--
1.  🚫 - This emoji can represent the `overscroll-none` utility class, which prevents the page from scrolling beyond the edges of the content. It can also signify the removal of unwanted or unnecessary scrolling behavior.
2.  🛠️ - This emoji can represent the `hoppscotch-common` package, which contains the shared styles and utilities for the Hoppscotch project. It can also signify the fixing or improving of the common components and features.
3.  🖥️ - This emoji can represent the `hoppscotch-sh-admin` and `hoppscotch-ui` packages, which contain the styles for the admin dashboard and the main user interface of the Hoppscotch API testing tool. It can also signify the enhancement or optimization of the user experience and interface design.
-->
Apply `overscroll-none` utility class to `html` and `body` elements in all packages. This prevents unwanted scrolling beyond the edges of the content in the Hoppscotch web app.

> _`overscroll-none`_
> _applied to html, body_
> _no more edge scrolling_

### Walkthrough
*  Prevent page from scrolling beyond edges of content by applying `overscroll-none` utility class to `html` and `body` elements in all packages ([link](https://github.com/hoppscotch/hoppscotch/pull/3221/files?diff=unified&w=0#diff-d3d67d4f57af5b5dea2f42b2746e17dca05e7b90714a231135dbab853f11d05fR7), [link](https://github.com/hoppscotch/hoppscotch/pull/3221/files?diff=unified&w=0#diff-e170c4199239be268cc69dd5a94f99997915f9648801e39f3d84a6c1d9c54063R7), [link](https://github.com/hoppscotch/hoppscotch/pull/3221/files?diff=unified&w=0#diff-5bf1f6af0d1183005848e78500dc64e5f9b6a28e1f905530faae464b470d58ceR7))
