### PR TITLE
fix: graphql operation highlight issue on focus changed

### DIFF
--- a/packages/hoppscotch-common/src/components/graphql/Query.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Query.vue
@@ -144,8 +144,6 @@ const selectedOperation = ref<gql.OperationDefinitionNode | null>(null)
 const gqlQueryString = useVModel(props, "modelValue", emit)
 
 const debouncedOnUpdateQueryState = debounce((update: ViewUpdate) => {
-  if (!update.selectionSet) return
-
   const selectedPos = update.state.selection.main.head
   const queryString = update.state.doc.toJSON().join(update.state.lineBreak)
 


### PR DESCRIPTION
Closes HFE-191

### Description
This PR fixes the issue of highlighting GraphQL Operation.
When multiple operations are in the same Tab we can highlight the operation with a cursor to run. If we run the request we basically defocused the cursor from the query editor. And after focusing on the query editor it doesn't update the operation name for the button. This PR fixed that issue.

- [ ] Not Completed
- [x] Completed

### Checks
<!-- Make sure your pull request passes the CI checks and check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
