### PR TITLE
refactor: keyboard shortcuts now supports different keyboard layouts including Dvorak

### DIFF
--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -56,7 +56,7 @@ export const bindings: {
   "alt-x": "request.method.delete",
   "ctrl-k": "modals.search.toggle",
   "ctrl-/": "flyouts.keybinds.toggle",
-  "?": "modals.support.toggle",
+  "shift-/": "modals.support.toggle",
   "ctrl-m": "modals.share.toggle",
   "alt-r": "navigation.jump.rest",
   "alt-q": "navigation.jump.graphql",
@@ -120,7 +120,8 @@ function generateKeybindingString(ev: KeyboardEvent): ShortcutKey | null {
 }
 
 function getPressedKey(ev: KeyboardEvent): Key | null {
-  const val = ev.key.toLowerCase()
+  const val = ev.code.toLowerCase()
+
   // Check arrow keys
   if (val === "arrowup") return "up"
   else if (val === "arrowdown") return "down"
@@ -132,17 +133,16 @@ function getPressedKey(ev: KeyboardEvent): Key | null {
   if (isLetter) return ev.code.toLowerCase().substring(3) as Key
 
   // Check if number keys
-  if (val.length === 1 && !isNaN(val as any)) return val as Key
+  const isDigit = ev.code.toLowerCase().startsWith("digit")
+  if (isDigit) return ev.code.toLowerCase().substring(5) as Key
 
-  // Check if question mark
-  if (val === "?") return "?"
-
-  // Check if question mark
-  if (val === "/") return "/"
+  // Check if slash
+  if (val === "slash") return "/"
 
   // Check if period
-  if (val === ".") return "."
+  if (val === "period") return "."
 
+  // Check if enter
   if (val === "enter") return "enter"
 
   // If no other cases match, this is not a valid key

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -129,12 +129,12 @@ function getPressedKey(ev: KeyboardEvent): Key | null {
   else if (val === "arrowright") return "right"
 
   // Check letter keys
-  const isLetter = ev.code.toLowerCase().startsWith("key")
-  if (isLetter) return ev.code.toLowerCase().substring(3) as Key
+  const isLetter = val.startsWith("key")
+  if (isLetter) return val.substring(3) as Key
 
   // Check if number keys
-  const isDigit = ev.code.toLowerCase().startsWith("digit")
-  if (isDigit) return ev.code.toLowerCase().substring(5) as Key
+  const isDigit = val.startsWith("digit")
+  if (isDigit) return val.substring(5) as Key
 
   // Check if slash
   if (val === "slash") return "/"


### PR DESCRIPTION
### Ticket

- Closes HFE-219
- Fixes #3322
- Suppressed #3314

### Description
This PR focuses on allowing the keyboard shortcuts in the app to support different keyboard layouts by using the unique key code parameter. This has been tested with QWERTY and DVORAK Keyboard Layouts and it works as expected.

### Objectives
- [x] Keyboard shortcuts should support DVORAK layout 
- Example: `CMD/CTRL - C` used to reset the request when using DVORAK Layout which has now been resolved. Only `CMD/CTRL - I` resets the request connection on both QWERTY and DVORAK Layouts

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
