### PR TITLE
fix(cli): environment resolution in the single-entry export format

### DIFF
--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoppscotch/cli",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A CLI to run Hoppscotch test scripts in CI environments.",
   "homepage": "https://hoppscotch.io",
   "main": "dist/index.js",

--- a/packages/hoppscotch-cli/src/__tests__/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/commands/test.spec.ts
@@ -118,6 +118,15 @@ describe("Test 'hopp test <file> --env <file>' command:", () => {
     const { error } = await runCLI(args);
     expect(error).toBeNull();
   });
+
+  test("Correctly resolves environment variables referenced in the request body", async () => {
+    const COLL_PATH = getTestJsonFilePath("req-body-env-vars-coll.json");
+    const ENVS_PATH = getTestJsonFilePath("req-body-env-vars-envs.json");
+    const args = `test ${COLL_PATH} --env ${ENVS_PATH}`;
+
+    const { error } = await runCLI(args);
+    expect(error).toBeNull();
+  });
 });
 
 describe("Test 'hopp test <file> --delay <delay_in_ms>' command:", () => {

--- a/packages/hoppscotch-cli/src/__tests__/samples/req-body-env-vars-coll.json
+++ b/packages/hoppscotch-cli/src/__tests__/samples/req-body-env-vars-coll.json
@@ -16,14 +16,14 @@
       },
       "body": {
         "contentType": "application/json",
-        "body": "{\n   \"firstName\": \"<<firstName>>\",\n   \"lastName\": \"<<lastName>>\" \n}"
+        "body": "{\n   \"firstName\": \"<<firstName>>\",\n   \"lastName\": \"<<lastName>>\",\n   \"greetText\": \"<<salutation>>, <<fullName>>\",\n   \"fullName\": \"<<fullName>>\",\n   \"id\": \"<<id>>\"\n}"
       },
       "preRequestScript": "",
-      "testScript": "pw.test(\"Status code is 200 and response body matches\", () => {\n  const expectedFirstName = \"John\"\n  const expectedLastName = \"Doe\"\n\n  pw.expect(pw.response.status).toBe(200)\n\n  const { firstName, lastName } = JSON.parse(pw.response.body.data)\n\n  pw.expect(expectedFirstName).toBe(firstName)\n  pw.expect(expectedLastName).toBe(lastName)\n});"
+      "testScript": "pw.test(\"Status code is 200\", ()=> {\n  pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully resolves environments recursively\", ()=> {\n  pw.expect(pw.env.getResolve(\"recursiveVarX\")).toBe(\"Hello\")\n  pw.expect(pw.env.getResolve(\"recursiveVarY\")).toBe(\"Hello\")\n  pw.expect(pw.env.getResolve(\"salutation\")).toBe(\"Hello\")\n});\n\npw.test(\"Successfully resolves environments referenced in the request body\", () => {\n  const expectedId = \"7\"\n  const expectedFirstName = \"John\"\n  const expectedLastName = \"Doe\"\n  const expectedFullName = `${expectedFirstName} ${expectedLastName}`\n  const expectedGreetText = `Hello, ${expectedFullName}`\n\n  pw.expect(pw.env.getResolve(\"recursiveVarX\")).toBe(\"Hello\")\n  pw.expect(pw.env.getResolve(\"recursiveVarY\")).toBe(\"Hello\")\n  pw.expect(pw.env.getResolve(\"salutation\")).toBe(\"Hello\")\n\n  const { id, firstName, lastName, fullName, greetText } = JSON.parse(pw.response.body.data)\n\n  pw.expect(id).toBe(expectedId)\n  pw.expect(expectedFirstName).toBe(firstName)\n  pw.expect(expectedLastName).toBe(lastName)\n  pw.expect(fullName).toBe(expectedFullName)\n  pw.expect(greetText).toBe(expectedGreetText)\n});"
     }
   ],
   "auth": {
-    "authType": "inherit",
+    "authType": "none",
     "authActive": true
   },
   "headers": []

--- a/packages/hoppscotch-cli/src/__tests__/samples/req-body-env-vars-coll.json
+++ b/packages/hoppscotch-cli/src/__tests__/samples/req-body-env-vars-coll.json
@@ -1,0 +1,30 @@
+{
+  "v": 2,
+  "name": "Test environment variables in request body",
+  "folders": [],
+  "requests": [
+    {
+      "v": "1",
+      "name": "test-request",
+      "endpoint": "https://echo.hoppscotch.io",
+      "method": "POST",
+      "headers": [],
+      "params": [],
+      "auth": {
+        "authType": "none",
+        "authActive": true
+      },
+      "body": {
+        "contentType": "application/json",
+        "body": "{\n   \"firstName\": \"<<firstName>>\",\n   \"lastName\": \"<<lastName>>\" \n}"
+      },
+      "preRequestScript": "",
+      "testScript": "pw.test(\"Status code is 200 and response body matches\", () => {\n  const expectedFirstName = \"John\"\n  const expectedLastName = \"Doe\"\n\n  pw.expect(pw.response.status).toBe(200)\n\n  const { firstName, lastName } = JSON.parse(pw.response.body.data)\n\n  pw.expect(expectedFirstName).toBe(firstName)\n  pw.expect(expectedLastName).toBe(lastName)\n});"
+    }
+  ],
+  "auth": {
+    "authType": "inherit",
+    "authActive": true
+  },
+  "headers": []
+}

--- a/packages/hoppscotch-cli/src/__tests__/samples/req-body-env-vars-envs.json
+++ b/packages/hoppscotch-cli/src/__tests__/samples/req-body-env-vars-envs.json
@@ -8,6 +8,30 @@
     {
       "key": "lastName",
       "value": "Doe"
+    },
+    {
+      "key": "id",
+      "value": "7"
+    },
+    {
+      "key": "fullName",
+      "value": "<<firstName>> <<lastName>>"
+    },
+    {
+      "key": "recursiveVarX",
+      "value": "<<recursiveVarY>>"
+    },
+    {
+      "key": "recursiveVarY",
+      "value": "<<salutation>>"
+    },
+    {
+      "key": "salutation",
+      "value": "Hello"
+    },
+    {
+      "key": "greetText",
+      "value": "<<salutation>> <<fullName>>"
     }
   ]
 }

--- a/packages/hoppscotch-cli/src/__tests__/samples/req-body-env-vars-envs.json
+++ b/packages/hoppscotch-cli/src/__tests__/samples/req-body-env-vars-envs.json
@@ -1,0 +1,13 @@
+{
+  "name": "Response body sample",
+  "variables": [
+    {
+      "key": "firstName",
+      "value": "John"
+    },
+    {
+      "key": "lastName",
+      "value": "Doe"
+    }
+  ]
+}

--- a/packages/hoppscotch-cli/src/__tests__/utils.ts
+++ b/packages/hoppscotch-cli/src/__tests__/utils.ts
@@ -22,12 +22,10 @@ export const trimAnsi = (target: string) => {
 
 export const getErrorCode = (out: string) => {
   const ansiTrimmedStr = trimAnsi(out);
-
   return ansiTrimmedStr.split(" ")[0];
 };
 
 export const getTestJsonFilePath = (file: string) => {
-  const filePath = `${process.cwd()}/src/__tests__/samples/${file}`;
-
+  const filePath = resolve(__dirname, `../../src/__tests__/samples/${file}`);
   return filePath;
 };

--- a/packages/hoppscotch-cli/src/options/test/env.ts
+++ b/packages/hoppscotch-cli/src/options/test/env.ts
@@ -37,8 +37,7 @@ export async function parseEnvsData(path: string) {
       envPairs.push({ key, value });
     }
   } else if (HoppEnvExportObjectResult.success) {
-    const { key, value } = HoppEnvExportObjectResult.data.variables[0];
-    envPairs.push({ key, value });
+    envPairs.push(...HoppEnvExportObjectResult.data.variables);
   }
 
   return <HoppEnvs>{ global: [], selected: envPairs };


### PR DESCRIPTION
### Description

This PR fixes an issue with the CLI where the [single environment entry export format](https://docs.hoppscotch.io/documentation/clients/cli#_1-single-environment-entry-export-format) omits the variables except the first. This led to the `ENV_EXPAND_LOOP` state when multiple environment variable entries were referred from a collection. For instance, in the request body, as mentioned in the below issue. A corresponding test case is added to verify the behavior.

https://github.com/hoppscotch/hoppscotch/blob/7db7b9b0683424a594b85ac5265c4a5ff749586b/packages/hoppscotch-data/src/environment/index.ts#L34-L55

Fixes #3675.

Closes HFE-370.

### Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed