### PR TITLE
chore: improved command labels and icons

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -653,11 +653,12 @@
       "chat": "Chat with support",
       "open_docs": "Read Documentation",
       "open_keybindings": "Keyboard shortcuts",
+      "open_github": "Open GitHub repository",
       "social": "Social",
       "title": "General"
     },
     "miscellaneous": {
-      "invite": "Invite people to Hoppscotch",
+      "invite": "Invite your friends to Hoppscotch",
       "title": "Miscellaneous"
     },
     "request": {
@@ -679,25 +680,25 @@
     "environments": {
       "new": "Create new environment",
       "new_variable": "Create a new environment variable",
-      "edit": "Edit selected environment",
-      "delete": "Delete selected environment",
-      "duplicate": "Duplicate selected environment",
+      "edit": "Edit current environment",
+      "delete": "Delete current environment",
+      "duplicate": "Duplicate current environment",
       "edit_global": "Edit global environment",
       "duplicate_global": "Duplicate global environment",
       "title": "Environments"
     },
     "workspace": {
       "new": "Create new team",
-      "edit": "Edit selected team",
-      "delete": "Delete selected team",
+      "edit": "Edit current team",
+      "delete": "Delete current team",
       "invite": "Invite people to team",
-      "switch_to_personal": "Switch to personal workspace",
+      "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
     },
     "tab": {
-      "duplicate": "Duplicate tab",
+      "duplicate": "Duplicate current tab",
       "close_current": "Close current tab",
-      "close_others": "Close other tabs",
+      "close_others": "Close all other tabs",
       "new_tab": "Open a new tab",
       "title": "Tabs"
     },
@@ -710,15 +711,15 @@
     "change_language": "Change Language",
     "settings": {
       "theme": {
-        "black": "Black Mode",
-        "dark": "Dark Mode",
-        "light": "Light Mode",
-        "system": "System Mode"
+        "black": "Black",
+        "dark": "Dark",
+        "light": "Light",
+        "system": "System preference"
       },
       "font": {
-        "size_sm": "Change to Small",
-        "size_md": "Change to Medium",
-        "size_lg": "Change to Large"
+        "size_sm": "Small",
+        "size_md": "Medium",
+        "size_lg": "Large"
       },
       "change_interceptor": "Change Interceptor",
       "change_language": "Change Language"

--- a/packages/hoppscotch-common/src/services/inspection/__tests__/index.spec.ts
+++ b/packages/hoppscotch-common/src/services/inspection/__tests__/index.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest"
 import { Inspector, InspectionService, InspectorResult } from "../"
 import { TestContainer } from "dioc/testing"
+import { ref } from "vue"
 
 const inspectorResultMock: InspectorResult[] = [
   {
@@ -21,7 +22,7 @@ const inspectorResultMock: InspectorResult[] = [
 
 const testInspector: Inspector = {
   inspectorID: "inspector1",
-  getInspectorFor: () => inspectorResultMock,
+  getInspections: () => ref(inspectorResultMock),
 }
 
 describe("InspectionService", () => {

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/general.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/general.searcher.ts
@@ -9,9 +9,9 @@ import {
 
 import IconLinkedIn from "~icons/brands/linkedin"
 import IconTwitter from "~icons/brands/twitter"
-import IconBook from "~icons/lucide/book"
-import IconDiscord from "~icons/lucide/link"
+import IconDiscord from "~icons/brands/discord"
 import IconGitHub from "~icons/lucide/github"
+import IconBook from "~icons/lucide/book"
 import IconLifeBuoy from "~icons/lucide/life-buoy"
 import IconZap from "~icons/lucide/zap"
 
@@ -61,9 +61,9 @@ export class GeneralSpotlightSearcherService extends StaticSpotlightSearcherServ
         invokeAction("flyouts.keybinds.toggle")
       },
     },
-    link_github: {
-      text: [this.t("spotlight.general.social"), "GitHub"],
-      alternates: ["social", "github", "link"],
+    open_github: {
+      text: this.t("spotlight.general.open_github"),
+      alternates: ["repository", "github", "documentation", "hoppscotch"],
       icon: markRaw(IconGitHub),
       action: () => this.openURL("https://hoppscotch.io/github"),
     },

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/settings.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/settings.searcher.ts
@@ -14,11 +14,11 @@ import IconGlobe from "~icons/lucide/globe"
 import IconMonitor from "~icons/lucide/monitor"
 import IconMoon from "~icons/lucide/moon"
 import IconSun from "~icons/lucide/sun"
-import IconType from "~icons/lucide/type"
+import IconCircle from "~icons/lucide/circle"
+import IconCheckCircle from "~icons/lucide/check-circle"
 
 type Doc = {
   text: string | string[]
-  excludeFromSearch?: boolean
   alternates: string[]
   icon: object | Component
 }
@@ -35,6 +35,7 @@ export class SettingsSpotlightSearcherService extends StaticSpotlightSearcherSer
   private t = getI18n()
 
   private activeFontSize = useSetting("FONT_SIZE")
+  private activeTheme = useSetting("BG_COLOR")
 
   public readonly searcherID = "settings"
   public searcherSectionTitle = this.t("navigation.settings")
@@ -48,7 +49,11 @@ export class SettingsSpotlightSearcherService extends StaticSpotlightSearcherSer
         this.t("spotlight.settings.theme.system"),
       ],
       alternates: ["theme"],
-      icon: markRaw(IconMonitor),
+      icon: computed(() =>
+        this.activeTheme.value === "system"
+          ? markRaw(IconCheckCircle)
+          : markRaw(IconMonitor)
+      ),
     },
     theme_light: {
       text: [
@@ -56,7 +61,11 @@ export class SettingsSpotlightSearcherService extends StaticSpotlightSearcherSer
         this.t("spotlight.settings.theme.light"),
       ],
       alternates: ["theme"],
-      icon: markRaw(IconSun),
+      icon: computed(() =>
+        this.activeTheme.value === "light"
+          ? markRaw(IconCheckCircle)
+          : markRaw(IconSun)
+      ),
     },
     theme_dark: {
       text: [
@@ -64,7 +73,11 @@ export class SettingsSpotlightSearcherService extends StaticSpotlightSearcherSer
         this.t("spotlight.settings.theme.dark"),
       ],
       alternates: ["theme"],
-      icon: markRaw(IconCloud),
+      icon: computed(() =>
+        this.activeTheme.value === "dark"
+          ? markRaw(IconCheckCircle)
+          : markRaw(IconCloud)
+      ),
     },
     theme_black: {
       text: [
@@ -72,7 +85,11 @@ export class SettingsSpotlightSearcherService extends StaticSpotlightSearcherSer
         this.t("spotlight.settings.theme.black"),
       ],
       alternates: ["theme"],
-      icon: markRaw(IconMoon),
+      icon: computed(() =>
+        this.activeTheme.value === "black"
+          ? markRaw(IconCheckCircle)
+          : markRaw(IconMoon)
+      ),
     },
     font_size_sm: {
       text: [
@@ -82,42 +99,51 @@ export class SettingsSpotlightSearcherService extends StaticSpotlightSearcherSer
       onClick: () => {
         console.log("clicked")
       },
-      excludeFromSearch: computed(() => this.activeFontSize.value === "small"),
       alternates: [
         "font size",
         "change font size",
         "change font",
         "increase font",
       ],
-      icon: markRaw(IconType),
+      icon: computed(() =>
+        this.activeFontSize.value === "small"
+          ? markRaw(IconCheckCircle)
+          : markRaw(IconCircle)
+      ),
     },
     font_size_md: {
       text: [
         this.t("settings.font_size"),
         this.t("spotlight.settings.font.size_md"),
       ],
-      excludeFromSearch: computed(() => this.activeFontSize.value === "medium"),
       alternates: [
         "font size",
         "change font size",
         "change font",
         "increase font",
       ],
-      icon: markRaw(IconType),
+      icon: computed(() =>
+        this.activeFontSize.value === "medium"
+          ? markRaw(IconCheckCircle)
+          : markRaw(IconCircle)
+      ),
     },
     font_size_lg: {
       text: [
         this.t("settings.font_size"),
         this.t("spotlight.settings.font.size_lg"),
       ],
-      excludeFromSearch: computed(() => this.activeFontSize.value === "large"),
       alternates: [
         "font size",
         "change font size",
         "change font",
         "increase font",
       ],
-      icon: markRaw(IconType),
+      icon: computed(() =>
+        this.activeFontSize.value === "large"
+          ? markRaw(IconCheckCircle)
+          : markRaw(IconCircle)
+      ),
     },
     change_lang: {
       text: [

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/tab.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/tab.searcher.ts
@@ -15,7 +15,10 @@ import {
   currentTabID,
   getActiveTabs,
 } from "~/helpers/rest/tab"
-import IconWindow from "~icons/lucide/app-window"
+import IconCopy from "~icons/lucide/copy"
+import IconCopyPlus from "~icons/lucide/copy-plus"
+import IconXCircle from "~icons/lucide/x-circle"
+import IconXSquare from "~icons/lucide/x-square"
 import { invokeAction } from "~/helpers/actions"
 
 type Doc = {
@@ -50,29 +53,29 @@ export class TabSpotlightSearcherService extends StaticSpotlightSearcherService<
     duplicate_tab: {
       text: this.t("spotlight.tab.duplicate"),
       alternates: ["tab", "duplicate", "duplicate tab"],
-      icon: markRaw(IconWindow),
+      icon: markRaw(IconCopy),
       excludeFromSearch: computed(() => !this.showAction.value),
     },
     close_current_tab: {
       text: this.t("spotlight.tab.close_current"),
       alternates: ["tab", "close", "close tab"],
-      icon: markRaw(IconWindow),
+      icon: markRaw(IconXCircle),
       excludeFromSearch: computed(
-        () => !this.showAction.value ?? getActiveTabs().value.length === 1
+        () => !this.showAction.value || getActiveTabs().value.length === 1
       ),
     },
     close_other_tabs: {
       text: this.t("spotlight.tab.close_others"),
       alternates: ["tab", "close", "close all"],
-      icon: markRaw(IconWindow),
+      icon: markRaw(IconXSquare),
       excludeFromSearch: computed(
-        () => !this.showAction.value ?? getActiveTabs().value.length < 2
+        () => !this.showAction.value || getActiveTabs().value.length < 2
       ),
     },
     open_new_tab: {
       text: this.t("spotlight.tab.new_tab"),
       alternates: ["tab", "new", "open tab"],
-      icon: markRaw(IconWindow),
+      icon: markRaw(IconCopyPlus),
       excludeFromSearch: computed(() => !this.showAction.value),
     },
   })


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at df28442</samp>

### Summary
🐛🌟🖼️

<!--
1.  🐛 for the first change, as it fixes a syntax error and a formatting issue in the code.
2.  🌟 for the second change, as it adds a new feature and enhances the user interface and experience of the app.
3.  🖼️ for the third change, as it updates the icons and visuals of the app without changing its functionality.
-->
This pull request enhances the user interface and experience of Hoppscotch by adding a new option to open the GitHub repository, improving the icons and texts of the spotlight search menu, and fixing some minor issues with the settings and tab options. It also applies some code formatting and syntax corrections to the `packages/hoppscotch-common` module.

> _We are the masters of the code, we shape it as we please_
> _We invoke the action with a comma and a `A`_
> _We open the gates of GitHub, we search the spotlight with ease_
> _We update the icons and the logic, we fix the bugs that we see_

### Walkthrough
*  Add a new option to open the GitHub repository of Hoppscotch from the general settings menu and update the wording of the invite and switch to personal workspace options ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-31b7742ac6fc2a6ebf4cc2f4dce1ef9a78727cea803993fc23813728efe1920eL656-R661), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-31b7742ac6fc2a6ebf4cc2f4dce1ef9a78727cea803993fc23813728efe1920eL691-R701))
* Modify the labels of the environment and team actions to use the term "current" instead of "selected" for consistency ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-31b7742ac6fc2a6ebf4cc2f4dce1ef9a78727cea803993fc23813728efe1920eL682-R685), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-31b7742ac6fc2a6ebf4cc2f4dce1ef9a78727cea803993fc23813728efe1920eL691-R701))
* Simplify the labels of the theme options and change the system theme option to use the term "System preference" for clarity ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-31b7742ac6fc2a6ebf4cc2f4dce1ef9a78727cea803993fc23813728efe1920eL713-R722))
* Import the appropriate icons for the social and settings options and reorder the imports alphabetically in `general.searcher.ts` and `settings.searcher.ts` ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-bc65f05f00e241e2038942a9a426e861b1106632c5801e7f33eb67ee91b7952cL12-R14), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034L17-R21))
* Rename the `link_github` option to `open_github` and update its text and alternates to match the new option added in `en.json` ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-bc65f05f00e241e2038942a9a426e861b1106632c5801e7f33eb67ee91b7952cL62-R64))
* Update the URLs of the social options to use the `hoppscotch.io` redirects and remove the trailing slash from the LinkedIn link in `general.searcher.ts` ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-bc65f05f00e241e2038942a9a426e861b1106632c5801e7f33eb67ee91b7952cL126-R130), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-bc65f05f00e241e2038942a9a426e861b1106632c5801e7f33eb67ee91b7952cL136-R136))
* Add a comma after the generic type parameter `A` in the `invokeAction` function in `actions.ts` for syntax and formatting ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-9c833b83287df3aec6199b00ad72a57230dfb104e0b76260add46b431a73de2fL185-R185))
* Add a private property `activeTheme` to the `SettingsSpotlightSearcherService` class to get the current theme value from the store in `settings.searcher.ts` ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034R38))
* Modify the icons of the theme and font size options to use computed properties that return either the `IconCheckCircle` or the corresponding icon depending on the current selection in `settings.searcher.ts` ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034L51-R56), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034L59-R68), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034L67-R80), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034L75-R92), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034L92-R112), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034L106-R129), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034L120-R146))
* Remove the `excludeFromSearch` property from the font size options, as it is unnecessary and inconsistent in `settings.searcher.ts` ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034L85), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034L99), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-853eb0e692290a402b949db2329d5111829f538aab19c82be2d707b71a42a034L113))
* Import the appropriate icons for the tab actions and remove the unused `IconWindow` import in `tab.searcher.ts` ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-5c1403ab07600a7904d4ae0adb3ee9f2322b2b4113fac7a5b29ccfba4cea2e16L18-R21))
* Modify the icons of the tab actions to use the `IconCopy`, `IconCopyPlus`, `IconXCircle`, and `IconXSquare` instead of the `IconWindow` for intuitiveness and consistency in `tab.searcher.ts` ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-5c1403ab07600a7904d4ae0adb3ee9f2322b2b4113fac7a5b29ccfba4cea2e16L53-R56), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-5c1403ab07600a7904d4ae0adb3ee9f2322b2b4113fac7a5b29ccfba4cea2e16L59-R64), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-5c1403ab07600a7904d4ae0adb3ee9f2322b2b4113fac7a5b29ccfba4cea2e16L67-R72), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-5c1403ab07600a7904d4ae0adb3ee9f2322b2b4113fac7a5b29ccfba4cea2e16L75-R78))
* Fix the logical errors in the `excludeFromSearch` property of the tab closing options, which used the nullish coalescing operator instead of the logical OR operator to check the `showAction` value in `tab.searcher.ts` ([link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-5c1403ab07600a7904d4ae0adb3ee9f2322b2b4113fac7a5b29ccfba4cea2e16L59-R64), [link](https://github.com/hoppscotch/hoppscotch/pull/3295/files?diff=unified&w=0#diff-5c1403ab07600a7904d4ae0adb3ee9f2322b2b4113fac7a5b29ccfba4cea2e16L67-R72))

