### PR TITLE
fix: dirty tab count incorrect when closing tabs

### DIFF
--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -229,11 +229,14 @@ const removeTab = (tabID: string) => {
 }
 
 const closeOtherTabsAction = (tabID: string) => {
+  const isTabDirty = getTabRef(tabID).value?.document.isDirty
   const dirtyTabCount = getDirtyTabsCount()
+  // If current tab is dirty, so we need to subtract 1 from the dirty tab count
+  const balanceDirtyTabCount = dirtyTabCount - (isTabDirty ? 1 : 0)
   // If there are dirty tabs, show the confirm modal
-  if (dirtyTabCount > 0) {
+  if (balanceDirtyTabCount > 0) {
     confirmingCloseAllTabs.value = true
-    unsavedTabsCount.value = dirtyTabCount
+    unsavedTabsCount.value = balanceDirtyTabCount
     exceptedTabID.value = tabID
   } else {
     closeOtherTabs(tabID)

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -232,7 +232,7 @@ const closeOtherTabsAction = (tabID: string) => {
   const isTabDirty = getTabRef(tabID).value?.document.isDirty
   const dirtyTabCount = getDirtyTabsCount()
   // If current tab is dirty, so we need to subtract 1 from the dirty tab count
-  const balanceDirtyTabCount = dirtyTabCount - (isTabDirty ? 1 : 0)
+  const balanceDirtyTabCount = isTabDirty ? dirtyTabCount - 1 : dirtyTabCount
   // If there are dirty tabs, show the confirm modal
   if (balanceDirtyTabCount > 0) {
     confirmingCloseAllTabs.value = true


### PR DESCRIPTION
Closes HFE-226

### Description
This PR fixes the issue where when a user clicks the option 'close all other tabs' the unsaved tabs count was wrong. 

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

