### PR TITLE
docs: add one-click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
   <p>
 
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen?logo=github)](CODE_OF_CONDUCT.md) [![Website](https://img.shields.io/website?url=https%3A%2F%2Fhoppscotch.io&logo=hoppscotch)](https://hoppscotch.io) [![Tests](https://github.com/hoppscotch/hoppscotch/actions/workflows/tests.yml/badge.svg)](https://github.com/hoppscotch/hoppscotch/actions) [![Tweet](https://img.shields.io/twitter/url?url=https%3A%2F%2Fhoppscotch.io%2F)](https://twitter.com/share?text=%F0%9F%91%BD%20Hoppscotch%20%E2%80%A2%20Open%20source%20API%20development%20ecosystem%20-%20Helps%20you%20create%20requests%20faster,%20saving%20precious%20time%20on%20development.&url=https://hoppscotch.io&hashtags=hoppscotch&via=hoppscotch_io)
+<br>
+[![Deploy To Dome](https://trydome.io/dome-badge.svg)](https://app.trydome.io/signup?package=hoppscotch)
 
   </p>
   <p>
@@ -264,6 +266,12 @@ _Add-ons are developed and maintained under **[Hoppscotch Organization](https://
 ## **Developing**
 
 Follow our [self-hosting documentation](https://docs.hoppscotch.io/documentation/self-host/getting-started) to get started with the development environment.
+
+## Deploying
+
+Deploy the self-hosted version of Hoppscotch with a free trial on Dome with [one-click](https://app.trydome.io/signup?package=hoppscotch):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=hoppscotch)
 
 ## **Contributing**
 


### PR DESCRIPTION
### Description
Adds [one-click deploy](https://app.trydome.io/signup?package=hoppscotch) with Dome to readme

### Checks
- [X ] My pull request adheres to the code style of this project
- [ X] My code requires changes to the documentation
- [ X] I have updated the documentation as required
- [ X] All the tests have passed
