### PR TITLE
feat: introduces ability to export single environment variables and allow CLI to accept the export format used by the app

### DIFF
--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoppscotch/cli",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A CLI to run Hoppscotch test scripts in CI environments.",
   "homepage": "https://hoppscotch.io",
   "main": "dist/index.js",

--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -55,9 +55,7 @@
     "qs": "^6.10.3",
     "ts-jest": "^27.1.4",
     "tsup": "^5.12.7",
-    "typescript": "^4.6.4"
-  },
-  "dependencies": {
+    "typescript": "^4.6.4",
     "zod": "^3.22.2"
   }
 }

--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -56,5 +56,8 @@
     "ts-jest": "^27.1.4",
     "tsup": "^5.12.7",
     "typescript": "^4.6.4"
+  },
+  "dependencies": {
+    "zod": "^3.22.2"
   }
 }

--- a/packages/hoppscotch-cli/src/handlers/error.ts
+++ b/packages/hoppscotch-cli/src/handlers/error.ts
@@ -48,6 +48,11 @@ export const handleError = <T extends HoppErrorCode>(error: HoppError<T>) => {
       ERROR_MSG = `Unavailable command: ${error.command}`;
       break;
     case "MALFORMED_ENV_FILE":
+      ERROR_MSG = `The environment file is not of the correct format.`;
+      break;
+    case "MALFORMED_BULK_ENV_FILE":
+      ERROR_MSG = `CLI doesnt support bulk environments export.`;
+      break;
     case "MALFORMED_COLLECTION":
       ERROR_MSG = `${error.path}\n${parseErrorData(error.data)}`;
       break;

--- a/packages/hoppscotch-cli/src/handlers/error.ts
+++ b/packages/hoppscotch-cli/src/handlers/error.ts
@@ -50,8 +50,8 @@ export const handleError = <T extends HoppErrorCode>(error: HoppError<T>) => {
     case "MALFORMED_ENV_FILE":
       ERROR_MSG = `The environment file is not of the correct format.`;
       break;
-    case "MALFORMED_BULK_ENV_FILE":
-      ERROR_MSG = `CLI doesnt support bulk environments export.`;
+    case "BULK_ENV_FILE":
+      ERROR_MSG = `CLI doesn't support bulk environments export.`;
       break;
     case "MALFORMED_COLLECTION":
       ERROR_MSG = `${error.path}\n${parseErrorData(error.data)}`;

--- a/packages/hoppscotch-cli/src/options/test/env.ts
+++ b/packages/hoppscotch-cli/src/options/test/env.ts
@@ -1,27 +1,30 @@
 import { error } from "../../types/errors";
-import { HoppEnvs, HoppEnvPair } from "../../types/request";
+import { HoppEnvs, HoppEnvPair, HoppEnvObject } from "../../types/request";
 import { readJsonFile } from "../../utils/mutators";
-
 /**
  * Parses env json file for given path and validates the parsed env json object.
  * @param path Path of env.json file to be parsed.
  * @returns For successful parsing we get HoppEnvs object.
  */
 export async function parseEnvsData(path: string) {
-  const contents = await readJsonFile(path)
+  const contents = await readJsonFile(path);
+  const envPairs: Array<HoppEnvPair> = [];
+  const HoppEnvPairResult = HoppEnvPair.safeParse(contents);
+  const HoppEnvObjectResult = HoppEnvObject.safeParse(contents);
 
-  if(!(contents && typeof contents === "object" && !Array.isArray(contents))) {
-    throw error({ code: "MALFORMED_ENV_FILE", path, data: null })
+  if (!(HoppEnvPairResult.success || HoppEnvObjectResult.success)) {
+    throw error({ code: "MALFORMED_ENV_FILE", path, data: error });
   }
 
-  const envPairs: Array<HoppEnvPair> = []
-
-  for( const [key,value] of Object.entries(contents)) {
-    if(typeof value !== "string") {
-      throw error({ code: "MALFORMED_ENV_FILE", path, data: {value: value} })
+  if (HoppEnvPairResult.success) {
+    for (const [key, value] of Object.entries(HoppEnvPairResult.data)) {
+      envPairs.push({ key, value });
     }
-
-    envPairs.push({key, value})
+  } else if (HoppEnvObjectResult.success) {
+    const key = HoppEnvObjectResult.data.variables[0].key;
+    const value = HoppEnvObjectResult.data.variables[0].value;
+    envPairs.push({ key, value });
   }
-  return <HoppEnvs>{ global: [], selected: envPairs }
+
+  return <HoppEnvs>{ global: [], selected: envPairs };
 }

--- a/packages/hoppscotch-cli/src/options/test/env.ts
+++ b/packages/hoppscotch-cli/src/options/test/env.ts
@@ -4,6 +4,7 @@ import {
   HoppEnvPair,
   HoppEnvArray,
   HoppEnvObject,
+  HoppBulkEnvObject,
 } from "../../types/request";
 import { readJsonFile } from "../../utils/mutators";
 /**
@@ -16,7 +17,16 @@ export async function parseEnvsData(path: string) {
   const envPairs: Array<HoppEnvPair> = [];
   const HoppEnvArrayResult = HoppEnvArray.safeParse(contents);
   const HoppEnvObjectResult = HoppEnvObject.safeParse(contents);
+  const HoppBulkEnvObjectResult = HoppBulkEnvObject.safeParse(contents);
 
+  // CLI doesnt support bulk environments export.
+  // Hence we check for this case and throw an error if it matches the format.
+  if (HoppBulkEnvObjectResult.success) {
+    throw error({ code: "MALFORMED_BULK_ENV_FILE", path, data: error });
+  }
+
+  //  Checks if the environment file is of the correct format.
+  // If it doesnt match either of them, we throw an error.
   if (!(HoppEnvArrayResult.success || HoppEnvObjectResult.success)) {
     throw error({ code: "MALFORMED_ENV_FILE", path, data: error });
   }

--- a/packages/hoppscotch-cli/src/options/test/env.ts
+++ b/packages/hoppscotch-cli/src/options/test/env.ts
@@ -1,5 +1,10 @@
 import { error } from "../../types/errors";
-import { HoppEnvs, HoppEnvPair, HoppEnvObject } from "../../types/request";
+import {
+  HoppEnvs,
+  HoppEnvPair,
+  HoppEnvArray,
+  HoppEnvObject,
+} from "../../types/request";
 import { readJsonFile } from "../../utils/mutators";
 /**
  * Parses env json file for given path and validates the parsed env json object.
@@ -9,15 +14,15 @@ import { readJsonFile } from "../../utils/mutators";
 export async function parseEnvsData(path: string) {
   const contents = await readJsonFile(path);
   const envPairs: Array<HoppEnvPair> = [];
-  const HoppEnvPairResult = HoppEnvPair.safeParse(contents);
+  const HoppEnvArrayResult = HoppEnvArray.safeParse(contents);
   const HoppEnvObjectResult = HoppEnvObject.safeParse(contents);
 
-  if (!(HoppEnvPairResult.success || HoppEnvObjectResult.success)) {
+  if (!(HoppEnvArrayResult.success || HoppEnvObjectResult.success)) {
     throw error({ code: "MALFORMED_ENV_FILE", path, data: error });
   }
 
-  if (HoppEnvPairResult.success) {
-    for (const [key, value] of Object.entries(HoppEnvPairResult.data)) {
+  if (HoppEnvArrayResult.success) {
+    for (const [key, value] of Object.entries(HoppEnvArrayResult.data)) {
       envPairs.push({ key, value });
     }
   } else if (HoppEnvObjectResult.success) {

--- a/packages/hoppscotch-cli/src/options/test/env.ts
+++ b/packages/hoppscotch-cli/src/options/test/env.ts
@@ -26,8 +26,7 @@ export async function parseEnvsData(path: string) {
       envPairs.push({ key, value });
     }
   } else if (HoppEnvObjectResult.success) {
-    const key = HoppEnvObjectResult.data.variables[0].key;
-    const value = HoppEnvObjectResult.data.variables[0].value;
+    const { key, value } = HoppEnvObjectResult.data.variables[0];
     envPairs.push({ key, value });
   }
 

--- a/packages/hoppscotch-cli/src/options/test/env.ts
+++ b/packages/hoppscotch-cli/src/options/test/env.ts
@@ -2,9 +2,9 @@ import { error } from "../../types/errors";
 import {
   HoppEnvs,
   HoppEnvPair,
-  HoppEnvArray,
-  HoppEnvObject,
-  HoppBulkEnvObject,
+  HoppEnvKeyPairObject,
+  HoppEnvExportObject,
+  HoppBulkEnvExportObject,
 } from "../../types/request";
 import { readJsonFile } from "../../utils/mutators";
 /**
@@ -15,28 +15,29 @@ import { readJsonFile } from "../../utils/mutators";
 export async function parseEnvsData(path: string) {
   const contents = await readJsonFile(path);
   const envPairs: Array<HoppEnvPair> = [];
-  const HoppEnvArrayResult = HoppEnvArray.safeParse(contents);
-  const HoppEnvObjectResult = HoppEnvObject.safeParse(contents);
-  const HoppBulkEnvObjectResult = HoppBulkEnvObject.safeParse(contents);
+  const HoppEnvKeyPairResult = HoppEnvKeyPairObject.safeParse(contents);
+  const HoppEnvExportObjectResult = HoppEnvExportObject.safeParse(contents);
+  const HoppBulkEnvExportObjectResult =
+    HoppBulkEnvExportObject.safeParse(contents);
 
   // CLI doesnt support bulk environments export.
   // Hence we check for this case and throw an error if it matches the format.
-  if (HoppBulkEnvObjectResult.success) {
-    throw error({ code: "MALFORMED_BULK_ENV_FILE", path, data: error });
+  if (HoppBulkEnvExportObjectResult.success) {
+    throw error({ code: "BULK_ENV_FILE", path, data: error });
   }
 
   //  Checks if the environment file is of the correct format.
   // If it doesnt match either of them, we throw an error.
-  if (!(HoppEnvArrayResult.success || HoppEnvObjectResult.success)) {
+  if (!(HoppEnvKeyPairResult.success || HoppEnvExportObjectResult.success)) {
     throw error({ code: "MALFORMED_ENV_FILE", path, data: error });
   }
 
-  if (HoppEnvArrayResult.success) {
-    for (const [key, value] of Object.entries(HoppEnvArrayResult.data)) {
+  if (HoppEnvKeyPairResult.success) {
+    for (const [key, value] of Object.entries(HoppEnvKeyPairResult.data)) {
       envPairs.push({ key, value });
     }
-  } else if (HoppEnvObjectResult.success) {
-    const { key, value } = HoppEnvObjectResult.data.variables[0];
+  } else if (HoppEnvExportObjectResult.success) {
+    const { key, value } = HoppEnvExportObjectResult.data.variables[0];
     envPairs.push({ key, value });
   }
 

--- a/packages/hoppscotch-cli/src/types/errors.ts
+++ b/packages/hoppscotch-cli/src/types/errors.ts
@@ -24,7 +24,7 @@ type HoppErrors = {
   REQUEST_ERROR: HoppErrorData;
   INVALID_ARGUMENT: HoppErrorData;
   MALFORMED_ENV_FILE: HoppErrorPath & HoppErrorData;
-  MALFORMED_BULK_ENV_FILE: HoppErrorPath & HoppErrorData;
+  BULK_ENV_FILE: HoppErrorPath & HoppErrorData;
   INVALID_FILE_TYPE: HoppErrorData;
 };
 

--- a/packages/hoppscotch-cli/src/types/errors.ts
+++ b/packages/hoppscotch-cli/src/types/errors.ts
@@ -24,6 +24,7 @@ type HoppErrors = {
   REQUEST_ERROR: HoppErrorData;
   INVALID_ARGUMENT: HoppErrorData;
   MALFORMED_ENV_FILE: HoppErrorPath & HoppErrorData;
+  MALFORMED_BULK_ENV_FILE: HoppErrorPath & HoppErrorData;
   INVALID_FILE_TYPE: HoppErrorData;
 };
 

--- a/packages/hoppscotch-cli/src/types/request.ts
+++ b/packages/hoppscotch-cli/src/types/request.ts
@@ -24,17 +24,7 @@ export const HoppEnvExportObject = z.object({
 });
 
 // Shape of the bulk environment export object that is exported from the app.
-export const HoppBulkEnvExportObject = z.array(
-  z.object({
-    name: z.string(),
-    variables: z.array(
-      z.object({
-        key: z.string(),
-        value: z.string(),
-      })
-    ),
-  })
-);
+export const HoppBulkEnvExportObject = z.array(HoppEnvExportObject);
 
 export type HoppEnvs = {
   global: HoppEnvPair[];

--- a/packages/hoppscotch-cli/src/types/request.ts
+++ b/packages/hoppscotch-cli/src/types/request.ts
@@ -10,11 +10,10 @@ export type FormDataEntry = {
 
 export type HoppEnvPair = { key: string; value: string };
 
-export const HoppEnvArray = z.record(z.string(), z.string());
+export const HoppEnvKeyPairObject = z.record(z.string(), z.string());
 
-export type HoppEnvArray = z.infer<typeof HoppEnvArray>;
-
-export const HoppEnvObject = z.object({
+// Shape of the single environment export object that is exported from the app.
+export const HoppEnvExportObject = z.object({
   name: z.string(),
   variables: z.array(
     z.object({
@@ -24,7 +23,8 @@ export const HoppEnvObject = z.object({
   ),
 });
 
-export const HoppBulkEnvObject = z.array(
+// Shape of the bulk environment export object that is exported from the app.
+export const HoppBulkEnvExportObject = z.array(
   z.object({
     name: z.string(),
     variables: z.array(
@@ -35,9 +35,6 @@ export const HoppBulkEnvObject = z.array(
     ),
   })
 );
-
-export type HoppEnvObject = z.infer<typeof HoppEnvObject>;
-export type HoppBulkEnvObject = z.infer<typeof HoppBulkEnvObject>;
 
 export type HoppEnvs = {
   global: HoppEnvPair[];

--- a/packages/hoppscotch-cli/src/types/request.ts
+++ b/packages/hoppscotch-cli/src/types/request.ts
@@ -24,7 +24,20 @@ export const HoppEnvObject = z.object({
   ),
 });
 
+export const HoppBulkEnvObject = z.array(
+  z.object({
+    name: z.string(),
+    variables: z.array(
+      z.object({
+        key: z.string(),
+        value: z.string(),
+      })
+    ),
+  })
+);
+
 export type HoppEnvObject = z.infer<typeof HoppEnvObject>;
+export type HoppBulkEnvObject = z.infer<typeof HoppBulkEnvObject>;
 
 export type HoppEnvs = {
   global: HoppEnvPair[];

--- a/packages/hoppscotch-cli/src/types/request.ts
+++ b/packages/hoppscotch-cli/src/types/request.ts
@@ -1,6 +1,7 @@
 import { HoppCollection, HoppRESTRequest } from "@hoppscotch/data";
 import { TestReport } from "../interfaces/response";
 import { HoppCLIError } from "./errors";
+import { z } from "zod";
 
 export type FormDataEntry = {
   key: string;
@@ -8,6 +9,22 @@ export type FormDataEntry = {
 };
 
 export type HoppEnvPair = { key: string; value: string };
+
+export const HoppEnvArray = z.record(z.string(), z.string());
+
+export type HoppEnvArray = z.infer<typeof HoppEnvArray>;
+
+export const HoppEnvObject = z.object({
+  name: z.string(),
+  variables: z.array(
+    z.object({
+      key: z.string(),
+      value: z.string(),
+    })
+  ),
+});
+
+export type HoppEnvObject = z.infer<typeof HoppEnvObject>;
 
 export type HoppEnvs = {
   global: HoppEnvPair[];

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -746,6 +746,7 @@
     "disconnected_from": "Disconnected from {name}",
     "docs_generated": "Documentation generated",
     "download_started": "Download started",
+    "download_failed": "Download failed",
     "enabled": "Enabled",
     "file_imported": "File imported",
     "finished_in": "Finished in {duration} ms",

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -46,7 +46,7 @@
             role="menu"
             @keyup.e="edit!.$el.click()"
             @keyup.d="duplicate!.$el.click()"
-            @keyup.j="exportAsJson!.$el.click()"
+            @keyup.j="exportAsJsonEl!.$el.click()"
             @keyup.delete="
               !(environmentIndex === 'Global')
                 ? deleteAction!.$el.click()
@@ -79,7 +79,7 @@
               "
             />
             <HoppSmartItem
-              ref="exportAsJson"
+              ref="exportAsJsonEl"
               :icon="IconEdit"
               :label="`${t('export.as_json')}`"
               :shortcut="['J']"
@@ -161,7 +161,7 @@ const tippyActions = ref<TippyComponent | null>(null)
 const options = ref<TippyComponent | null>(null)
 const edit = ref<typeof HoppSmartItem>()
 const duplicate = ref<typeof HoppSmartItem>()
-const exportAsJson = ref<typeof HoppSmartItem>()
+const exportAsJsonEl = ref<typeof HoppSmartItem>()
 const deleteAction = ref<typeof HoppSmartItem>()
 
 const removeEnvironment = () => {

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -152,8 +152,8 @@ const confirmRemove = ref(false)
 
 const exportEnvironmentAsJSON = () =>
   exportJSON(props.environment, props.environmentIndex)
-    ? toast.success(t("state.download_started").toString())
-    : toast.error(t("state.download_failed").toString())
+    ? toast.success(t("state.download_started"))
+    : toast.error(t("state.download_failed"))
 
 const tippyActions = ref<TippyComponent | null>(null)
 const options = ref<TippyComponent | null>(null)

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -134,7 +134,7 @@ import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
 import { TippyComponent } from "vue-tippy"
 import { HoppSmartItem } from "@hoppscotch/ui"
-import { exportJSON } from "~/helpers/import-export/export/envToJson"
+import { exportAsJSON } from "~/helpers/import-export/export/environment"
 
 const t = useI18n()
 const toast = useToast()
@@ -150,10 +150,12 @@ const emit = defineEmits<{
 
 const confirmRemove = ref(false)
 
-const exportEnvironmentAsJSON = () =>
-  exportJSON(props.environment, props.environmentIndex)
+const exportEnvironmentAsJSON = () => {
+  const { environment, environmentIndex } = props
+  exportAsJSON(environment, environmentIndex)
     ? toast.success(t("state.download_started"))
     : toast.error(t("state.download_failed"))
+}
 
 const tippyActions = ref<TippyComponent | null>(null)
 const options = ref<TippyComponent | null>(null)

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -165,11 +165,13 @@ const removeEnvironment = () => {
 }
 
 const environmentJson = () => {
+  const { ...newEnvironment } = props.environment
+  delete newEnvironment.id
+
   return props.environmentIndex !== null
-    ? JSON.stringify(props.environment.variables, null, 2)
+    ? JSON.stringify(newEnvironment, null, 2)
     : undefined
 }
-
 const exportJSON = () => {
   const dataToWrite = environmentJson()
   if (!dataToWrite) return

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -85,7 +85,7 @@
               :shortcut="['J']"
               @click="
                 () => {
-                  exportJSON()
+                  exportEnvironmentAsJSON()
                   hide()
                 }
               "
@@ -134,6 +134,7 @@ import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
 import { TippyComponent } from "vue-tippy"
 import { HoppSmartItem } from "@hoppscotch/ui"
+import { exportJSON } from "~/helpers/import-export/export/envToJson"
 
 const t = useI18n()
 const toast = useToast()
@@ -149,6 +150,11 @@ const emit = defineEmits<{
 
 const confirmRemove = ref(false)
 
+const exportEnvironmentAsJSON = () =>
+  exportJSON(props.environment, props.environmentIndex)
+    ? toast.success(t("state.download_started").toString())
+    : toast.error(t("state.download_failed").toString())
+
 const tippyActions = ref<TippyComponent | null>(null)
 const options = ref<TippyComponent | null>(null)
 const edit = ref<typeof HoppSmartItem>()
@@ -162,33 +168,6 @@ const removeEnvironment = () => {
     deleteEnvironment(props.environmentIndex, props.environment.id)
   }
   toast.success(`${t("state.deleted")}`)
-}
-
-const environmentJson = () => {
-  const { ...newEnvironment } = props.environment
-  delete newEnvironment.id
-
-  return props.environmentIndex !== null
-    ? JSON.stringify(newEnvironment, null, 2)
-    : undefined
-}
-const exportJSON = () => {
-  const dataToWrite = environmentJson()
-  if (!dataToWrite) return
-  const file = new Blob([dataToWrite], { type: "application/json" })
-  const a = document.createElement("a")
-  const url = URL.createObjectURL(file)
-  a.href = url
-
-  // TODO: get uri from meta
-  a.download = `${url.split("/").pop()!.split("#")[0].split("?")[0]}.json`
-  document.body.appendChild(a)
-  a.click()
-  toast.success(t("state.download_started").toString())
-  setTimeout(() => {
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-  }, 1000)
 }
 
 const duplicateEnvironments = () => {

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -46,6 +46,7 @@
             role="menu"
             @keyup.e="edit!.$el.click()"
             @keyup.d="duplicate!.$el.click()"
+            @keyup.j="exportAsJson!.$el.click()"
             @keyup.delete="
               !(environmentIndex === 'Global')
                 ? deleteAction!.$el.click()
@@ -73,6 +74,18 @@
               @click="
                 () => {
                   duplicateEnvironments()
+                  hide()
+                }
+              "
+            />
+            <HoppSmartItem
+              ref="exportAsJson"
+              :icon="IconEdit"
+              :label="`${t('export.as_json')}`"
+              :shortcut="['J']"
+              @click="
+                () => {
+                  exportJSON()
                   hide()
                 }
               "
@@ -140,6 +153,7 @@ const tippyActions = ref<TippyComponent | null>(null)
 const options = ref<TippyComponent | null>(null)
 const edit = ref<typeof HoppSmartItem>()
 const duplicate = ref<typeof HoppSmartItem>()
+const exportAsJson = ref<typeof HoppSmartItem>()
 const deleteAction = ref<typeof HoppSmartItem>()
 
 const removeEnvironment = () => {
@@ -148,6 +162,31 @@ const removeEnvironment = () => {
     deleteEnvironment(props.environmentIndex, props.environment.id)
   }
   toast.success(`${t("state.deleted")}`)
+}
+
+const environmentJson = () => {
+  return props.environmentIndex !== null
+    ? JSON.stringify(props.environment.variables, null, 2)
+    : undefined
+}
+
+const exportJSON = () => {
+  const dataToWrite = environmentJson()
+  if (!dataToWrite) return
+  const file = new Blob([dataToWrite], { type: "application/json" })
+  const a = document.createElement("a")
+  const url = URL.createObjectURL(file)
+  a.href = url
+
+  // TODO: get uri from meta
+  a.download = `${url.split("/").pop()!.split("#")[0].split("?")[0]}.json`
+  document.body.appendChild(a)
+  a.click()
+  toast.success(t("state.download_started").toString())
+  setTimeout(() => {
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }, 1000)
 }
 
 const duplicateEnvironments = () => {

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -39,6 +39,7 @@
             role="menu"
             @keyup.e="edit!.$el.click()"
             @keyup.d="duplicate!.$el.click()"
+            @keyup.j="exportAsJson!.$el.click()"
             @keyup.delete="deleteAction!.$el.click()"
             @keyup.escape="options!.tippy().hide()"
           >
@@ -50,6 +51,19 @@
               @click="
                 () => {
                   emit('edit-environment')
+                  hide()
+                }
+              "
+            />
+
+            <HoppSmartItem
+              ref="exportAsJson"
+              :icon="IconEdit"
+              :label="`${t('export.as_json')}`"
+              :shortcut="['J']"
+              @click="
+                () => {
+                  exportJSON()
                   hide()
                 }
               "
@@ -129,6 +143,7 @@ const options = ref<TippyComponent | null>(null)
 const edit = ref<typeof HoppSmartItem>()
 const duplicate = ref<typeof HoppSmartItem>()
 const deleteAction = ref<typeof HoppSmartItem>()
+const exportAsJson = ref<typeof HoppSmartItem>()
 
 const removeEnvironment = () => {
   pipe(
@@ -143,6 +158,34 @@ const removeEnvironment = () => {
       }
     )
   )()
+}
+
+const environmentJson = () => {
+  const { ...newEnvironment } = props.environment.environment
+  delete newEnvironment.id
+
+  return props.environment.id !== null
+    ? JSON.stringify(newEnvironment, null, 2)
+    : undefined
+}
+
+const exportJSON = () => {
+  const dataToWrite = environmentJson()
+  if (!dataToWrite) return
+  const file = new Blob([dataToWrite], { type: "application/json" })
+  const a = document.createElement("a")
+  const url = URL.createObjectURL(file)
+  a.href = url
+
+  // TODO: get uri from meta
+  a.download = `${url.split("/").pop()!.split("#")[0].split("?")[0]}.json`
+  document.body.appendChild(a)
+  a.click()
+  toast.success(t("state.download_started").toString())
+  setTimeout(() => {
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }, 1000)
 }
 
 const duplicateEnvironments = () => {

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -141,8 +141,8 @@ const confirmRemove = ref(false)
 
 const exportEnvironmentAsJSON = () =>
   exportJSON(props.environment)
-    ? toast.success(t("state.download_started").toString())
-    : toast.error(t("state.download_failed").toString())
+    ? toast.success(t("state.download_started"))
+    : toast.error(t("state.download_failed"))
 
 const tippyActions = ref<TippyComponent | null>(null)
 const options = ref<TippyComponent | null>(null)

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -63,7 +63,7 @@
               :shortcut="['J']"
               @click="
                 () => {
-                  exportJSON()
+                  exportEnvironmentAsJSON()
                   hide()
                 }
               "
@@ -123,6 +123,7 @@ import IconTrash2 from "~icons/lucide/trash-2"
 import IconMoreVertical from "~icons/lucide/more-vertical"
 import { TippyComponent } from "vue-tippy"
 import { HoppSmartItem } from "@hoppscotch/ui"
+import { exportJSON } from "~/helpers/import-export/export/envToJson"
 
 const t = useI18n()
 const toast = useToast()
@@ -137,6 +138,11 @@ const emit = defineEmits<{
 }>()
 
 const confirmRemove = ref(false)
+
+const exportEnvironmentAsJSON = () =>
+  exportJSON(props.environment)
+    ? toast.success(t("state.download_started").toString())
+    : toast.error(t("state.download_failed").toString())
 
 const tippyActions = ref<TippyComponent | null>(null)
 const options = ref<TippyComponent | null>(null)
@@ -158,34 +164,6 @@ const removeEnvironment = () => {
       }
     )
   )()
-}
-
-const environmentJson = () => {
-  const { ...newEnvironment } = props.environment.environment
-  delete newEnvironment.id
-
-  return props.environment.id !== null
-    ? JSON.stringify(newEnvironment, null, 2)
-    : undefined
-}
-
-const exportJSON = () => {
-  const dataToWrite = environmentJson()
-  if (!dataToWrite) return
-  const file = new Blob([dataToWrite], { type: "application/json" })
-  const a = document.createElement("a")
-  const url = URL.createObjectURL(file)
-  a.href = url
-
-  // TODO: get uri from meta
-  a.download = `${url.split("/").pop()!.split("#")[0].split("?")[0]}.json`
-  document.body.appendChild(a)
-  a.click()
-  toast.success(t("state.download_started").toString())
-  setTimeout(() => {
-    document.body.removeChild(a)
-    URL.revokeObjectURL(url)
-  }, 1000)
 }
 
 const duplicateEnvironments = () => {

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -39,7 +39,7 @@
             role="menu"
             @keyup.e="edit!.$el.click()"
             @keyup.d="duplicate!.$el.click()"
-            @keyup.j="exportAsJson!.$el.click()"
+            @keyup.j="exportAsJsonEl!.$el.click()"
             @keyup.delete="deleteAction!.$el.click()"
             @keyup.escape="options!.tippy().hide()"
           >
@@ -69,7 +69,7 @@
               "
             />
             <HoppSmartItem
-              ref="exportAsJson"
+              ref="exportAsJsonEl"
               :icon="IconEdit"
               :label="`${t('export.as_json')}`"
               :shortcut="['J']"
@@ -149,7 +149,7 @@ const options = ref<TippyComponent | null>(null)
 const edit = ref<typeof HoppSmartItem>()
 const duplicate = ref<typeof HoppSmartItem>()
 const deleteAction = ref<typeof HoppSmartItem>()
-const exportAsJson = ref<typeof HoppSmartItem>()
+const exportAsJsonEl = ref<typeof HoppSmartItem>()
 
 const removeEnvironment = () => {
   pipe(

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -57,18 +57,6 @@
             />
 
             <HoppSmartItem
-              ref="exportAsJson"
-              :icon="IconEdit"
-              :label="`${t('export.as_json')}`"
-              :shortcut="['J']"
-              @click="
-                () => {
-                  exportEnvironmentAsJSON()
-                  hide()
-                }
-              "
-            />
-            <HoppSmartItem
               ref="duplicate"
               :icon="IconCopy"
               :label="`${t('action.duplicate')}`"
@@ -76,6 +64,18 @@
               @click="
                 () => {
                   duplicateEnvironments()
+                  hide()
+                }
+              "
+            />
+            <HoppSmartItem
+              ref="exportAsJson"
+              :icon="IconEdit"
+              :label="`${t('export.as_json')}`"
+              :shortcut="['J']"
+              @click="
+                () => {
+                  exportEnvironmentAsJSON()
                   hide()
                 }
               "

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -123,7 +123,7 @@ import IconTrash2 from "~icons/lucide/trash-2"
 import IconMoreVertical from "~icons/lucide/more-vertical"
 import { TippyComponent } from "vue-tippy"
 import { HoppSmartItem } from "@hoppscotch/ui"
-import { exportJSON } from "~/helpers/import-export/export/envToJson"
+import { exportAsJSON } from "~/helpers/import-export/export/environment"
 
 const t = useI18n()
 const toast = useToast()
@@ -140,7 +140,7 @@ const emit = defineEmits<{
 const confirmRemove = ref(false)
 
 const exportEnvironmentAsJSON = () =>
-  exportJSON(props.environment)
+  exportAsJSON(props.environment)
     ? toast.success(t("state.download_started"))
     : toast.error(t("state.download_failed"))
 

--- a/packages/hoppscotch-common/src/helpers/import-export/export/envToJson.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/envToJson.ts
@@ -1,0 +1,49 @@
+import { Environment } from "@hoppscotch/data"
+import { TeamEnvironment } from "~/helpers/teams/TeamEnvironment"
+
+const getEnvironmentJson = (
+  environment: TeamEnvironment | Environment,
+  environmentIndex?: number | "Global" | null
+) => {
+  if ("environment" in environment) {
+    const { ...newEnvironment } = environment.environment
+    delete newEnvironment.id
+
+    return environment.id !== null
+      ? JSON.stringify(newEnvironment, null, 2)
+      : undefined
+  } else {
+    const { ...newEnvironment } = environment
+    delete newEnvironment.id
+
+    return environmentIndex !== null
+      ? JSON.stringify(newEnvironment, null, 2)
+      : undefined
+  }
+}
+
+export const exportJSON = (
+  environment: Environment | TeamEnvironment,
+  environmentIndex?: number | "Global" | null
+): boolean => {
+  const dataToWrite = environmentIndex
+    ? getEnvironmentJson(environment, environmentIndex)
+    : getEnvironmentJson(environment)
+
+  if (!dataToWrite) return false
+
+  const file = new Blob([dataToWrite], { type: "application/json" })
+  const a = document.createElement("a")
+  const url = URL.createObjectURL(file)
+  a.href = url
+
+  // Extracts the path from url, removes fragment identifier and query parameters if any, appends the ".json" extension, and assigns it
+  a.download = `${url.split("/").pop()!.split("#")[0].split("?")[0]}.json`
+  document.body.appendChild(a)
+  a.click()
+  setTimeout(() => {
+    document.body.removeChild(a)
+    window.URL.revokeObjectURL(url)
+  }, 0)
+  return true
+}

--- a/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
@@ -1,34 +1,33 @@
 import { Environment } from "@hoppscotch/data"
 import { TeamEnvironment } from "~/helpers/teams/TeamEnvironment"
+import { cloneDeep } from "lodash-es"
 
 const getEnvironmentJson = (
-  environment: TeamEnvironment | Environment,
+  environmentObj: TeamEnvironment | Environment,
   environmentIndex?: number | "Global" | null
 ) => {
-  if ("environment" in environment) {
-    const { ...newEnvironment } = environment.environment
-    delete newEnvironment.id
+  const newEnvironment =
+    "environment" in environmentObj
+      ? cloneDeep(environmentObj.environment)
+      : cloneDeep(environmentObj)
 
-    return environment.id !== null
-      ? JSON.stringify(newEnvironment, null, 2)
-      : undefined
-  } else {
-    const { ...newEnvironment } = environment
-    delete newEnvironment.id
+  delete newEnvironment.id
 
-    return environmentIndex !== null
-      ? JSON.stringify(newEnvironment, null, 2)
-      : undefined
-  }
+  const environmentId =
+    environmentIndex || environmentIndex === 0
+      ? environmentIndex
+      : environmentObj.id
+
+  return environmentId !== null
+    ? JSON.stringify(newEnvironment, null, 2)
+    : undefined
 }
 
-export const exportJSON = (
-  environment: Environment | TeamEnvironment,
+export const exportAsJSON = (
+  environmentObj: Environment | TeamEnvironment,
   environmentIndex?: number | "Global" | null
 ): boolean => {
-  const dataToWrite = environmentIndex
-    ? getEnvironmentJson(environment, environmentIndex)
-    : getEnvironmentJson(environment)
+  const dataToWrite = getEnvironmentJson(environmentObj, environmentIndex)
 
   if (!dataToWrite) return false
 

--- a/packages/hoppscotch-sh-admin/src/components.d.ts
+++ b/packages/hoppscotch-sh-admin/src/components.d.ts
@@ -24,6 +24,7 @@ declare module '@vue/runtime-core' {
     HoppSmartModal: typeof import('@hoppscotch/ui')['HoppSmartModal']
     HoppSmartPicture: typeof import('@hoppscotch/ui')['HoppSmartPicture']
     HoppSmartSpinner: typeof import('@hoppscotch/ui')['HoppSmartSpinner']
+    HoppSmartTable: typeof import('@hoppscotch/ui')['HoppSmartTable']
     IconLucideArrowLeft: typeof import('~icons/lucide/arrow-left')['default']
     IconLucideChevronDown: typeof import('~icons/lucide/chevron-down')['default']
     IconLucideInbox: typeof import('~icons/lucide/inbox')['default']

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 packageExtensionsChecksum: 18e898b62612ac7acc736e0323d495da
 
 importers:
@@ -201,7 +197,7 @@ importers:
         version: 9.1.5
       '@nestjs/schematics':
         specifier: ^9.0.3
-        version: 9.0.3(typescript@4.9.3)
+        version: 9.0.3(chokidar@3.5.3)(typescript@4.8.4)
       '@nestjs/testing':
         specifier: ^9.2.1
         version: 9.2.1(@nestjs/common@9.2.1)(@nestjs/core@9.2.1)(@nestjs/platform-express@9.2.1)
@@ -300,6 +296,10 @@ importers:
         version: 4.9.3
 
   packages/hoppscotch-cli:
+    dependencies:
+      zod:
+        specifier: ^3.22.2
+        version: 3.22.2
     devDependencies:
       '@hoppscotch/data':
         specifier: workspace:^
@@ -934,7 +934,7 @@ importers:
         version: 3.2.0(graphql@16.8.0)
       '@intlify/vite-plugin-vue-i18n':
         specifier: ^7.0.0
-        version: 7.0.0(vite@4.4.9)
+        version: 7.0.0(vite@3.2.4)(vue-i18n@9.2.2)
       '@rushstack/eslint-patch':
         specifier: ^1.3.3
         version: 1.3.3
@@ -994,7 +994,7 @@ importers:
         version: 0.7.38(rollup@2.79.1)(vite@4.4.9)
       vite-plugin-pages:
         specifier: ^0.31.0
-        version: 0.31.0(vite@4.4.9)
+        version: 0.31.0(@vue/compiler-sfc@3.3.4)(vite@4.4.9)
       vite-plugin-pages-sitemap:
         specifier: ^1.6.1
         version: 1.6.1
@@ -1093,7 +1093,7 @@ importers:
         version: 0.14.9(@vue/compiler-sfc@3.2.45)(vite@3.2.4)
       unplugin-vue-components:
         specifier: ^0.21.0
-        version: 0.21.0(vite@3.2.4)(vue@3.2.45)
+        version: 0.21.0(esbuild@0.19.2)(rollup@2.79.1)(vite@3.2.4)(vue@3.2.45)
       vue:
         specifier: ^3.2.6
         version: 3.2.45
@@ -1169,7 +1169,7 @@ importers:
         version: 1.0.3(vite@3.2.4)
       vite:
         specifier: ^3.1.4
-        version: 3.2.4(@types/node@18.17.6)(sass@1.58.0)
+        version: 3.2.4(@types/node@17.0.27)(sass@1.53.0)(terser@5.19.2)
       vite-plugin-pages:
         specifier: ^0.26.0
         version: 0.26.0(@vue/compiler-sfc@3.2.45)(vite@3.2.4)
@@ -1272,7 +1272,7 @@ importers:
         version: 8.29.0
       eslint-plugin-prettier:
         specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@8.5.0)(eslint@8.29.0)(prettier@2.8.4)
+        version: 4.2.1(eslint-config-prettier@8.6.0)(eslint@8.19.0)(prettier@2.8.4)
       eslint-plugin-vue:
         specifier: ^9.5.1
         version: 9.5.1(eslint@8.29.0)
@@ -1732,13 +1732,13 @@ packages:
     resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.18.6
+      '@babel/highlight': 7.22.20
 
   /@babel/code-frame@7.22.10:
     resolution: {integrity: sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.22.10
+      '@babel/highlight': 7.22.20
       chalk: 2.4.2
     dev: true
 
@@ -1898,7 +1898,7 @@ packages:
       '@babel/helper-module-imports': 7.22.5
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
 
   /@babel/helper-optimise-call-expression@7.22.5:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
@@ -1964,10 +1964,6 @@ packages:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-validator-identifier@7.19.1:
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
-    engines: {node: '>=6.9.0'}
-
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
     engines: {node: '>=6.9.0'}
@@ -1997,23 +1993,6 @@ packages:
       '@babel/types': 7.22.10
     transitivePeerDependencies:
       - supports-color
-
-  /@babel/highlight@7.18.6:
-    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-
-  /@babel/highlight@7.22.10:
-    resolution: {integrity: sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.22.5
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-    dev: true
 
   /@babel/highlight@7.22.20:
     resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
@@ -2546,7 +2525,7 @@ packages:
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.10)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
 
   /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.22.10):
     resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==}
@@ -2968,7 +2947,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
     dev: true
 
@@ -3376,7 +3355,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-arm@0.15.15:
@@ -3410,7 +3388,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/android-x64@0.16.17:
@@ -3436,7 +3413,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.16.17:
@@ -3462,7 +3438,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.16.17:
@@ -3488,7 +3463,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.16.17:
@@ -3514,7 +3488,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.16.17:
@@ -3540,7 +3513,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.16.17:
@@ -3566,7 +3538,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.16.17:
@@ -3592,7 +3563,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.16.17:
@@ -3618,7 +3588,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.15.15:
@@ -3652,7 +3621,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.16.17:
@@ -3678,7 +3646,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.16.17:
@@ -3704,7 +3671,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.16.17:
@@ -3730,7 +3696,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.16.17:
@@ -3756,7 +3721,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.16.17:
@@ -3782,7 +3746,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.16.17:
@@ -3808,7 +3771,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.16.17:
@@ -3834,7 +3796,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/sunos-x64@0.16.17:
@@ -3860,7 +3821,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.16.17:
@@ -3886,7 +3846,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.16.17:
@@ -3912,7 +3871,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.16.17:
@@ -3938,7 +3896,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@eslint-community/eslint-utils@4.4.0(eslint@8.29.0):
@@ -6096,7 +6053,7 @@ packages:
       escodegen: 2.1.0
       estree-walker: 2.0.2
       jsonc-eslint-parser: 1.4.1
-      magic-string: 0.30.3
+      magic-string: 0.30.4
       mlly: 1.4.0
       source-map: 0.6.1
       yaml-eslint-parser: 0.3.2
@@ -6202,35 +6159,8 @@ packages:
       debug: 4.3.4(supports-color@9.2.2)
       fast-glob: 3.3.1
       source-map: 0.6.1
-      vite: 3.2.4(@types/node@18.17.6)(sass@1.58.0)
+      vite: 3.2.4(@types/node@17.0.27)(sass@1.53.0)(terser@5.19.2)
       vue-i18n: 9.2.2(vue@3.2.45)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@intlify/vite-plugin-vue-i18n@7.0.0(vite@4.4.9):
-    resolution: {integrity: sha512-2TbDOQ8XD+vkc0s5OFmr+IY/k4mYMC7pzvx0xGQn+cU/ev314+yi7Z7N7rWcBgiYk1WOUalbGSo3d4nJDxOOyw==}
-    engines: {node: '>= 14.6'}
-    deprecated: This plugin support until Vite 3. If you would like to use on Vite 4, please use @intlify/unplugin-vue-i18n
-    peerDependencies:
-      petite-vue-i18n: '*'
-      vite: ^2.9.0 || ^3.0.0
-      vue-i18n: '*'
-    peerDependenciesMeta:
-      petite-vue-i18n:
-        optional: true
-      vite:
-        optional: true
-      vue-i18n:
-        optional: true
-    dependencies:
-      '@intlify/bundle-utils': 3.4.0(vue-i18n@9.2.2)
-      '@intlify/shared': 9.4.1
-      '@rollup/pluginutils': 4.2.1
-      debug: 4.3.4(supports-color@9.2.2)
-      fast-glob: 3.3.1
-      source-map: 0.6.1
-      vite: 4.4.9(@types/node@17.0.27)(sass@1.53.0)(terser@5.19.2)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6930,8 +6860,8 @@ packages:
       - supports-color
     dev: false
 
-  /@mdn/browser-compat-data@5.3.19:
-    resolution: {integrity: sha512-3k0I0sqa9vyO1z687O4hfoeXnTIf68WI0UBksBj0GPbXdNrOA4VOntP08jtvuaTG7yYHRVXSyoA9xRWxSGv3mw==}
+  /@mdn/browser-compat-data@5.3.20:
+    resolution: {integrity: sha512-UoZWTHXYXPm0AOcCgmbeirzJqE3fZ2P16qAs9kgMpckw67yCsYgdrQ2NqhlxJYpe6h/62I10+uX8xUZjwTp1sA==}
     dev: true
 
   /@microsoft/api-extractor-model@7.27.5(@types/node@17.0.27):
@@ -7234,21 +7164,6 @@ packages:
       jsonc-parser: 3.2.0
       pluralize: 8.0.0
       typescript: 4.8.4
-    transitivePeerDependencies:
-      - chokidar
-    dev: true
-
-  /@nestjs/schematics@9.0.3(typescript@4.9.3):
-    resolution: {integrity: sha512-kZrU/lrpVd2cnK8I3ibDb3Wi1ppl3wX3U3lVWoL+DzRRoezWKkh8upEL4q0koKmuXnsmLiu3UPxFeMOrJV7TSA==}
-    peerDependencies:
-      typescript: ^4.3.5
-    dependencies:
-      '@angular-devkit/core': 14.2.1(chokidar@3.5.3)
-      '@angular-devkit/schematics': 14.2.1(chokidar@3.5.3)
-      fs-extra: 10.1.0
-      jsonc-parser: 3.2.0
-      pluralize: 8.0.0
-      typescript: 4.9.3
     transitivePeerDependencies:
       - chokidar
     dev: true
@@ -9304,7 +9219,7 @@ packages:
   /@vitest/snapshot@0.34.2:
     resolution: {integrity: sha512-qhQ+xy3u4mwwLxltS4Pd4SR+XHv4EajiTPNY3jkIBLUApE6/ce72neJPSUQZ7bL3EBuKI+NhvzhGj3n5baRQUQ==}
     dependencies:
-      magic-string: 0.30.3
+      magic-string: 0.30.4
       pathe: 1.1.1
       pretty-format: 29.5.0
     dev: true
@@ -9612,7 +9527,7 @@ packages:
       '@vue/compiler-core': 3.3.4
       '@vue/shared': 3.3.4
       estree-walker: 2.0.2
-      magic-string: 0.30.3
+      magic-string: 0.30.4
 
   /@vue/reactivity@3.2.45:
     resolution: {integrity: sha512-PRvhCcQcyEVohW0P8iQ7HDcIOXRjZfAsOds3N99X/Dzewy8TVhTCT4uXpAHfoKjVTJRA0O0K+6QNkDIZAxNi3A==}
@@ -10149,7 +10064,7 @@ packages:
       '@windicss/config': 1.9.1
       debug: 4.3.4(supports-color@9.2.2)
       fast-glob: 3.3.1
-      magic-string: 0.30.3
+      magic-string: 0.30.4
       micromatch: 4.0.5
       windicss: 3.5.6
     transitivePeerDependencies:
@@ -10288,7 +10203,7 @@ packages:
     hasBin: true
 
   /after@0.8.2:
-    resolution: {integrity: sha512-QbJ0NTQ/I9DI3uSJA4cbexiwQeRAfjPScqIbSjUDd9TOrcg6pTkdgziesOqxBMBzit8vFCTwrP27t13vFOORRA==}
+    resolution: {integrity: sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=}
     dev: false
 
   /agent-base@6.0.2:
@@ -10937,7 +10852,7 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   /base64-arraybuffer@0.1.4:
-    resolution: {integrity: sha512-a1eIFi4R9ySrbiMuyTGx5e92uRH5tQY6kArNcFaKBUleIoLjdjBg7Zxm3Mqm3Kmkf27HLR/1fnxX9q8GQ7Iavg==}
+    resolution: {integrity: sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=}
     engines: {node: '>= 0.6.0'}
     dev: false
 
@@ -11055,7 +10970,7 @@ packages:
     resolution: {integrity: sha512-ZFz4mAOgqm0cbwKaZsfJbYDbTXGoPANlte7qRsRJOfjB9KmmISQrXJxAVrnXG8C8v/QHNzXyeJt0Cfcks6zZvQ==}
     engines: {node: '>=16.15.1', npm: '>=7.0.0', pnpm: '>=3.2.0', yarn: '>=1.13'}
     dependencies:
-      '@mdn/browser-compat-data': 5.3.19
+      '@mdn/browser-compat-data': 5.3.20
       '@types/object-path': 0.11.1
       '@types/semver': 7.5.0
       '@types/ua-parser-js': 0.7.36
@@ -11593,14 +11508,14 @@ packages:
     dev: true
 
   /component-bind@1.0.0:
-    resolution: {integrity: sha512-WZveuKPeKAG9qY+FkYDeADzdHyTYdIboXS59ixDeRJL5ZhxpqUnxSOwop4FQjMsiYm3/Or8cegVbpAHNA7pHxw==}
+    resolution: {integrity: sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=}
     dev: false
 
   /component-emitter@1.3.0:
     resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==}
 
   /component-inherit@0.0.3:
-    resolution: {integrity: sha512-w+LhYREhatpVqTESyGFg3NlP6Iu0kEKUHETY9GoZP/pQyW4mHFZuFWRUCIqVPZ36ueVLtoOEZaAqbCF2RDndaA==}
+    resolution: {integrity: sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=}
     dev: false
 
   /concat-map@0.0.1:
@@ -12631,7 +12546,7 @@ packages:
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
       is-weakref: 1.0.2
-      object-inspect: 1.12.2
+      object-inspect: 1.12.3
       object-keys: 1.1.1
       object.assign: 4.1.4
       regexp.prototype.flags: 1.5.0
@@ -13188,7 +13103,6 @@ packages:
       '@esbuild/win32-arm64': 0.19.2
       '@esbuild/win32-ia32': 0.19.2
       '@esbuild/win32-x64': 0.19.2
-    dev: true
 
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -14119,7 +14033,7 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.13
       chalk: 4.1.2
       chokidar: 3.5.3
       cosmiconfig: 7.0.1
@@ -14868,7 +14782,7 @@ packages:
     dev: false
 
   /has-cors@1.1.0:
-    resolution: {integrity: sha512-g5VNKdkFuUuVCP9gYfDJHjK2nqdQJ7aDLTnycnc2+RvsOQbuLdF5pm7vuE5J76SEBIQjs4kQY/BWq74JUmjbXA==}
+    resolution: {integrity: sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=}
     dev: false
 
   /has-flag@3.0.0:
@@ -15294,7 +15208,7 @@ packages:
     dev: true
 
   /indexof@0.0.1:
-    resolution: {integrity: sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==}
+    resolution: {integrity: sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=}
     dev: false
 
   /inflight@1.0.6:
@@ -17657,8 +17571,8 @@ packages:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  /magic-string@0.30.3:
-    resolution: {integrity: sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==}
+  /magic-string@0.30.4:
+    resolution: {integrity: sha512-Q/TKtsC5BPm0kGqgBIF9oXAs/xEf2vRKiIB4wCRQTJOQIByZ1d+NnUOotvJOvNpi5RNIgVOMC3pOuaP1ZTDlVg==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -18666,10 +18580,6 @@ packages:
   /object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
-
-  /object-inspect@1.12.2:
-    resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
-    dev: true
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
@@ -20011,7 +19921,7 @@ packages:
       rollup: ^3.25
       typescript: ^4.5 || ^5.0
     dependencies:
-      magic-string: 0.30.3
+      magic-string: 0.30.4
       rollup: 3.29.3
       typescript: 5.2.2
     optionalDependencies:
@@ -20218,6 +20128,7 @@ packages:
       chokidar: 3.5.3
       immutable: 4.3.2
       source-map-js: 1.0.2
+    dev: true
 
   /sass@1.66.0:
     resolution: {integrity: sha512-C3U+RgpAAlTXULZkWwzfysgbbBBo8IZudNAOJAVBLslFbIaZv4MBPkTqhuvpK4lqgdoFiWhnOGMoV4L1FyOBag==}
@@ -20979,7 +20890,7 @@ packages:
       graphql: 15.8.0
       iterall: 1.3.0
       symbol-observable: 1.2.0
-      ws: 7.5.9
+      ws: 7.4.6
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -21409,7 +21320,7 @@ packages:
     dev: true
 
   /to-array@0.1.4:
-    resolution: {integrity: sha512-LhVdShQD/4Mk4zXNroIQZJC+Ap3zgLcDuwEdcmLv9CCO73NWockQDwyUnW/m8VX/EElfL6FcYx7EeutN4HJA6A==}
+    resolution: {integrity: sha1-F+bBH3PdTz10zaek/zI46a2b+JA=}
     dev: false
 
   /to-fast-properties@2.0.0:
@@ -22285,36 +22196,6 @@ packages:
       - supports-color
       - vite
       - webpack
-    dev: true
-
-  /unplugin-vue-components@0.21.0(vite@3.2.4)(vue@3.2.45):
-    resolution: {integrity: sha512-U7uOMNmRJ2eAv9CNjP8QRvxs6nAe3FVQUEIUphC1FGguBp3BWSLgGAcSHaX2nQy0gFoDY2mLF2M52W/t/eDaKg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/parser': ^7.15.8
-      vue: 2 || 3
-    peerDependenciesMeta:
-      '@babel/parser':
-        optional: true
-    dependencies:
-      '@antfu/utils': 0.5.2
-      '@rollup/pluginutils': 4.2.1
-      chokidar: 3.5.3
-      debug: 4.3.4(supports-color@9.2.2)
-      fast-glob: 3.3.1
-      local-pkg: 0.4.3
-      magic-string: 0.26.7
-      minimatch: 5.1.6
-      resolve: 1.22.4
-      unplugin: 0.7.1(vite@3.2.4)
-      vue: 3.2.45
-    transitivePeerDependencies:
-      - esbuild
-      - rollup
-      - supports-color
-      - vite
-      - webpack
-    dev: false
 
   /unplugin-vue-components@0.25.1(rollup@2.79.1)(vue@3.3.4):
     resolution: {integrity: sha512-kzS2ZHVMaGU2XEO2keYQcMjNZkanDSGDdY96uQT9EPe+wqSZwwgbFfKVJ5ti0+8rGAcKHColwKUvctBhq2LJ3A==}
@@ -22398,31 +22279,6 @@ packages:
       vite: 3.2.4(@types/node@17.0.27)(sass@1.53.0)(terser@5.19.2)
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.4.4
-    dev: true
-
-  /unplugin@0.7.1(vite@3.2.4):
-    resolution: {integrity: sha512-Z6hNDXDNh9aimMkPU1mEjtk+2ova8gh0y7rJeJdGH1vWZOHwF2lLQiQ/R97rv9ymmzEQXsR2fyMet72T8jy6ew==}
-    peerDependencies:
-      esbuild: '>=0.13'
-      rollup: ^2.50.0
-      vite: ^2.3.0 || ^3.0.0-0
-      webpack: 4 || 5
-    peerDependenciesMeta:
-      esbuild:
-        optional: true
-      rollup:
-        optional: true
-      vite:
-        optional: true
-      webpack:
-        optional: true
-    dependencies:
-      acorn: 8.10.0
-      chokidar: 3.5.3
-      vite: 3.2.4(@types/node@18.17.6)(sass@1.58.0)
-      webpack-sources: 3.2.3
-      webpack-virtual-modules: 0.4.4
-    dev: false
 
   /unplugin@0.9.5(vite@3.2.4):
     resolution: {integrity: sha512-luraheyfxwtvkvHpsOvMNv7IjLdORTWKZp0gWYNHGLi2ImON3iIZOj464qEyyEwLA/EMt12fC415HW9zRpOfTg==}
@@ -22443,7 +22299,7 @@ packages:
     dependencies:
       acorn: 8.10.0
       chokidar: 3.5.3
-      vite: 3.2.4(@types/node@18.17.6)(sass@1.58.0)
+      vite: 3.2.4(@types/node@17.0.27)(sass@1.53.0)(terser@5.19.2)
       webpack-sources: 3.2.3
       webpack-virtual-modules: 0.4.4
     dev: false
@@ -22675,7 +22531,7 @@ packages:
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
-      vite: 4.4.9(@types/node@18.17.6)(sass@1.66.0)(terser@5.19.2)
+      vite: 4.4.9(@types/node@17.0.27)(sass@1.53.0)(terser@5.19.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -23002,29 +22858,6 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-pages@0.31.0(vite@4.4.9):
-    resolution: {integrity: sha512-fw3onBfVTXQI7rOzAbSZhmfwvk50+3qNnGZpERjmD93c8nEjrGLyd53eFXYMxcJV4KA1vzi4qIHt2+6tS4dEMw==}
-    peerDependencies:
-      '@vue/compiler-sfc': ^2.7.0 || ^3.0.0
-      vite: ^2.0.0 || ^3.0.0-0 || ^4.0.0
-    peerDependenciesMeta:
-      '@vue/compiler-sfc':
-        optional: true
-    dependencies:
-      '@types/debug': 4.1.8
-      debug: 4.3.4(supports-color@9.2.2)
-      deep-equal: 2.2.2
-      extract-comments: 1.1.0
-      fast-glob: 3.3.1
-      json5: 2.2.3
-      local-pkg: 0.4.3
-      picocolors: 1.0.0
-      vite: 4.4.9(@types/node@17.0.27)(sass@1.53.0)(terser@5.19.2)
-      yaml: 2.3.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /vite-plugin-pwa@0.13.1(vite@3.2.4)(workbox-build@6.6.0)(workbox-window@6.6.0):
     resolution: {integrity: sha512-NR3dIa+o2hzlzo4lF4Gu0cYvoMjSw2DdRc6Epw1yjmCqWaGuN86WK9JqZie4arNlE1ZuWT3CLiMdiX5wcmmUmg==}
     peerDependencies:
@@ -23084,7 +22917,7 @@ packages:
       '@vue/compiler-sfc': 3.3.4
       debug: 4.3.4(supports-color@9.2.2)
       fast-glob: 3.3.1
-      vite: 3.2.4(@types/node@18.17.6)(sass@1.58.0)
+      vite: 3.2.4(@types/node@17.0.27)(sass@1.53.0)(terser@5.19.2)
       vue: 3.2.45
       vue-router: 4.1.0(vue@3.2.45)
     transitivePeerDependencies:
@@ -23185,40 +23018,6 @@ packages:
       rollup: 2.79.1
       sass: 1.53.0
       terser: 5.19.2
-    optionalDependencies:
-      fsevents: 2.3.2
-
-  /vite@3.2.4(@types/node@18.17.6)(sass@1.58.0):
-    resolution: {integrity: sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.17.6
-      esbuild: 0.15.15
-      postcss: 8.4.28
-      resolve: 1.22.4
-      rollup: 2.79.1
-      sass: 1.58.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -23421,7 +23220,7 @@ packages:
       tinybench: 2.5.0
       tinypool: 0.4.0
       tinyspy: 1.1.1
-      vite: 3.2.4(@types/node@18.17.6)(sass@1.58.0)
+      vite: 3.2.4(@types/node@17.0.27)(sass@1.53.0)(terser@5.19.2)
       vite-node: 0.29.8(@types/node@18.17.6)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
@@ -24661,6 +24460,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: true
 
   /ws@8.11.0:
     resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}
@@ -24916,7 +24716,7 @@ packages:
     dev: false
 
   /yeast@0.1.2:
-    resolution: {integrity: sha512-8HFIh676uyGYP6wP13R/j6OJ/1HwJ46snpvzE7aHAN3Ryqh2yX6Xox2B4CUmTwwOIzlG3Bs7ocsP5dZH/R1Qbg==}
+    resolution: {integrity: sha1-AI4G2AlDIMNy28L47XagymyKxBk=}
     dev: false
 
   /yn@3.1.1:
@@ -24958,4 +24758,8 @@ packages:
 
   /zhead@2.0.10:
     resolution: {integrity: sha512-irug8fXNKjqazkA27cFQs7C6/ZD3qNiEzLC56kDyzQART/Z9GMGfg8h2i6fb9c8ZWnIx/QgOgFJxK3A/CYHG0g==}
+    dev: false
+
+  /zod@3.22.2:
+    resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,10 +296,6 @@ importers:
         version: 4.9.3
 
   packages/hoppscotch-cli:
-    dependencies:
-      zod:
-        specifier: ^3.22.2
-        version: 3.22.2
     devDependencies:
       '@hoppscotch/data':
         specifier: workspace:^
@@ -361,6 +357,9 @@ importers:
       typescript:
         specifier: ^4.6.4
         version: 4.7.4
+      zod:
+        specifier: ^3.22.2
+        version: 3.22.2
 
   packages/hoppscotch-common:
     dependencies:
@@ -24762,4 +24761,4 @@ packages:
 
   /zod@3.22.2:
     resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
-    dev: false
+    dev: true


### PR DESCRIPTION
### Ticket
Closes HFE-203

### Description
This PR introduces the following features and fixes to the `Hoppscotch App` and `Hoppscotch CLI`

**Features Added:**
- Added the ability to export single environment variables from the `Hoppscotch App` 
- CLI can now accept environment variables from the format in which the `Hoppscotch App` exports.
- Introduced `Zod` package into the `Hoppscotch CLI` to check the validity of the formats for the Environment variables.
- CLI now informs the user that bulk environment export is not supported by the CLI when the file matches the bulk export format.

**Issues Fixes:**
- Fix the malformed environments error when importing a environment file that was exported from the `Hoppscotch App` to the CLI.   
- Fix the issue when there are are no error messages being given when it is a malformed environment error

### Objectives
- [x] Add ability to export single environment variables
- [x] On export of environment variables, remove id from environment and send only the name and variables.
- [x] The CLI should be able to receive the format that is exported when exporting environment variables from the Hoppscotch App.
- [x] Fix the malformed environments error when importing a environment file that was exported from the app to the CLI.   
- [x] CLI should inform the user that bulk environment export is not supported by the CLI when the file matches the bulk export format.   

### Note

> Requires changes to the Documentation as the CLI can now accept the format that the `Hoppscotch App` uses to export environment variables. The new format must be mentioned in the documentation. Also need to mention that bulk environment export is not supported by the CLI.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed