### PR TITLE
fix(common): ensure the add-environment modal value field is empty when opened via the inspector

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -296,7 +296,7 @@ watch(
 
 defineActionHandler("modals.environment.add", ({ envName, variableName }) => {
   editingVariableName.value = envName
-  if (variableName) editingVariableValue.value = variableName
+  editingVariableValue.value = variableName
   displayModalNew(true)
 })
 </script>

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -296,7 +296,7 @@ watch(
 
 defineActionHandler("modals.environment.add", ({ envName, variableName }) => {
   editingVariableName.value = envName
-  editingVariableValue.value = variableName
+  editingVariableValue.value = variableName ?? ""
   displayModalNew(true)
 })
 </script>


### PR DESCRIPTION
### Description

When opened via the inspector, the add environment modal showed the value associated with the previous attempt to set an environment via the context menu. This PR aims to fix this behavior by removing the truthy check before assigning environment values at the parent environments component, thereby permitting empty strings.

https://github.com/hoppscotch/hoppscotch/assets/25279263/9dd2e560-bfb8-4152-819c-90a0e07f84ce

Closes HFE-347.

### Checks
- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed