### PR TITLE
fix(common): use tab service within helpers

### DIFF
--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -1,5 +1,6 @@
 import { GQLHeader, HoppGQLAuth, makeGQLRequest } from "@hoppscotch/data"
 import { OperationType } from "@urql/core"
+import * as E from "fp-ts/Either"
 import {
   GraphQLEnumType,
   GraphQLInputObjectType,
@@ -11,11 +12,12 @@ import {
   printSchema,
 } from "graphql"
 import { computed, reactive, ref } from "vue"
-import { addGraphqlHistoryEntry, makeGQLHistoryEntry } from "~/newstore/history"
-import { currentTabID } from "./tab"
 import { getService } from "~/modules/dioc"
+
+import { addGraphqlHistoryEntry, makeGQLHistoryEntry } from "~/newstore/history"
+
 import { InterceptorService } from "~/services/interceptor.service"
-import * as E from "fp-ts/Either"
+import { GQLTabService } from "~/services/tab/graphql"
 
 const GQL_SCHEMA_POLL_INTERVAL = 7000
 
@@ -60,6 +62,9 @@ type Connection = {
   socket: WebSocket | undefined
   schema: GraphQLSchema | null
 }
+
+const tabs = getService(GQLTabService)
+const currentTabID = computed(() => tabs.currentTabID.value)
 
 export const connection = reactive<Connection>({
   state: "DISCONNECTED",


### PR DESCRIPTION
### Description

With #3367, we moved away from helpers for tab-related functionalities to a service. However, there was a stale import that led to the build failure. This PR fixes it by replacing it with the service implementation. It also organizes imports used in the file.

### Checks
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed