### PR TITLE
fix(common): ensure banner colors are displayed correctly

### DIFF
--- a/packages/hoppscotch-common/src/components/http/TestResult.vue
+++ b/packages/hoppscotch-common/src/components/http/TestResult.vue
@@ -41,7 +41,7 @@
             <div class="divide-y divide-dividerLight">
               <div
                 v-if="noEnvSelected && !globalHasAdditions"
-                class="flex bg-info p-4 text-secondaryDark"
+                class="flex bg-bannerInfo p-4 text-secondaryDark"
                 role="alert"
               >
                 <icon-lucide-alert-triangle class="svg-icons mr-4" />

--- a/packages/hoppscotch-common/src/components/profile/UserDelete.vue
+++ b/packages/hoppscotch-common/src/components/profile/UserDelete.vue
@@ -26,7 +26,7 @@
         </div>
         <div
           v-else-if="myTeams.length"
-          class="bg-info flex flex-col space-y-2 rounded-lg border border-red-500 p-4 text-secondaryDark"
+          class="bg-bannerInfo flex flex-col space-y-2 rounded-lg border border-red-500 p-4 text-secondaryDark"
         >
           <h2 class="font-bold text-red-500">
             {{ t("error.danger_zone") }}
@@ -45,7 +45,7 @@
         </div>
         <div v-else>
           <div
-            class="bg-info mb-4 flex flex-col space-y-2 rounded-lg border border-red-500 p-4 text-secondaryDark"
+            class="bg-bannerInfo mb-4 flex flex-col space-y-2 rounded-lg border border-red-500 p-4 text-secondaryDark"
           >
             <h2 class="font-bold text-red-500">
               {{ t("error.danger_zone") }}


### PR DESCRIPTION
### Description

Banner color classes were updated in #3497. The old set of classes was referred to in a few places, and the banner color wasn't displayed correctly. This PR updates all the instances with the updated class names. It also includes fixes for errors raised by ESLint across the package.

### Before

![image](https://github.com/hoppscotch/hoppscotch/assets/25279263/b420cf8b-a65b-4894-85c4-71861ae9d477)

![image](https://github.com/hoppscotch/hoppscotch/assets/25279263/2fd797b9-6c10-41b7-bb54-57ab0c8f7e39)

### After

![image](https://github.com/hoppscotch/hoppscotch/assets/25279263/8e15037d-1f8a-423f-a161-9dfd5d830541)

![image](https://github.com/hoppscotch/hoppscotch/assets/25279263/9471cbf6-38a4-447f-9c86-bc351a8ba4ff)

### Checks
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed