### PR TITLE
fix: overflowing modal fix on small screens

### DIFF
--- a/packages/hoppscotch-ui/src/components/smart/Modal.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Modal.vue
@@ -54,7 +54,7 @@
               </span>
             </div>
             <div
-              class="flex flex-col overflow-y-auto max-h-[60vh]"
+              class="flex flex-col overflow-y-auto max-h-[50vh]"
               :class="{ 'p-4': !fullWidth }"
             >
               <slot name="body"></slot>

--- a/packages/hoppscotch-ui/src/components/smart/Modal.vue
+++ b/packages/hoppscotch-ui/src/components/smart/Modal.vue
@@ -54,7 +54,7 @@
               </span>
             </div>
             <div
-              class="max-h-lg flex flex-col overflow-y-auto"
+              class="flex flex-col overflow-y-auto max-h-[60vh]"
               :class="{ 'p-4': !fullWidth }"
             >
               <slot name="body"></slot>


### PR DESCRIPTION
Modal max height is set based on view port size instead of using hard coded value

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3642 

### Description
Used `60vh` as body height of modal instead of `lg`

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
[Screencast from 12-12-23 01:18:44 PM IST.webm](https://github.com/hoppscotch/hoppscotch/assets/55492635/6c66bb13-2ea3-4197-8929-6d18cfcb5528)

