### PR TITLE
fix: use base url instead of hardcoded url

### DIFF
--- a/packages/hoppscotch-common/src/components/embeds/index.vue
+++ b/packages/hoppscotch-common/src/components/embeds/index.vue
@@ -105,9 +105,11 @@ const requestCancelFunc: Ref<(() => void) | null> = ref(null)
 
 const loading = ref(false)
 
-const baseURL = import.meta.env.VITE_SHORTCODE_BASE_URL ?? "https://hopp.sh"
+const shortcodeBaseURL =
+  import.meta.env.VITE_SHORTCODE_BASE_URL ?? "https://hopp.sh"
+
 const sharedRequestURL = computed(() => {
-  return `${baseURL}/r/${props.sharedRequestID}`
+  return `${shortcodeBaseURL}/r/${props.sharedRequestID}`
 })
 
 const { subscribeToStream } = useStreamSubscriber()

--- a/packages/hoppscotch-common/src/components/history/index.vue
+++ b/packages/hoppscotch-common/src/components/history/index.vue
@@ -3,7 +3,7 @@
     <div
       class="sticky top-0 z-10 flex flex-shrink-0 flex-col overflow-x-auto border-b border-dividerLight bg-primary"
     >
-      <WorkspaceCurrent :section="t('tab.history')" />
+      <WorkspaceCurrent :section="t('tab.history')" :is-only-personal="true" />
       <div class="flex">
         <input
           v-model="filterText"

--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -181,6 +181,18 @@
                   @keyup.enter="hide()"
                 />
                 <HoppSmartItem
+                  ref="saveRequestAction"
+                  :label="`${t('request.save_as')}`"
+                  :icon="IconFolderPlus"
+                  @click="
+                    () => {
+                      showSaveRequestModal = true
+                      hide()
+                    }
+                  "
+                />
+                <hr />
+                <HoppSmartItem
                   ref="copyRequestAction"
                   :label="t('request.share_request')"
                   :icon="IconShare2"
@@ -188,18 +200,6 @@
                   @click="
                     () => {
                       shareRequest()
-                      hide()
-                    }
-                  "
-                />
-                <hr />
-                <HoppSmartItem
-                  ref="saveRequestAction"
-                  :label="`${t('request.save_as')}`"
-                  :icon="IconFolderPlus"
-                  @click="
-                    () => {
-                      showSaveRequestModal = true
                       hide()
                     }
                   "

--- a/packages/hoppscotch-common/src/components/share/CustomizeModal.vue
+++ b/packages/hoppscotch-common/src/components/share/CustomizeModal.vue
@@ -370,10 +370,11 @@ const linkVariants: LinkVariant[] = [
   },
 ]
 
-const baseURL = import.meta.env.VITE_SHORTCODE_BASE_URL ?? "https://hopp.sh"
+const shortcodeBaseURL =
+  import.meta.env.VITE_SHORTCODE_BASE_URL ?? "https://hopp.sh"
 
 const copyEmbed = () => {
-  return `<iframe src="${baseURL}/e/${props.request?.id}' style='width: 100%; height: 500px; border: 0; border-radius: 4px; overflow: hidden;'></iframe>`
+  return `<iframe src="${shortcodeBaseURL}/e/${props.request?.id}" title="Hoppscotch Embed" style="width: 100%; height: 480px; border-radius: 4px; border: 1px solid rgba(0, 0, 0, 0.1);"></iframe>`
 }
 
 const copyButton = (
@@ -390,18 +391,18 @@ const copyButton = (
   }
 
   if (type === "markdown") {
-    return `[![Run in Hoppscotch](${baseURL}/${badge})](${baseURL}/r/${props.request?.id})`
+    return `[![Run in Hoppscotch](${shortcodeBaseURL}/${badge})](${shortcodeBaseURL}/r/${props.request?.id})`
   }
-  return `<a href="${baseURL}/r/${props.request?.id}"><img src="${baseURL}/${badge}" alt="Run in Hoppscotch" /></a>`
+  return `<a href="${shortcodeBaseURL}/r/${props.request?.id}"><img src="${shortcodeBaseURL}/${badge}" alt="Run in Hoppscotch" /></a>`
 }
 
 const copyLink = (variationID: string) => {
   if (variationID === "link1") {
-    return `${baseURL}/r/${props.request?.id}`
+    return `${shortcodeBaseURL}/r/${props.request?.id}`
   } else if (variationID === "link2") {
-    return `<a href="${baseURL}/r/${props.request?.id}">Run in Hoppscotch</a>`
+    return `<a href="${shortcodeBaseURL}/r/${props.request?.id}">Run in Hoppscotch</a>`
   }
-  return `[Run in Hoppscotch](${baseURL}/r/${props.request?.id})`
+  return `[Run in Hoppscotch](${shortcodeBaseURL}/r/${props.request?.id})`
 }
 
 const copyContent = ({

--- a/packages/hoppscotch-common/src/components/share/index.vue
+++ b/packages/hoppscotch-common/src/components/share/index.vue
@@ -13,7 +13,7 @@
     >
       <HoppButtonSecondary
         v-tippy="{ theme: 'tooltip' }"
-        to="https://docs.hoppscotch.io/documentation/features/shared-request"
+        to="https://docs.hoppscotch.io/documentation/features/share-requests"
         blank
         :title="t('app.wiki')"
         :icon="IconHelpCircle"

--- a/packages/hoppscotch-common/src/components/share/templates/Link.vue
+++ b/packages/hoppscotch-common/src/components/share/templates/Link.vue
@@ -21,7 +21,12 @@ const props = defineProps<{
   label?: string | undefined
 }>()
 
+const shortcodeBaseURL =
+  import.meta.env.VITE_SHORTCODE_BASE_URL ?? "https://hopp.sh"
+
 const text = computed(() => {
-  return props.label ? t(props.label) : `hopp.sh/r/${props.link ?? "xxxx"}`
+  return props.label
+    ? t(props.label)
+    : `${shortcodeBaseURL}/r/${props.link ?? "xxxx"}`
 })
 </script>

--- a/packages/hoppscotch-ui/src/components/button/Primary.vue
+++ b/packages/hoppscotch-ui/src/components/button/Primary.vue
@@ -2,7 +2,7 @@
   <HoppSmartLink
     :to="to"
     :blank="blank"
-    class="button-primary relative inline-flex items-center justify-center whitespace-nowrap py-2 font-semibold transition focus:outline-none focus-visible:bg-accentDark"
+    class="relative inline-flex items-center justify-center whitespace-nowrap py-2 font-semibold transition focus:outline-none focus-visible:bg-accentDark"
     :exact="exact"
     :class="[
       color


### PR DESCRIPTION
- Use `env.VITE_SHORTCODE_BASE_URL` instead of hardcoded value for shared requests.
- Minor UI improvements.