### PR TITLE
feat(cli): support collection level authorization and headers

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/commands/test.spec.ts
@@ -71,6 +71,13 @@ describe("Test 'hopp test <file>' command:", () => {
 
     expect(error).toBeNull();
   });
+
+  test("Supports inheriting headers and authorization set at the root collection", async () => {
+    const cmd = `node ./bin/hopp test ${getTestJsonFilePath("collection-level-headers-auth.json")}`;
+    const { error } = await execAsync(cmd);
+
+    expect(error).toBeNull();
+  })
 });
 
 describe("Test 'hopp test <file> --env <file>' command:", () => {

--- a/packages/hoppscotch-cli/src/__tests__/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/commands/test.spec.ts
@@ -1,63 +1,64 @@
 import { ExecException } from "child_process";
+
 import { HoppErrorCode } from "../../types/errors";
-import { execAsync, getErrorCode, getTestJsonFilePath } from "../utils";
+import { runCLI, getErrorCode, getTestJsonFilePath } from "../utils";
 
 describe("Test 'hopp test <file>' command:", () => {
   test("No collection file path provided.", async () => {
-    const cmd = `node ./bin/hopp test`;
-    const { stderr } = await execAsync(cmd);
-    const out = getErrorCode(stderr);
+    const args = "test";
+    const { stderr } = await runCLI(args);
 
+    const out = getErrorCode(stderr);
     expect(out).toBe<HoppErrorCode>("INVALID_ARGUMENT");
   });
 
   test("Collection file not found.", async () => {
-    const cmd = `node ./bin/hopp test notfound.json`;
-    const { stderr } = await execAsync(cmd);
-    const out = getErrorCode(stderr);
+    const args = "test notfound.json";
+    const { stderr } = await runCLI(args);
 
+    const out = getErrorCode(stderr);
     expect(out).toBe<HoppErrorCode>("FILE_NOT_FOUND");
   });
 
   test("Collection file is invalid JSON.", async () => {
-    const cmd = `node ./bin/hopp test ${getTestJsonFilePath(
+    const args = `test ${getTestJsonFilePath(
       "malformed-collection.json"
     )}`;
-    const { stderr } = await execAsync(cmd);
-    const out = getErrorCode(stderr);
+    const { stderr } = await runCLI(args);
 
+    const out = getErrorCode(stderr);
     expect(out).toBe<HoppErrorCode>("UNKNOWN_ERROR");
   });
 
   test("Malformed collection file.", async () => {
-    const cmd = `node ./bin/hopp test ${getTestJsonFilePath(
+    const args = `test ${getTestJsonFilePath(
       "malformed-collection2.json"
     )}`;
-    const { stderr } = await execAsync(cmd);
-    const out = getErrorCode(stderr);
+    const { stderr } = await runCLI(args);
 
+    const out = getErrorCode(stderr);
     expect(out).toBe<HoppErrorCode>("MALFORMED_COLLECTION");
   });
 
   test("Invalid arguement.", async () => {
-    const cmd = `node ./bin/hopp invalid-arg`;
-    const { stderr } = await execAsync(cmd);
-    const out = getErrorCode(stderr);
+    const args = "invalid-arg";
+    const { stderr } = await runCLI(args);
 
+    const out = getErrorCode(stderr);
     expect(out).toBe<HoppErrorCode>("INVALID_ARGUMENT");
   });
 
   test("Collection file not JSON type.", async () => {
-    const cmd = `node ./bin/hopp test ${getTestJsonFilePath("notjson.txt")}`;
-    const { stderr } = await execAsync(cmd);
-    const out = getErrorCode(stderr);
+    const args = `test ${getTestJsonFilePath("notjson.txt")}`;
+    const { stderr } = await runCLI(args);
 
+    const out = getErrorCode(stderr);
     expect(out).toBe<HoppErrorCode>("INVALID_FILE_TYPE");
   });
 
   test("Some errors occured (exit code 1).", async () => {
-    const cmd = `node ./bin/hopp test ${getTestJsonFilePath("fails.json")}`;
-    const { error } = await execAsync(cmd);
+    const args = `test ${getTestJsonFilePath("fails.json")}`;
+    const { error } = await runCLI(args);
 
     expect(error).not.toBeNull();
     expect(error).toMatchObject(<ExecException>{
@@ -66,82 +67,83 @@ describe("Test 'hopp test <file>' command:", () => {
   });
 
   test("No errors occured (exit code 0).", async () => {
-    const cmd = `node ./bin/hopp test ${getTestJsonFilePath("passes.json")}`;
-    const { error } = await execAsync(cmd);
+    const args = `test ${getTestJsonFilePath("passes.json")}`;
+    const { error } = await runCLI(args);
 
     expect(error).toBeNull();
   });
 
   test("Supports inheriting headers and authorization set at the root collection", async () => {
-    const cmd = `node ./bin/hopp test ${getTestJsonFilePath("collection-level-headers-auth.json")}`;
-    const { error } = await execAsync(cmd);
+    const args = `test ${getTestJsonFilePath("collection-level-headers-auth.json")}`;
+    const { error } = await runCLI(args);
 
     expect(error).toBeNull();
   })
 });
 
 describe("Test 'hopp test <file> --env <file>' command:", () => {
-  const VALID_TEST_CMD = `node ./bin/hopp test ${getTestJsonFilePath(
+  const VALID_TEST_ARGS = `test ${getTestJsonFilePath(
     "passes.json"
   )}`;
 
   test("No env file path provided.", async () => {
-    const cmd = `${VALID_TEST_CMD} --env`;
-    const { stderr } = await execAsync(cmd);
-    const out = getErrorCode(stderr);
+    const args = `${VALID_TEST_ARGS} --env`;
+    const { stderr } = await runCLI(args);
 
+    const out = getErrorCode(stderr);
     expect(out).toBe<HoppErrorCode>("INVALID_ARGUMENT");
   });
 
   test("ENV file not JSON type.", async () => {
-    const cmd = `${VALID_TEST_CMD} --env ${getTestJsonFilePath("notjson.txt")}`;
-    const { stderr } = await execAsync(cmd);
-    const out = getErrorCode(stderr);
+    const args = `${VALID_TEST_ARGS} --env ${getTestJsonFilePath("notjson.txt")}`;
+    const { stderr } = await runCLI(args);
 
+    const out = getErrorCode(stderr);
     expect(out).toBe<HoppErrorCode>("INVALID_FILE_TYPE");
   });
 
   test("ENV file not found.", async () => {
-    const cmd = `${VALID_TEST_CMD} --env notfound.json`;
-    const { stderr } = await execAsync(cmd);
-    const out = getErrorCode(stderr);
+    const args = `${VALID_TEST_ARGS} --env notfound.json`;
+    const { stderr } = await runCLI(args);
 
+    const out = getErrorCode(stderr);
     expect(out).toBe<HoppErrorCode>("FILE_NOT_FOUND");
   });
 
   test("No errors occured (exit code 0).", async () => {
     const TESTS_PATH = getTestJsonFilePath("env-flag-tests.json");
     const ENV_PATH = getTestJsonFilePath("env-flag-envs.json");
-    const cmd = `node ./bin/hopp test ${TESTS_PATH} --env ${ENV_PATH}`;
-    const { error, stdout } = await execAsync(cmd);
+    const args = `test ${TESTS_PATH} --env ${ENV_PATH}`;
 
+    const { error } = await runCLI(args);
     expect(error).toBeNull();
   });
 });
 
 describe("Test 'hopp test <file> --delay <delay_in_ms>' command:", () => {
-  const VALID_TEST_CMD = `node ./bin/hopp test ${getTestJsonFilePath(
+  const VALID_TEST_ARGS = `test ${getTestJsonFilePath(
     "passes.json"
   )}`;
 
   test("No value passed to delay flag.", async () => {
-    const cmd = `${VALID_TEST_CMD} --delay`;
-    const { stderr } = await execAsync(cmd);
-    const out = getErrorCode(stderr);
+    const args = `${VALID_TEST_ARGS} --delay`;
+    const { stderr } = await runCLI(args);
 
+    const out = getErrorCode(stderr);
     expect(out).toBe<HoppErrorCode>("INVALID_ARGUMENT");
   });
 
   test("Invalid value passed to delay flag.", async () => {
-    const cmd = `${VALID_TEST_CMD} --delay 'NaN'`;
-    const { stderr } = await execAsync(cmd);
+    const args = `${VALID_TEST_ARGS} --delay 'NaN'`;
+    const { stderr } = await runCLI(args);
+
     const out = getErrorCode(stderr);
     expect(out).toBe<HoppErrorCode>("INVALID_ARGUMENT");
   });
 
   test("Valid value passed to delay flag.", async () => {
-    const cmd = `${VALID_TEST_CMD} --delay 1`;
-    const { error } = await execAsync(cmd);
+    const args = `${VALID_TEST_ARGS} --delay 1`;
+    const { error } = await runCLI(args);
 
     expect(error).toBeNull();
   });

--- a/packages/hoppscotch-cli/src/__tests__/samples/collection-level-headers-auth.json
+++ b/packages/hoppscotch-cli/src/__tests__/samples/collection-level-headers-auth.json
@@ -1,0 +1,221 @@
+[
+  {
+    "v": 1,
+    "name": "CollectionA",
+    "folders": [
+      {
+        "v": 1,
+        "name": "FolderA",
+        "folders": [
+          {
+            "v": 1,
+            "name": "FolderB",
+            "folders": [
+              {
+                "v": 1,
+                "name": "FolderC",
+                "folders": [],
+                "requests": [
+                  {
+                    "v": "1",
+                    "endpoint": "https://echo.hoppscotch.io",
+                    "name": "RequestD",
+                    "params": [],
+                    "headers": [
+                      {
+                        "active": true,
+                        "key": "X-Test-Header",
+                        "value": "Overriden at RequestD"
+                      }
+                    ],
+                    "method": "GET",
+                    "auth": {
+                      "authType": "basic",
+                      "authActive": true,
+                      "username": "username",
+                      "password": "password"
+                    },
+                    "preRequestScript": "",
+                    "testScript": "pw.test(\"Overrides auth and headers set at the parent folder\", ()=> {\n    pw.expect(pw.response.body.headers[\"x-test-header\"]).toBe(\"Overriden at RequestD\");\n  pw.expect(pw.response.body.headers[\"authorization\"]).toBe(\"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\");\n});",
+                    "body": {
+                      "contentType": null,
+                      "body": null
+                    }
+                  }
+                ],
+                "auth": {
+                  "authType": "inherit",
+                  "authActive": true
+                },
+                "headers": []
+              }
+            ],
+            "requests": [
+              {
+                "v": "1",
+                "endpoint": "https://echo.hoppscotch.io",
+                "name": "RequestC",
+                "params": [],
+                "headers": [],
+                "method": "GET",
+                "auth": {
+                  "authType": "inherit",
+                  "authActive": true
+                },
+                "preRequestScript": "",
+                "testScript": "pw.test(\"Correctly inherits auth and headers from the parent folder\", ()=> {\n    pw.expect(pw.response.body.headers[\"x-test-header\"]).toBe(\"Overriden at FolderB\");\n  pw.expect(pw.response.body.headers[\"key\"]).toBe(\"test-key\");\n});",
+                "body": {
+                  "contentType": null,
+                  "body": null
+                }
+              }
+            ],
+            "auth": {
+              "authType": "api-key",
+              "authActive": true,
+              "addTo": "Headers",
+              "key": "key",
+              "value": "test-key"
+            },
+            "headers": [
+              {
+                "active": true,
+                "key": "X-Test-Header",
+                "value": "Overriden at FolderB"
+              }
+            ]
+          }
+        ],
+        "requests": [
+          {
+            "v": "1",
+            "endpoint": "https://echo.hoppscotch.io",
+            "name": "RequestB",
+            "params": [],
+            "headers": [],
+            "method": "GET",
+            "auth": {
+              "authType": "inherit",
+              "authActive": true
+            },
+            "preRequestScript": "",
+            "testScript": "pw.test(\"Correctly inherits auth and headers from the parent folder\", ()=> {\n    pw.expect(pw.response.body.headers[\"x-test-header\"]).toBe(\"Set at root collection\");\n  pw.expect(pw.response.body.headers[\"authorization\"]).toBe(\"Bearer BearerToken\");\n});",
+            "body": {
+              "contentType": null,
+              "body": null
+            },
+            "id": "clpttpdq00003qp16kut6doqv"
+          }
+        ],
+        "auth": {
+          "authType": "inherit",
+          "authActive": true
+        },
+        "headers": []
+      }
+    ],
+    "requests": [
+      {
+        "v": "1",
+        "endpoint": "https://echo.hoppscotch.io",
+        "name": "RequestA",
+        "params": [],
+        "headers": [],
+        "method": "GET",
+        "auth": {
+          "authType": "inherit",
+          "authActive": true
+        },
+        "preRequestScript": "",
+        "testScript": "pw.test(\"Correctly inherits auth and headers from the root collection\", ()=> {\n    pw.expect(pw.response.body.headers[\"x-test-header\"]).toBe(\"Set at root collection\");\n  pw.expect(pw.response.body.headers[\"authorization\"]).toBe(\"Bearer BearerToken\");\n});",
+        "body": {
+          "contentType": null,
+          "body": null
+        },
+        "id": "clpttpdq00003qp16kut6doqv"
+      }
+    ],
+    "headers": [
+      {
+        "active": true,
+        "key": "X-Test-Header",
+        "value": "Set at root collection"
+      }
+    ],
+    "auth": {
+      "authType": "bearer",
+      "authActive": true,
+      "token": "BearerToken"
+    }
+  },
+  {
+    "v": 1,
+    "name": "CollectionB",
+    "folders": [
+      {
+        "v": 1,
+        "name": "FolderA",
+        "folders": [],
+        "requests": [
+          {
+            "v": "1",
+            "endpoint": "https://echo.hoppscotch.io",
+            "name": "RequestB",
+            "params": [],
+            "headers": [],
+            "method": "GET",
+            "auth": {
+              "authType": "inherit",
+              "authActive": true
+            },
+            "preRequestScript": "",
+            "testScript": "pw.test(\"Correctly inherits auth and headers from the parent folder\", ()=> {\n    pw.expect(pw.response.body.headers[\"x-test-header\"]).toBe(\"Set at root collection\");\n  pw.expect(pw.response.body.headers[\"authorization\"]).toBe(\"Bearer BearerToken\");\n});",
+            "body": {
+              "contentType": null,
+              "body": null
+            },
+            "id": "clpttpdq00003qp16kut6doqv"
+          }
+        ],
+        "auth": {
+          "authType": "inherit",
+          "authActive": true
+        },
+        "headers": []
+      }
+    ],
+    "requests": [
+      {
+        "v": "1",
+        "endpoint": "https://echo.hoppscotch.io",
+        "name": "RequestA",
+        "params": [],
+        "headers": [],
+        "method": "GET",
+        "auth": {
+          "authType": "inherit",
+          "authActive": true
+        },
+        "preRequestScript": "",
+        "testScript": "pw.test(\"Correctly inherits auth and headers from the root collection\", ()=> {\n    pw.expect(pw.response.body.headers[\"x-test-header\"]).toBe(\"Set at root collection\");\n  pw.expect(pw.response.body.headers[\"authorization\"]).toBe(\"Bearer BearerToken\");\n});",
+        "body": {
+          "contentType": null,
+          "body": null
+        },
+        "id": "clpttpdq00003qp16kut6doqv"
+      }
+    ],
+    "headers": [
+      {
+        "active": true,
+        "key": "X-Test-Header",
+        "value": "Set at root collection"
+      }
+    ],
+    "auth": {
+      "authType": "bearer",
+      "authActive": true,
+      "token": "BearerToken"
+    }
+  }
+]

--- a/packages/hoppscotch-cli/src/__tests__/utils.ts
+++ b/packages/hoppscotch-cli/src/__tests__/utils.ts
@@ -1,10 +1,17 @@
 import { exec } from "child_process";
+import { resolve } from "path";
+
 import { ExecResponse } from "./types";
 
-export const execAsync = (command: string): Promise<ExecResponse> =>
-  new Promise((resolve) =>
-    exec(command, (error, stdout, stderr) => resolve({ error, stdout, stderr }))
-  );
+export const runCLI = (args: string): Promise<ExecResponse> =>
+  {
+    const CLI_PATH = resolve(__dirname, "../../bin/hopp");
+    const command = `node ${CLI_PATH} ${args}`
+
+    return new Promise((resolve) =>
+      exec(command, (error, stdout, stderr) => resolve({ error, stdout, stderr }))
+    );
+  }
 
 export const trimAnsi = (target: string) => {
   const ansiRegex =

--- a/packages/hoppscotch-cli/src/utils/collections.ts
+++ b/packages/hoppscotch-cli/src/utils/collections.ts
@@ -1,21 +1,23 @@
-import * as A from "fp-ts/Array";
-import { pipe } from "fp-ts/function";
+import { HoppCollection, HoppRESTRequest } from "@hoppscotch/data";
 import { bold } from "chalk";
 import { log } from "console";
+import * as A from "fp-ts/Array";
+import { pipe } from "fp-ts/function";
 import round from "lodash/round";
-import { HoppCollection, HoppRESTRequest } from "@hoppscotch/data";
+
+import { CollectionRunnerParam } from "../types/collections";
 import {
-  HoppEnvs,
   CollectionStack,
-  RequestReport,
+  HoppEnvs,
   ProcessRequestParams,
+  RequestReport,
 } from "../types/request";
 import {
-  getRequestMetrics,
-  preProcessRequest,
-  processRequest,
-} from "./request";
-import { exceptionColors } from "./getters";
+  PreRequestMetrics,
+  RequestMetrics,
+  TestMetrics,
+} from "../types/response";
+import { DEFAULT_DURATION_PRECISION } from "./constants";
 import {
   printErrorsReport,
   printFailedTestsReport,
@@ -23,15 +25,14 @@ import {
   printRequestsMetrics,
   printTestsMetrics,
 } from "./display";
-import {
-  PreRequestMetrics,
-  RequestMetrics,
-  TestMetrics,
-} from "../types/response";
-import { getTestMetrics } from "./test";
-import { DEFAULT_DURATION_PRECISION } from "./constants";
+import { exceptionColors } from "./getters";
 import { getPreRequestMetrics } from "./pre-request";
-import { CollectionRunnerParam } from "../types/collections";
+import {
+  getRequestMetrics,
+  preProcessRequest,
+  processRequest,
+} from "./request";
+import { getTestMetrics } from "./test";
 
 const { WARN, FAIL } = exceptionColors;
 
@@ -84,7 +85,7 @@ export const collectionsRunner = async (
 
       // Pushing remaining folders realted collection to stack.
       for (const folder of collection.folders) {
-        const updatedFolder = { ...folder }
+        const updatedFolder: HoppCollection = { ...folder }
 
         if (updatedFolder.auth?.authType === "inherit") {
           updatedFolder.auth = collection.auth;

--- a/packages/hoppscotch-cli/src/utils/collections.ts
+++ b/packages/hoppscotch-cli/src/utils/collections.ts
@@ -86,12 +86,17 @@ export const collectionsRunner = async (
       for (const folder of collection.folders) {
         const updatedFolder = { ...folder }
 
-        if (updatedFolder.auth.authType === "inherit") {
+        if (updatedFolder.auth?.authType === "inherit") {
           updatedFolder.auth = collection.auth;
         }
 
-        if (collection.headers) {
-          updatedFolder.headers.push(...collection.headers);
+        if (collection.headers?.length) {
+          // Filter out header entries present in the parent collection under the same name
+          // This ensures the folder headers take precedence over the collection headers
+          const filteredHeaders = collection.headers.filter((collectionHeaderEntries) => {
+            return !updatedFolder.headers.some((folderHeaderEntries) => folderHeaderEntries.key === collectionHeaderEntries.key)
+          })
+          updatedFolder.headers.push(...filteredHeaders);
         }
 
         collectionStack.push({

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -1,31 +1,31 @@
+import { HoppCollection, HoppRESTRequest } from "@hoppscotch/data";
 import axios, { Method } from "axios";
-import { URL } from "url";
-import * as S from "fp-ts/string";
 import * as A from "fp-ts/Array";
-import * as T from "fp-ts/Task";
 import * as E from "fp-ts/Either";
+import * as T from "fp-ts/Task";
 import * as TE from "fp-ts/TaskEither";
-import { HoppRESTRequest } from "@hoppscotch/data";
-import { responseErrors } from "./constants";
-import { getDurationInSeconds, getMetaDataPairs } from "./getters";
-import { testRunner, getTestScriptParams, hasFailedTestCases } from "./test";
-import { RequestConfig, EffectiveHoppRESTRequest } from "../interfaces/request";
+import { pipe } from "fp-ts/function";
+import * as S from "fp-ts/string";
+import { hrtime } from "process";
+import { URL } from "url";
+import { EffectiveHoppRESTRequest, RequestConfig } from "../interfaces/request";
 import { RequestRunnerResponse } from "../interfaces/response";
-import { preRequestScriptRunner } from "./pre-request";
+import { HoppCLIError, error } from "../types/errors";
 import {
   HoppEnvs,
   ProcessRequestParams,
   RequestReport,
 } from "../types/request";
+import { RequestMetrics } from "../types/response";
+import { responseErrors } from "./constants";
 import {
   printPreRequestRunner,
   printRequestRunner,
   printTestRunner,
 } from "./display";
-import { error, HoppCLIError } from "../types/errors";
-import { hrtime } from "process";
-import { RequestMetrics } from "../types/response";
-import { pipe } from "fp-ts/function";
+import { getDurationInSeconds, getMetaDataPairs } from "./getters";
+import { preRequestScriptRunner } from "./pre-request";
+import { getTestScriptParams, hasFailedTestCases, testRunner } from "./test";
 
 // !NOTE: The `config.supported` checks are temporary until OAuth2 and Multipart Forms are supported
 
@@ -309,9 +309,12 @@ export const processRequest =
  * @returns Updated request object free of invalid/missing data.
  */
 export const preProcessRequest = (
-  request: HoppRESTRequest
+  request: HoppRESTRequest,
+  collection: HoppCollection<HoppRESTRequest>,
 ): HoppRESTRequest => {
   const tempRequest = Object.assign({}, request);
+  const { headers: parentHeaders, auth: parentAuth } = collection;
+
   if (!tempRequest.v) {
     tempRequest.v = "1";
   }
@@ -327,18 +330,26 @@ export const preProcessRequest = (
   if (!tempRequest.params) {
     tempRequest.params = [];
   }
-  if (!tempRequest.headers) {
+
+  if (parentHeaders?.length) {
+    tempRequest.headers.push(...parentHeaders);
+  } else if (!tempRequest.headers) {
     tempRequest.headers = [];
   }
+
   if (!tempRequest.preRequestScript) {
     tempRequest.preRequestScript = "";
   }
   if (!tempRequest.testScript) {
     tempRequest.testScript = "";
   }
-  if (!tempRequest.auth) {
+
+  if (tempRequest.auth?.authType === "inherit") {
+    tempRequest.auth = parentAuth;
+  } else if (!tempRequest.auth) {
     tempRequest.auth = { authActive: false, authType: "none" };
   }
+
   if (!tempRequest.body) {
     tempRequest.body = { contentType: null, body: null };
   }

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -332,7 +332,12 @@ export const preProcessRequest = (
   }
 
   if (parentHeaders?.length) {
-    tempRequest.headers.push(...parentHeaders);
+    // Filter out header entries present in the parent (folder/collection) under the same name
+    // This ensures the child headers take precedence over the parent headers
+    const filteredEntries = parentHeaders.filter((parentHeaderEntries) => {
+      return !tempRequest.headers.some((reqHeaderEntries) => reqHeaderEntries.key === parentHeaderEntries.key)
+    })
+    tempRequest.headers.push(...filteredEntries);
   } else if (!tempRequest.headers) {
     tempRequest.headers = [];
   }

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -310,7 +310,7 @@ export const processRequest =
  */
 export const preProcessRequest = (
   request: HoppRESTRequest,
-  collection: HoppCollection<HoppRESTRequest>,
+  collection: HoppCollection,
 ): HoppRESTRequest => {
   const tempRequest = Object.assign({}, request);
   const { headers: parentHeaders, auth: parentAuth } = collection;


### PR DESCRIPTION
### Description

This PR includes the necessary changes to the CLI for processing the updated export format with authorization and headers set at the collection level.

- For `auth` fields for folders/requests, the value at the current level is updated to be based on the immediate parent.
- For `header` fields, the value at the current level is extended based on the immediate parent. If there are header entries with keys under the same name, the value set at the child level takes precedence.

> The test suite has been updated with a relevant test case to verify the new behavior. Along with that, the `execAsync` helper function has been modified to maintain the CLI path locally and construct the command structure based on the received arguments, and renamed to `runCLI`.

Depends on #3505.

Closes HFE-295.

### Steps to verify

Given below is a comprehensive sample to verify the behavior involving multiple auth types and headers. For a relatively simple example, please refer to the [test suite](https://github.com/hoppscotch/hoppscotch/blob/828d771da9e60f2587a6a86f3cc48aa8c08e7b59/packages/hoppscotch-cli/src/__tests__/commands/test.spec.ts#L76-L82).

- Spin up an `Express.js` based server as below. Initialize `package.json` with `npm init -y` and add `express` as a dependency. Start the server with `node index.js`. Optionally, add it as a `start` script.

  ```js
  const express = require('express');

  const app = express();
  const port = process.env.PORT || 4000;

  // Middleware to check for Basic Auth credentials in headers
  const basicAuth = (req, res, next) => {
    const authHeader = req.headers.authorization;
    const authActiveHeader = req.headers['auth-active']
    const authTypeHeader = req.headers['auth-type'];

    if (authActiveHeader !== 'true' ||  authTypeHeader !== 'basic-auth' || !authHeader || !authHeader.startsWith('Basic ')) {
      return res.status(401).json({ error: 'Unauthorized', headers: req.headers });
    }

    const credentials = Buffer.from(authHeader.split(' ')[1], 'base64').toString('utf-8');
    const [username, password] = credentials.split(':');

    if (username !== 'username' || password !== 'password') {
      return res.status(401).json({ error: 'Invalid username/password', headers: req.headers });
    }

    next();
  };

  // Middleware to check for API Key in the request header
  const apiKeyAuth = (req, res, next) => {
    const apiKey = req.headers['key'];
    const authActiveHeader = req.headers['auth-active']
    const authTypeHeader = req.headers['auth-type'];

    if (authActiveHeader !== 'true' || authTypeHeader !== 'api-key' || !apiKey || apiKey !== 'test-key') {
      return res.status(401).json({ error: 'Unauthorized', headers: req.headers });
    }

    next();
  };

  // Middleware to check for Bearer Token in the Authorization header
  const bearerTokenAuth = (req, res, next) => {
    const authHeader = req.headers.authorization;
    const authActiveHeader = req.headers['auth-active']
    const authTypeHeader = req.headers['auth-type'];

    if (authActiveHeader !== 'true'  || authTypeHeader !== 'bearer-token' || !authHeader || !authHeader.startsWith('Bearer ')) {
      return res.status(401).json({ error: 'Unauthorized', headers: req.headers });
    }

    const token = authHeader.split(' ')[1];
    if (token !== 'test-token') {
      return res.status(401).json({ error: 'Invalid bearer token', headers: req.headers });
    }

    next();
  };

  const publicEndPointMiddleware = (req, res, next) => {
    const authActiveHeader = req.headers['auth-active']
    const authTypeHeader = req.headers['auth-type'];

    if (authActiveHeader === 'false' && !authTypeHeader) {
      return next();
    }

    return res.status(401).json({ error: 'Public endpoint should not require auth headers' });
  }

  // Endpoint with Basic Auth
  app.get('/basic-auth', basicAuth, (req, res) => {
    res.json({ message: 'Basic Auth endpoint accessed successfully!', headers: req.headers });
  });

  // Endpoint with API key Auth
  app.get('/api-key', apiKeyAuth, (req, res) => {
    res.json({ message: 'API key endpoint accessed successfully!', headers: req.headers });
  });

  // Endpoint with Bearer Token Auth
  app.get('/bearer-token', bearerTokenAuth, (req, res) => {
    res.json({ message: 'Bearer token endpoint accessed successfully!', headers: req.headers });
  });

  // Endpoint accessible without any auth
  app.get('/public', publicEndPointMiddleware, (req, res) => {
    res.json({ message: 'Public endpoint accessed successfully!', headers: req.headers });
  });

  // Start the server
  app.listen(port, () => {
    console.log(`Server is running on port ${port}`);
  });
  ```
-  Grab the following collection JSON contents and name it `collection.json`.

  ```json
  {
    "v": 1,
    "name": "Collection level headers and authorization",
    "folders": [
      {
        "v": 1,
        "name": "request-types",
        "folders": [
          {
            "v": 1,
            "name": "public-endpoint",
            "folders": [],
            "requests": [
              {
                "v": "1",
                "endpoint": "http://localhost:4000/public",
                "name": "non-auth-request",
                "params": [],
                "headers": [],
                "method": "GET",
                "auth": {
                  "authType": "inherit",
                  "authActive": true
                },
                "preRequestScript": "",
                "testScript": "pw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Correctly inherits authorization and headers from the parent folder\", ()=> {  \n  pw.expect(pw.response.body.headers[\"auth-active\"]).toBe(\"false\");\n  pw.expect(pw.response.body.headers[\"auth-type\"]).toBe(\"\");\n});",
                "body": {
                  "contentType": null,
                  "body": null
                },
                "id": "clpttpdq00003qp16kut6doqv"
              }
            ],
            "auth": {
              "authType": "none",
              "authActive": true
            },
            "headers": [
              {
                "active": true,
                "key": "auth-active",
                "value": "false"
              },
              {
                "active": true,
                "key": "auth-type",
                "value": ""
              }
            ]
          },
          {
            "v": 1,
            "name": "api-key-auth-headers",
            "folders": [],
            "requests": [
              {
                "v": "1",
                "endpoint": "http://localhost:4000/api-key",
                "name": "api-key-request",
                "params": [],
                "headers": [],
                "method": "GET",
                "auth": {
                  "authType": "inherit",
                  "authActive": true
                },
                "preRequestScript": "",
                "testScript": "pw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Correctly inherits authorization and headers from the parent folder\", ()=> {  \n  pw.expect(pw.response.body.headers[\"auth-active\"]).toBe(\"true\");\n  pw.expect(pw.response.body.headers[\"auth-type\"]).toBe(\"api-key\");\n  pw.expect(pw.response.body.headers[\"key\"]).toBe(\"test-key\");\n});",
                "body": {
                  "contentType": null,
                  "body": null
                }
              }
            ],
            "auth": {
              "authType": "api-key",
              "authActive": true,
              "key": "key",
              "value": "test-key",
              "addTo": "Headers"
            },
            "headers": [
              {
                "active": true,
                "key": "auth-type",
                "value": "api-key"
              }
            ]
          },
          {
            "v": 1,
            "name": "bearer-token",
            "folders": [],
            "requests": [
              {
                "v": "1",
                "endpoint": "http://localhost:4000/bearer-token",
                "name": "bearer-token-request",
                "params": [],
                "headers": [],
                "method": "GET",
                "auth": {
                  "authType": "inherit",
                  "authActive": true
                },
                "preRequestScript": "",
                "testScript": "pw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Correctly inherits authorization and headers from the parent folder\", ()=> {  \n  pw.expect(pw.response.body.headers[\"auth-active\"]).toBe(\"true\");\n  pw.expect(pw.response.body.headers[\"auth-type\"]).toBe(\"bearer-token\");\n  pw.expect(pw.response.body.headers[\"authorization\"]).toBe(\"Bearer test-token\");\n});",
                "body": {
                  "contentType": null,
                  "body": null
                }
              }
            ],
            "auth": {
              "authType": "bearer",
              "authActive": true,
              "token": "test-token"
            },
            "headers": [
              {
                "active": true,
                "key": "auth-type",
                "value": "bearer-token"
              }
            ]
          }
        ],
        "requests": [
          {
            "v": "1",
            "endpoint": "http://localhost:4000/basic-auth",
            "name": "basic-auth-request",
            "params": [],
            "headers": [],
            "method": "GET",
            "auth": {
              "authType": "inherit",
              "authActive": true
            },
            "preRequestScript": "",
            "testScript": "pw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Correctly inherits authorization and headers from the root collection\", ()=> {  \n  pw.expect(pw.response.body.headers[\"authorization\"]).toBe(\"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\");\n  pw.expect(pw.response.body.headers[\"auth-active\"]).toBe(\"true\");\n  pw.expect(pw.response.body.headers[\"auth-type\"]).toBe(\"basic-auth\");\n});",
            "body": {
              "contentType": null,
              "body": null
            },
            "id": "clpttpdq00003qp16kut6doqv"
          }
        ],
        "auth": {
          "authType": "inherit",
          "authActive": true
        },
        "headers": []
      }
    ],
    "requests": [
      {
        "v": "1",
        "endpoint": "http://localhost:4000/basic-auth",
        "name": "basic-auth-top-level-request",
        "params": [],
        "headers": [],
        "method": "GET",
        "auth": {
          "authType": "inherit",
          "authActive": true,
          "addTo": "Headers",
          "key": "key",
          "value": "value"
        },
        "preRequestScript": "",
        "testScript": "pw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Correctly inherits authorization and headers from the root collection\", ()=> {  \n  pw.expect(pw.response.body.headers[\"authorization\"]).toBe(\"Basic dXNlcm5hbWU6cGFzc3dvcmQ=\");\n  pw.expect(pw.response.body.headers[\"auth-active\"]).toBe(\"true\");\n  pw.expect(pw.response.body.headers[\"auth-type\"]).toBe(\"basic-auth\");\n});",
        "body": {
          "contentType": null,
          "body": null
        },
        "id": "clpttpdq00003qp16kut6doqv"
      }
    ],
    "headers": [
      {
        "active": true,
        "key": "auth-active",
        "value": "true"
      },
      {
        "active": true,
        "key": "auth-type",
        "value": "basic-auth"
      }
    ],
    "auth": {
      "authType": "basic",
      "authActive": true,
      "token": "BearerToken",
      "username": "username",
      "password": "password"
    }
  }
  ```

  - Navigate to the `hoppscotch-cli` package path, invoke the CLI supplying the above collection contents with
    ```
      node bin/hopp test collection.json
    ```

  - Relevant tests are added to the above collection file under `testScript` to assert the expected results at each level. Observe all the tests pass ✅

### Checks
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed