### PR TITLE
fix: actions not working when sidebar is hidden

### DIFF
--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -1,15 +1,16 @@
 <template>
   <Splitpanes
-    class="smart-splitter"
     :rtl="SIDEBAR_ON_LEFT && mdAndLarger"
     :class="{
       '!flex-row-reverse': SIDEBAR_ON_LEFT && mdAndLarger,
+      'smart-splitter': SIDEBAR && hasSidebar,
+      'no-splitter': !(SIDEBAR && hasSidebar),
     }"
     :horizontal="!mdAndLarger"
     @resize="setPaneEvent($event, 'vertical')"
   >
     <Pane
-      :size="PANE_MAIN_SIZE"
+      :size="SIDEBAR && hasSidebar ? PANE_MAIN_SIZE : 100"
       min-size="65"
       class="flex flex-col !overflow-auto"
     >
@@ -36,9 +37,8 @@
       </Splitpanes>
     </Pane>
     <Pane
-      v-if="SIDEBAR && hasSidebar"
-      :size="PANE_SIDEBAR_SIZE"
-      min-size="25"
+      :size="SIDEBAR && hasSidebar ? PANE_SIDEBAR_SIZE : 0"
+      :min-size="25"
       class="flex flex-col !overflow-auto bg-primaryContrast"
     >
       <slot name="sidebar" />


### PR DESCRIPTION
Fixes HFE-357

**Before**

If the sidebar is hidden, actions from components inside the sidebar are not working.

this is caused by the Sidebar Pane unmounting, resulting in the components which houses these environment models unmounting, which results in the actions defined by the defineActionHandlers unbinding, which when triggered does nothing.
this is also affecting entires in the spotlight,

1. New Collection
2. Create New Environment
3. Delete Current Environment
4. Edit Environment
5. Edit Global Environment
etc.

**After**

First idea was to just use v-show instead of v-if for the pane. which will just hide the pane instead of unmounting it. this will fix our problem. but the library we use 'splitpanes' is not working properly with 'v-show'. But we simulate the behaviour by setting the pane size to 0 and hiding the splitter. This fixes the issue.

Note: this is a hotfix. The ideal way is to make a place where all our global models can be managed from. we need to make their state available globally as a service or something similar. this will be worked on later. 

