### PR TITLE
fix: Frontend/Admin ports are wrong. #3336

### DIFF
--- a/packages/hoppscotch-selfhost-web/Caddyfile
+++ b/packages/hoppscotch-selfhost-web/Caddyfile
@@ -1,4 +1,4 @@
-:8080 {
+:3000 {
   try_files {path} /
   root * /site
   file_server

--- a/packages/hoppscotch-sh-admin/Caddyfile
+++ b/packages/hoppscotch-sh-admin/Caddyfile
@@ -1,4 +1,4 @@
-:8080 {
+:3100 {
   try_files {path} /
   root * /site
   file_server


### PR DESCRIPTION
Closes #3336

### Description

According to [documentation](https://docs.hoppscotch.io/documentation/self-host/community-edition/install-and-build#using-individual-containers-for-the-services), frontend runs on port 3000 and admin on port 3100. So Caddyfiles are wrong and this fixes it.

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
