### PR TITLE
fix(common): parentheses and single quotes support to curl imports

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
@@ -49,7 +49,12 @@ const parseURL = (urlText: string | number) =>
     urlText,
     O.fromNullable,
     // preprocess url string
-    O.map((u) => u.toString().replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;\s]/g, "")),
+    O.map((u) =>
+      u
+        .toString()
+        .replace(/^'|'$/g, "")
+        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'\s]/g, "")
+    ),
     O.filter((u) => u.length > 0),
     O.chain((u) =>
       pipe(


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3485 

### Description
Added parentheses and single quotes support to importing from curl. Changed the regex to include the parentheses and single quotes. Before that the single quotes existing at the start and end of URL are removed using `replace(/^'|'$/g, "")`. Also ran a lint fix.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
[Screencast from 08-11-23 09:45:44 PM IST.webm](https://github.com/hoppscotch/hoppscotch/assets/55492635/106f9057-24e1-48b2-a70d-ba98615d3674)
