### PR TITLE
fix: tooltip position in editor instance

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -137,10 +137,10 @@ a {
 
 .cm-tooltip {
   .tippy-box {
-    @apply shadow-none;
+    @apply shadow-none #{!important};
     @apply fixed;
     @apply inline-flex;
-    @apply -mt-8;
+    @apply -mt-7.5;
   }
 }
 

--- a/packages/hoppscotch-sh-admin/assets/scss/styles.scss
+++ b/packages/hoppscotch-sh-admin/assets/scss/styles.scss
@@ -137,14 +137,14 @@ a {
 
 .cm-tooltip {
   .tippy-box {
-    @apply shadow-none;
+    @apply shadow-none #{!important};
     @apply fixed;
     @apply inline-flex;
-    @apply -mt-8;
+    @apply -mt-7.5;
   }
 }
 
-.tippy-box[data-theme~="tooltip"] {
+.tippy-box[data-theme~='tooltip'] {
   @apply bg-tooltip;
   @apply border-solid border-tooltip;
   @apply rounded;
@@ -183,7 +183,7 @@ a {
   }
 }
 
-.tippy-box[data-theme~="popover"] {
+.tippy-box[data-theme~='popover'] {
   @apply bg-popover;
   @apply border-solid border-dividerDark;
   @apply rounded;
@@ -263,8 +263,8 @@ button {
   @apply disabled:cursor-not-allowed;
 }
 
-.input[type="file"],
-.input[type="radio"],
+.input[type='file'],
+.input[type='radio'],
 #installPWA {
   @apply hidden;
 }
@@ -563,16 +563,16 @@ details[open] summary .indicator {
   @apply bg-accent #{!important};
 }
 
-.color-picker[type="color"] {
+.color-picker[type='color'] {
   @apply appearance-none;
 }
 
-.color-picker[type="color"]::-webkit-color-swatch-wrapper {
+.color-picker[type='color']::-webkit-color-swatch-wrapper {
   @apply rounded;
   @apply p-0;
 }
 
-.color-picker[type="color"]::-webkit-color-swatch {
+.color-picker[type='color']::-webkit-color-swatch {
   @apply rounded;
   @apply border-0;
 }

--- a/packages/hoppscotch-sh-admin/src/components/users/Table.vue
+++ b/packages/hoppscotch-sh-admin/src/components/users/Table.vue
@@ -160,9 +160,3 @@ const getCreatedTime = (date: string) => format(new Date(date), 'hh:mm a');
 // Template refs
 const tippyActions = ref<TippyComponent | null>(null);
 </script>
-
-<style scoped>
-.tippy-box[data-theme~='popover'] .tippy-content {
-  padding: 0;
-}
-</style>

--- a/packages/hoppscotch-ui/src/assets/scss/styles.scss
+++ b/packages/hoppscotch-ui/src/assets/scss/styles.scss
@@ -137,10 +137,10 @@ a {
 
 .cm-tooltip {
   .tippy-box {
-    @apply shadow-none;
+    @apply shadow-none #{!important};
     @apply fixed;
     @apply inline-flex;
-    @apply -mt-8;
+    @apply -mt-7.5;
   }
 }
 


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8a380a</samp>

This pull request refactors and fixes the tooltip and popover styles across different packages. It moves the common styles to the `hoppscotch-common` package, removes the redundant and conflicting styles from the `hoppscotch-sh-admin` and `hoppscotch-ui` packages, and adjusts the alignment and shadow of the CodeMirror tooltip.