### PR TITLE
fix: notify that the user is not an admin when trying to login with a non admin account in admin dashboard

### DIFF
--- a/packages/hoppscotch-sh-admin/locales/en.json
+++ b/packages/hoppscotch-sh-admin/locales/en.json
@@ -131,7 +131,7 @@
     "send_magic_link": "Send magic link",
     "sign_in_agreement": "By signing in, you are agreeing to our",
     "sign_in_options": "All sign in option",
-    "sign_out": "sign out",
+    "sign_out": "Sign out",
     "team_name_long": "Team name should be atleast 6 characters long!!",
     "user_not_found": "User not found in the infra!!"
   },

--- a/packages/hoppscotch-sh-admin/src/components.d.ts
+++ b/packages/hoppscotch-sh-admin/src/components.d.ts
@@ -30,7 +30,6 @@ declare module '@vue/runtime-core' {
     HoppSmartTable: typeof import('@hoppscotch/ui')['HoppSmartTable']
     HoppSmartTabs: typeof import('@hoppscotch/ui')['HoppSmartTabs']
     HoppSmartToggle: typeof import('@hoppscotch/ui')['HoppSmartToggle']
-    IconLucideArrowLeft: typeof import('~icons/lucide/arrow-left')['default']
     IconLucideChevronDown: typeof import('~icons/lucide/chevron-down')['default']
     IconLucideInbox: typeof import('~icons/lucide/inbox')['default']
     SettingsAuthProvider: typeof import('./components/settings/AuthProvider.vue')['default']

--- a/packages/hoppscotch-sh-admin/src/components/app/Login.vue
+++ b/packages/hoppscotch-sh-admin/src/components/app/Login.vue
@@ -184,6 +184,10 @@ const nonAdminUser = ref(false);
 const allowedAuthProviders = ref<string[]>([]);
 
 onMounted(async () => {
+  const user = auth.getCurrentUser();
+  if (user && !user.isAdmin) {
+    nonAdminUser.value = true;
+  }
   allowedAuthProviders.value = await getAllowedAuthProviders();
 });
 


### PR DESCRIPTION
### Ticket
Closes HFE-349

### Description
This PR fixes an issue where users where not notified that he/she is trying to login into the admin dashboard with a non admin account.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed