### PR TITLE
refactor: updated dashboard gql queries and components to use the new infra type of the updated schema

### DIFF
--- a/packages/hoppscotch-sh-admin/src/components.d.ts
+++ b/packages/hoppscotch-sh-admin/src/components.d.ts
@@ -23,9 +23,14 @@ declare module '@vue/runtime-core' {
     HoppSmartItem: typeof import('@hoppscotch/ui')['HoppSmartItem'];
     HoppSmartModal: typeof import('@hoppscotch/ui')['HoppSmartModal'];
     HoppSmartPicture: typeof import('@hoppscotch/ui')['HoppSmartPicture'];
+    HoppSmartPlaceholder: typeof import('@hoppscotch/ui')['HoppSmartPlaceholder'];
     HoppSmartSpinner: typeof import('@hoppscotch/ui')['HoppSmartSpinner'];
+    HoppSmartTab: typeof import('@hoppscotch/ui')['HoppSmartTab'];
+    IconLucideArrowLeft: typeof import('~icons/lucide/arrow-left')['default'];
     IconLucideChevronDown: typeof import('~icons/lucide/chevron-down')['default'];
+    IconLucideHelpCircle: typeof import('~icons/lucide/help-circle')['default'];
     IconLucideInbox: typeof import('~icons/lucide/inbox')['default'];
+    IconLucideUser: typeof import('~icons/lucide/user')['default'];
     TeamsAdd: typeof import('./components/teams/Add.vue')['default'];
     TeamsDetails: typeof import('./components/teams/Details.vue')['default'];
     TeamsInvite: typeof import('./components/teams/Invite.vue')['default'];

--- a/packages/hoppscotch-sh-admin/src/components/teams/Details.vue
+++ b/packages/hoppscotch-sh-admin/src/components/teams/Details.vue
@@ -79,7 +79,7 @@ const t = useI18n();
 const toast = useToast();
 
 const props = defineProps<{
-  team: TeamInfoQuery['admin']['teamInfo'];
+  team: TeamInfoQuery['infra']['teamInfo'];
   teamName: string;
   showRenameInput: boolean;
 }>();

--- a/packages/hoppscotch-sh-admin/src/components/teams/Invite.vue
+++ b/packages/hoppscotch-sh-admin/src/components/teams/Invite.vue
@@ -213,11 +213,11 @@ const t = useI18n();
 
 // Get Users List
 const { data } = useQuery({ query: MetricsDocument });
-const usersPerPage = computed(() => data.value?.admin.usersCount || 10000);
+const usersPerPage = computed(() => data.value?.infra.usersCount || 10000);
 
 const { list: usersList } = usePagedQuery(
   UsersListDocument,
-  (x) => x.admin.allUsers,
+  (x) => x.infra.allUsers,
   (x) => x.uid,
   usersPerPage.value,
   { cursor: undefined, take: usersPerPage.value }

--- a/packages/hoppscotch-sh-admin/src/components/teams/Members.vue
+++ b/packages/hoppscotch-sh-admin/src/components/teams/Members.vue
@@ -187,7 +187,7 @@ const emit = defineEmits<{
 const showInvite = ref(false);
 
 // Get Team Details
-const team = ref<TeamInfoQuery['admin']['teamInfo'] | undefined>();
+const team = ref<TeamInfoQuery['infra']['teamInfo'] | undefined>();
 const fetching = ref(true);
 const route = useRoute();
 const { client } = useClientHandle();
@@ -201,8 +201,8 @@ const getTeamInfo = async () => {
   if (result.error) {
     return toast.error(`${t('teams.load_info_error')}`);
   }
-  if (result.data?.admin.teamInfo) {
-    team.value = result.data.admin.teamInfo;
+  if (result.data?.infra.teamInfo) {
+    team.value = result.data.infra.teamInfo;
   }
   fetching.value = false;
 };

--- a/packages/hoppscotch-sh-admin/src/components/teams/PendingInvites.vue
+++ b/packages/hoppscotch-sh-admin/src/components/teams/PendingInvites.vue
@@ -72,9 +72,9 @@ const fetching = ref(true);
 const error = ref(false);
 const { client } = useClientHandle();
 const route = useRoute();
-const team = ref<TeamInfoQuery['admin']['teamInfo'] | undefined>();
+const team = ref<TeamInfoQuery['infra']['teamInfo'] | undefined>();
 const pendingInvites = ref<
-  TeamInfoQuery['admin']['teamInfo']['teamInvitations'] | undefined
+  TeamInfoQuery['infra']['teamInfo']['teamInvitations'] | undefined
 >();
 
 const getTeamInfo = async () => {
@@ -88,8 +88,8 @@ const getTeamInfo = async () => {
     return toast.error(`${t('teams.load_info_error')}`);
   }
 
-  if (result.data?.admin.teamInfo) {
-    team.value = result.data.admin.teamInfo;
+  if (result.data?.infra.teamInfo) {
+    team.value = result.data.infra.teamInfo;
     pendingInvites.value = team.value.teamInvitations;
   }
   fetching.value = false;

--- a/packages/hoppscotch-sh-admin/src/components/teams/Table.vue
+++ b/packages/hoppscotch-sh-admin/src/components/teams/Table.vue
@@ -92,7 +92,7 @@ import { TeamListQuery } from '~/helpers/backend/graphql';
 const tippyActions = ref<TippyComponent | null>(null);
 
 defineProps<{
-  teamList: TeamListQuery['admin']['allTeams'];
+  teamList: TeamListQuery['infra']['allTeams'];
 }>();
 
 defineEmits<{

--- a/packages/hoppscotch-sh-admin/src/components/users/Table.vue
+++ b/packages/hoppscotch-sh-admin/src/components/users/Table.vue
@@ -143,7 +143,7 @@ import { useI18n } from '~/composables/i18n';
 const t = useI18n();
 
 defineProps<{
-  usersList: UsersListQuery['admin']['allUsers'];
+  usersList: UsersListQuery['infra']['allUsers'];
 }>();
 
 defineEmits<{

--- a/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/InvitedUsers.graphql
+++ b/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/InvitedUsers.graphql
@@ -1,5 +1,5 @@
 query InvitedUsers {
-  admin {
+  infra {
     invitedUsers {
       adminUid
       adminEmail

--- a/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/Metrics.graphql
+++ b/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/Metrics.graphql
@@ -1,5 +1,5 @@
 query Metrics {
-  admin {
+  infra {
     usersCount
     teamsCount
     teamRequestsCount

--- a/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/TeamInfo.graphql
+++ b/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/TeamInfo.graphql
@@ -1,5 +1,5 @@
 query TeamInfo($teamID: ID!) {
-  admin {
+  infra {
     teamInfo(teamID: $teamID) {
       id
       name

--- a/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/TeamList.graphql
+++ b/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/TeamList.graphql
@@ -1,5 +1,5 @@
 query TeamList($cursor: ID, $take: Int) {
-  admin {
+  infra {
     allTeams(cursor: $cursor, take: $take) {
       id
       name

--- a/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/UserInfo.graphql
+++ b/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/UserInfo.graphql
@@ -1,5 +1,5 @@
 query UserInfo($uid: ID!) {
-  admin {
+  infra {
     userInfo(userUid: $uid) {
       uid
       displayName

--- a/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/UsersList.graphql
+++ b/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/UsersList.graphql
@@ -1,6 +1,6 @@
 # Write your query or mutation here
 query UsersList($cursor: ID, $take: Int) {
-  admin {
+  infra {
     allUsers(cursor: $cursor, take: $take) {
       uid
       displayName

--- a/packages/hoppscotch-sh-admin/src/pages/dashboard.vue
+++ b/packages/hoppscotch-sh-admin/src/pages/dashboard.vue
@@ -57,5 +57,5 @@ const t = useI18n();
 
 // Get Metrics Data
 const { fetching, error, data } = useQuery({ query: MetricsDocument });
-const metrics = computed(() => data?.value?.admin);
+const metrics = computed(() => data?.value?.infra);
 </script>

--- a/packages/hoppscotch-sh-admin/src/pages/teams/_id.vue
+++ b/packages/hoppscotch-sh-admin/src/pages/teams/_id.vue
@@ -91,7 +91,7 @@ const currentTabName = computed(() => {
 });
 
 // Get the details of the team
-const team = ref<TeamInfoQuery['admin']['teamInfo'] | undefined>();
+const team = ref<TeamInfoQuery['infra']['teamInfo'] | undefined>();
 const teamName = ref('');
 const route = useRoute();
 const fetching = ref(true);
@@ -105,8 +105,8 @@ const getTeamInfo = async () => {
   if (result.error) {
     return toast.error(`${t('team.load_info_error')}`);
   }
-  if (result.data?.admin.teamInfo) {
-    team.value = result.data.admin.teamInfo;
+  if (result.data?.infra.teamInfo) {
+    team.value = result.data.infra.teamInfo;
     teamName.value = team.value.name;
   }
   fetching.value = false;

--- a/packages/hoppscotch-sh-admin/src/pages/teams/index.vue
+++ b/packages/hoppscotch-sh-admin/src/pages/teams/index.vue
@@ -77,11 +77,11 @@ const t = useI18n();
 const toast = useToast();
 // Get Users List
 const { data } = useQuery({ query: MetricsDocument });
-const usersPerPage = computed(() => data.value?.admin.usersCount || 10000);
+const usersPerPage = computed(() => data.value?.infra.usersCount || 10000);
 
 const { list: usersList } = usePagedQuery(
   UsersListDocument,
-  (x) => x.admin.allUsers,
+  (x) => x.infra.allUsers,
   (x) => x.uid,
   usersPerPage.value,
   { cursor: undefined, take: usersPerPage.value }
@@ -100,7 +100,7 @@ const {
   hasNextPage,
 } = usePagedQuery(
   TeamListDocument,
-  (x) => x.admin.allTeams,
+  (x) => x.infra.allTeams,
   (x) => x.id,
   teamsPerPage,
   { cursor: undefined, take: teamsPerPage }

--- a/packages/hoppscotch-sh-admin/src/pages/users/_id.vue
+++ b/packages/hoppscotch-sh-admin/src/pages/users/_id.vue
@@ -179,7 +179,7 @@ onMounted(async () => {
   if (result.error) {
     toast.error(`${t('users.load_info_error')}`);
   }
-  user.value = result.data?.admin.userInfo ?? {};
+  user.value = result.data?.infra.userInfo ?? {};
   fetching.value = false;
 });
 

--- a/packages/hoppscotch-sh-admin/src/pages/users/index.vue
+++ b/packages/hoppscotch-sh-admin/src/pages/users/index.vue
@@ -112,7 +112,7 @@ const {
   hasNextPage,
 } = usePagedQuery(
   UsersListDocument,
-  (x) => x.admin.allUsers,
+  (x) => x.infra.allUsers,
   (x) => x.uid,
   usersPerPage,
   { cursor: undefined, take: usersPerPage }

--- a/packages/hoppscotch-sh-admin/src/pages/users/invited.vue
+++ b/packages/hoppscotch-sh-admin/src/pages/users/invited.vue
@@ -101,5 +101,5 @@ const getCreatedTime = (date: string) => format(new Date(date), 'hh:mm a');
 
 // Get Invited Users
 const { fetching, error, data } = useQuery({ query: InvitedUsersDocument });
-const invitedUsers = computed(() => data?.value?.admin.invitedUsers);
+const invitedUsers = computed(() => data?.value?.infra.invitedUsers);
 </script>


### PR DESCRIPTION
### Ticket

- Closes HFE-286
- Dependent on #3445 

### Description
This PR focuses on updating the backend gql queries and the components used in the Admin Dashboard to now use `infra` type instead of the previously used `admin` type because of the new schema change in the backend.

### Objectives
- [x] Update GQL Queries in the Admin Dashboard to now use `infra` type.
- [x] Update components in the Dashboard to now use and refer to the new `infra` type instead of `admin` type.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed