### PR TITLE
chore(fix/devcontainer): make devcontainer copy .env.example

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,5 +5,5 @@
   "features": {
     "ghcr.io/NicoVIII/devcontainer-features/pnpm:1": {}
   },
-  "postCreateCommand": "mv .env.example .env && pnpm i"
+  "postCreateCommand": "cp .env.example .env && pnpm i"
 }


### PR DESCRIPTION
### Description
Make devcontainer copy `.env.example` instead of moving it.

This prevents the example from getting destroyed when the container is booted.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires **no** changes to the documentation
- [x] I have updated the documentation as required (n/a)
- [x] All the tests have passed

### Additional Information
This is useful when the devcontainer is used in a workspace or GitHub Codespace as it means that, when a commit is subsequently made, it does not destroy the `.env.example` file.
