### PR TITLE
feat: embeds

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -434,7 +434,7 @@
     "confirm": "Confirm",
     "customize_request": "Customize Request",
     "edit_request": "Edit Request",
-    "share_request":"Share Request",
+    "share_request": "Share Request",
     "import_export": "Import / Export"
   },
   "mqtt": {
@@ -623,30 +623,30 @@
     "additional": "Additional Settings",
     "verify_email": "Verify email"
   },
-  "shared_requests":{
-    "button":"Button",
+  "shared_requests": {
+    "button": "Button",
     "button_info": "Create a 'Run in Hoppscotch' button for your website, blog or a README.",
     "customize": "Customize",
     "creating_widget": "Creating widget",
     "copy_html": "Copy HTML",
     "copy_link": "Copy Link",
     "copy_markdown": "Copy Markdown",
-    "deleted":"Shared request deleted",
+    "deleted": "Shared request deleted",
     "description": "Select a widget, you can change and customize this later",
-    "embed":"Embed",
+    "embed": "Embed",
     "embed_info": "Add a mini 'Hoppscotch API Playground' to your website, blog or documentation.",
-    "link":"Link",
+    "link": "Link",
     "link_info": "Create a shareable link to share with anyone on the internet with view access.",
     "modified": "Shared request modified",
-    "not_found":"Shared request not found",
+    "not_found": "Shared request not found",
     "open_new_tab": "Open in new tab",
-    "preview":"Preview",
-    "run_in_hoppscotch":"Run in Hoppscotch",
-    "theme":{
-      "dark":"Dark",
-      "light":"Light",
-      "system" :"System",
-      "title":"Theme"
+    "preview": "Preview",
+    "run_in_hoppscotch": "Run in Hoppscotch",
+    "theme": {
+      "dark": "Dark",
+      "light": "Light",
+      "system": "System",
+      "title": "Theme"
     }
   },
   "shortcut": {
@@ -692,7 +692,7 @@
       "save_to_collections": "Save to Collections",
       "send_request": "Send Request",
       "show_code": "Generate code snippet",
-      "share_request":"Share Request",
+      "share_request": "Share Request",
       "title": "Request"
     },
     "response": {

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -432,6 +432,7 @@
     "close_unsaved_tab": "You have unsaved changes",
     "collections": "Collections",
     "confirm": "Confirm",
+    "customize_request": "Customize Request",
     "edit_request": "Edit Request",
     "share_request":"Share Request",
     "import_export": "Import / Export"
@@ -636,6 +637,7 @@
     "embed_info": "Add a mini 'Hoppscotch API Playground' to your website, blog or documentation.",
     "link":"Link",
     "link_info": "Create a shareable link to share with anyone on the internet with view access.",
+    "modified": "Shared request modified",
     "not_found":"Shared request not found",
     "open_new_tab": "Open in new tab",
     "preview":"Preview",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -96,6 +96,7 @@
     "keyboard_shortcuts": "Keyboard shortcuts",
     "name": "Hoppscotch",
     "new_version_found": "New version found. Refresh to update.",
+    "open_in_hoppscotch": "Open in Hoppscotch",
     "options": "Options",
     "proxy_privacy_policy": "Proxy privacy policy",
     "reload": "Reload",

--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -61,6 +61,7 @@ declare module 'vue' {
     CollectionsTeamCollections: typeof import('./components/collections/TeamCollections.vue')['default']
     CookiesAllModal: typeof import('./components/cookies/AllModal.vue')['default']
     CookiesEditCookie: typeof import('./components/cookies/EditCookie.vue')['default']
+    Embeds: typeof import('./components/embeds/index.vue')['default']
     Environments: typeof import('./components/environments/index.vue')['default']
     EnvironmentsAdd: typeof import('./components/environments/Add.vue')['default']
     EnvironmentsImportExport: typeof import('./components/environments/ImportExport.vue')['default']

--- a/packages/hoppscotch-common/src/components/embeds/index.vue
+++ b/packages/hoppscotch-common/src/components/embeds/index.vue
@@ -96,6 +96,7 @@
       <HttpRequestOptions
         v-model="tab.document.request"
         v-model:option-tab="selectedOptionTab"
+        :properties="properties"
       />
     </div>
 
@@ -131,7 +132,7 @@ const props = defineProps<{
 
 const tab = useModel(props, "modelTab")
 
-const selectedOptionTab = ref("params")
+const selectedOptionTab = ref(props.properties[0])
 
 console.log("request", tab.value.document.request)
 

--- a/packages/hoppscotch-common/src/components/embeds/index.vue
+++ b/packages/hoppscotch-common/src/components/embeds/index.vue
@@ -7,7 +7,8 @@
         <HoppButtonSecondary
           class="!font-bold uppercase tracking-wide !text-secondaryDark hover:bg-primaryDark focus-visible:bg-primaryDark"
           :label="t('app.name')"
-          to="/"
+          to="https://hoppscotch.io/"
+          blank
         />
         <div class="flex">
           <HoppSmartItem
@@ -27,66 +28,43 @@
           class="min-w-52 flex flex-1 whitespace-nowrap rounded border border-divider"
         >
           <div class="relative flex">
-            <label for="method">
-              <tippy
-                interactive
-                trigger="click"
-                theme="popover"
-                :on-shown="() => methodTippyActions?.focus()"
-              >
-                <span class="select-wrapper">
-                  <input
-                    id="method"
-                    class="flex w-26 cursor-pointer rounded-l bg-primaryLight px-4 py-2 font-semibold text-secondaryDark transition"
-                    :value="tab.document.request.method"
-                    :readonly="!isCustomMethod"
-                    :placeholder="`${t('request.method')}`"
-                    @input="onSelectMethod($event)"
-                  />
-                </span>
-                <template #content="{ hide }">
-                  <div
-                    ref="methodTippyActions"
-                    class="flex flex-col focus:outline-none"
-                    tabindex="0"
-                    @keyup.escape="hide()"
-                  >
-                    <HoppSmartItem
-                      v-for="(method, index) in methods"
-                      :key="`method-${index}`"
-                      :label="method"
-                      @click="
-                        () => {
-                          updateMethod(method)
-                          hide()
-                        }
-                      "
-                    />
-                  </div>
-                </template>
-              </tippy>
-            </label>
+            <span
+              class="flex justify-center items-center w-26 cursor-pointer rounded-l bg-primaryLight px-4 py-2 font-semibold text-secondaryDark transition"
+            >
+              {{ tab.document.request.method }}
+            </span>
           </div>
           <div
             class="flex flex-1 whitespace-nowrap rounded-r border-l border-divider bg-primaryLight transition"
           >
-            <SmartEnvInput
-              v-model="tab.document.request.endpoint"
-              :placeholder="`${t('request.url')}`"
-              @enter="newSendRequest"
+            <input
+              name="method"
+              :value="tab.document.request.endpoint"
+              class="flex-1 px-4 bg-primary"
+              disabled
             />
           </div>
         </div>
         <div class="mt-2 flex sm:mt-0">
           <HoppButtonPrimary
             id="send"
-            v-tippy="{ theme: 'tooltip', delay: [500, 20], allowHTML: true }"
             :title="`${t(
               'action.send'
             )} <kbd>${getSpecialKey()}</kbd><kbd>↩</kbd>`"
             :label="`${!loading ? t('action.send') : t('action.cancel')}`"
             class="min-w-20 flex-1"
             @click="!loading ? newSendRequest() : cancelRequest()"
+          />
+          <HoppButtonSecondary
+            :title="`${t(
+              'request.save'
+            )} <kbd>${getSpecialKey()}</kbd><kbd>S</kbd>`"
+            :label="t('request.save')"
+            filled
+            :icon="IconSave"
+            class="flex-1 rounded rounded-r-none"
+            blank
+            :to="sharedRequestURL"
           />
         </div>
       </div>
@@ -106,7 +84,6 @@
 import { Ref } from "vue"
 import { computed, useModel } from "vue"
 import { ref } from "vue"
-import { TippyComponent } from "vue-tippy"
 import { useI18n } from "~/composables/i18n"
 import { useToast } from "~/composables/toast"
 import { getPlatformSpecialKey as getSpecialKey } from "~/helpers/platformutils"
@@ -116,7 +93,7 @@ import { HoppRESTResponse } from "~/helpers/types/HoppRESTResponse"
 import { runRESTRequest$ } from "~/helpers/RequestRunner"
 import { HoppTab } from "~/services/tab"
 import { HoppRESTDocument } from "~/helpers/rest/document"
-
+import IconSave from "~icons/lucide/save"
 const t = useI18n()
 const toast = useToast()
 
@@ -139,29 +116,7 @@ const sharedRequestURL = computed(() => {
   return `${baseURL}/r/${props.sharedRequestID}`
 })
 
-const methods = [
-  "GET",
-  "POST",
-  "PUT",
-  "PATCH",
-  "DELETE",
-  "HEAD",
-  "CONNECT",
-  "OPTIONS",
-  "TRACE",
-  "CUSTOM",
-]
-
 const { subscribeToStream } = useStreamSubscriber()
-
-const updateMethod = (method: string) => {
-  tab.value.document.request.method = method
-}
-
-const onSelectMethod = (e: Event | any) => {
-  // type any because of value property not being recognized by TS in the event.target object. It is a valid property though.
-  updateMethod(e.target.value)
-}
 
 const newSendRequest = async () => {
   if (newEndpoint.value === "" || /^\s+$/.test(newEndpoint.value)) {
@@ -254,11 +209,4 @@ const cancelRequest = () => {
 
   updateRESTResponse(null)
 }
-
-const isCustomMethod = computed(() => {
-  return tab.value.document.request.method === "CUSTOM"
-})
-
-// Template refs
-const methodTippyActions = ref<TippyComponent | null>(null)
 </script>

--- a/packages/hoppscotch-common/src/components/embeds/index.vue
+++ b/packages/hoppscotch-common/src/components/embeds/index.vue
@@ -10,7 +10,11 @@
           to="/"
         />
         <div class="flex">
-          <HoppSmartItem :label="t('app.open_in_hoppscotch')" />
+          <HoppSmartItem
+            :label="t('app.open_in_hoppscotch')"
+            :to="sharedRequestURL"
+            blank
+          />
         </div>
       </div>
     </header>
@@ -96,7 +100,6 @@
     </div>
 
     <div>
-      {{ tab.document.response }}
       <HttpResponse :document="tab.document" />
     </div>
   </div>
@@ -122,6 +125,8 @@ const toast = useToast()
 
 const props = defineProps<{
   modelTab: HoppTab<HoppRESTDocument>
+  properties: string[]
+  sharedRequestID: string
 }>()
 
 const tab = useModel(props, "modelTab")
@@ -133,6 +138,11 @@ console.log("request", tab.value.document.request)
 const requestCancelFunc: Ref<(() => void) | null> = ref(null)
 
 const loading = ref(false)
+
+const baseURL = import.meta.env.VITE_SHORTCODE_BASE_URL ?? "https://hopp.sh"
+const sharedRequestURL = computed(() => {
+  return `${baseURL}/r/${props.sharedRequestID}`
+})
 
 const methods = [
   "GET",

--- a/packages/hoppscotch-common/src/components/embeds/index.vue
+++ b/packages/hoppscotch-common/src/components/embeds/index.vue
@@ -100,7 +100,7 @@
     </div>
 
     <div>
-      <HttpResponse :document="tab.document" />
+      <HttpResponse :document="tab.document" :is-embed="true" />
     </div>
   </div>
 </template>

--- a/packages/hoppscotch-common/src/components/embeds/index.vue
+++ b/packages/hoppscotch-common/src/components/embeds/index.vue
@@ -21,7 +21,7 @@
 
     <div class="flex-1">
       <div
-        class="top-0 z-20 flex-none flex-shrink-0 bg-primary p-4 sm:flex sm:flex-shrink-0 sm:space-x-2"
+        class="flex-none flex-shrink-0 bg-primary p-4 sm:flex sm:flex-shrink-0 sm:space-x-2"
       >
         <div
           class="min-w-52 flex flex-1 whitespace-nowrap rounded border border-divider"
@@ -92,17 +92,13 @@
       </div>
     </div>
 
-    <div>
-      <HttpRequestOptions
-        v-model="tab.document.request"
-        v-model:option-tab="selectedOptionTab"
-        :properties="properties"
-      />
-    </div>
+    <HttpRequestOptions
+      v-model="tab.document.request"
+      v-model:option-tab="selectedOptionTab"
+      :properties="properties"
+    />
 
-    <div>
-      <HttpResponse :document="tab.document" :is-embed="true" />
-    </div>
+    <HttpResponse :document="tab.document" :is-embed="true" />
   </div>
 </template>
 
@@ -133,8 +129,6 @@ const props = defineProps<{
 const tab = useModel(props, "modelTab")
 
 const selectedOptionTab = ref(props.properties[0])
-
-console.log("request", tab.value.document.request)
 
 const requestCancelFunc: Ref<(() => void) | null> = ref(null)
 

--- a/packages/hoppscotch-common/src/components/embeds/index.vue
+++ b/packages/hoppscotch-common/src/components/embeds/index.vue
@@ -1,0 +1,259 @@
+<template>
+  <div class="flex flex-1 flex-col">
+    <header
+      class="flex flex-1 flex-shrink-0 items-center justify-between space-x-2 overflow-x-auto overflow-y-hidden px-2 py-2"
+    >
+      <div class="flex flex-1 items-center justify-between space-x-2">
+        <HoppButtonSecondary
+          class="!font-bold uppercase tracking-wide !text-secondaryDark hover:bg-primaryDark focus-visible:bg-primaryDark"
+          :label="t('app.name')"
+          to="/"
+        />
+        <div class="flex">
+          <HoppSmartItem :label="t('app.open_in_hoppscotch')" />
+        </div>
+      </div>
+    </header>
+
+    <div class="flex-1">
+      <div
+        class="top-0 z-20 flex-none flex-shrink-0 bg-primary p-4 sm:flex sm:flex-shrink-0 sm:space-x-2"
+      >
+        <div
+          class="min-w-52 flex flex-1 whitespace-nowrap rounded border border-divider"
+        >
+          <div class="relative flex">
+            <label for="method">
+              <tippy
+                interactive
+                trigger="click"
+                theme="popover"
+                :on-shown="() => methodTippyActions?.focus()"
+              >
+                <span class="select-wrapper">
+                  <input
+                    id="method"
+                    class="flex w-26 cursor-pointer rounded-l bg-primaryLight px-4 py-2 font-semibold text-secondaryDark transition"
+                    :value="tab.document.request.method"
+                    :readonly="!isCustomMethod"
+                    :placeholder="`${t('request.method')}`"
+                    @input="onSelectMethod($event)"
+                  />
+                </span>
+                <template #content="{ hide }">
+                  <div
+                    ref="methodTippyActions"
+                    class="flex flex-col focus:outline-none"
+                    tabindex="0"
+                    @keyup.escape="hide()"
+                  >
+                    <HoppSmartItem
+                      v-for="(method, index) in methods"
+                      :key="`method-${index}`"
+                      :label="method"
+                      @click="
+                        () => {
+                          updateMethod(method)
+                          hide()
+                        }
+                      "
+                    />
+                  </div>
+                </template>
+              </tippy>
+            </label>
+          </div>
+          <div
+            class="flex flex-1 whitespace-nowrap rounded-r border-l border-divider bg-primaryLight transition"
+          >
+            <SmartEnvInput
+              v-model="tab.document.request.endpoint"
+              :placeholder="`${t('request.url')}`"
+              @enter="newSendRequest"
+            />
+          </div>
+        </div>
+        <div class="mt-2 flex sm:mt-0">
+          <HoppButtonPrimary
+            id="send"
+            v-tippy="{ theme: 'tooltip', delay: [500, 20], allowHTML: true }"
+            :title="`${t(
+              'action.send'
+            )} <kbd>${getSpecialKey()}</kbd><kbd>↩</kbd>`"
+            :label="`${!loading ? t('action.send') : t('action.cancel')}`"
+            class="min-w-20 flex-1"
+            @click="!loading ? newSendRequest() : cancelRequest()"
+          />
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <HttpRequestOptions
+        v-model="tab.document.request"
+        v-model:option-tab="selectedOptionTab"
+      />
+    </div>
+
+    <div>
+      {{ tab.document.response }}
+      <HttpResponse :document="tab.document" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { Ref } from "vue"
+import { computed, useModel } from "vue"
+import { ref } from "vue"
+import { TippyComponent } from "vue-tippy"
+import { useI18n } from "~/composables/i18n"
+import { useToast } from "~/composables/toast"
+import { getPlatformSpecialKey as getSpecialKey } from "~/helpers/platformutils"
+import * as E from "fp-ts/Either"
+import { useStreamSubscriber } from "~/composables/stream"
+import { HoppRESTResponse } from "~/helpers/types/HoppRESTResponse"
+import { runRESTRequest$ } from "~/helpers/RequestRunner"
+import { HoppTab } from "~/services/tab"
+import { HoppRESTDocument } from "~/helpers/rest/document"
+
+const t = useI18n()
+const toast = useToast()
+
+const props = defineProps<{
+  modelTab: HoppTab<HoppRESTDocument>
+}>()
+
+const tab = useModel(props, "modelTab")
+
+const selectedOptionTab = ref("params")
+
+console.log("request", tab.value.document.request)
+
+const requestCancelFunc: Ref<(() => void) | null> = ref(null)
+
+const loading = ref(false)
+
+const methods = [
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "CONNECT",
+  "OPTIONS",
+  "TRACE",
+  "CUSTOM",
+]
+
+const { subscribeToStream } = useStreamSubscriber()
+
+const updateMethod = (method: string) => {
+  tab.value.document.request.method = method
+}
+
+const onSelectMethod = (e: Event | any) => {
+  // type any because of value property not being recognized by TS in the event.target object. It is a valid property though.
+  updateMethod(e.target.value)
+}
+
+const newSendRequest = async () => {
+  if (newEndpoint.value === "" || /^\s+$/.test(newEndpoint.value)) {
+    toast.error(`${t("empty.endpoint")}`)
+    return
+  }
+
+  ensureMethodInEndpoint()
+
+  loading.value = true
+
+  const [cancel, streamPromise] = runRESTRequest$(tab)
+  const streamResult = await streamPromise
+
+  requestCancelFunc.value = cancel
+  if (E.isRight(streamResult)) {
+    subscribeToStream(
+      streamResult.right,
+      (responseState) => {
+        if (loading.value) {
+          // Check exists because, loading can be set to false
+          // when cancelled
+          updateRESTResponse(responseState)
+        }
+      },
+      () => {
+        loading.value = false
+      },
+      () => {
+        // TODO: Change this any to a proper type
+        const result = (streamResult.right as any).value
+        if (
+          result.type === "network_fail" &&
+          result.error?.error === "NO_PW_EXT_HOOK"
+        ) {
+          const errorResponse: HoppRESTResponse = {
+            type: "extension_error",
+            error: result.error.humanMessage.heading,
+            component: result.error.component,
+            req: result.req,
+          }
+          updateRESTResponse(errorResponse)
+        }
+        loading.value = false
+      }
+    )
+  } else {
+    loading.value = false
+    toast.error(`${t("error.script_fail")}`)
+    let error: Error
+    if (typeof streamResult.left === "string") {
+      error = { name: "RequestFailure", message: streamResult.left }
+    } else {
+      error = streamResult.left
+    }
+    updateRESTResponse({
+      type: "script_fail",
+      error,
+    })
+  }
+}
+
+const updateRESTResponse = (response: HoppRESTResponse | null) => {
+  tab.value.document.response = response
+}
+
+const newEndpoint = computed(() => {
+  return tab.value.document.request.endpoint
+})
+
+const ensureMethodInEndpoint = () => {
+  if (
+    !/^http[s]?:\/\//.test(newEndpoint.value) &&
+    !newEndpoint.value.startsWith("<<")
+  ) {
+    const domain = newEndpoint.value.split(/[/:#?]+/)[0]
+    if (domain === "localhost" || /([0-9]+\.)*[0-9]/.test(domain)) {
+      tab.value.document.request.endpoint =
+        "http://" + tab.value.document.request.endpoint
+    } else {
+      tab.value.document.request.endpoint =
+        "https://" + tab.value.document.request.endpoint
+    }
+  }
+}
+
+const cancelRequest = () => {
+  loading.value = false
+  requestCancelFunc.value?.()
+
+  updateRESTResponse(null)
+}
+
+const isCustomMethod = computed(() => {
+  return tab.value.document.request.method === "CUSTOM"
+})
+
+// Template refs
+const methodTippyActions = ref<TippyComponent | null>(null)
+</script>

--- a/packages/hoppscotch-common/src/components/http/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestOptions.vue
@@ -5,13 +5,18 @@
     render-inactive-tabs
   >
     <HoppSmartTab
+      v-if="properties ? properties.includes('parameters') : true"
       :id="'params'"
       :label="`${t('tab.parameters')}`"
       :info="`${newActiveParamsCount$}`"
     >
       <HttpParameters v-model="request.params" />
     </HoppSmartTab>
-    <HoppSmartTab :id="'bodyParams'" :label="`${t('tab.body')}`">
+    <HoppSmartTab
+      v-if="properties ? properties.includes('body') : true"
+      :id="'bodyParams'"
+      :label="`${t('tab.body')}`"
+    >
       <HttpBody
         v-model:headers="request.headers"
         v-model:body="request.body"
@@ -19,16 +24,22 @@
       />
     </HoppSmartTab>
     <HoppSmartTab
+      v-if="properties ? properties.includes('headers') : true"
       :id="'headers'"
       :label="`${t('tab.headers')}`"
       :info="`${newActiveHeadersCount$}`"
     >
       <HttpHeaders v-model="request" @change-tab="changeOptionTab" />
     </HoppSmartTab>
-    <HoppSmartTab :id="'authorization'" :label="`${t('tab.authorization')}`">
+    <HoppSmartTab
+      v-if="properties ? properties.includes('authorization') : true"
+      :id="'authorization'"
+      :label="`${t('tab.authorization')}`"
+    >
       <HttpAuthorization v-model="request.auth" />
     </HoppSmartTab>
     <HoppSmartTab
+      v-if="properties ? properties.includes('preRequestScript') : true"
       :id="'preRequestScript'"
       :label="`${t('tab.pre_request_script')}`"
       :indicator="
@@ -40,6 +51,7 @@
       <HttpPreRequestScript v-model="request.preRequestScript" />
     </HoppSmartTab>
     <HoppSmartTab
+      v-if="properties ? properties.includes('tests') : true"
       :id="'tests'"
       :label="`${t('tab.tests')}`"
       :indicator="
@@ -76,6 +88,7 @@ const props = withDefaults(
   defineProps<{
     modelValue: HoppRESTRequest
     optionTab: RESTOptionTabs
+    properties?: string[]
   }>(),
   {
     optionTab: "params",

--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="relative flex flex-1 flex-col">
-    <HttpResponseMeta :response="doc.response" />
+    <HttpResponseMeta :response="doc.response" :is-embed="isEmbed" />
     <LensesResponseBodyRenderer
       v-if="!loading && hasResponse"
       v-model:document="doc"
@@ -15,6 +15,7 @@ import { HoppRESTDocument } from "~/helpers/rest/document"
 
 const props = defineProps<{
   document: HoppRESTDocument
+  isEmbed: boolean
 }>()
 
 const emit = defineEmits<{

--- a/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
+++ b/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
@@ -2,8 +2,20 @@
   <div
     class="sticky top-0 z-10 flex flex-shrink-0 items-center justify-center overflow-auto overflow-x-auto whitespace-nowrap bg-primary p-4"
   >
-    <AppShortcutsPrompt v-if="response == null" class="flex-1" />
-    <div v-else class="flex flex-1 flex-col">
+    <AppShortcutsPrompt v-if="response == null && !isEmbed" class="flex-1" />
+
+    <div v-if="response == null && isEmbed">
+      <HoppButtonSecondary
+        :label="`${t('app.documentation')}`"
+        to="https://docs.hoppscotch.io/documentation/features/rest-api-testing#response"
+        :icon="IconExternalLink"
+        blank
+        outline
+        reverse
+      />
+    </div>
+
+    <div v-else-if="response" class="flex flex-1 flex-col">
       <div
         v-if="response.type === 'loading'"
         class="flex flex-col items-center justify-center"
@@ -105,6 +117,7 @@ import { getStatusCodeReasonPhrase } from "~/helpers/utils/statusCodes"
 import { useService } from "dioc/vue"
 import { InspectionService } from "~/services/inspection"
 import { RESTTabService } from "~/services/tab/rest"
+import IconExternalLink from "~icons/lucide/external-link"
 
 const t = useI18n()
 const colorMode = useColorMode()
@@ -112,6 +125,7 @@ const tabs = useService(RESTTabService)
 
 const props = defineProps<{
   response: HoppRESTResponse | null | undefined
+  isEmbed?: boolean
 }>()
 
 /**

--- a/packages/hoppscotch-common/src/components/share/CreateModal.vue
+++ b/packages/hoppscotch-common/src/components/share/CreateModal.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="selectedWidget"
-    class="divide-y divide-divider rounded border border-divider"
+    class="border divide-y rounded divide-divider border-divider"
   >
     <div v-if="loading" class="px-4 py-2">
       {{ t("shared_requests.creating_widget") }}
@@ -10,17 +10,17 @@
       {{ t("shared_requests.description") }}
     </div>
     <div class="flex flex-col divide-y divide-divider">
-      <div class="flex flex-col space-y-4 p-4">
+      <div class="flex flex-col p-4 space-y-4">
         <div
           v-for="widget in widgets"
           :key="widget.value"
-          class="flex cursor-pointer flex-col space-y-2 rounded border border-divider px-4 py-3 hover:bg-dividerLight"
+          class="flex flex-col p-4 border rounded cursor-pointer border-divider hover:bg-dividerLight"
           :class="{
             '!border-accentLight': selectedWidget.value === widget.value,
           }"
           @click="selectedWidget = widget"
         >
-          <span class="text-md font-bold">
+          <span class="mb-1 font-bold text-secondaryDark">
             {{ widget.label }}
           </span>
           <span class="text-tiny">
@@ -28,9 +28,13 @@
           </span>
         </div>
       </div>
-      <div class="flex flex-col divide-y divide-divider">
-        <div class="px-4 py-3">{{ t("shared_requests.preview") }}</div>
-        <div class="flex flex-col items-center justify-center px-4 py-10">
+      <div class="flex flex-col items-center justify-center p-4">
+        <span
+          class="flex justify-center flex-1 mb-2 text-secondaryLight text-tiny"
+        >
+          {{ t("shared_requests.preview") }}
+        </span>
+        <div class="w-full">
           <ShareTemplatesEmbeds
             v-if="selectedWidget.value === 'embed'"
             :endpoint="request?.endpoint"

--- a/packages/hoppscotch-common/src/components/share/CreateModal.vue
+++ b/packages/hoppscotch-common/src/components/share/CreateModal.vue
@@ -132,7 +132,7 @@ const embedOption = ref<EmbedOption>({
     {
       value: "authorization",
       label: t("tab.authorization"),
-      enabled: true,
+      enabled: false,
     },
   ],
   theme: "system",

--- a/packages/hoppscotch-common/src/components/share/CustomizeModal.vue
+++ b/packages/hoppscotch-common/src/components/share/CustomizeModal.vue
@@ -205,6 +205,35 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  embedOptions: {
+    type: Object as PropType<EmbedOption>,
+    default: () => ({
+      selectedTab: "parameters",
+      tabs: [
+        {
+          value: "parameters",
+          label: "shared_requests.parameters",
+          enabled: true,
+        },
+        {
+          value: "body",
+          label: "shared_requests.body",
+          enabled: true,
+        },
+        {
+          value: "headers",
+          label: "shared_requests.headers",
+          enabled: true,
+        },
+        {
+          value: "authorization",
+          label: "shared_requests.authorization",
+          enabled: false,
+        },
+      ],
+      theme: "system",
+    }),
+  },
 })
 
 const emit = defineEmits<{
@@ -213,6 +242,7 @@ const emit = defineEmits<{
     request: {
       sharedRequestID: string | undefined
       content: string | undefined
+      type: string | undefined
     }
   ): void
   (e: "hide-modal"): void
@@ -220,6 +250,7 @@ const emit = defineEmits<{
 }>()
 
 const selectedWidget = useVModel(props, "modelValue")
+const embedOptions = useVModel(props, "embedOptions")
 
 type WidgetID = "embed" | "button" | "link"
 
@@ -254,34 +285,6 @@ type EmbedOption = {
   }[]
   theme: "light" | "dark" | "system"
 }
-
-const embedOptions = ref<EmbedOption>({
-  selectedTab: "parameters",
-  tabs: [
-    {
-      value: "parameters",
-      label: t("tab.parameters"),
-      enabled: true,
-    },
-    {
-      value: "body",
-      label: t("tab.body"),
-      enabled: true,
-    },
-    {
-      value: "headers",
-      label: t("tab.headers"),
-      enabled: true,
-    },
-    {
-      value: "authorization",
-      label: t("tab.authorization"),
-      enabled: true,
-    },
-  ],
-  theme: "system",
-})
-
 const embedThemeIcon = computed(() => {
   if (embedOptions.value.theme === "system") {
     return IconMonitor
@@ -355,12 +358,13 @@ const linkVariants: LinkVariant[] = [
 const baseURL = import.meta.env.VITE_SHORTCODE_BASE_URL ?? "https://hopp.sh"
 
 const copyEmbed = () => {
-  const options = embedOptions.value
-  const enabledEmbedOptions = options.tabs
-    .filter((tab) => tab.enabled)
-    .map((tab) => tab.value)
-    .toString()
-  return `<iframe src="${baseURL}/e/${props.request?.id}/${enabledEmbedOptions}' style='width: 100%; height: 500px; border: 0; border-radius: 4px; overflow: hidden;'></iframe>`
+  //const options = embedOptions.value
+  // const enabledEmbedOptions = options.tabs
+  //   .filter((tab) => tab.enabled)
+  //   .map((tab) => tab.value)
+  //   .toString()
+  //return `<iframe src="${baseURL}/e/${props.request?.id}' style='width: 100%; height: 500px; border: 0; border-radius: 4px; overflow: hidden;'></iframe>`
+  return `${baseURL}/e/${props.request?.id} `
 }
 
 const copyButton = (
@@ -410,7 +414,11 @@ const copyContent = ({
   } else {
     content = copyEmbed()
   }
-  const copyContent = { sharedRequestID: props.request?.id, content }
+  const copyContent = {
+    sharedRequestID: props.request?.id,
+    content,
+    type: widget,
+  }
   emit("copy-shared-request", copyContent)
 }
 

--- a/packages/hoppscotch-common/src/components/share/CustomizeModal.vue
+++ b/packages/hoppscotch-common/src/components/share/CustomizeModal.vue
@@ -358,13 +358,7 @@ const linkVariants: LinkVariant[] = [
 const baseURL = import.meta.env.VITE_SHORTCODE_BASE_URL ?? "https://hopp.sh"
 
 const copyEmbed = () => {
-  //const options = embedOptions.value
-  // const enabledEmbedOptions = options.tabs
-  //   .filter((tab) => tab.enabled)
-  //   .map((tab) => tab.value)
-  //   .toString()
-  //return `<iframe src="${baseURL}/e/${props.request?.id}' style='width: 100%; height: 500px; border: 0; border-radius: 4px; overflow: hidden;'></iframe>`
-  return `${baseURL}/e/${props.request?.id} `
+  return `<iframe src="${baseURL}/e/${props.request?.id}' style='width: 100%; height: 500px; border: 0; border-radius: 4px; overflow: hidden;'></iframe>`
 }
 
 const copyButton = (

--- a/packages/hoppscotch-common/src/components/share/CustomizeModal.vue
+++ b/packages/hoppscotch-common/src/components/share/CustomizeModal.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="selectedWidget"
-    class="divide-y divide-divider rounded border border-divider"
+    class="border divide-y rounded divide-divider border-divider"
   >
     <div v-if="loading" class="px-4 py-2">
       {{ t("shared_requests.creating_widget") }}
@@ -14,7 +14,7 @@
       <span class="text-secondaryLight">{{ t("state.loading") }}</span>
     </div>
     <div v-else class="flex flex-col divide-y divide-divider">
-      <div class="flex flex-col space-y-4 p-4">
+      <div class="flex flex-col p-2 space-y-2">
         <HoppSmartRadioGroup
           v-model="selectedWidget.value"
           :radios="widgets"
@@ -22,9 +22,9 @@
         />
       </div>
       <div class="flex flex-col divide-y divide-divider">
-        <div class="flex items-center justify-center px-4 py-8">
-          <div v-if="selectedWidget.value === 'embed'" class="w-full flex-1">
-            <div class="flex flex-col pb-8">
+        <div class="flex items-center justify-center px-6 py-4">
+          <div v-if="selectedWidget.value === 'embed'" class="w-full">
+            <div class="flex flex-col pb-4">
               <div
                 v-for="option in embedOptions.tabs"
                 :key="option.value"
@@ -36,7 +36,8 @@
                 <HoppSmartCheckbox
                   :on="option.enabled"
                   @change="removeEmbedOption(option.value)"
-                />
+                >
+                </HoppSmartCheckbox>
               </div>
               <div class="flex items-center justify-between">
                 <span>
@@ -49,13 +50,11 @@
                     theme="popover"
                     :on-shown="() => tippyActions!.focus()"
                   >
-                    <span class="select-wrapper">
-                      <HoppButtonSecondary
-                        class="ml-2 rounded-none pr-8 capitalize"
-                        :label="embedOptions.theme"
-                        :icon="embedThemeIcon"
-                      />
-                    </span>
+                    <HoppButtonSecondary
+                      class="!py-2 !px-0 capitalize"
+                      :label="embedOptions.theme"
+                      :icon="embedThemeIcon"
+                    />
                     <template #content="{ hide }">
                       <div
                         ref="tippyActions"
@@ -102,14 +101,20 @@
                 </div>
               </div>
             </div>
+            <span
+              class="flex justify-center mb-2 text-secondaryLight text-tiny"
+            >
+              {{ t("shared_requests.preview") }}
+            </span>
             <ShareTemplatesEmbeds
               :endpoint="request?.endpoint"
               :method="request?.method"
               :model-value="embedOptions"
             />
-            <div class="flex items-center justify-center py-4">
+            <div class="flex items-center justify-center">
               <HoppButtonSecondary
                 :label="t('shared_requests.copy_html')"
+                class="underline text-secondaryDark"
                 @click="
                   copyContent({
                     widget: 'embed',
@@ -126,12 +131,18 @@
             <div
               v-for="variant in buttonVariants"
               :key="variant.id"
-              class="flex flex-col space-y-4"
+              class="flex flex-col"
             >
+              <span
+                class="flex justify-center mb-2 text-secondaryLight text-tiny"
+              >
+                {{ t("shared_requests.preview") }}
+              </span>
               <ShareTemplatesButton :img="variant.img" />
               <div class="flex items-center justify-between">
                 <HoppButtonSecondary
                   :label="t('shared_requests.copy_html')"
+                  class="underline text-secondaryDark"
                   @click="
                     copyContent({
                       widget: 'button',
@@ -142,6 +153,7 @@
                 />
                 <HoppButtonSecondary
                   :label="t('shared_requests.copy_markdown')"
+                  class="underline text-secondaryDark"
                   @click="
                     copyContent({
                       widget: 'button',
@@ -157,12 +169,17 @@
             <div
               v-for="variant in linkVariants"
               :key="variant.type"
-              class="flex flex-col items-center justify-center space-y-2"
+              class="flex flex-col items-center justify-center"
             >
+              <span
+                class="flex justify-center mb-2 text-secondaryLight text-tiny"
+              >
+                {{ t("shared_requests.preview") }}
+              </span>
               <ShareTemplatesLink :link="variant.link" :label="variant.label" />
-
               <HoppButtonSecondary
                 :label="t(`shared_requests.copy_${variant.type}`)"
+                class="underline text-secondaryDark"
                 @click="
                   copyContent({
                     widget: 'link',

--- a/packages/hoppscotch-common/src/components/share/CustomizeModal.vue
+++ b/packages/hoppscotch-common/src/components/share/CustomizeModal.vue
@@ -242,7 +242,6 @@ const emit = defineEmits<{
     request: {
       sharedRequestID: string | undefined
       content: string | undefined
-      type: string | undefined
     }
   ): void
   (e: "hide-modal"): void
@@ -411,7 +410,6 @@ const copyContent = ({
   const copyContent = {
     sharedRequestID: props.request?.id,
     content,
-    type: widget,
   }
   emit("copy-shared-request", copyContent)
 }

--- a/packages/hoppscotch-common/src/components/share/Modal.vue
+++ b/packages/hoppscotch-common/src/components/share/Modal.vue
@@ -2,7 +2,9 @@
   <HoppSmartModal
     v-if="show"
     dialog
-    :title="t('modal.share_request')"
+    :title="
+      step === 1 ? t('modal.share_request') : t('modal.customize_request')
+    "
     styles="sm:max-w-md"
     @close="hideModal"
   >
@@ -29,19 +31,25 @@
     </template>
 
     <template #footer>
-      <div v-if="step === 1" class="flex justify-end">
+      <div class="flex justify-start flex-1">
         <HoppButtonPrimary
+          v-if="step === 1"
           :label="t('action.create')"
           :loading="loading"
           @click="createSharedRequest"
         />
+        <HoppButtonPrimary
+          v-else
+          :label="t('action.save')"
+          :loading="loading"
+          @click="saveSharedRequest"
+        />
         <HoppButtonSecondary
           :label="t('action.cancel')"
-          class="mr-2"
+          class="ml-2"
           @click="hideModal"
         />
       </div>
-      <HoppButtonPrimary v-else :label="t('action.close')" @click="hideModal" />
     </template>
   </HoppSmartModal>
 </template>
@@ -137,24 +145,29 @@ const emit = defineEmits<{
   (e: "update:step", value: number): void
   (
     e: "copy-shared-request",
-    request: {
+    payload: {
       sharedRequestID: string | undefined
       content: string | undefined
       type: string | undefined
     }
   ): void
+  (e: "save-shared-request"): void
 }>()
 
 const createSharedRequest = () => {
   emit("create-shared-request", props.request as HoppRESTRequest)
 }
 
-const copySharedRequest = (request: {
+const copySharedRequest = (payload: {
   sharedRequestID: string | undefined
   content: string | undefined
   type: string | undefined
 }) => {
-  emit("copy-shared-request", request)
+  emit("copy-shared-request", payload)
+}
+
+const saveSharedRequest = () => {
+  emit("save-shared-request")
 }
 
 const hideModal = () => {

--- a/packages/hoppscotch-common/src/components/share/Modal.vue
+++ b/packages/hoppscotch-common/src/components/share/Modal.vue
@@ -38,15 +38,11 @@
           :loading="loading"
           @click="createSharedRequest"
         />
-        <HoppButtonPrimary
-          v-else
-          :label="t('action.save')"
-          :loading="loading"
-          @click="saveSharedRequest"
-        />
         <HoppButtonSecondary
-          :label="t('action.cancel')"
+          :label="step === 1 ? t('action.cancel') : t('action.close')"
           class="ml-2"
+          filled
+          outline
           @click="hideModal"
         />
       </div>
@@ -151,7 +147,6 @@ const emit = defineEmits<{
       type: string | undefined
     }
   ): void
-  (e: "save-shared-request"): void
 }>()
 
 const createSharedRequest = () => {
@@ -164,10 +159,6 @@ const copySharedRequest = (payload: {
   type: string | undefined
 }) => {
   emit("copy-shared-request", payload)
-}
-
-const saveSharedRequest = () => {
-  emit("save-shared-request")
 }
 
 const hideModal = () => {

--- a/packages/hoppscotch-common/src/components/share/Modal.vue
+++ b/packages/hoppscotch-common/src/components/share/Modal.vue
@@ -144,7 +144,6 @@ const emit = defineEmits<{
     payload: {
       sharedRequestID: string | undefined
       content: string | undefined
-      type: string | undefined
     }
   ): void
 }>()
@@ -156,7 +155,6 @@ const createSharedRequest = () => {
 const copySharedRequest = (payload: {
   sharedRequestID: string | undefined
   content: string | undefined
-  type: string | undefined
 }) => {
   emit("copy-shared-request", payload)
 }

--- a/packages/hoppscotch-common/src/components/share/Modal.vue
+++ b/packages/hoppscotch-common/src/components/share/Modal.vue
@@ -21,6 +21,7 @@
       <ShareCustomizeModal
         v-else-if="step === 2"
         v-model="selectedWidget"
+        v-model:embed-options="embedOptions"
         :request="request"
         :loading="loading"
         @copy-shared-request="copySharedRequest"
@@ -53,6 +54,18 @@ import { useI18n } from "~/composables/i18n"
 
 const t = useI18n()
 
+type EmbedTabs = "parameters" | "body" | "headers" | "authorization"
+
+type EmbedOption = {
+  selectedTab: EmbedTabs
+  tabs: {
+    value: EmbedTabs
+    label: string
+    enabled: boolean
+  }[]
+  theme: "light" | "dark" | "system"
+}
+
 const props = defineProps({
   request: {
     type: Object as PropType<HoppRESTRequest | null>,
@@ -75,6 +88,35 @@ const props = defineProps({
     type: Number,
     default: 1,
   },
+  embedOptions: {
+    type: Object as PropType<EmbedOption>,
+    default: () => ({
+      selectedTab: "parameters",
+      tabs: [
+        {
+          value: "parameters",
+          label: "shared_requests.parameters",
+          enabled: true,
+        },
+        {
+          value: "body",
+          label: "shared_requests.body",
+          enabled: true,
+        },
+        {
+          value: "headers",
+          label: "shared_requests.headers",
+          enabled: true,
+        },
+        {
+          value: "authorization",
+          label: "shared_requests.authorization",
+          enabled: false,
+        },
+      ],
+      theme: "system",
+    }),
+  },
 })
 
 type WidgetID = "embed" | "button" | "link"
@@ -86,6 +128,7 @@ type Widget = {
 }
 
 const selectedWidget = useVModel(props, "modelValue")
+const embedOptions = useVModel(props, "embedOptions")
 
 const emit = defineEmits<{
   (e: "create-shared-request", request: HoppRESTRequest | null): void
@@ -97,6 +140,7 @@ const emit = defineEmits<{
     request: {
       sharedRequestID: string | undefined
       content: string | undefined
+      type: string | undefined
     }
   ): void
 }>()
@@ -108,6 +152,7 @@ const createSharedRequest = () => {
 const copySharedRequest = (request: {
   sharedRequestID: string | undefined
   content: string | undefined
+  type: string | undefined
 }) => {
   emit("copy-shared-request", request)
 }

--- a/packages/hoppscotch-common/src/components/share/Request.vue
+++ b/packages/hoppscotch-common/src/components/share/Request.vue
@@ -121,7 +121,12 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: "customize-shared-request", request: HoppRESTRequest, id: string): void
+  (
+    e: "customize-shared-request",
+    request: HoppRESTRequest,
+    id: string,
+    embedProperties?: string | null
+  ): void
   (e: "delete-shared-request", codeID: string): void
   (e: "open-new-tab", request: HoppRESTRequest): void
 }>()
@@ -144,7 +149,13 @@ const openInNewTab = () => {
 }
 
 const customizeSharedRequest = () => {
-  emit("customize-shared-request", parseRequest.value, props.request.id)
+  const embedProperties = props.request.properties
+  emit(
+    "customize-shared-request",
+    parseRequest.value,
+    props.request.id,
+    embedProperties
+  )
 }
 
 const deleteSharedRequest = () => {

--- a/packages/hoppscotch-common/src/components/share/Request.vue
+++ b/packages/hoppscotch-common/src/components/share/Request.vue
@@ -1,31 +1,31 @@
 <template>
   <div
-    class="group flex items-stretch"
+    class="flex items-stretch group"
     @contextmenu.prevent="options!.tippy.show()"
   >
     <div
       v-tippy="{ theme: 'tooltip', delay: [500, 20] }"
-      class="pointer-events-auto flex min-w-0 flex-1 cursor-pointer items-center justify-center py-2"
+      class="flex items-center justify-center flex-1 min-w-0 py-2 cursor-pointer pointer-events-auto"
       :title="`${timeStamp}`"
       @click="openInNewTab"
     >
       <span
-        class="pointer-events-none flex w-16 items-center justify-center truncate px-2"
+        class="flex items-center justify-center w-16 px-2 truncate pointer-events-none"
         :style="{ color: requestLabelColor }"
       >
-        <span class="truncate text-tiny font-semibold">
+        <span class="font-semibold truncate text-tiny">
           {{ parseRequest.method }}
         </span>
       </span>
       <span
-        class="pointer-events-none flex min-w-0 flex-1 items-center pr-2 transition group-hover:text-secondaryDark"
+        class="flex items-center flex-1 min-w-0 pr-2 transition pointer-events-none group-hover:text-secondaryDark"
       >
         <span class="flex-1 truncate">
           {{ parseRequest.endpoint }}
         </span>
       </span>
       <span
-        class="flex-1 truncate border-l border-dividerDark px-2 text-secondaryLight group-hover:text-secondaryDark"
+        class="flex px-2 truncate text-secondaryLight group-hover:text-secondaryDark"
       >
         {{ parseRequest.name }}
       </span>
@@ -69,7 +69,7 @@
               />
               <HoppSmartItem
                 ref="customizeAction"
-                :icon="IconFileEdit"
+                :icon="IconCustomize"
                 :label="`${t('shared_requests.customize')}`"
                 :shortcut="['E']"
                 @click="
@@ -110,7 +110,7 @@ import { getMethodLabelColorClassOf } from "~/helpers/rest/labelColoring"
 import { Shortcode } from "~/helpers/shortcode/Shortcode"
 import IconArrowUpRight from "~icons/lucide/arrow-up-right-square"
 import IconMoreVertical from "~icons/lucide/more-vertical"
-import IconFileEdit from "~icons/lucide/file-edit"
+import IconCustomize from "~icons/lucide/settings-2"
 import IconTrash2 from "~icons/lucide/trash-2"
 import { shortDateTime } from "~/helpers/utils/date"
 
@@ -135,6 +135,7 @@ const tippyActions = ref<TippyComponent | null>(null)
 const openInNewTabAction = ref<HTMLButtonElement | null>(null)
 const customizeAction = ref<HTMLButtonElement | null>(null)
 const deleteAction = ref<HTMLButtonElement | null>(null)
+const options = ref<any | null>(null)
 
 const parseRequest = computed(() =>
   pipe(props.request.request, JSON.parse, translateToNewRequest)

--- a/packages/hoppscotch-common/src/components/share/index.vue
+++ b/packages/hoppscotch-common/src/components/share/index.vue
@@ -80,11 +80,12 @@
   />
   <ShareModal
     v-model="selectedWidget"
+    v-model:embed-options="embedOptions"
+    :step="step"
     :request="requestToShare"
     :show="showShareRequestModal"
     :loading="shareRequestCreatingLoading"
-    :step="step"
-    @hide-modal="displayCustomizeRequestModal(false)"
+    @hide-modal="displayCustomizeRequestModal(false, null)"
     @copy-shared-request="copySharedRequest"
     @create-shared-request="createSharedRequest"
   />
@@ -105,6 +106,7 @@ import * as TE from "fp-ts/TaskEither"
 import {
   deleteShortcode as backendDeleteShortcode,
   createShortcode,
+  updateEmbedProperties,
 } from "~/helpers/backend/mutations/Shortcode"
 import { GQLError } from "~/helpers/backend/GQLClient"
 import { useToast } from "~/composables/toast"
@@ -130,6 +132,67 @@ const shareRequestCreatingLoading = ref(false)
 
 const requestToShare = ref<HoppRESTRequest | null>(null)
 
+const embedOptions = ref<EmbedOption>({
+  selectedTab: "parameters",
+  tabs: [
+    {
+      value: "parameters",
+      label: t("tab.parameters"),
+      enabled: true,
+    },
+    {
+      value: "body",
+      label: t("tab.body"),
+      enabled: true,
+    },
+    {
+      value: "headers",
+      label: t("tab.headers"),
+      enabled: true,
+    },
+    {
+      value: "authorization",
+      label: t("tab.authorization"),
+      enabled: false,
+    },
+  ],
+  theme: "system",
+})
+
+const updateEmbedProperty = async (
+  shareRequestID: string,
+  properties: string
+) => {
+  const customizeEmbedResult = await updateEmbedProperties(
+    shareRequestID,
+    properties
+  )()
+
+  if (E.isLeft(customizeEmbedResult)) {
+    toast.error(`${customizeEmbedResult.left.error}`)
+    toast.error(t("error.something_went_wrong"))
+  } else if (E.isRight(customizeEmbedResult)) {
+    if (customizeEmbedResult.right.updateEmbedProperties) {
+      if (customizeEmbedResult.right.updateEmbedProperties.properties) {
+        const parsedEmbedProperties = JSON.parse(
+          customizeEmbedResult.right.updateEmbedProperties.properties
+        )
+
+        embedOptions.value = {
+          selectedTab: parsedEmbedProperties.options[0],
+          tabs: embedOptions.value.tabs.map((tab) => {
+            return {
+              ...tab,
+              enabled: parsedEmbedProperties.options.includes(tab.value),
+            }
+          }),
+          theme: parsedEmbedProperties.theme,
+        }
+      }
+    }
+  }
+}
+
 const restTab = useService(RESTTabService)
 
 const currentUser = useReadonlyStream(
@@ -138,6 +201,18 @@ const currentUser = useReadonlyStream(
 )
 
 const step = ref(1)
+
+type EmbedTabs = "parameters" | "body" | "headers" | "authorization"
+
+type EmbedOption = {
+  selectedTab: EmbedTabs
+  tabs: {
+    value: EmbedTabs
+    label: string
+    enabled: boolean
+  }[]
+  theme: "light" | "dark" | "system"
+}
 
 type WidgetID = "embed" | "button" | "link"
 
@@ -218,15 +293,46 @@ const displayShareRequestModal = (show: boolean) => {
   showShareRequestModal.value = show
   step.value = 1
 }
-const displayCustomizeRequestModal = (show: boolean) => {
+const displayCustomizeRequestModal = (
+  show: boolean,
+  embedProperties?: string | null
+) => {
   showShareRequestModal.value = show
   step.value = 2
+  if (!embedProperties) {
+    selectedWidget.value = {
+      value: "button",
+      label: t("shared_requests.button"),
+      info: t("shared_requests.button_info"),
+    }
+  } else {
+    const parsedEmbedProperties = JSON.parse(embedProperties)
+    embedOptions.value = {
+      selectedTab: parsedEmbedProperties.options[0],
+      tabs: embedOptions.value.tabs.map((tab) => {
+        return {
+          ...tab,
+          enabled: parsedEmbedProperties.options.includes(tab.value),
+        }
+      }),
+      theme: parsedEmbedProperties.theme,
+    }
+  }
 }
 
 const createSharedRequest = async (request: HoppRESTRequest | null) => {
   if (request && selectedWidget.value) {
+    const properties = {
+      options: ["parameters", "body", "headers"],
+      theme: "system",
+    }
     shareRequestCreatingLoading.value = true
-    const sharedRequestResult = await createShortcode(request)()
+    const sharedRequestResult = await createShortcode(
+      request,
+      selectedWidget.value.value === "embed"
+        ? JSON.stringify(properties)
+        : undefined
+    )()
 
     platform.analytics?.logEvent({
       type: "HOPP_SHORTCODE_CREATED",
@@ -243,6 +349,23 @@ const createSharedRequest = async (request: HoppRESTRequest | null) => {
           id: sharedRequestResult.right.createShortcode.id,
         }
         step.value = 2
+
+        if (sharedRequestResult.right.createShortcode.properties) {
+          const parsedEmbedProperties = JSON.parse(
+            sharedRequestResult.right.createShortcode.properties
+          )
+
+          embedOptions.value = {
+            selectedTab: parsedEmbedProperties.options[0],
+            tabs: embedOptions.value.tabs.map((tab) => {
+              return {
+                ...tab,
+                enabled: parsedEmbedProperties.options.includes(tab.value),
+              }
+            }),
+            theme: parsedEmbedProperties.theme,
+          }
+        }
       }
     }
   }
@@ -250,22 +373,37 @@ const createSharedRequest = async (request: HoppRESTRequest | null) => {
 
 const customizeSharedRequest = (
   request: HoppRESTRequest,
-  shredRequestID: string
+  shredRequestID: string,
+  embedProperties?: string | null
 ) => {
   requestToShare.value = {
     ...request,
     id: shredRequestID,
   }
-  displayCustomizeRequestModal(true)
+  displayCustomizeRequestModal(true, embedProperties)
 }
 
 const copySharedRequest = (request: {
   sharedRequestID: string | undefined
   content: string | undefined
+  type: string | undefined
 }) => {
   if (request.content) {
     copyToClipboard(request.content)
     toast.success(t("state.copied_to_clipboard"))
+    if (
+      requestToShare.value &&
+      requestToShare.value.id &&
+      request.type === "embed"
+    ) {
+      const properties = {
+        options: embedOptions.value.tabs
+          .filter((tab) => tab.enabled)
+          .map((tab) => tab.value),
+        theme: embedOptions.value.theme,
+      }
+      updateEmbedProperty(requestToShare.value.id, JSON.stringify(properties))
+    }
   }
 }
 

--- a/packages/hoppscotch-common/src/components/share/index.vue
+++ b/packages/hoppscotch-common/src/components/share/index.vue
@@ -297,6 +297,7 @@ const displayShareRequestModal = (show: boolean) => {
   showShareRequestModal.value = show
   step.value = 1
 }
+
 const displayCustomizeRequestModal = (
   show: boolean,
   embedProperties?: string | null
@@ -416,7 +417,6 @@ const customizeSharedRequest = (
 const copySharedRequest = (payload: {
   sharedRequestID: string | undefined
   content: string | undefined
-  type: string | undefined
 }) => {
   if (payload.content) {
     copyToClipboard(payload.content)

--- a/packages/hoppscotch-common/src/components/share/index.vue
+++ b/packages/hoppscotch-common/src/components/share/index.vue
@@ -88,6 +88,7 @@
     @hide-modal="displayCustomizeRequestModal(false, null)"
     @copy-shared-request="copySharedRequest"
     @create-shared-request="createSharedRequest"
+    @save-shared-request="saveSharedRequest"
   />
 </template>
 
@@ -161,7 +162,7 @@ const embedOptions = ref<EmbedOption>({
 
 const updateEmbedProperty = async (
   shareRequestID: string,
-  properties: string
+  properties: string | null
 ) => {
   const customizeEmbedResult = await updateEmbedProperties(
     shareRequestID,
@@ -383,19 +384,20 @@ const customizeSharedRequest = (
   displayCustomizeRequestModal(true, embedProperties)
 }
 
-const copySharedRequest = (request: {
+const copySharedRequest = (payload: {
   sharedRequestID: string | undefined
   content: string | undefined
   type: string | undefined
 }) => {
-  if (request.content) {
-    copyToClipboard(request.content)
+  if (payload.content) {
+    copyToClipboard(payload.content)
     toast.success(t("state.copied_to_clipboard"))
-    if (
-      requestToShare.value &&
-      requestToShare.value.id &&
-      request.type === "embed"
-    ) {
+  }
+}
+
+const saveSharedRequest = () => {
+  if (requestToShare.value && requestToShare.value.id) {
+    if (selectedWidget.value.value === "embed") {
       const properties = {
         options: embedOptions.value.tabs
           .filter((tab) => tab.enabled)
@@ -403,7 +405,12 @@ const copySharedRequest = (request: {
         theme: embedOptions.value.theme,
       }
       updateEmbedProperty(requestToShare.value.id, JSON.stringify(properties))
+    } else {
+      updateEmbedProperty(requestToShare.value.id, null)
     }
+
+    toast.success(t("shared_requests.modified"))
+    displayShareRequestModal(false)
   }
 }
 

--- a/packages/hoppscotch-common/src/components/share/templates/Button.vue
+++ b/packages/hoppscotch-common/src/components/share/templates/Button.vue
@@ -1,10 +1,6 @@
 <template>
-  <div
-    class="flex items-center justify-center rounded border border-dotted border-dividerDark p-5"
-  >
-    <a href="/" target="_blank">
-      <img :src="img" :alt="t('shared_requests.run_in_hoppscotch')" />
-    </a>
+  <div class="flex flex-col items-center p-4 border rounded border-dividerDark">
+    <img :src="img" :alt="t('shared_requests.run_in_hoppscotch')" />
   </div>
 </template>
 

--- a/packages/hoppscotch-common/src/components/share/templates/Embeds.vue
+++ b/packages/hoppscotch-common/src/components/share/templates/Embeds.vue
@@ -6,13 +6,13 @@
     }"
   >
     <div
-      class="flex items-stretch space-x-4 rounded border-divider"
+      class="flex items-stretch space-x-2 rounded border-divider"
       :class="{
         'bg-accentContrast': isEmbedThemeLight,
       }"
     >
       <span
-        class="flex max-w-[4rem] items-center justify-center rounded border border-divider px-1 py-2 text-tiny"
+        class="flex max-w-[4rem] items-center justify-center rounded border border-divider p-2 text-tiny"
         :class="{
           '!border-dividerLight bg-accentContrast text-primary':
             isEmbedThemeLight,

--- a/packages/hoppscotch-common/src/components/share/templates/Embeds.vue
+++ b/packages/hoppscotch-common/src/components/share/templates/Embeds.vue
@@ -1,32 +1,30 @@
 <template>
   <div
-    class="flex flex-col rounded border border-dotted border-divider p-5"
+    class="flex flex-col p-4 border rounded border-dividerDark"
     :class="{
       'bg-accentContrast': isEmbedThemeLight,
     }"
   >
     <div
-      class="flex items-stretch space-x-2 rounded border-divider"
+      class="flex items-stretch space-x-2"
       :class="{
         'bg-accentContrast': isEmbedThemeLight,
       }"
     >
-      <span
-        class="flex max-w-[4rem] items-center justify-center rounded border border-divider p-2 text-tiny"
-        :class="{
-          '!border-dividerLight bg-accentContrast text-primary':
-            isEmbedThemeLight,
-        }"
-      >
-        <span class="truncate">
-          {{ method }}
-        </span>
-      </span>
-      <span
-        class="flex max-w-46 items-center rounded border border-divider p-2"
-      >
+      <span class="flex items-center min-w-0 border rounded border-divider">
         <span
-          class="min-w-0 truncate"
+          class="flex max-w-[4rem] rounded-l h-full items-center justify-center border-r border-divider text-tiny"
+          :class="{
+            '!border-dividerLight bg-accentContrast text-primary':
+              isEmbedThemeLight,
+          }"
+        >
+          <span class="px-3 truncate">
+            {{ method }}
+          </span>
+        </span>
+        <span
+          class="px-3 truncate"
           :class="{
             'text-primary': isEmbedThemeLight,
           }"
@@ -35,7 +33,7 @@
         </span>
       </span>
       <button
-        class="flex items-center justify-center rounded border border-dividerDark bg-primaryDark px-3 py-2 font-semibold text-secondary"
+        class="flex items-center justify-center flex-shrink-0 px-3 py-2 font-semibold border rounded border-dividerDark bg-primaryDark text-secondary"
         :class="{
           '!bg-accentContrast text-primaryLight': isEmbedThemeLight,
         }"
@@ -44,10 +42,10 @@
       </button>
     </div>
     <div
-      class="flex border-divider"
+      class="flex"
       :class="{
         'bg-accentContrast text-primary': isEmbedThemeLight,
-        'border-b pt-2 ': !noActiveTab,
+        'border-b border-divider pt-2': !noActiveTab,
       }"
     >
       <span
@@ -57,7 +55,8 @@
         class="px-2 py-2"
         :class="{
           'border-b border-dividerDark':
-            embedOptions.selectedTab === option.value,
+            embedOptions.tabs.filter((tab) => tab.enabled)[0]?.value ===
+            option.value,
         }"
       >
         {{ option.label }}

--- a/packages/hoppscotch-common/src/components/share/templates/Link.vue
+++ b/packages/hoppscotch-common/src/components/share/templates/Link.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    class="flex items-center justify-center rounded border border-dotted border-dividerDark p-5"
-  >
+  <div class="flex flex-col items-center p-4 border rounded border-dividerDark">
     <span
       :class="{
         'border-b border-secondary': label,

--- a/packages/hoppscotch-common/src/helpers/backend/gql/mutations/CreateShortcode.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/mutations/CreateShortcode.graphql
@@ -1,5 +1,5 @@
-mutation CreateShortcode($request: String!) {
-  createShortcode(request: $request) {
+mutation CreateShortcode($request: String!, $properties: String) {
+  createShortcode(request: $request, properties: $properties) {
     id
     request
     createdOn

--- a/packages/hoppscotch-common/src/helpers/backend/gql/mutations/UpdateEmbedProperties.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/mutations/UpdateEmbedProperties.graphql
@@ -1,0 +1,8 @@
+mutation UpdateEmbedProperties($code: ID!, $properties: String!) {
+  updateEmbedProperties(code: $code, properties: $properties) {
+    id
+    request
+    properties
+    createdOn
+  }
+}

--- a/packages/hoppscotch-common/src/helpers/backend/gql/queries/ResolveShortcode.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/queries/ResolveShortcode.graphql
@@ -2,5 +2,6 @@ query ResolveShortcode($code: ID!) {
   shortcode(code: $code) {
     id
     request
+    properties
   }
 }

--- a/packages/hoppscotch-common/src/helpers/backend/gql/subscriptions/ShortcodeUpdated.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/subscriptions/ShortcodeUpdated.graphql
@@ -1,0 +1,8 @@
+subscription ShortcodeUpdated {
+  myShortcodesUpdated {
+    id
+    request
+    createdOn
+    properties
+  }
+}

--- a/packages/hoppscotch-common/src/helpers/backend/mutations/Shortcode.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/mutations/Shortcode.ts
@@ -7,15 +7,22 @@ import {
   DeleteShortcodeDocument,
   DeleteShortcodeMutation,
   DeleteShortcodeMutationVariables,
+  UpdateEmbedPropertiesDocument,
+  UpdateEmbedPropertiesMutation,
+  UpdateEmbedPropertiesMutationVariables,
 } from "../graphql"
 
 type DeleteShortcodeErrors = "shortcode/not_found"
 
-export const createShortcode = (request: HoppRESTRequest) =>
+export const createShortcode = (
+  request: HoppRESTRequest,
+  properties?: string
+) =>
   runMutation<CreateShortcodeMutation, CreateShortcodeMutationVariables, "">(
     CreateShortcodeDocument,
     {
       request: JSON.stringify(request),
+      properties,
     }
   )
 
@@ -26,4 +33,14 @@ export const deleteShortcode = (code: string) =>
     DeleteShortcodeErrors
   >(DeleteShortcodeDocument, {
     code,
+  })
+
+export const updateEmbedProperties = (code: string, properties: string) =>
+  runMutation<
+    UpdateEmbedPropertiesMutation,
+    UpdateEmbedPropertiesMutationVariables,
+    ""
+  >(UpdateEmbedPropertiesDocument, {
+    code,
+    properties,
   })

--- a/packages/hoppscotch-common/src/helpers/backend/mutations/Shortcode.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/mutations/Shortcode.ts
@@ -35,10 +35,7 @@ export const deleteShortcode = (code: string) =>
     code,
   })
 
-export const updateEmbedProperties = (
-  code: string,
-  properties: string | null
-) =>
+export const updateEmbedProperties = (code: string, properties: string) =>
   runMutation<
     UpdateEmbedPropertiesMutation,
     UpdateEmbedPropertiesMutationVariables,

--- a/packages/hoppscotch-common/src/helpers/backend/mutations/Shortcode.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/mutations/Shortcode.ts
@@ -35,7 +35,10 @@ export const deleteShortcode = (code: string) =>
     code,
   })
 
-export const updateEmbedProperties = (code: string, properties: string) =>
+export const updateEmbedProperties = (
+  code: string,
+  properties: string | null
+) =>
   runMutation<
     UpdateEmbedPropertiesMutation,
     UpdateEmbedPropertiesMutationVariables,

--- a/packages/hoppscotch-common/src/helpers/shortcode/Shortcode.ts
+++ b/packages/hoppscotch-common/src/helpers/shortcode/Shortcode.ts
@@ -4,6 +4,6 @@
 export interface Shortcode {
   id: string
   request: string
-  properties?: string | null | undefined
+  properties?: string | null
   createdOn: Date
 }

--- a/packages/hoppscotch-common/src/pages/e/_id.vue
+++ b/packages/hoppscotch-common/src/pages/e/_id.vue
@@ -1,7 +1,101 @@
 <template>
-  <div class="flex flex-col items-center justify-between p-8">
-    Temporary page for Embed till the feature is ready
+  <div class="flex flex-col flex-1 w-full">
+    <Embeds v-if="tab" v-model:modelTab="tab" />
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { ref } from "vue"
+import { watch } from "vue"
+import { useRoute } from "vue-router"
+import { useGQLQuery } from "~/composables/graphql"
+import {
+  ResolveShortcodeDocument,
+  ResolveShortcodeQuery,
+  ResolveShortcodeQueryVariables,
+} from "~/helpers/backend/graphql"
+import * as E from "fp-ts/Either"
+import { onMounted } from "vue"
+import {
+  getDefaultRESTRequest,
+  safelyExtractRESTRequest,
+} from "@hoppscotch/data"
+import { HoppTab } from "~/services/tab"
+import { HoppRESTDocument } from "~/helpers/rest/document"
+import { applySetting } from "~/newstore/settings"
+
+const route = useRoute()
+
+const sharedRequestID = ref("")
+const invalidLink = ref(false)
+
+const sharedRequestDetails = useGQLQuery<
+  ResolveShortcodeQuery,
+  ResolveShortcodeQueryVariables,
+  ""
+>({
+  query: ResolveShortcodeDocument,
+  variables: {
+    code: route.params.id.toString(),
+  },
+})
+
+const tab = ref<HoppTab<HoppRESTDocument>>({
+  id: "0",
+  document: {
+    request: getDefaultRESTRequest(),
+    response: null,
+    isDirty: false,
+  },
+})
+
+watch(
+  () => sharedRequestDetails.data,
+  () => {
+    if (sharedRequestDetails.loading) return
+
+    const data = sharedRequestDetails.data
+
+    if (E.isRight(data)) {
+      if (!data.right.shortcode?.request) {
+        invalidLink.value = true
+        return
+      }
+
+      const request: unknown = JSON.parse(
+        data.right.shortcode?.request as string
+      )
+
+      tab.value.document.request = safelyExtractRESTRequest(
+        request,
+        getDefaultRESTRequest()
+      )
+
+      if (data.right.shortcode && data.right.shortcode.properties) {
+        const parsedProperties = JSON.parse(data.right.shortcode.properties)
+        if (parsedProperties.theme === "dark") {
+          applySetting("BG_COLOR", "dark")
+        } else if (parsedProperties.theme === "light") {
+          applySetting("BG_COLOR", "light")
+        } else if (parsedProperties.theme === "auto") {
+          applySetting("BG_COLOR", "system")
+        }
+        console.log("properties", JSON.parse(data.right.shortcode.properties))
+      }
+    }
+  }
+)
+
+onMounted(() => {
+  if (typeof route.params.id === "string") {
+    sharedRequestID.value = route.params.id
+    sharedRequestDetails.execute()
+  }
+  invalidLink.value = !sharedRequestID.value
+})
+</script>
+
+<route lang="yaml">
+meta:
+  layout: empty
+</route>

--- a/packages/hoppscotch-common/src/pages/e/_id.vue
+++ b/packages/hoppscotch-common/src/pages/e/_id.vue
@@ -86,7 +86,6 @@ watch(
         } else if (parsedProperties.theme === "auto") {
           applySetting("BG_COLOR", "system")
         }
-        console.log("properties", JSON.parse(data.right.shortcode.properties))
         properties.value = parsedProperties.options
       }
     }

--- a/packages/hoppscotch-common/src/pages/e/_id.vue
+++ b/packages/hoppscotch-common/src/pages/e/_id.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="flex flex-col flex-1 w-full">
-    <Embeds v-if="tab" v-model:modelTab="tab" />
+    <Embeds
+      v-if="tab"
+      v-model:modelTab="tab"
+      :properties="properties"
+      :shared-request-i-d="sharedRequestID"
+    />
   </div>
 </template>
 
@@ -28,6 +33,7 @@ const route = useRoute()
 
 const sharedRequestID = ref("")
 const invalidLink = ref(false)
+const properties = ref([])
 
 const sharedRequestDetails = useGQLQuery<
   ResolveShortcodeQuery,
@@ -81,6 +87,7 @@ watch(
           applySetting("BG_COLOR", "system")
         }
         console.log("properties", JSON.parse(data.right.shortcode.properties))
+        properties.value = parsedProperties.options
       }
     }
   }

--- a/packages/hoppscotch-ui/src/components/smart/Checkbox.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Checkbox.vue
@@ -75,6 +75,7 @@ const emit = defineEmits<{
       @apply w-4;
       @apply mr-2;
       @apply transition;
+      @apply empty:mr-0;
       content: "";
     }
 


### PR DESCRIPTION
Closes HFE-250

### Description
This feature adds the ability to embed hoppscotch app as iframe on any place like blogs, personal websites etc, by creating a shared request as type embed.

<img width="948" alt="image" src="https://github.com/hoppscotch/hoppscotch/assets/53208152/1ae0bf25-c19a-4be0-9962-1ea3d2cadbf7">


### Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

