### PR TITLE
feat: Persist Wrap Line Setting for Tabs

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -85,6 +85,7 @@ import { platform } from "~/platform"
 import { useService } from "dioc/vue"
 import { RESTTabService } from "~/services/tab/rest"
 import { GQLTabService } from "~/services/tab/graphql"
+import { RESTEditorSettings } from "~/helpers/rest/document"
 
 const t = useI18n()
 const toast = useToast()
@@ -219,6 +220,15 @@ const saveRequestAs = async () => {
       ? cloneDeep(RESTTabs.currentActiveTab.value.document.request)
       : cloneDeep(GQLTabs.currentActiveTab.value.document.request)
 
+  // TODO: Change when adding GraphQL Tab Support
+  const editorSettings =
+    props.mode === "rest"
+      ? cloneDeep(RESTTabs.currentActiveTab.value.document.editorSettings)
+      : {
+          requestWrapLines: true,
+          responseWrapLines: true,
+        }
+
   requestUpdated.name = requestName.value
 
   if (picked.value.pickedType === "my-collection") {
@@ -233,6 +243,7 @@ const saveRequestAs = async () => {
     RESTTabs.currentActiveTab.value.document = {
       request: requestUpdated,
       isDirty: false,
+      editorSettings: editorSettings,
       saveContext: {
         originLocation: "user-collection",
         folderPath: `${picked.value.collectionIndex}`,
@@ -260,6 +271,7 @@ const saveRequestAs = async () => {
     RESTTabs.currentActiveTab.value.document = {
       request: requestUpdated,
       isDirty: false,
+      editorSettings: editorSettings,
       saveContext: {
         originLocation: "user-collection",
         folderPath: picked.value.folderPath,
@@ -288,6 +300,7 @@ const saveRequestAs = async () => {
     RESTTabs.currentActiveTab.value.document = {
       request: requestUpdated,
       isDirty: false,
+      editorSettings: editorSettings,
       saveContext: {
         originLocation: "user-collection",
         folderPath: picked.value.folderPath,
@@ -307,7 +320,11 @@ const saveRequestAs = async () => {
     if (!isHoppRESTRequest(requestUpdated))
       throw new Error("requestUpdated is not a REST Request")
 
-    updateTeamCollectionOrFolder(picked.value.collectionID, requestUpdated)
+    updateTeamCollectionOrFolder(
+      picked.value.collectionID,
+      requestUpdated,
+      editorSettings
+    )
 
     platform.analytics?.logEvent({
       type: "HOPP_SAVE_REQUEST",
@@ -319,7 +336,11 @@ const saveRequestAs = async () => {
     if (!isHoppRESTRequest(requestUpdated))
       throw new Error("requestUpdated is not a REST Request")
 
-    updateTeamCollectionOrFolder(picked.value.folderID, requestUpdated)
+    updateTeamCollectionOrFolder(
+      picked.value.folderID,
+      requestUpdated,
+      editorSettings
+    )
 
     platform.analytics?.logEvent({
       type: "HOPP_SAVE_REQUEST",
@@ -420,7 +441,8 @@ const saveRequestAs = async () => {
  */
 const updateTeamCollectionOrFolder = (
   collectionID: string,
-  requestUpdated: HoppRESTRequest
+  requestUpdated: HoppRESTRequest,
+  editorSettings: RESTEditorSettings
 ) => {
   if (
     collectionsType.value.type !== "team-collections" ||
@@ -448,6 +470,7 @@ const updateTeamCollectionOrFolder = (
         RESTTabs.currentActiveTab.value.document = {
           request: requestUpdated,
           isDirty: false,
+          editorSettings: editorSettings,
           saveContext: {
             originLocation: "team-collection",
             requestID: createRequestInCollection.id,

--- a/packages/hoppscotch-common/src/components/http/Body.vue
+++ b/packages/hoppscotch-common/src/components/http/Body.vue
@@ -105,7 +105,11 @@
       v-else-if="body.contentType === 'application/x-www-form-urlencoded'"
       v-model="body"
     />
-    <HttpRawBody v-else-if="body.contentType !== null" v-model="body" />
+    <HttpRawBody
+      v-else-if="body.contentType !== null"
+      v-model="body"
+      v-model:editor-settings="editorSettings"
+    />
     <HoppSmartPlaceholder
       v-if="body.contentType == null"
       :src="`/images/states/${colorMode.value}/upload_single_file.svg`"
@@ -139,6 +143,7 @@ import IconExternalLink from "~icons/lucide/external-link"
 import IconInfo from "~icons/lucide/info"
 import IconRefreshCW from "~icons/lucide/refresh-cw"
 import { RESTOptionTabs } from "./RequestOptions.vue"
+import { RESTEditorSettings } from "~/helpers/rest/document"
 
 const colorMode = useColorMode()
 const t = useI18n()
@@ -146,16 +151,19 @@ const t = useI18n()
 const props = defineProps<{
   body: HoppRESTReqBody
   headers: HoppRESTHeader[]
+  editorSettings: RESTEditorSettings
 }>()
 
 const emit = defineEmits<{
   (e: "change-tab", value: RESTOptionTabs): void
   (e: "update:headers", value: HoppRESTHeader[]): void
   (e: "update:body", value: HoppRESTReqBody): void
+  (e: "update:editorSettings", value: RESTEditorSettings): void
 }>()
 
 const headers = useVModel(props, "headers", emit)
 const body = useVModel(props, "body", emit)
+const editorSettings = useVModel(props, "editorSettings", emit)
 
 const overridenContentType = computed(() =>
   pipe(

--- a/packages/hoppscotch-common/src/components/http/RawBody.vue
+++ b/packages/hoppscotch-common/src/components/http/RawBody.vue
@@ -85,6 +85,7 @@ import { isJSONContentType } from "~/helpers/utils/contenttypes"
 import jsonLinter from "~/helpers/editor/linting/json"
 import { readFileAsText } from "~/helpers/functional/files"
 import xmlFormat from "xml-formatter"
+import { RESTEditorSettings } from "~/helpers/rest/document"
 
 type PossibleContentTypes = Exclude<
   ValidContentTypes,
@@ -95,13 +96,16 @@ type Body = HoppRESTReqBody & { contentType: PossibleContentTypes }
 
 const props = defineProps<{
   modelValue: Body
+  editorSettings: RESTEditorSettings
 }>()
 
 const emit = defineEmits<{
   (e: "update:modelValue", val: Body): void
+  (e: "update:editorSettings", val: RESTEditorSettings): void
 }>()
 
 const body = useVModel(props, "modelValue", emit)
+const editorSettings = useVModel(props, "editorSettings", emit)
 
 const t = useI18n()
 
@@ -110,6 +114,7 @@ const payload = ref<HTMLInputElement | null>(null)
 const toast = useToast()
 
 const rawParamsBody = pluckRef(body, "body")
+const requestWrapLines = pluckRef(editorSettings, "requestWrapLines")
 
 const prettifyIcon = refAutoReset<
   typeof IconWand2 | typeof IconCheck | typeof IconInfo
@@ -122,7 +127,7 @@ const langLinter = computed(() =>
   isJSONContentType(body.value.contentType) ? jsonLinter : null
 )
 
-const linewrapEnabled = ref(true)
+const linewrapEnabled = ref(requestWrapLines.value)
 const rawBodyParameters = ref<any | null>(null)
 
 const codemirrorValue: Ref<string | undefined> =
@@ -134,6 +139,12 @@ watch(rawParamsBody, (newVal) => {
   typeof newVal == "string"
     ? (codemirrorValue.value = newVal)
     : (codemirrorValue.value = undefined)
+})
+
+watch(linewrapEnabled, (newVal) => {
+  typeof newVal == "boolean"
+    ? (requestWrapLines.value = newVal)
+    : (requestWrapLines.value = requestWrapLines.value)
 })
 
 // propagate the edits from codemirror back to the body

--- a/packages/hoppscotch-common/src/components/http/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestOptions.vue
@@ -15,6 +15,7 @@
       <HttpBody
         v-model:headers="request.headers"
         v-model:body="request.body"
+        v-model:editor-settings="currentEditorSettings"
         @change-tab="changeOptionTab"
       />
     </HoppSmartTab>
@@ -57,6 +58,7 @@ import { HoppRESTRequest } from "@hoppscotch/data"
 import { useVModel } from "@vueuse/core"
 import { computed } from "vue"
 import { defineActionHandler } from "~/helpers/actions"
+import { RESTEditorSettings } from "~/helpers/rest/document"
 
 const VALID_OPTION_TABS = [
   "params",
@@ -76,6 +78,7 @@ const props = withDefaults(
   defineProps<{
     modelValue: HoppRESTRequest
     optionTab: RESTOptionTabs
+    editorSettings: RESTEditorSettings
   }>(),
   {
     optionTab: "params",
@@ -85,10 +88,12 @@ const props = withDefaults(
 const emit = defineEmits<{
   (e: "update:modelValue", value: HoppRESTRequest): void
   (e: "update:optionTab", value: RESTOptionTabs): void
+  (e: "update:editorSettings", value: RESTEditorSettings): void
 }>()
 
 const request = useVModel(props, "modelValue", emit)
 const selectedOptionTab = useVModel(props, "optionTab", emit)
+const currentEditorSettings = useVModel(props, "editorSettings", emit)
 
 const changeOptionTab = (e: RESTOptionTabs) => {
   selectedOptionTab.value = e

--- a/packages/hoppscotch-common/src/components/http/RequestTab.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestTab.vue
@@ -5,10 +5,14 @@
       <HttpRequestOptions
         v-model="tab.document.request"
         v-model:option-tab="tab.document.optionTabPreference"
+        v-model:editor-settings="tab.document.editorSettings"
       />
     </template>
     <template #secondary>
-      <HttpResponse v-model:document="tab.document" />
+      <HttpResponse
+        v-model:document="tab.document"
+        v-model:editor-settings="tab.document.editorSettings"
+      />
     </template>
   </AppPaneLayout>
 </template>

--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -4,6 +4,7 @@
     <LensesResponseBodyRenderer
       v-if="!loading && hasResponse"
       v-model:document="doc"
+      v-model:editor-settings="editorSettings"
     />
   </div>
 </template>
@@ -11,17 +12,20 @@
 <script setup lang="ts">
 import { useVModel } from "@vueuse/core"
 import { computed } from "vue"
-import { HoppRESTDocument } from "~/helpers/rest/document"
+import { HoppRESTDocument, RESTEditorSettings } from "~/helpers/rest/document"
 
 const props = defineProps<{
   document: HoppRESTDocument
+  editorSettings: RESTEditorSettings
 }>()
 
 const emit = defineEmits<{
   (e: "update:tab", val: HoppRESTDocument): void
+  (e: "update:editorSettings", val: RESTEditorSettings): void
 }>()
 
 const doc = useVModel(props, "document", emit)
+const editorSettings = useVModel(props, "editorSettings", emit)
 
 const hasResponse = computed(
   () =>

--- a/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
@@ -13,6 +13,7 @@
     >
       <component
         :is="lensRendererFor(lens.renderer)"
+        v-model:editor-settings="editorSettings"
         :response="doc.response"
       />
     </HoppSmartTab>
@@ -31,7 +32,10 @@
       :indicator="showIndicator"
       class="flex flex-col flex-1"
     >
-      <HttpTestResult v-model="doc.testResults" />
+      <HttpTestResult
+        v-model="doc.testResults"
+        v-model:editor-settings="editorSettings"
+      />
     </HoppSmartTab>
   </HoppSmartTabs>
 </template>
@@ -45,17 +49,20 @@ import {
 } from "~/helpers/lenses/lenses"
 import { useI18n } from "@composables/i18n"
 import { useVModel } from "@vueuse/core"
-import { HoppRESTDocument } from "~/helpers/rest/document"
+import { HoppRESTDocument, RESTEditorSettings } from "~/helpers/rest/document"
 
 const props = defineProps<{
   document: HoppRESTDocument
+  editorSettings: RESTEditorSettings
 }>()
 
 const emit = defineEmits<{
   (e: "update:document", document: HoppRESTDocument): void
+  (e: "update:editorSettings", value: RESTEditorSettings): void
 }>()
 
 const doc = useVModel(props, "document", emit)
+const editorSettings = useVModel(props, "editorSettings", emit)
 
 const showIndicator = computed(() => {
   if (!doc.value.testResults) return false

--- a/packages/hoppscotch-common/src/helpers/rest/document.ts
+++ b/packages/hoppscotch-common/src/helpers/rest/document.ts
@@ -3,6 +3,11 @@ import { HoppRESTResponse } from "../types/HoppRESTResponse"
 import { HoppTestResult } from "../types/HoppTestResult"
 import { RESTOptionTabs } from "~/components/http/RequestOptions.vue"
 
+export type RESTEditorSettings = {
+  requestWrapLines: boolean
+  responseWrapLines: boolean
+}
+
 export type HoppRESTSaveContext =
   | {
       /**
@@ -80,4 +85,9 @@ export type HoppRESTDocument = {
    * Options tab preference for the current tab's document
    */
   optionTabPreference?: RESTOptionTabs
+
+  /**
+   * Settings for the current tab's editors
+   */
+  editorSettings: RESTEditorSettings
 }

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -197,6 +197,10 @@ const addNewTab = () => {
   const tab = tabs.createNewTab({
     request: getDefaultRESTRequest(),
     isDirty: false,
+    editorSettings: {
+      requestWrapLines: true,
+      responseWrapLines: true,
+    },
   })
 
   tabs.setActiveTab(tab.id)
@@ -240,6 +244,7 @@ const duplicateTab = (tabID: string) => {
     const newTab = tabs.createNewTab({
       request: cloneDeep(tab.value.document.request),
       isDirty: true,
+      editorSettings: tab.value.document.editorSettings,
     })
     tabs.setActiveTab(newTab.id)
   }

--- a/packages/hoppscotch-common/src/services/context-menu/menu/url.menu.ts
+++ b/packages/hoppscotch-common/src/services/context-menu/menu/url.menu.ts
@@ -59,6 +59,10 @@ export class URLMenuService extends Service implements ContextMenu {
     this.restTab.createNewTab({
       request: request,
       isDirty: false,
+      editorSettings: {
+        requestWrapLines: true,
+        responseWrapLines: true,
+      },
     })
   }
 

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/collections.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/collections.searcher.ts
@@ -309,6 +309,10 @@ export class CollectionsSpotlightSearcherService
           {
             request: req,
             isDirty: false,
+            editorSettings: {
+              requestWrapLines: true,
+              responseWrapLines: true,
+            },
             saveContext: {
               originLocation: "user-collection",
               folderPath: folderPath.join("/"),

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -16,6 +16,10 @@ export class RESTTabService extends TabService<HoppRESTDocument> {
         request: getDefaultRESTRequest(),
         isDirty: false,
         optionTabPreference: "params",
+        editorSettings: {
+          requestWrapLines: true,
+          responseWrapLines: true,
+        },
       },
     })
 


### PR DESCRIPTION
Added support for persisting the wrap line setting for both request and response views in REST tabs. 

- [x] Add support for REST Tabs
- [ ] Add support for GraphQL Tabs
- [ ] Add Support for Websocket Tab
- [ ] Update tests for supporting new document format

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3641 

### Description
Added an additional field called editorSettings in REST Tabs which contains requestWrapLines and responseWrapLines which'll store the boolean of `Wrap Line` button on both request and response sections. 

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

### Additional Information
Tests need to be changed to accommodate the new document format
