### PR TITLE
chore(cli): update error message

### DIFF
--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoppscotch/cli",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A CLI to run Hoppscotch test scripts in CI environments.",
   "homepage": "https://hoppscotch.io",
   "main": "dist/index.js",

--- a/packages/hoppscotch-cli/src/handlers/error.ts
+++ b/packages/hoppscotch-cli/src/handlers/error.ts
@@ -42,7 +42,7 @@ export const handleError = <T extends HoppErrorCode>(error: HoppError<T>) => {
 
   switch (error.code) {
     case "FILE_NOT_FOUND":
-      ERROR_MSG = `File doesn't exists: ${error.path}`;
+      ERROR_MSG = `File doesn't exist: ${error.path}`;
       break;
     case "UNKNOWN_COMMAND":
       ERROR_MSG = `Unavailable command: ${error.command}`;


### PR DESCRIPTION
### Description

This PR includes a grammatical correction in the error message displayed when a non-existent file is supplied to the `test` command and the `--env / -e` flag.

### Preview

> Non-existent file supplied to the `test` command

  <img width="627" alt="image" src="https://github.com/hoppscotch/hoppscotch/assets/25279263/fa67eb19-d141-4800-bffe-e0bea806fe83">

> Non-existent file supplied to the `--env / -e` flag

  <img width="625" alt="image" src="https://github.com/hoppscotch/hoppscotch/assets/25279263/83ce08eb-c653-4f26-a96e-6042cf1bf316">

### Checks
<!-- Make sure your pull request passes the CI checks and check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed

### Additional Information
N/A