### PR TITLE
fix: broken link to `REST API Testing` docs

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Parameters.vue
+++ b/packages/hoppscotch-common/src/components/http/Parameters.vue
@@ -9,7 +9,7 @@
       <div class="flex">
         <HoppButtonSecondary
           v-tippy="{ theme: 'tooltip' }"
-          to="https://docs.hoppscotch.io/documentation/getting-started/rest/using-parameters"
+          to="https://docs.hoppscotch.io/documentation/features/rest-api-testing"
           blank
           :title="t('app.wiki')"
           :icon="IconHelpCircle"


### PR DESCRIPTION
### Description

This PR aims at fixing a broken link to the [REST API Testing docs](https://docs.hoppscotch.io/documentation/features/rest-api-testing) from the `wiki` button in the search bar that was yielding `404` previously.

### Checks

- [x] All the tests have passed