### PR TITLE
Polish Environment Selector

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -190,10 +190,11 @@ a {
   @apply border-solid border-dividerDark;
   @apply rounded;
   @apply shadow-lg;
+  @apply max-w-[45vw] #{!important};
 
   .tippy-content {
     @apply flex flex-col;
-    @apply max-h-56;
+    @apply max-h-[45vh];
     @apply items-stretch;
     @apply overflow-y-auto;
     @apply text-secondary text-body;
@@ -201,6 +202,10 @@ a {
     @apply leading-normal;
     @apply focus:outline-none;
     scroll-behavior: smooth;
+
+    & > span {
+      @apply block #{!important};
+    }
   }
 
   .tippy-svg-arrow {

--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -9,7 +9,7 @@
       <span
         v-tippy="{ theme: 'tooltip' }"
         :title="`${t('environment.select')}`"
-        class="bg-transparent border-b border-dividerLight select-wrapper"
+        class="select-wrapper"
       >
         <HoppButtonSecondary
           :icon="IconLayers"
@@ -50,7 +50,11 @@
           />
           <HoppSmartTabs
             v-model="selectedEnvTab"
-            styles="sticky overflow-x-auto my-2 border border-divider rounded flex-shrink-0 z-0 top-0 bg-primary"
+            :styles="`sticky overflow-x-auto my-2 border border-divider rounded flex-shrink-0 z-0 top-0 bg-primary ${
+              !isTeamSelected || workspace.type === 'personal'
+                ? 'bg-primaryLight'
+                : ''
+            }`"
             render-inactive-tabs
           >
             <HoppSmartTab
@@ -189,12 +193,12 @@
                 "
               />
             </div>
-            <div class="my-2 flex flex-col flex-1 space-y-2 pl-4">
+            <div class="my-2 flex flex-col flex-1 space-y-2 pl-4 pr-2">
               <div class="flex flex-1 space-x-4">
-                <span class="w-20 truncate text-tiny font-semibold">
+                <span class="w-1/4 min-w-32 truncate text-tiny font-semibold">
                   {{ t("environment.name") }}
                 </span>
-                <span class="w-36 truncate text-tiny font-semibold">
+                <span class="w-full min-w-32 truncate text-tiny font-semibold">
                   {{ t("environment.value") }}
                 </span>
               </div>
@@ -203,10 +207,10 @@
                 :key="index"
                 class="flex flex-1 space-x-4"
               >
-                <span class="text-secondaryLight w-20 truncate">
+                <span class="text-secondaryLight w-1/4 min-w-32 truncate">
                   {{ variable.key }}
                 </span>
-                <span class="text-secondaryLight w-36 truncate">
+                <span class="text-secondaryLight w-full min-w-32 truncate">
                   {{ variable.value }}
                 </span>
               </div>
@@ -215,15 +219,15 @@
               </div>
             </div>
             <div
-              class="sticky top-0 font-semibold truncate flex items-center justify-between text-secondaryDark bg-primary border border-divider rounded pl-4"
+              class="sticky top-0 mt-2 font-semibold truncate flex items-center justify-between text-secondaryDark bg-primary border border-divider rounded pl-4"
               :class="{
-                'py-2 pr-4': !selectedEnv.variables,
+                'bg-primaryLight': !selectedEnv.variables,
               }"
             >
               {{ t("environment.list") }}
               <HoppButtonSecondary
-                v-if="selectedEnv.variables"
                 v-tippy="{ theme: 'tooltip' }"
+                :disabled="!selectedEnv.variables"
                 :title="t('action.edit')"
                 :icon="IconEdit"
                 @click="
@@ -240,12 +244,12 @@
             >
               {{ t("environment.no_active_environment") }}
             </div>
-            <div v-else class="my-2 flex flex-col flex-1 space-y-2 pl-4">
+            <div v-else class="my-2 flex flex-col flex-1 space-y-2 pl-4 pr-2">
               <div class="flex flex-1 space-x-4">
-                <span class="w-20 truncate text-tiny font-semibold">
+                <span class="w-1/4 min-w-32 truncate text-tiny font-semibold">
                   {{ t("environment.name") }}
                 </span>
-                <span class="w-36 truncate text-tiny font-semibold">
+                <span class="w-full min-w-32 truncate text-tiny font-semibold">
                   {{ t("environment.value") }}
                 </span>
               </div>
@@ -254,10 +258,10 @@
                 :key="index"
                 class="flex flex-1 space-x-4"
               >
-                <span class="text-secondaryLight w-20 truncate">
+                <span class="text-secondaryLight w-1/4 min-w-32 truncate">
                   {{ variable.key }}
                 </span>
-                <span class="text-secondaryLight w-36 truncate">
+                <span class="text-secondaryLight w-full min-w-32 truncate">
                   {{ variable.value }}
                 </span>
               </div>

--- a/packages/hoppscotch-sh-admin/assets/scss/styles.scss
+++ b/packages/hoppscotch-sh-admin/assets/scss/styles.scss
@@ -190,10 +190,11 @@ a {
   @apply border-solid border-dividerDark;
   @apply rounded;
   @apply shadow-lg;
+  @apply max-w-[45vw] #{!important};
 
   .tippy-content {
     @apply flex flex-col;
-    @apply max-h-56;
+    @apply max-h-[45vh];
     @apply items-stretch;
     @apply overflow-y-auto;
     @apply text-secondary text-body;
@@ -201,6 +202,10 @@ a {
     @apply leading-normal;
     @apply focus:outline-none;
     scroll-behavior: smooth;
+
+    & > span {
+      @apply block #{!important};
+    }
   }
 
   .tippy-svg-arrow {

--- a/packages/hoppscotch-ui/src/assets/scss/styles.scss
+++ b/packages/hoppscotch-ui/src/assets/scss/styles.scss
@@ -190,10 +190,11 @@ a {
   @apply border-solid border-dividerDark;
   @apply rounded;
   @apply shadow-lg;
+  @apply max-w-[45vw] #{!important};
 
   .tippy-content {
     @apply flex flex-col;
-    @apply max-h-56;
+    @apply max-h-[45vh];
     @apply items-stretch;
     @apply overflow-y-auto;
     @apply text-secondary text-body;
@@ -201,6 +202,10 @@ a {
     @apply leading-normal;
     @apply focus:outline-none;
     scroll-behavior: smooth;
+
+    & > span {
+      @apply block #{!important};
+    }
   }
 
   .tippy-svg-arrow {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c1ff4f3</samp>

### Summary
🎨📱🛠️

<!--
1.  🎨 - This emoji represents the improvement of the appearance and functionality of the environment selector and the environment variable table. It is often used for changes related to UI design, layout, or styling.
2.  📱 - This emoji represents the improvement of the responsiveness and layout of the tippy popover component on different screen sizes and content lengths. It is often used for changes related to mobile or responsive design, or cross-device compatibility.
3.  🛠️ - This emoji represents the addition of some utility classes and selectors to the tippy popover component in the `styles.scss` files of the `hoppscotch-sh-admin` and `hoppscotch-ui` packages. It is often used for changes related to tools, utilities, or configuration.
-->
This pull request enhances the tippy popover component used in various parts of the hoppscotch app. It adds utility classes and selectors to the `styles.scss` files of the `hoppscotch-common`, `hoppscotch-sh-admin`, and `hoppscotch-ui` packages to improve the popover's responsiveness and layout. It also improves the environment selector and the environment variable table in the `Selector.vue` component of the `hoppscotch-common` package.

> _We are the masters of the tippy popover_
> _We make it fit and look good on any screen_
> _We are the lords of the environment selector_
> _We control the variables and the edit scene_

### Walkthrough
*  Limit the width of the tippy popover component to 45% of the viewport width using the `max-w-[45vw]` utility class, to prevent overflow on smaller devices or long content ([link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-d3d67d4f57af5b5dea2f42b2746e17dca05e7b90714a231135dbab853f11d05fL193-R197), [link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-e170c4199239be268cc69dd5a94f99997915f9648801e39f3d84a6c1d9c54063L193-R197), [link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-5bf1f6af0d1183005848e78500dc64e5f9b6a28e1f905530faae464b470d58ceL193-R197))
*  Display the direct child span elements of the tippy popover component as block-level elements using the `block` utility class, to avoid wrapping or alignment issues ([link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-d3d67d4f57af5b5dea2f42b2746e17dca05e7b90714a231135dbab853f11d05fR205-R208), [link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-e170c4199239be268cc69dd5a94f99997915f9648801e39f3d84a6c1d9c54063R205-R208), [link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-5bf1f6af0d1183005848e78500dc64e5f9b6a28e1f905530faae464b470d58ceR205-R208))
*  Remove the border below the environment selector button in `Selector.vue`, to make it consistent with the rest of the UI and reduce clutter ([link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L12-R12))
*  Apply a conditional background color to the tabs container element in `Selector.vue`, based on the workspace type or team selection, using a ternary expression and the `bg-primaryLight` utility class, to provide a visual cue to the user and match the design mockups ([link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L53-R57))
*  Make the environment variable table more responsive and adaptable to different screen sizes and content lengths, by using the `w-1/4 min-w-32` and `w-full min-w-32` utility classes for the name and value span elements, instead of the fixed `w-20` and `w-36` classes ([link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L192-R201), [link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L206-R213), [link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L243-R252), [link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L257-R264))
*  Add some spacing between the environment list header and the variable form in `Selector.vue`, by using the `mt-2` utility class for the header element, and remove the unnecessary padding classes from the header element ([link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L218-R230))
*  Disable the edit button in the environment list header in `Selector.vue`, when there are no environment variables, by using the `:disabled` prop of the `HoppButtonSecondary` component, to prevent user confusion and indicate the state of the list ([link](https://github.com/hoppscotch/hoppscotch/pull/3260/files?diff=unified&w=0#diff-584d8291b417c80e6df02186ce776cf6bf6bb10c3a9627c2512fbb0ac34fa664L218-R230))

