### PR TITLE
fix(persistence-service): update schemas found to differ in runtime

### DIFF
--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -244,7 +244,7 @@ export class PersistenceService extends Service {
   private setupSettingsPersistence() {
     const settingsKey = "settings"
     let settingsData = JSON.parse(
-      window.localStorage.getItem(settingsKey) as string
+      window.localStorage.getItem(settingsKey) ?? "null"
     )
 
     if (!settingsData) {

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -244,8 +244,12 @@ export class PersistenceService extends Service {
   private setupSettingsPersistence() {
     const settingsKey = "settings"
     let settingsData = JSON.parse(
-      window.localStorage.getItem(settingsKey) || "{}"
+      window.localStorage.getItem(settingsKey) as string
     )
+
+    if (!settingsData) {
+      settingsData = getDefaultSettings()
+    }
 
     // Validate data read from localStorage
     const result = SETTINGS_SCHEMA.safeParse(settingsData)

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -103,13 +103,10 @@ export const LOCAL_STATE_SCHEMA = z.union([
     .strict(),
 ])
 
-export const SETTINGS_SCHEMA = z.union([
-  z.object({}),
-  SettingsDefSchema.extend({
-    EXTENSIONS_ENABLED: z.optional(z.boolean()),
-    PROXY_ENABLED: z.optional(z.boolean()),
-  }),
-])
+export const SETTINGS_SCHEMA = SettingsDefSchema.extend({
+  EXTENSIONS_ENABLED: z.optional(z.boolean()),
+  PROXY_ENABLED: z.optional(z.boolean()),
+})
 
 export const REST_HISTORY_ENTRY_SCHEMA = z
   .object({

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -104,7 +104,7 @@ export const LOCAL_STATE_SCHEMA = z.union([
 ])
 
 export const SETTINGS_SCHEMA = z.union([
-  z.object({}).strict(),
+  z.object({}),
   SettingsDefSchema.extend({
     EXTENSIONS_ENABLED: z.optional(z.boolean()),
     PROXY_ENABLED: z.optional(z.boolean()),
@@ -208,7 +208,7 @@ export const MQTT_REQUEST_SCHEMA = z.nullable(
   z
     .object({
       endpoint: z.string(),
-      clientID: z.string(),
+      clientID: z.optional(z.string()),
     })
     .strict()
 )

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -36,7 +36,7 @@ const SettingsDefSchema = z.object({
     httpUser: z.boolean(),
     httpPassword: z.boolean(),
     bearerToken: z.boolean(),
-    oauth2Token: z.boolean(),
+    oauth2Token: z.optional(z.boolean()),
   }),
   THEME_COLOR: ThemeColorSchema,
   BG_COLOR: BgColorSchema,


### PR DESCRIPTION
### Description

This PR aims at updating a few schemas under the persistence service that were found to differ from the incoming data at runtime.

- Removes the empty object fallback for settings and makes it fallback to the default set of values if the key is not present in `localStorage`. The corresponding schema has also been updated.
- Marks the `clientID` field as optional for the MQTT request schema and the `oauth2Token` field under `URL_EXCLUDES` for `settings`.

### Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed