### PR TITLE
fix: environment variables usage in meta tags

### DIFF
--- a/packages/hoppscotch-selfhost-web/meta.ts
+++ b/packages/hoppscotch-selfhost-web/meta.ts
@@ -36,7 +36,7 @@ export const META_TAGS = (env: Record<string, string>): IHTMLTag[] => [
   },
   {
     name: "image",
-    content: `${env.APP_BASE_URL}/banner.png`,
+    content: `${env.VITE_BASE_URL}/banner.png`,
   },
   // Open Graph tags
   {
@@ -49,7 +49,7 @@ export const META_TAGS = (env: Record<string, string>): IHTMLTag[] => [
   },
   {
     name: "og:image",
-    content: `${env.APP_BASE_URL}/banner.png`,
+    content: `${env.VITE_BASE_URL}/banner.png`,
   },
   // Twitter tags
   {
@@ -74,7 +74,7 @@ export const META_TAGS = (env: Record<string, string>): IHTMLTag[] => [
   },
   {
     name: "twitter:image",
-    content: `${env.APP_BASE_URL}/banner.png`,
+    content: `${env.VITE_BASE_URL}/banner.png`,
   },
   // Add to homescreen for Chrome on Android. Fallback for PWA (handled by nuxt)
   {
@@ -84,7 +84,7 @@ export const META_TAGS = (env: Record<string, string>): IHTMLTag[] => [
   // Windows phone tile icon
   {
     name: "msapplication-TileImage",
-    content: `${env.APP_BASE_URL}/icon.png`,
+    content: `${env.VITE_BASE_URL}/icon.png`,
   },
   {
     name: "msapplication-TileColor",


### PR DESCRIPTION
### Description

Currently, the `content` attribute for meta tags with the following name attributes resolves to `undefined` since they don't follow the expected format while referring to the base URL environment variable.

Fixes HFE-258.

- `image`
- `og:image`
- `twitter:image`
- `msapplication-TileImage`

This PR aims at fixing the usage across the meta entry definitions.

### Checks
<!-- Make sure your pull request passes the CI checks and check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed

### Additional Information
