### PR TITLE
fix: remove scrollbar from smart env input component on firefox

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -31,6 +31,10 @@
   @apply h-0;
 }
 
+.no-scrollbar {
+  scrollbar-width: none;
+}
+
 input::placeholder,
 textarea::placeholder,
 .cm-placeholder {

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="autoCompleteWrapper" class="autocomplete-wrapper">
     <div
-      class="absolute inset-0 flex flex-1 divide-x divide-dividerLight overflow-x-auto"
+      class="absolute inset-0 flex flex-1 divide-x divide-dividerLight overflow-x-auto no-scrollbar"
     >
       <div
         ref="editor"

--- a/packages/hoppscotch-sh-admin/assets/scss/styles.scss
+++ b/packages/hoppscotch-sh-admin/assets/scss/styles.scss
@@ -31,6 +31,10 @@
   @apply h-0;
 }
 
+.no-scrollbar {
+  scrollbar-width: none;
+}
+
 input::placeholder,
 textarea::placeholder,
 .cm-placeholder {

--- a/packages/hoppscotch-ui/src/assets/scss/styles.scss
+++ b/packages/hoppscotch-ui/src/assets/scss/styles.scss
@@ -31,6 +31,10 @@
   @apply h-0;
 }
 
+.no-scrollbar {
+  scrollbar-width: none;
+}
+
 input::placeholder,
 textarea::placeholder,
 .cm-placeholder {


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1fb847</samp>

Added a new CSS class `.no-scrollbar` to hide the scrollbar in some UI elements of the app. Applied the class to the environment variables input field, and to the shared and specific styles of the main app, the admin dashboard, and the UI components packages.