### PR TITLE
fix: duplicate tab reference bug

### DIFF
--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -141,6 +141,7 @@ import { InspectionService } from "~/services/inspection"
 import { HeaderInspectorService } from "~/services/inspection/inspectors/header.inspector"
 import { EnvironmentInspectorService } from "~/services/inspection/inspectors/environment.inspector"
 import { ResponseInspectorService } from "~/services/inspection/inspectors/response.inspector"
+import { cloneDeep } from "lodash-es"
 
 const savingRequest = ref(false)
 const confirmingCloseForTabID = ref<string | null>(null)
@@ -243,7 +244,7 @@ const duplicateTab = (tabID: string) => {
   const tab = getTabRef(tabID)
   if (tab.value) {
     const newTab = createNewTab({
-      request: tab.value.document.request,
+      request: cloneDeep(tab.value.document.request),
       isDirty: true,
     })
     currentTabID.value = newTab.id


### PR DESCRIPTION
Closes HFE-225

### Description
This PR fixes the bug when duplicating a tab where when a user makes changes to a duplicated tab the same change is effected on the tab which is duplicated.

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
