### PR TITLE
feat: add client credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,23 +60,6 @@ services:
     ports:
       - "3100:8080"
 
-  # The service that spins up all 3 services at once in one container
-  hoppscotch-aio:
-    container_name: hoppscotch-aio
-    build:
-      dockerfile: prod.Dockerfile
-      context: .
-      target: aio
-    env_file:
-      - ./.env
-    depends_on:
-      hoppscotch-db:
-        condition: service_healthy
-    ports:
-      - "3000:3000"
-      - "3100:3100"
-      - "3170:3170"
-
   # The preset DB service, you can delete/comment the below lines if
   # you are using an external postgres instance
   # This will be exposed at port 5432
@@ -100,51 +83,3 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
-
-  # All the services listed below are deprececated
-  hoppscotch-old-backend:
-    container_name: hoppscotch-old-backend
-    build:
-      dockerfile: packages/hoppscotch-backend/Dockerfile
-      context: .
-      target: prod
-    env_file:
-      - ./.env
-    restart: always
-    environment:
-      # Edit the below line to match your PostgresDB URL if you have an outside DB (make sure to update the .env file as well)
-      - DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch?connect_timeout=300
-      - PORT=3000
-    volumes:
-      # Uncomment the line below when modifying code. Only applicable when using the "dev" target.
-      # - ./packages/hoppscotch-backend/:/usr/src/app
-      - /usr/src/app/node_modules/
-    depends_on:
-      hoppscotch-db:
-        condition: service_healthy
-    ports:
-      - "3170:3000"
-
-  hoppscotch-old-app:
-    container_name: hoppscotch-old-app
-    build:
-      dockerfile: packages/hoppscotch-selfhost-web/Dockerfile
-      context: .
-    env_file:
-      - ./.env
-    depends_on:
-      - hoppscotch-old-backend
-    ports:
-      - "3000:8080"
-
-  hoppscotch-old-sh-admin:
-    container_name: hoppscotch-old-sh-admin
-    build:
-      dockerfile: packages/hoppscotch-sh-admin/Dockerfile
-      context: .
-    env_file:
-      - ./.env
-    depends_on:
-      - hoppscotch-old-backend
-    ports:
-      - "3100:8080"

--- a/packages/hoppscotch-common/assets/scss/themes.scss
+++ b/packages/hoppscotch-common/assets/scss/themes.scss
@@ -43,15 +43,15 @@
 @mixin light-theme {
   --primary-color: theme("colors.white");
   --primary-light-color: theme("colors.gray.50");
-  --primary-dark-color: theme("colors.gray.100");
+  --primary-dark-color: theme("colors.gray.200");
   --primary-contrast-color: theme("colors.light.50");
 
   --secondary-color: theme("colors.gray.500");
   --secondary-light-color: theme("colors.gray.400");
-  --secondary-dark-color: theme("colors.gray.900");
+  --secondary-dark-color: theme("colors.neutral.900");
 
-  --divider-color: theme("colors.gray.100");
-  --divider-light-color: theme("colors.gray.100");
+  --divider-color: theme("colors.gray.200");
+  --divider-light-color: theme("colors.gray.400");
   --divider-dark-color: theme("colors.gray.300");
 
   --error-color: theme("colors.yellow.100");

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -118,7 +118,10 @@
     "password": "Password",
     "token": "Token",
     "type": "Authorization Type",
-    "username": "Username"
+    "username": "Username",
+    "grant_type": "Grant Type",
+    "code": "Authorization Code",
+    "client_credentials": "Client Credentials"
   },
   "collection": {
     "created": "Collection created",

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -10,14 +10,14 @@
         :class="styles"
         @click="emit('click', $event)"
         @keydown="handleKeystroke"
-        @focusin="showSuggestionPopover = true"
-      ></div>
+        ></div>
+        <!-- @focusin="showSuggestionPopover = true" -->
       <AppInspection
         :inspection-results="inspectionResults"
         class="sticky inset-y-0 right-0 bg-primary rounded-r"
       />
     </div>
-    <ul
+    <!-- <ul
       v-if="
         showSuggestionPopover && autoCompleteSource && suggestions.length > 0
       "
@@ -41,7 +41,7 @@
           <span class="ml-2 truncate">to select</span>
         </div>
       </li>
-    </ul>
+    </ul> -->
   </div>
 </template>
 

--- a/packages/hoppscotch-common/src/helpers/terndoc/pw-pre.json
+++ b/packages/hoppscotch-common/src/helpers/terndoc/pw-pre.json
@@ -7,5 +7,9 @@
       "getResolve": "fn(key: string) -> string",
       "resolve": "fn(value: string) -> string"
     }
+  },
+  "exp": {
+    "request": "fn(url: string, method: string, params: Object, headers: Object, token?: string) -> XMLHttpRequest",
+    "log": "fn(value: any) -> void"
   }
 }

--- a/packages/hoppscotch-common/src/index.ts
+++ b/packages/hoppscotch-common/src/index.ts
@@ -31,13 +31,4 @@ export function createHoppApp(el: string | Element, platformDef: PlatformDef) {
   platformDef.addedHoppModules?.forEach((mod) => mod.onVueAppInit?.(app))
 
   app.mount(el)
-
-  console.info(
-    "%cWE ♥️ OPEN SOURCE",
-    "margin:8px 0;font-family:sans-serif;font-weight:600;font-size:60px;color:violet;"
-  )
-  console.info(
-    "%cContribute: https://github.com/hoppscotch/hoppscotch",
-    "margin:8px 0;font-family:sans-serif;font-weight:500;font-size:24px;color:violet;"
-  )
 }

--- a/packages/hoppscotch-data/src/rest/HoppRESTAuth.ts
+++ b/packages/hoppscotch-data/src/rest/HoppRESTAuth.ts
@@ -18,6 +18,8 @@ export type HoppRESTAuthBearer = {
 export type HoppRESTAuthOAuth2 = {
   authType: "oauth-2"
 
+  grantType: "code" | "client_credentials"
+  clientCredentialsIn: "body" | "header"
   token: string
   oidcDiscoveryURL: string
   authURL: string


### PR DESCRIPTION
Closes https://github.com/hoppscotch/hoppscotch/issues/874 partially, supercedes https://github.com/hoppscotch/hoppscotch/pull/2209 and https://github.com/hoppscotch/hoppscotch/pull/3298

Description
This PR fixes and update this PR https://github.com/hoppscotch/hoppscotch/pull/3298 with updated main.
Adds the option to use the OAuth 2.0 Client Credentials flow.
Adds the option to send Oauth 2.0 Client Credentials in POST body or in Authorization Header.

![image](https://github.com/hoppscotch/hoppscotch/assets/82985065/fbbf5ce3-4d43-44f8-9d33-1037859cca01)


* [ ]  Nicer UI
* [ ]  Show 'Place client credentials in' option only if 'client credentials' is checked
* [ ]  Update docs
* [ ]  Update tests

### Checks
* [x]  My pull request adheres to the code style of this project
* [ ]  My code requires changes to the documentation
* [ ]  I have updated the documentation as required
* [ ]  All the tests have passed