### PR TITLE
fix: disable line wrapping in EnvInput component

### DIFF
--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -342,7 +342,6 @@ const initView = (el: any) => {
   el.addEventListener("keyup", debounceFn)
 
   const extensions: Extension = [
-    EditorView.lineWrapping,
     EditorView.contentAttributes.of({ "aria-label": props.placeholder }),
     EditorView.contentAttributes.of({ "data-enable-grammarly": "false" }),
     EditorView.updateListener.of((update) => {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 90633d7</samp>

Removed line wrapping option for `EnvInput.vue` editor, which is not a multi-line input instance to prevent overflow and scrolling issues.

| Before | After |
|-|-|
| <img width="1470" alt="Screenshot 2023-08-03 at 3 59 20 PM" src="https://github.com/hoppscotch/hoppscotch/assets/10395817/b44de146-6950-4c35-b419-bc92dcb8b160"> | <img width="1470" alt="Screenshot 2023-08-03 at 3 59 08 PM" src="https://github.com/hoppscotch/hoppscotch/assets/10395817/090c24ad-6046-4138-9daf-238f70bcfd61"> |