### PR TITLE
HBE-248 feat: prefix VITE_ added in conditional auth provider env variable 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ SESSION_SECRET='add some secret here'
 # Hoppscotch App Domain Config
 REDIRECT_URL="http://localhost:3000"
 WHITELISTED_ORIGINS = "http://localhost:3170,http://localhost:3000,http://localhost:3100"
-ALLOWED_AUTH_PROVIDERS = GOOGLE,GITHUB,MICROSOFT,EMAIL
+VITE_ALLOWED_AUTH_PROVIDERS = GOOGLE,GITHUB,MICROSOFT,EMAIL
 
 # Google Auth Config
 GOOGLE_CLIENT_ID="************************************************"

--- a/packages/hoppscotch-backend/src/auth/helper.ts
+++ b/packages/hoppscotch-backend/src/auth/helper.ts
@@ -107,7 +107,7 @@ export const subscriptionContextCookieParser = (rawCookies: string) => {
 };
 
 /**
- * Check to see if given auth provider is present in the ALLOWED_AUTH_PROVIDERS env variable
+ * Check to see if given auth provider is present in the VITE_ALLOWED_AUTH_PROVIDERS env variable
  *
  * @param provider Provider we want to check the presence of
  * @returns Boolean if provider specified is present or not
@@ -117,8 +117,8 @@ export function authProviderCheck(provider: string) {
     throwErr(AUTH_PROVIDER_NOT_SPECIFIED);
   }
 
-  const envVariables = process.env.ALLOWED_AUTH_PROVIDERS
-    ? process.env.ALLOWED_AUTH_PROVIDERS.split(',').map((provider) =>
+  const envVariables = process.env.VITE_ALLOWED_AUTH_PROVIDERS
+    ? process.env.VITE_ALLOWED_AUTH_PROVIDERS.split(',').map((provider) =>
         provider.trim().toUpperCase(),
       )
     : [];

--- a/packages/hoppscotch-backend/src/errors.ts
+++ b/packages/hoppscotch-backend/src/errors.ts
@@ -29,22 +29,22 @@ export const JSON_INVALID = 'json_invalid';
 export const AUTH_PROVIDER_NOT_SPECIFIED = 'auth/provider_not_specified';
 
 /**
- * Environment variable "ALLOWED_AUTH_PROVIDERS" is not present in .env file
+ * Environment variable "VITE_ALLOWED_AUTH_PROVIDERS" is not present in .env file
  */
 export const ENV_NOT_FOUND_KEY_AUTH_PROVIDERS =
-  '"ALLOWED_AUTH_PROVIDERS" is not present in .env file';
+  '"VITE_ALLOWED_AUTH_PROVIDERS" is not present in .env file';
 
 /**
- * Environment variable "ALLOWED_AUTH_PROVIDERS" is empty in .env file
+ * Environment variable "VITE_ALLOWED_AUTH_PROVIDERS" is empty in .env file
  */
 export const ENV_EMPTY_AUTH_PROVIDERS =
-  '"ALLOWED_AUTH_PROVIDERS" is empty in .env file';
+  '"VITE_ALLOWED_AUTH_PROVIDERS" is empty in .env file';
 
 /**
- * Environment variable "ALLOWED_AUTH_PROVIDERS" contains unsupported provider in .env file
+ * Environment variable "VITE_ALLOWED_AUTH_PROVIDERS" contains unsupported provider in .env file
  */
 export const ENV_NOT_SUPPORT_AUTH_PROVIDERS =
-  '"ALLOWED_AUTH_PROVIDERS" contains an unsupported auth provider in .env file';
+  '"VITE_ALLOWED_AUTH_PROVIDERS" contains an unsupported auth provider in .env file';
 
 /**
  * Tried to delete a user data document from fb firestore but failed.

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -9,7 +9,12 @@ import * as E from 'fp-ts/Either';
 import * as A from 'fp-ts/Array';
 import { TeamMemberRole } from './team/team.model';
 import { User } from './user/user.model';
-import { ENV_EMPTY_AUTH_PROVIDERS, ENV_NOT_FOUND_KEY_AUTH_PROVIDERS, ENV_NOT_SUPPORT_AUTH_PROVIDERS, JSON_INVALID } from './errors';
+import {
+  ENV_EMPTY_AUTH_PROVIDERS,
+  ENV_NOT_FOUND_KEY_AUTH_PROVIDERS,
+  ENV_NOT_SUPPORT_AUTH_PROVIDERS,
+  JSON_INVALID,
+} from './errors';
 import { AuthProvider } from './auth/helper';
 
 /**
@@ -156,21 +161,21 @@ export function isValidLength(title: string, length: number) {
 
 /**
  * This function is called by bootstrap() in main.ts
- *  It checks if the "ALLOWED_AUTH_PROVIDERS" environment variable is properly set or not.
+ *  It checks if the "VITE_ALLOWED_AUTH_PROVIDERS" environment variable is properly set or not.
  * If not, it throws an error.
  */
 export function checkEnvironmentAuthProvider() {
-  if (!process.env.hasOwnProperty('ALLOWED_AUTH_PROVIDERS')) {
+  if (!process.env.hasOwnProperty('VITE_ALLOWED_AUTH_PROVIDERS')) {
     throw new Error(ENV_NOT_FOUND_KEY_AUTH_PROVIDERS);
   }
 
-  if (process.env.ALLOWED_AUTH_PROVIDERS === '') {
+  if (process.env.VITE_ALLOWED_AUTH_PROVIDERS === '') {
     throw new Error(ENV_EMPTY_AUTH_PROVIDERS);
   }
 
-  const givenAuthProviders = process.env.ALLOWED_AUTH_PROVIDERS.split(',').map(
-    (provider) => provider.toLocaleUpperCase(),
-  );
+  const givenAuthProviders = process.env.VITE_ALLOWED_AUTH_PROVIDERS.split(
+    ',',
+  ).map((provider) => provider.toLocaleUpperCase());
   const supportedAuthProviders = Object.values(AuthProvider).map(
     (provider: string) => provider.toLocaleUpperCase(),
   );


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HBE-248

### Description
<!-- Add a brief description of the pull request -->
Introducing Seamless Dynamic Authentication Provider Selection

Previously, we relied on the `ALLOWED_AUTH_PROVIDERS` environment variable. However, we recognized a challenge: the frontend applications were unable to access or read this vital piece of information.

To ensure a harmonious connection between the frontend and the backend, we've revamped the environment variable nomenclature. Say hello to `VITE_ALLOWED_AUTH_PROVIDERS` – our new, unified identifier that effortlessly synchronizes authentication provider preferences across the board.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
Change .env variable `ALLOWED_AUTH_PROVIDERS` -> `VITE_ALLOWED_AUTH_PROVIDERS`
