### PR TITLE
refactor: allow banner service to hold multiple banners and display the banner with the highest score

### DIFF
--- a/packages/hoppscotch-common/src/components/app/Banner.vue
+++ b/packages/hoppscotch-common/src/components/app/Banner.vue
@@ -8,10 +8,10 @@
 
     <span class="text-white">
       <span v-if="banner.alternateText" class="md:hidden">
-        {{ banner.alternateText }}
+        {{ banner.alternateText(t) }}
       </span>
-      <span class="<md:hidden">
-        {{ banner.text }}
+      <span :class="banner.alternateText ? '<md:hidden' : ''">
+        {{ banner.text(t) }}
       </span>
     </span>
   </div>
@@ -19,8 +19,8 @@
 
 <script setup lang="ts">
 import { computed } from "vue"
-
 import { BannerContent, BannerType } from "~/services/banner.service"
+import { useI18n } from "@composables/i18n"
 
 import IconAlertCircle from "~icons/lucide/alert-circle"
 import IconAlertTriangle from "~icons/lucide/alert-triangle"
@@ -29,6 +29,8 @@ import IconInfo from "~icons/lucide/info"
 const props = defineProps<{
   banner: BannerContent
 }>()
+
+const t = useI18n()
 
 const ariaRoles: Record<BannerType, string> = {
   error: "alert",

--- a/packages/hoppscotch-common/src/components/app/Header.vue
+++ b/packages/hoppscotch-common/src/components/app/Header.vue
@@ -289,7 +289,7 @@ const breakpoints = useBreakpoints(breakpointsTailwind)
 const mdAndLarger = breakpoints.greater("md")
 
 const banner = useService(BannerService)
-const network = reactive(useNetwork())
+const bannerContent = computed(() => banner.content.value?.content)
 let bannerID: number | null = null
 
 const offlineBanner: BannerContent = {
@@ -299,8 +299,10 @@ const offlineBanner: BannerContent = {
   score: BANNER_PRIORITY_HIGH,
 }
 
+const network = reactive(useNetwork())
 const isOnline = computed(() => network.isOnline)
 
+// Show the offline banner if the user is offline
 watch(isOnline, () => {
   if (!isOnline.value) {
     bannerID = banner.showBanner(offlineBanner)
@@ -311,8 +313,6 @@ watch(isOnline, () => {
     }
   }
 })
-
-const bannerContent = computed(() => banner.content.value?.content)
 
 const currentUser = useReadonlyStream(
   platform.auth.getProbableUserStream(),

--- a/packages/hoppscotch-common/src/services/__tests__/banner.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/banner.service.spec.ts
@@ -10,7 +10,7 @@ import {
 
 describe("BannerService", () => {
   const container = new TestContainer()
-  const bannerService = container.bind(BannerService)
+  const banner = container.bind(BannerService)
 
   it("should be able to show and remove a banner", () => {
     const bannerContent: BannerContent = {
@@ -19,14 +19,14 @@ describe("BannerService", () => {
       score: BANNER_PRIORITY_LOW,
     }
 
-    const bannerId = bannerService.showBanner(bannerContent)
-    expect(bannerService.content.value).toEqual({
+    const bannerId = banner.showBanner(bannerContent)
+    expect(banner.content.value).toEqual({
       id: bannerId,
       content: bannerContent,
     })
 
-    bannerService.removeBanner(bannerId)
-    expect(bannerService.content.value).toBeNull()
+    banner.removeBanner(bannerId)
+    expect(banner.content.value).toBeNull()
   })
 
   it("should show the banner with the highest score", () => {
@@ -42,9 +42,12 @@ describe("BannerService", () => {
       score: BANNER_PRIORITY_HIGH,
     }
 
-    bannerService.showBanner(lowPriorityBanner)
-    bannerService.showBanner(highPriorityBanner)
+    banner.showBanner(lowPriorityBanner)
+    const highPriorityBannerID = banner.showBanner(highPriorityBanner)
 
-    expect(bannerService.content.value?.content).toEqual(highPriorityBanner)
+    expect(banner.content.value).toEqual({
+      id: highPriorityBannerID,
+      content: highPriorityBanner,
+    })
   })
 })

--- a/packages/hoppscotch-common/src/services/__tests__/banner.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/banner.service.spec.ts
@@ -1,38 +1,50 @@
 import { describe, expect, it } from "vitest"
-import { BannerContent, BannerService } from "../banner.service"
 import { TestContainer } from "dioc/testing"
+import { getI18n } from "~/modules/i18n"
+import {
+  BannerService,
+  BANNER_PRIORITY_LOW,
+  BANNER_PRIORITY_HIGH,
+  BannerContent,
+} from "../banner.service"
 
 describe("BannerService", () => {
   const container = new TestContainer()
-  const service = container.bind(BannerService)
+  const bannerService = container.bind(BannerService)
 
-  it("initally there are no banners defined", () => {
-    expect(service.content.value).toEqual(null)
-  })
-
-  it("should be able to set and retrieve banner content", () => {
-    const sampleBanner: BannerContent = {
+  it("should be able to show and remove a banner", () => {
+    const bannerContent: BannerContent = {
       type: "info",
-      text: "Info Banner",
+      text: (t: ReturnType<typeof getI18n>) => t("Info Banner"),
+      score: BANNER_PRIORITY_LOW,
     }
 
-    const banner = service.content
-    banner.value = sampleBanner
-    const retrievedBanner = service.content.value
+    const bannerId = bannerService.showBanner(bannerContent)
+    expect(bannerService.content.value).toEqual({
+      id: bannerId,
+      content: bannerContent,
+    })
 
-    expect(retrievedBanner).toEqual(sampleBanner)
+    bannerService.removeBanner(bannerId)
+    expect(bannerService.content.value).toBeNull()
   })
 
-  it("should be able to update the banner content", () => {
-    const updatedBanner: BannerContent = {
-      type: "warning",
-      text: "Updated Banner Content",
-      alternateText: "Updated Banner",
+  it("should show the banner with the highest score", () => {
+    const lowPriorityBanner: BannerContent = {
+      type: "info",
+      text: (t: ReturnType<typeof getI18n>) => t("Low Priority Banner"),
+      score: BANNER_PRIORITY_LOW,
     }
 
-    service.content.value = updatedBanner
-    const retrievedBanner = service.content.value
+    const highPriorityBanner: BannerContent = {
+      type: "warning",
+      text: (t: ReturnType<typeof getI18n>) => t("High Priority Banner"),
+      score: BANNER_PRIORITY_HIGH,
+    }
 
-    expect(retrievedBanner).toEqual(updatedBanner)
+    bannerService.showBanner(lowPriorityBanner)
+    bannerService.showBanner(highPriorityBanner)
+
+    expect(bannerService.content.value?.content).toEqual(highPriorityBanner)
   })
 })


### PR DESCRIPTION
### Ticket
Closes HFE-317

### Description
This PR focuses on allowing the banner service to handle multiple banners. Currently, the service can hold only one banner at a time. However, there can be instances where multiple services or components may access the banner at the same time. This is solved by allowing the banner service to hold multiple banners and display the banner which has the highest priority score.

### Objectives
- [x] The Banner Service should be able to hold multiple banners instead of one.
- [x] The Banner Service should display the banner which has the highest score value.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed