### PR TITLE
chore: remove expand widget from the GQL collections import/export modal

### DIFF
--- a/packages/hoppscotch-common/src/components/importExport/ImportExportList.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col">
-    <HoppSmartExpand>
+    <HoppSmartExpand v-if="showExpand">
       <template #body>
         <HoppSmartItem
           v-for="importer in importers"
@@ -11,6 +11,16 @@
         />
       </template>
     </HoppSmartExpand>
+
+    <div v-else class="flex flex-col space-y-2">
+      <HoppSmartItem
+        v-for="importer in importers"
+        :key="importer.id"
+        :icon="importer.icon"
+        :label="t(`${importer.name}`)"
+        @click="emit('importer-selected', importer.id)"
+      />
+    </div>
     <hr />
     <div class="flex flex-col space-y-2">
       <template v-for="exporter in exporters" :key="exporter.id">
@@ -49,7 +59,7 @@
 
 <script setup lang="ts">
 import { useI18n } from "@composables/i18n"
-import { Component } from "vue"
+import { Component, computed } from "vue"
 
 const t = useI18n()
 
@@ -63,7 +73,7 @@ type ImportExportEntryMeta = {
   isVisible?: boolean
 }
 
-defineProps<{
+const props = defineProps<{
   importers: ImportExportEntryMeta[]
   exporters: ImportExportEntryMeta[]
 }>()
@@ -72,4 +82,6 @@ const emit = defineEmits<{
   (e: "importer-selected", importerID: string): void
   (e: "exporter-selected", exporterID: string): void
 }>()
+
+const showExpand = computed(() => props.importers.length >= 4)
 </script>


### PR DESCRIPTION
### Description

The GQL collections importer section in the import/export modal only had two options, and showing the expand widget isn't necessary. This PR updates the `ImportExportList` component to show the expand widget only if there are `4` or more import options.

Closes HFE-340.

### Preview

> #### Before

  ![image](https://github.com/hoppscotch/hoppscotch/assets/25279263/e9d534e5-c116-4fc5-a542-514fceb50bb6)

> #### After

  ![image](https://github.com/hoppscotch/hoppscotch/assets/25279263/872bda85-5d54-4ac9-8952-f59446ccd0d8)

### Checks
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed