### PR TITLE
fix: placeholder size and text overflow on tab head

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -221,6 +221,7 @@ a {
 
 [data-v-tippy] {
   @apply flex flex-1;
+  @apply truncate;
 }
 
 [interactive] > div {

--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -97,6 +97,7 @@ declare module '@vue/runtime-core' {
     HoppSmartSpinner: typeof import('@hoppscotch/ui')['HoppSmartSpinner']
     HoppSmartTab: typeof import('@hoppscotch/ui')['HoppSmartTab']
     HoppSmartTabs: typeof import('@hoppscotch/ui')['HoppSmartTabs']
+    HoppSmartToggle: typeof import('@hoppscotch/ui')['HoppSmartToggle']
     HoppSmartWindow: typeof import('@hoppscotch/ui')['HoppSmartWindow']
     HoppSmartWindows: typeof import('@hoppscotch/ui')['HoppSmartWindows']
     HttpAuthorization: typeof import('./components/http/Authorization.vue')['default']

--- a/packages/hoppscotch-common/src/components/app/Inspection.vue
+++ b/packages/hoppscotch-common/src/components/app/Inspection.vue
@@ -31,7 +31,7 @@
           <div
             v-for="(inspector, index) in inspectionResults"
             :key="index"
-            class="flex self-stretch"
+            class="flex self-stretch max-w-md w-full"
           >
             <div
               class="flex flex-col flex-1 rounded border border-dashed border-dividerDark divide-y divide-dashed divide-dividerDark"

--- a/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
+++ b/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
@@ -17,6 +17,7 @@
         :alt="`${t('error.network_fail')}`"
         :heading="t('error.network_fail')"
         :text="t('helpers.network_fail')"
+        large
       >
         <AppInterceptor class="p-2 border rounded border-dividerLight" />
       </HoppSmartPlaceholder>
@@ -26,6 +27,7 @@
         :alt="`${t('error.script_fail')}`"
         :label="t('error.script_fail')"
         :text="t('helpers.script_fail')"
+        large
       >
         <div
           class="mt-2 w-full px-4 py-2 overflow-auto font-mono text-red-400 whitespace-normal rounded bg-primaryLight"

--- a/packages/hoppscotch-common/src/components/http/TabHead.vue
+++ b/packages/hoppscotch-common/src/components/http/TabHead.vue
@@ -21,7 +21,7 @@
       theme="popover"
       :on-shown="() => tippyActions!.focus()"
     >
-      <span class="leading-8 px-2">
+      <span class="leading-8 px-2 truncate">
         {{ tab.document.request.name }}
       </span>
       <template #content="{ hide }">

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="autocomplete-wrapper">
-    <div class="absolute inset-0 flex flex-1 overflow-x-auto">
+    <div
+      class="absolute inset-0 flex flex-1 divide-x divide-dividerLight overflow-x-auto"
+    >
       <div
         ref="editor"
         :placeholder="placeholder"
@@ -10,7 +12,10 @@
         @keydown="handleKeystroke"
         @focusin="showSuggestionPopover = true"
       ></div>
-      <AppInspection :inspection-results="inspectionResults" />
+      <AppInspection
+        :inspection-results="inspectionResults"
+        class="sticky inset-y-0 right-0 bg-primary rounded-r"
+      />
     </div>
     <ul
       v-if="showSuggestionPopover && autoCompleteSource"

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -71,9 +71,9 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
 
       const selectedEnvType = getSelectedEnvironmentType()
 
-      const envTypeIcon = `<i class="inline-flex -my-1 -mx-0.5 opacity-65 items-center text-base material-icons border-secondary">${
-        selectedEnvType === "TEAM_ENV" ? "people" : "person"
-      }</i>`
+      const envTypeIcon = `<span class="inline-flex -my-2 -mx-0.5 opacity-65 items-center text-base font-icon">${
+        selectedEnvType === "TEAM_ENV" ? "group" : "person"
+      }</span>`
 
       const appendEditAction = (tooltip: HTMLElement) => {
         const editIcon = document.createElement("span")
@@ -88,7 +88,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
             variableName: parsedEnvKey,
           })
         })
-        editIcon.innerHTML = `<i class="inline-flex items-center px-1 -mx-1 -my-1 text-base material-icons border-secondary">drive_file_rename_outline</i>`
+        editIcon.innerHTML = `<span class="inline-flex items-center px-1 -mx-1 -my-2 text-base font-icon">edit</span>`
         tooltip.appendChild(editIcon)
       }
 

--- a/packages/hoppscotch-sh-admin/assets/scss/styles.scss
+++ b/packages/hoppscotch-sh-admin/assets/scss/styles.scss
@@ -221,6 +221,7 @@ a {
 
 [data-v-tippy] {
   @apply flex flex-1;
+  @apply truncate;
 }
 
 [interactive] > div {

--- a/packages/hoppscotch-ui/src/assets/scss/styles.scss
+++ b/packages/hoppscotch-ui/src/assets/scss/styles.scss
@@ -221,6 +221,7 @@ a {
 
 [data-v-tippy] {
   @apply flex flex-1;
+  @apply truncate;
 }
 
 [interactive] > div {

--- a/packages/hoppscotch-ui/src/components/smart/Placeholder.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Placeholder.vue
@@ -4,22 +4,19 @@
       v-if="src"
       :src="src"
       loading="lazy"
-      class="inline-flex flex-col object-contain object-center w-16 h-16 mb-4"
+      class="inline-flex flex-col object-contain object-center my-4"
+      :class="large ? 'w-32 h-32' : 'w-16 h-16'"
       :alt="alt"
     />
-
     <slot name="icon"></slot>
-
     <span v-if="heading" class="mb-2 font-semibold text-center">
       {{ heading }}
     </span>
-
     <span
       class="max-w-sm mb-4 text-center whitespace-normal text-secondaryLight"
     >
       {{ text }}
     </span>
-
     <slot></slot>
   </div>
 </template>
@@ -31,6 +28,7 @@ withDefaults(
     alt?: string
     heading?: string
     text?: string
+    large?: boolean
   }>(),
   {
     alt: "",


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 5c360a9</samp>

### Summary
📐🌎🖼️

<!--
1.  📐 - This emoji can represent the changes that involve truncating, resizing, and limiting the width of the components to improve the layout and readability of the UI.
2.  🌎 - This emoji can represent the changes that involve editing and inspecting environment variables, which are related to the global settings and context of the application.
3.  🖼️ - This emoji can represent the changes that involve updating and enhancing the icons and images used in the UI, which are related to the visual appearance and aesthetics of the application.
-->
This pull request improves the UI and UX of various components in the `hoppscotch` project, such as the `EnvInput`, the `ResponseMeta`, and the `Placeholder` components. It also updates the icons for the environment editor and adds the `truncate` utility class to the `app-inspection` component in different packages. These changes aim to make the components more responsive, accessible, consistent, and readable.

> _This pull request has many changes_
> _To improve the UI in stages_
> _It adds `truncate` and `large`_
> _To components that need a charge_
> _And updates the icons and pages_

### Walkthrough
*  Add `truncate` utility class to `app-inspection` component to improve readability and layout of inspection results ([link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-d3d67d4f57af5b5dea2f42b2746e17dca05e7b90714a231135dbab853f11d05fR224), [link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-e170c4199239be268cc69dd5a94f99997915f9648801e39f3d84a6c1d9c54063R224), [link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-5bf1f6af0d1183005848e78500dc64e5f9b6a28e1f905530faae464b470d58ceR224))
*  Limit maximum width and enable horizontal scrolling of `app-inspection` component to make it responsive and accessible ([link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-50ac3e0294c3007185c20899f82bace97cbd1e0bbfd03ba514fe7c1acecfbf00L34-R34), [link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-77b8f4b02b324137697f8b9f9666a4109da9f05ffca983065e49f7ff302de548L3-R5), [link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-77b8f4b02b324137697f8b9f9666a4109da9f05ffca983065e49f7ff302de548L13-R18))
*  Increase button size in `ResponseMeta.vue` to make them more prominent and consistent ([link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-ed20f7f0c2a9b694a71350a82e926f3107da5815d4e8660dc222da2bec4ce04bR20), [link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-ed20f7f0c2a9b694a71350a82e926f3107da5815d4e8660dc222da2bec4ce04bR30))
*  Prevent tab name from wrapping to the next line in `TabHead.vue` to make the tab bar more compact and neat ([link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-139aac9bae1f9fc5ca0792589a9398f40bbbbca50c07908c6e026ee737bcb347L24-R24))
*  Add vertical divider between editor and inspection sections in `EnvInput.vue` to improve separation and accessibility ([link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-77b8f4b02b324137697f8b9f9666a4109da9f05ffca983065e49f7ff302de548L3-R5))
*  Use custom font icons instead of material icons and change icon names to make them more consistent and clear in `HoppEnvironment.ts` ([link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-7a8f789eae1d1f6baadadbf622d120c73ebb34e6c701982e799552716a4a6deeL74-R76), [link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-7a8f789eae1d1f6baadadbf622d120c73ebb34e6c701982e799552716a4a6deeL91-R91))
*  Increase image size and add vertical margin in `Placeholder.vue` to make the image more visible and balanced ([link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-43204d0417f2efef3de79695998f89679d57fe1b1123c87e5676525c01f24a50L7-R14), [link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-43204d0417f2efef3de79695998f89679d57fe1b1123c87e5676525c01f24a50R31))
*  Remove empty line from `Placeholder.vue` to remove unnecessary whitespace and make the code more concise and clean ([link](https://github.com/hoppscotch/hoppscotch/pull/3261/files?diff=unified&w=0#diff-43204d0417f2efef3de79695998f89679d57fe1b1123c87e5676525c01f24a50L22))

