### PR TITLE
fix(self-hosted/web): add "useCredentials: true" to Vite PWA options

### DIFF
--- a/packages/hoppscotch-selfhost-web/vite.config.ts
+++ b/packages/hoppscotch-selfhost-web/vite.config.ts
@@ -147,6 +147,7 @@ export default defineConfig({
       },
     }),
     VitePWA({
+      useCredentials: true,
       manifest: {
         name: APP_INFO.name,
         short_name: APP_INFO.name,


### PR DESCRIPTION
### Description
Set useCredentials: true in Vite PWA options to prevent 401 errors when accessing the app with a basic HTTP auth.

When using a Basic HTTP Authentication, Google Chrome reports 401 errors when trying to fetch the manifest:  
![image](https://github.com/hoppscotch/hoppscotch/assets/2478146/760a24b3-ba16-4e91-a860-274eb5ad54c3)

Vite PWA docs FAQ recommend to use the `useCredentials` option: https://vite-pwa-org.netlify.app/guide/faq.html#web-app-manifest-and-401-status-code-unauthorized.  

This PR does only that.  

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code **does not** require changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
This should have no impact except avoiding 401 errors for the manifest.  

A workaround is to open the manifest file in a new tab, then reload the UI, but having this option would make it much easier.  