### PR TITLE
fix: auth-header not inheriting properties

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -121,7 +121,7 @@
     "generate_token": "Generate Token",
     "graphql_headers": "Authorization Headers are sent as part of the payload to connection_init",
     "include_in_url": "Include in URL",
-    "inherited_from": "Inherited from {auth} from Parent Collection {collection} ",
+    "inherited_from": "Inherited {auth} from parent collection {collection} ",
     "learn": "Learn how",
     "oauth": {
       "redirect_auth_server_returned_error": "Auth Server returned an error state",


### PR DESCRIPTION
Closes HFE-362

### Description
This PR fixes the issue in the header-auth feature where the request failed to inherit properties in some cases, also updated i18n string.



### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
