### PR TITLE
fix: authorisation headers not being sent along with subscriptions when using graphql

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -112,6 +112,7 @@
   },
   "authorization": {
     "generate_token": "Generate Token",
+    "graphql_headers": "Authorization Headers are sent as part of the payload to connection_init",
     "include_in_url": "Include in URL",
     "learn": "Learn how",
     "pass_key_by": "Pass by",

--- a/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
@@ -136,6 +136,9 @@ const runQuery = async (
     const duration = Date.now() - startTime
     completePageProgress()
     toast.success(`${t("state.finished_in", { duration })}`)
+    if (definition?.operation === "subscription" && request.value.auth) {
+      toast.success(t("authorization.graphql_headers"))
+    }
   } catch (e: any) {
     console.log(e)
     // response.value = [`${e}`]

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -301,7 +301,7 @@ export const runGQLOperation = async (options: RunQueryOptions) => {
 
 export const runSubscription = (
   options: RunQueryOptions,
-  headers: Record<string, string>
+  headers?: Record<string, string>
 ) => {
   const { url, query, operationName } = options
   const wsUrl = url.replace(/^http/, "ws")
@@ -312,12 +312,21 @@ export const runSubscription = (
 
   connection.socket.onopen = (event) => {
     console.log("WebSocket is open now.", event)
-    connection.socket?.send(
-      JSON.stringify({
-        type: GQL.CONNECTION_INIT,
-        payload: { ...headers },
-      })
-    )
+    if (headers) {
+      connection.socket?.send(
+        JSON.stringify({
+          type: GQL.CONNECTION_INIT,
+          payload: { ...headers },
+        })
+      )
+    } else {
+      connection.socket?.send(
+        JSON.stringify({
+          type: GQL.CONNECTION_INIT,
+          payload: {},
+        })
+      )
+    }
 
     connection.socket?.send(
       JSON.stringify({

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -312,21 +312,13 @@ export const runSubscription = (
 
   connection.socket.onopen = (event) => {
     console.log("WebSocket is open now.", event)
-    if (headers) {
-      connection.socket?.send(
-        JSON.stringify({
-          type: GQL.CONNECTION_INIT,
-          payload: { ...headers },
-        })
-      )
-    } else {
-      connection.socket?.send(
-        JSON.stringify({
-          type: GQL.CONNECTION_INIT,
-          payload: {},
-        })
-      )
-    }
+
+    connection.socket?.send(
+      JSON.stringify({
+        type: GQL.CONNECTION_INIT,
+        payload: headers ?? {},
+      })
+    )
 
     connection.socket?.send(
       JSON.stringify({

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -268,7 +268,7 @@ export const runGQLOperation = async (options: RunQueryOptions) => {
   }
 
   if (operationType === "subscription") {
-    return runSubscription(options)
+    return runSubscription(options, finalHeaders)
   }
 
   const interceptorService = getService(InterceptorService)
@@ -299,9 +299,14 @@ export const runGQLOperation = async (options: RunQueryOptions) => {
   return responseText
 }
 
-export const runSubscription = (options: RunQueryOptions) => {
+export const runSubscription = (
+  options: RunQueryOptions,
+  headers: Record<string, string>
+) => {
   const { url, query, operationName } = options
   const wsUrl = url.replace(/^http/, "ws")
+
+  console.log("Headers", headers)
 
   connection.subscriptionState.set(currentTabID.value, "SUBSCRIBING")
 
@@ -312,7 +317,7 @@ export const runSubscription = (options: RunQueryOptions) => {
     connection.socket?.send(
       JSON.stringify({
         type: GQL.CONNECTION_INIT,
-        payload: {},
+        payload: { ...headers },
       })
     )
 

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -306,8 +306,6 @@ export const runSubscription = (
   const { url, query, operationName } = options
   const wsUrl = url.replace(/^http/, "ws")
 
-  console.log("Headers", headers)
-
   connection.subscriptionState.set(currentTabID.value, "SUBSCRIBING")
 
   connection.socket = new WebSocket(wsUrl, "graphql-ws")


### PR DESCRIPTION
### Ticket
Closes HFE-210

### Description
This PR aims to fix the issue where authorisation headers are not being sent when a subscription is invoked using GraphQL.
Since WebSocket connection do not support sending headers, the headers will be sent as part of the payload in ‘connection_init’

### Objectives
- [x] Fix the issue where auth headers are not being sent when using subscriptions in GraphQL
- [x] Notify the user when auth headers are sent as part of the payload in ‘connection_init'


### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed