### PR TITLE
Extend Github Oauth2 Strategy for use with Github Enterprise

### DIFF
--- a/packages/hoppscotch-backend/src/auth/strategies/github.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/github.strategy.ts
@@ -13,6 +13,10 @@ export class GithubStrategy extends PassportStrategy(Strategy) {
     private usersService: UserService,
   ) {
     super({
+      authorizationURL: process.env.GITHUB_AUTHORIZATION_URL,
+      tokenURL: process.env.GITHUB_TOKEN_URL,
+      userProfileURL: process.env.GITHUB_USER_PROFILE_URL,
+      userEmailURL: process.env.GITHUB_USER_EMAIL_URL,
       clientID: process.env.GITHUB_CLIENT_ID,
       clientSecret: process.env.GITHUB_CLIENT_SECRET,
       callbackURL: process.env.GITHUB_CALLBACK_URL,


### PR DESCRIPTION
### Description
The GitHub Oauth2 SSO strategy is built on top of the [passport-github2 package](https://www.npmjs.com/package/passport-github2). That package, by default, is configured to use public GitHub as the identity provider:
[Authorization URL Setting](https://github.com/cfsghost/passport-github/blob/6c4e593ca4557ab841bae87378037a1379e35c26/lib/strategy.js#L53)
[Token URL Setting](https://github.com/cfsghost/passport-github/blob/6c4e593ca4557ab841bae87378037a1379e35c26/lib/strategy.js#L54)
[User Profile URL Setting](https://github.com/cfsghost/passport-github/blob/6c4e593ca4557ab841bae87378037a1379e35c26/lib/strategy.js#L64)
[User Email URL Setting](https://github.com/cfsghost/passport-github/blob/6c4e593ca4557ab841bae87378037a1379e35c26/lib/strategy.js#L65)

However, those defaults can be overridden so that an instance of GitHub Enterprise server can be used as the identity provider.
The purpose of this PR is to enable that by setting the following environment variables:
- `GITHUB_AUTHORIZATION_URL`: Authorization endpoint. 
- `GITHUB_TOKEN_URL`: Endpoint to retrieve access token. 
- `GITHUB_USER_PROFILE_URL`: Endpoint to retrieve general user info (e.g., full name).
- `GITHUB_USER_EMAIL_URL`: Endpoint to retrieve user emails.

Sample configuration:
```
# New configuration settings================================================
GITHUB_AUTHORIZATION_URL=https://{{ENTERPRISE_INSTANCE_HOST_NAME}}/login/oauth/authorize
GITHUB_TOKEN_URL=https://{{ENTERPRISE_INSTANCE_HOST_NAME}}/login/oauth/access_token
GITHUB_USER_PROFILE_URL=https:/{{ENTERPRISE_INSTANCE_HOST_NAME}}/api/v3/user
GITHUB_USER_EMAIL_URL=https://{{ENTERPRISE_INSTANCE_HOST_NAME}}/api/v3/user/emails

# Configuration settings that remain unchanged in meaning============================= 
GITHUB_CLIENT_ID=*****************************************
GITHUB_CLIENT_SECRET=*****************************************
GITHUB_CALLBACK_URL=http://localhost:3170/v1/auth/github/callback
GITHUB_SCOPE="user:email"
```

The changes introduced in this PR are completed backwards compatible. As such, if if the intent is to use public Github as the identity provider, nothing changes. However, to use an isntance of Gihub Enterprise as the identity provider, the environment variables listed above must be set appropriately. 


### Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
[PR](https://www.npmjs.com/package/passport-github2) to update documentation.
