### PR TITLE
fix: context-menu position fixed while scrolling

### DIFF
--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -311,35 +311,36 @@ const envVars = computed(() =>
 
 const envTooltipPlugin = new HoppReactiveEnvPlugin(envVars, view)
 
-const initView = (el: any) => {
-  function handleTextSelection() {
-    const selection = view.value?.state.selection.main
-    if (selection) {
-      const from = selection.from
-      const to = selection.to
-      const text = view.value?.state.doc.sliceString(from, to)
-      const { top, left } = view.value?.coordsAtPos(from)
-      if (text) {
-        invokeAction("contextmenu.open", {
-          position: {
-            top,
-            left,
-          },
-          text,
-        })
-        showSuggestionPopover.value = false
-      } else {
-        invokeAction("contextmenu.open", {
-          position: {
-            top,
-            left,
-          },
-          text: null,
-        })
-      }
+function handleTextSelection() {
+  const selection = view.value?.state.selection.main
+  if (selection) {
+    const from = selection.from
+    const to = selection.to
+    if (from === to) return
+    const text = view.value?.state.doc.sliceString(from, to)
+    const { top, left } = view.value?.coordsAtPos(from)
+    if (text) {
+      invokeAction("contextmenu.open", {
+        position: {
+          top,
+          left,
+        },
+        text,
+      })
+      showSuggestionPopover.value = false
+    } else {
+      invokeAction("contextmenu.open", {
+        position: {
+          top,
+          left,
+        },
+        text: null,
+      })
     }
   }
+}
 
+const initView = (el: any) => {
   // Debounce to prevent double click from selecting the word
   const debounceFn = useDebounceFn(() => {
     handleTextSelection()
@@ -380,6 +381,11 @@ const initView = (el: any) => {
       },
       drop(ev) {
         ev.preventDefault()
+      },
+      scroll(event) {
+        if (event.target) {
+          handleTextSelection()
+        }
       },
     }),
     ViewPlugin.fromClass(


### PR DESCRIPTION
Closes HFE-212

### Description
This PR fixes the issue with the context menu where the position of the menu was not updating when a user selects a text and scrolls the content, the context menu was fixed to the viewport rather than relative to the selected text.

### Objectives
- [x] Fixed the scrolling issue in the response section
- [x] Fixed the scrolling issue in the URL bar

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

