### PR TITLE
HBE-258 hotfix: skip parameter in findMany in shortcode module

### DIFF
--- a/packages/hoppscotch-backend/src/shortcode/shortcode.service.ts
+++ b/packages/hoppscotch-backend/src/shortcode/shortcode.service.ts
@@ -150,7 +150,7 @@ export class ShortcodeService implements UserDataHandler, OnModuleInit {
       orderBy: {
         createdOn: 'desc',
       },
-      skip: 1,
+      skip: args.cursor ? 1 : 0,
       take: args.take,
       cursor: args.cursor ? { id: args.cursor } : undefined,
     });


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HBE-258

### Description
<!-- Add a brief description of the pull request -->
This hotfix PR solves the fetch shortcode issue. When the request comes for fetchUserShortCodes, the `this.prisma.shortcode.findMany` skip the first data (in default). The correct logic should be, the there is cursor parameter in arg (for pagination), only that time `skip: 1` should pass in the findMany() operation.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
Nil