### PR TITLE
fix: search input autofocus

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -19,10 +19,10 @@
     >
       <WorkspaceCurrent :section="t('tab.collections')" />
 
-      <HoppSmartInput
+      <input
         v-model="filterTexts"
         :placeholder="t('action.search')"
-        input-styles="py-2 pl-4 pr-2 bg-transparent !border-0"
+        class="py-2 pl-4 pr-2 bg-transparent !border-0"
         type="search"
         :disabled="collectionsType.type === 'team-collections'"
       />


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 7218bb1</samp>

### Summary
🐛🎨🚀

<!--
1.  🐛 - This emoji represents the bug that was fixed by replacing the `HoppSmartInput` component with a native `input` element. It is a common emoji to use for bug fixes or issues in code.
2.  🎨 - This emoji represents the styling and attributes that were applied to the native `input` element to match the `HoppSmartInput` component. It is a common emoji to use for design or UI improvements or changes.
3.  🚀 - This emoji represents the improvement to the user experience of the collections feature by allowing the input to clear when the escape key is pressed. It is a common emoji to use for new features or enhancements that benefit the users or customers.
-->
Replaced `HoppSmartInput` with native `input` in `collections/index.vue` to fix input autofocus bug. This improves the user experience of the collections feature.

> _`HoppSmartInput`_
> _Gone with the autumn wind_
> _`input` clears itself_

### Walkthrough
*  Replaced `HoppSmartInput` component with native `input` element to fix input autofocus bug in collections feature ([link](https://github.com/hoppscotch/hoppscotch/pull/3265/files?diff=unified&w=0#diff-bea4d3e00e3d1167aa2228f3ce3d9a582dc3a006e0753c3806c6e8f1ec0d4080L22-R25))

