### PR TITLE
feat(js-sandbox): add `pw.env.unset` method

### DIFF
--- a/packages/hoppscotch-common/src/components/http/TestResult.vue
+++ b/packages/hoppscotch-common/src/components/http/TestResult.vue
@@ -80,6 +80,13 @@
                 global
               />
               <HttpTestResultEnv
+                v-for="(env, index) in testResults.envDiff.global.deletions"
+                :key="`env-${env.key}-${index}`"
+                :env="env"
+                status="deletions"
+                global
+              />
+              <HttpTestResultEnv
                 v-for="(env, index) in testResults.envDiff.selected.additions"
                 :key="`env-${env.key}-${index}`"
                 :env="env"

--- a/packages/hoppscotch-common/src/helpers/terndoc/ecma.json
+++ b/packages/hoppscotch-common/src/helpers/terndoc/ecma.json
@@ -8,7 +8,8 @@
       "value": "?",
       "writable": "bool",
       "get": "fn() -> ?",
-      "set": "fn(value: ?)"
+      "set": "fn(value: ?)",
+      "unset": "fn(value: ?)"
     },
     "Promise.prototype": {
       "catch": {

--- a/packages/hoppscotch-common/src/helpers/terndoc/pw-pre.json
+++ b/packages/hoppscotch-common/src/helpers/terndoc/pw-pre.json
@@ -3,6 +3,7 @@
   "pw": {
     "env": {
       "set": "fn(key: string, value: string)",
+      "unset": "fn(key: string)",
       "get": "fn(key: string) -> string",
       "getResolve": "fn(key: string) -> string",
       "resolve": "fn(value: string) -> string"

--- a/packages/hoppscotch-common/src/helpers/terndoc/pw-test.json
+++ b/packages/hoppscotch-common/src/helpers/terndoc/pw-test.json
@@ -22,6 +22,7 @@
     },
     "env": {
       "set": "fn(key: string, value: string)",
+      "unset": "fn(key: string)",
       "get": "fn(key: string) -> string",
       "getResolve": "fn(key: string) -> string",
       "resolve": "fn(value: string) -> string"

--- a/packages/hoppscotch-js-sandbox/src/__tests__/preRequest.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/preRequest.spec.ts
@@ -1,8 +1,9 @@
-import { runPreRequestScript } from "~/pre-request/node-vm"
 import "@relmify/jest-fp-ts"
 
-describe("execPreRequestScript", () => {
-  test("returns the updated envirionment properly", () => {
+import { runPreRequestScript } from "~/pre-request/node-vm"
+
+describe("runPreRequestScript", () => {
+  test("returns the updated environment properly", () => {
     return expect(
       runPreRequestScript(
         `

--- a/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/unset.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/unset.spec.ts
@@ -1,0 +1,243 @@
+import * as TE from "fp-ts/TaskEither"
+import { pipe } from "fp-ts/function"
+
+import { runTestScript } from "~/test-runner/node-vm"
+import { TestResponse, TestResult } from "~/types"
+
+const fakeResponse: TestResponse = {
+  status: 200,
+  body: "hoi",
+  headers: [],
+}
+
+const func = (script: string, envs: TestResult["envs"]) =>
+  pipe(
+    runTestScript(script, envs, fakeResponse),
+    TE.map((x) => x.envs)
+  )
+
+const funcTest = (script: string, envs: TestResult["envs"]) =>
+  pipe(
+    runTestScript(script, envs, fakeResponse),
+    TE.map((x) => x.tests)
+  )
+
+describe("pw.env.unset", () => {
+  test("removes the variable set in selected environment variables correctly", () => {
+    return expect(
+      func(
+        `
+          pw.env.unset("baseUrl")
+        `,
+        {
+          global: [],
+          selected: [
+            {
+              key: "baseUrl",
+              value: "https://echo.hoppscotch.io",
+            },
+          ],
+        }
+      )()
+    ).resolves.toEqualRight(
+      expect.objectContaining({
+        selected: [],
+      })
+    )
+  })
+
+  test("removes the variable set in global environment variables correctly", () => {
+    return expect(
+      func(
+        `
+          pw.env.unset("baseUrl")
+        `,
+        {
+          global: [
+            {
+              key: "baseUrl",
+              value: "https://echo.hoppscotch.io",
+            },
+          ],
+          selected: [],
+        }
+      )()
+    ).resolves.toEqualRight(
+      expect.objectContaining({
+        global: [],
+      })
+    )
+  })
+
+  test("removes the variable from selected environment variables if the entry is present in both selected and global context", () => {
+    return expect(
+      func(
+        `
+          pw.env.unset("baseUrl")
+        `,
+        {
+          global: [
+            {
+              key: "baseUrl",
+              value: "https://httpbin.org",
+            },
+          ],
+          selected: [
+            {
+              key: "baseUrl",
+              value: "https://echo.hoppscotch.io",
+            },
+          ],
+        }
+      )()
+    ).resolves.toEqualRight(
+      expect.objectContaining({
+        global: [
+          {
+            key: "baseUrl",
+            value: "https://httpbin.org",
+          },
+        ],
+        selected: [],
+      })
+    )
+  })
+
+  test("removes the initial occurrence of an entry if duplicate entries exist in the selected environment", () => {
+    return expect(
+      func(
+        `
+          pw.env.unset("baseUrl")
+        `,
+        {
+          global: [
+            {
+              key: "baseUrl",
+              value: "https://echo.hoppscotch.io",
+            },
+          ],
+          selected: [
+            {
+              key: "baseUrl",
+              value: "https://httpbin.org",
+            },
+            {
+              key: "baseUrl",
+              value: "https://echo.hoppscotch.io",
+            },
+          ],
+        }
+      )()
+    ).resolves.toEqualRight(
+      expect.objectContaining({
+        global: [
+          {
+            key: "baseUrl",
+            value: "https://echo.hoppscotch.io",
+          },
+        ],
+        selected: [
+          {
+            key: "baseUrl",
+            value: "https://echo.hoppscotch.io",
+          },
+        ],
+      })
+    )
+  })
+
+  test("removes the initial occurrence of an entry if duplicate entries exist in the global environment", () => {
+    return expect(
+      func(
+        `
+          pw.env.unset("baseUrl")
+        `,
+        {
+          global: [
+            {
+              key: "baseUrl",
+              value: "https://httpbin.org/",
+            },
+            {
+              key: "baseUrl",
+              value: "https://echo.hoppscotch.io",
+            },
+          ],
+          selected: [],
+        }
+      )()
+    ).resolves.toEqualRight(
+      expect.objectContaining({
+        global: [
+          {
+            key: "baseUrl",
+            value: "https://echo.hoppscotch.io",
+          },
+        ],
+        selected: [],
+      })
+    )
+  })
+
+  test("no change if attempting to delete non-existent keys", () => {
+    return expect(
+      func(
+        `
+          pw.env.unset("baseUrl")
+        `,
+        {
+          global: [],
+          selected: [],
+        }
+      )()
+    ).resolves.toEqualRight(
+      expect.objectContaining({
+        global: [],
+        selected: [],
+      })
+    )
+  })
+
+  test("keys should be a string", () => {
+    return expect(
+      func(
+        `
+          pw.env.unset(5)
+        `,
+        {
+          global: [],
+          selected: [],
+        }
+      )()
+    ).resolves.toBeLeft()
+  })
+
+  test("set environment values are reflected in the script execution", () => {
+    return expect(
+      funcTest(
+        `
+          pw.env.unset("baseUrl")
+          pw.expect(pw.env.get("baseUrl")).toBe(undefined)
+        `,
+        {
+          global: [],
+          selected: [
+            {
+              key: "baseUrl",
+              value: "https://echo.hoppscotch.io",
+            },
+          ],
+        }
+      )()
+    ).resolves.toEqualRight([
+      expect.objectContaining({
+        expectResults: [
+          {
+            status: "pass",
+            message: "Expected 'undefined' to be 'undefined'",
+          },
+        ],
+      }),
+    ])
+  })
+})

--- a/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/unset.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/unset.spec.ts
@@ -23,7 +23,7 @@ const funcTest = (script: string, envs: TestResult["envs"]) =>
   )
 
 describe("pw.env.unset", () => {
-  test("removes the variable set in selected environment variables correctly", () => {
+  test("removes the variable set in selected environment correctly", () => {
     return expect(
       func(
         `
@@ -46,7 +46,7 @@ describe("pw.env.unset", () => {
     )
   })
 
-  test("removes the variable set in global environment variables correctly", () => {
+  test("removes the variable set in global environment correctly", () => {
     return expect(
       func(
         `
@@ -69,7 +69,7 @@ describe("pw.env.unset", () => {
     )
   })
 
-  test("removes the variable from selected environment variables if the entry is present in both selected and global context", () => {
+  test("removes the variable from selected environment if the entry is present in both selected and global environments", () => {
     return expect(
       func(
         `

--- a/packages/hoppscotch-js-sandbox/src/__tests__/testing/test-runner.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/testing/test-runner.spec.ts
@@ -16,8 +16,8 @@ const func = (script: string, res: TestResponse) =>
     TE.map((x) => x.tests)
   )
 
-describe("execTestScript function behavior", () => {
-  test("returns a resolved promise for a valid test scripts with all green", () => {
+describe("runTestScript", () => {
+  test("returns a resolved promise for a valid test script with all green", () => {
     return expect(
       func(
         `

--- a/packages/hoppscotch-js-sandbox/src/utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils.ts
@@ -176,7 +176,7 @@ const unsetEnv = (
 
   // Found the match in selected
   if (indexInSelected >= 0) {
-    // delete envs.selected[indexInSelected]
+    // delete selected[indexInSelected]
     selected.splice(indexInSelected, 1)
 
     return {
@@ -187,9 +187,9 @@ const unsetEnv = (
 
   const indexInGlobal = global.findIndex((x: GlobalEnvItem) => x.key == envName)
 
-  // Found a match in globals
+  // Found a match in global
   if (indexInGlobal >= 0) {
-    // delete envs.selected[indexInSelected]
+    // delete global[indexInGlobal]
     global.splice(indexInGlobal, 1)
 
     return {

--- a/packages/hoppscotch-js-sandbox/src/utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils.ts
@@ -79,6 +79,16 @@ const getSharedMethods = (envs: TestResult["envs"]) => {
     return undefined
   }
 
+  const envUnsetFn = (key: any) => {
+    if (typeof key !== "string") {
+      throw new Error("Expected key to be a string")
+    }
+
+    updatedEnvs = unsetEnv(key, updatedEnvs)
+
+    return undefined
+  }
+
   const envResolveFn = (value: any) => {
     if (typeof value !== "string") {
       throw new Error("Expected value to be a string")
@@ -101,6 +111,7 @@ const getSharedMethods = (envs: TestResult["envs"]) => {
         get: envGetFn,
         getResolve: envGetResolveFn,
         set: envSetFn,
+        unset: envUnsetFn,
         resolve: envResolveFn,
       },
     },
@@ -147,6 +158,47 @@ const setEnv = (
     value: envValue,
   })
 
+  return {
+    global,
+    selected,
+  }
+}
+
+const unsetEnv = (
+  envName: string,
+  envs: TestResult["envs"]
+): TestResult["envs"] => {
+  const { global, selected } = envs
+
+  const indexInSelected = selected.findIndex(
+    (x: SelectedEnvItem) => x.key === envName
+  )
+
+  // Found the match in selected
+  if (indexInSelected >= 0) {
+    // delete envs.selected[indexInSelected]
+    selected.splice(indexInSelected, 1)
+
+    return {
+      global,
+      selected,
+    }
+  }
+
+  const indexInGlobal = global.findIndex((x: GlobalEnvItem) => x.key == envName)
+
+  // Found a match in globals
+  if (indexInGlobal >= 0) {
+    // delete envs.selected[indexInSelected]
+    global.splice(indexInGlobal, 1)
+
+    return {
+      global,
+      selected,
+    }
+  }
+
+  // Didn't find in both places
   return {
     global,
     selected,

--- a/packages/hoppscotch-js-sandbox/src/utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils.ts
@@ -18,6 +18,63 @@ const getEnv = (envName: string, envs: TestResult["envs"]) => {
   )
 }
 
+const findEnvIndex = (
+  envName: string,
+  envList: SelectedEnvItem[] | GlobalEnvItem[]
+): number => {
+  return envList.findIndex(
+    (envItem: SelectedEnvItem) => envItem.key === envName
+  )
+}
+
+const setEnv = (
+  envName: string,
+  envValue: string,
+  envs: TestResult["envs"]
+): TestResult["envs"] => {
+  const { global, selected } = envs
+
+  const indexInSelected = findEnvIndex(envName, selected)
+  const indexInGlobal = findEnvIndex(envName, global)
+
+  if (indexInSelected >= 0) {
+    selected[indexInSelected].value = envValue
+  } else if (indexInGlobal >= 0) {
+    global[indexInGlobal].value = envValue
+  } else {
+    selected.push({
+      key: envName,
+      value: envValue,
+    })
+  }
+
+  return {
+    global,
+    selected,
+  }
+}
+
+const unsetEnv = (
+  envName: string,
+  envs: TestResult["envs"]
+): TestResult["envs"] => {
+  const { global, selected } = envs
+
+  const indexInSelected = findEnvIndex(envName, selected)
+  const indexInGlobal = findEnvIndex(envName, global)
+
+  if (indexInSelected >= 0) {
+    selected.splice(indexInSelected, 1)
+  } else if (indexInGlobal >= 0) {
+    global.splice(indexInGlobal, 1)
+  }
+
+  return {
+    global,
+    selected,
+  }
+}
+
 // Compiles shared scripting API methods for use in both pre and post request scripts
 const getSharedMethods = (envs: TestResult["envs"]) => {
   let updatedEnvs = envs
@@ -116,92 +173,6 @@ const getSharedMethods = (envs: TestResult["envs"]) => {
       },
     },
     updatedEnvs,
-  }
-}
-
-const setEnv = (
-  envName: string,
-  envValue: string,
-  envs: TestResult["envs"]
-): TestResult["envs"] => {
-  const { global, selected } = envs
-
-  const indexInSelected = selected.findIndex(
-    (x: SelectedEnvItem) => x.key === envName
-  )
-
-  // Found the match in selected
-  if (indexInSelected >= 0) {
-    selected[indexInSelected].value = envValue
-
-    return {
-      global,
-      selected,
-    }
-  }
-
-  const indexInGlobal = global.findIndex((x: GlobalEnvItem) => x.key == envName)
-
-  // Found a match in globals
-  if (indexInGlobal >= 0) {
-    global[indexInGlobal].value = envValue
-
-    return {
-      global,
-      selected,
-    }
-  }
-
-  // Didn't find in both places, create a new variable in selected
-  selected.push({
-    key: envName,
-    value: envValue,
-  })
-
-  return {
-    global,
-    selected,
-  }
-}
-
-const unsetEnv = (
-  envName: string,
-  envs: TestResult["envs"]
-): TestResult["envs"] => {
-  const { global, selected } = envs
-
-  const indexInSelected = selected.findIndex(
-    (x: SelectedEnvItem) => x.key === envName
-  )
-
-  // Found the match in selected
-  if (indexInSelected >= 0) {
-    // delete selected[indexInSelected]
-    selected.splice(indexInSelected, 1)
-
-    return {
-      global,
-      selected,
-    }
-  }
-
-  const indexInGlobal = global.findIndex((x: GlobalEnvItem) => x.key == envName)
-
-  // Found a match in global
-  if (indexInGlobal >= 0) {
-    // delete global[indexInGlobal]
-    global.splice(indexInGlobal, 1)
-
-    return {
-      global,
-      selected,
-    }
-  }
-
-  // Didn't find in both places
-  return {
-    global,
-    selected,
   }
 }
 


### PR DESCRIPTION
We can unset variables using unset function in pre-request script and test script

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3398 

### Description
Unset function is added to the Javascript Sandbox. It will work on both pre-request scripts and test scripts. An associated test suite was added. Also, the test results UI will now show deletions for the global environment.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] Documentation updates required are tracked [here](https://linear.app/hoppscotch/issue/HP-187/document-the-pwenvunset-method-under-scripts).
- [x] All the tests have passed

### Additional Information

![Screenshot from 2023-12-15 11-45-38](https://github.com/hoppscotch/hoppscotch/assets/55492635/b5e6b95f-1adc-40f8-97a9-90e44d1e400b)
![Screenshot from 2023-12-15 11-46-17](https://github.com/hoppscotch/hoppscotch/assets/55492635/10c5b49b-4443-49ea-b9b4-61da44182945)
![Screenshot from 2023-12-15 11-47-09](https://github.com/hoppscotch/hoppscotch/assets/55492635/0f3d976b-673b-4efb-83d5-e52b6eeaf8e9)
