### PR TITLE
fix: fix issues in displaying the suggestions menu on EnvInput

### DIFF
--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="autocomplete-wrapper">
+  <div ref="autoCompleteWrapper" class="autocomplete-wrapper">
     <div
       class="absolute inset-0 flex flex-1 divide-x divide-dividerLight overflow-x-auto"
     >
@@ -125,8 +125,9 @@ const currentSuggestionIndex = ref(-1)
 const showSuggestionPopover = ref(false)
 
 const suggestionsMenu = ref<any | null>(null)
+const autoCompleteWrapper = ref<any | null>(null)
 
-onClickOutside(suggestionsMenu, () => {
+onClickOutside(autoCompleteWrapper, () => {
   showSuggestionPopover.value = false
 })
 


### PR DESCRIPTION
fixs HFE-148

**Before**

Suggestions menu was not displayed when the EnvInput was focused. 

We had an `onClickOutside` handler defined for suggestionsMenu, it hides the suggestions menu. 
But the input div was outside of this suggestions menu, causing the onClickOutside handler to run everytime someone clicked on the input div, which infact hid the suggestions menu.
 
**After**

Suggestions menu is displayed properly. moved the onClickOutside to target the `autoCompleteWrapper` instead of the suggestions menu.