### PR TITLE
HBE-343 hotfix: improve smtp email validation and fix enableAndDisableSSO mutation

### DIFF
--- a/packages/hoppscotch-backend/src/errors.ts
+++ b/packages/hoppscotch-backend/src/errors.ts
@@ -29,6 +29,13 @@ export const JSON_INVALID = 'json_invalid';
 export const AUTH_PROVIDER_NOT_SPECIFIED = 'auth/provider_not_specified';
 
 /**
+ * Auth Provider not specified
+ * (Auth)
+ */
+export const AUTH_PROVIDER_NOT_CONFIGURED =
+  'auth/provider_not_configured_correctly';
+
+/**
  * Environment variable "VITE_ALLOWED_AUTH_PROVIDERS" is not present in .env file
  */
 export const ENV_NOT_FOUND_KEY_AUTH_PROVIDERS =

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -131,6 +131,19 @@ export class InfraConfigService implements OnModuleInit {
   }
 
   /**
+   * Get all the InfraConfigs as map
+   * @returns InfraConfig map
+   */
+  async getInfraConfigsMap() {
+    const infraConfigs = await this.prisma.infraConfig.findMany();
+    const infraConfigMap: Record<string, string> = {};
+    infraConfigs.forEach((config) => {
+      infraConfigMap[config.name] = config.value;
+    });
+    return infraConfigMap;
+  }
+
+  /**
    * Update InfraConfig by name
    * @param name Name of the InfraConfig
    * @param value Value of the InfraConfig
@@ -223,11 +236,7 @@ export class InfraConfigService implements OnModuleInit {
 
     let updatedAuthProviders = allowedAuthProviders;
 
-    const infraConfigs = await this.prisma.infraConfig.findMany();
-    const infraConfigMap = {};
-    infraConfigs.forEach((config) => {
-      infraConfigMap[config.name] = config.value;
-    });
+    const infraConfigMap = await this.getInfraConfigsMap();
 
     providerInfo.forEach(({ provider, status }) => {
       if (status === ServiceStatus.ENABLE) {

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -17,7 +17,7 @@ import {
   INFRA_CONFIG_UPDATE_FAILED,
   INFRA_CONFIG_SERVICE_NOT_CONFIGURED,
 } from 'src/errors';
-import { throwErr, validateEmail, validateSMTPUrl } from 'src/utils';
+import { throwErr, validateSMTPEmail, validateSMTPUrl } from 'src/utils';
 import { ConfigService } from '@nestjs/config';
 import { ServiceStatus, stopApp } from './helper';
 import { EnableAndDisableSSOArgs, InfraConfigArgs } from './input-args';
@@ -340,7 +340,7 @@ export class InfraConfigService implements OnModuleInit {
           if (!isValidUrl) return E.left(INFRA_CONFIG_INVALID_INPUT);
           break;
         case InfraConfigEnumForClient.MAILER_ADDRESS_FROM:
-          const isValidEmail = validateEmail(infraConfigs[i].value);
+          const isValidEmail = validateSMTPEmail(infraConfigs[i].value);
           if (!isValidEmail) return E.left(INFRA_CONFIG_INVALID_INPUT);
           break;
         case InfraConfigEnumForClient.GOOGLE_CLIENT_ID:

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -19,7 +19,7 @@ import {
 } from 'src/errors';
 import { throwErr, validateSMTPEmail, validateSMTPUrl } from 'src/utils';
 import { ConfigService } from '@nestjs/config';
-import { ServiceStatus, stopApp } from './helper';
+import { ServiceStatus, getConfiguredSSOProviders, stopApp } from './helper';
 import { EnableAndDisableSSOArgs, InfraConfigArgs } from './input-args';
 import { AuthProvider } from 'src/auth/helper';
 
@@ -71,7 +71,7 @@ export class InfraConfigService implements OnModuleInit {
       },
       {
         name: InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS,
-        value: process.env.VITE_ALLOWED_AUTH_PROVIDERS.toLocaleUpperCase(),
+        value: getConfiguredSSOProviders(),
       },
     ];
 

--- a/packages/hoppscotch-backend/src/main.ts
+++ b/packages/hoppscotch-backend/src/main.ts
@@ -17,7 +17,8 @@ async function bootstrap() {
   console.log(`Port: ${configService.get('PORT')}`);
 
   checkEnvironmentAuthProvider(
-    configService.get('VITE_ALLOWED_AUTH_PROVIDERS'),
+    configService.get('INFRA.VITE_ALLOWED_AUTH_PROVIDERS') ??
+      configService.get('VITE_ALLOWED_AUTH_PROVIDERS'),
   );
 
   app.use(

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -131,20 +131,20 @@ export const validateEmail = (email: string) => {
   ).test(email);
 };
 
+// Regular expressions for supported address object formats by nodemailer
+// check out for more info https://nodemailer.com/message/addresses
+const emailRegex1 = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+const emailRegex2 =
+  /^[\w\s]* <([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>$/;
+const emailRegex3 =
+  /^"[\w\s]+" <([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>$/;
+
 /**
  * Checks to see if the SMTP email is valid or not
  * @param email
  * @returns A Boolean depending on the format of the email
  */
 export const validateSMTPEmail = (email: string) => {
-  // Regular expressions for supported address object formats by nodemailer
-  // check out for more info https://nodemailer.com/message/addresses
-  const emailRegex1 = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
-  const emailRegex2 =
-    /^[\w\s]* <([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>$/;
-  const emailRegex3 =
-    /^"[\w\s]+" <([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>$/;
-
   // Check if the input matches any of the formats
   return (
     emailRegex1.test(email) ||

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -131,6 +131,22 @@ export const validateEmail = (email: string) => {
   ).test(email);
 };
 
+export const validateSMTPEmail = (email: string) => {
+  // Regular expressions for the specified formats
+  const emailRegex1 = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+  const emailRegex2 =
+    /^[\w\s]* <([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>$/;
+  const emailRegex3 =
+    /^"[\w\s]+" <([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>$/;
+
+  // Check if the input matches any of the formats
+  return (
+    emailRegex1.test(email) ||
+    emailRegex2.test(email) ||
+    emailRegex3.test(email)
+  );
+};
+
 /**
  * Checks to see if the URL is valid or not
  * @param url The URL to validate

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -137,7 +137,8 @@ export const validateEmail = (email: string) => {
  * @returns A Boolean depending on the format of the email
  */
 export const validateSMTPEmail = (email: string) => {
-  // Regular expressions for the specified formats
+  // Regular expressions for supported address object formats by nodemailer
+  // check out for more info https://nodemailer.com/message/addresses
   const emailRegex1 = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
   const emailRegex2 =
     /^[\w\s]* <([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})>$/;

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -131,6 +131,11 @@ export const validateEmail = (email: string) => {
   ).test(email);
 };
 
+/**
+ * Checks to see if the SMTP email is valid or not
+ * @param email
+ * @returns A Boolean depending on the format of the email
+ */
 export const validateSMTPEmail = (email: string) => {
   // Regular expressions for the specified formats
   const emailRegex1 = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HBE-343

### Description
<!-- Add a brief description of the pull request -->

This PR fixed the following issues in `hoppscotch-backend` package

1. Improve SMTP email validation by allowing a total of 3 formats that the nodemailer npm package allows. https://nodemailer.com/message/addresses.
This error encountered when `updateInfraConfigs` mutation called.

2. To resolve error on `enableAndDisableSSO` mutation, introduced Database call `findMany()` instead of `configService.get()` to get latest data


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Current Problem

1. Regarding the SMTP email format
The npm Nodemailer package has 3 acceptable formats where `hoppscotch-backend` previously accepts only email as `MAILER_ADDRESS_FROM`.
```
Backend Server | [Nest] 65  - 12/19/2023, 5:46:40 PM   ERROR [ExceptionsHandler] infra_config/invalid_input 
Backend Server | Error: infra_config/invalid_input 
Backend Server |     at throwErr (/usr/src/app/packages/hoppscotch-backend/dist/utils.js:14:11) 
Backend Server |     at InfraResolver.updateInfraConfigs (/usr/src/app/packages/hoppscotch-backend/dist/admin/infra.resolver.js:121:34)
```

2. When `enableAndDisableSSO` mutation called, is checks `isServiceConfigured` with old data from `configService` instead of new data from database.

```
{ "errors": [ { 
    "message": "infra_config/service_not_configured", 
    "locations": [ { "line": 2, "column": 3 } ], 
    "path": [ "enableAndDisableSSO" ], 
    "extensions": { 
      "code": "INTERNAL_SERVER_ERROR", 
      "stacktrace": [ "Error: infra_config/service_not_configured", 
      "    at throwErr (/usr/src/app/packages/hoppscotch-backend/dist/utils.js:14:11)", 
      "    at InfraConfigService.enableAndDisableSSO (/usr/src/app/packages/hoppscotch-backend/dist/infra-config/infra-config.service.js:167:42)", 
      "    at InfraResolver.enableAndDisableSSO (/usr/src/app/packages/hoppscotch-backend/dist/admin/infra.resolver.js:131:57)", 
      "    at /usr/src/app/node_modules/.pnpm/@nestjs+core@10.2.7_@nestjs+common@10.2.7_@nestjs+platform-express@10.2.7_reflect-metadata@0.1.13_rxjs@7.6.0/node_modules/@nestjs/core/helpers/external-context-creator.js:67:33", 
      "    at async target (/usr/src/app/node_modules/.pnpm/@nestjs+core@10.2.7_@nestjs+common@10.2.7_@nestjs+platform-express@10.2.7_reflect-metadata@0.1.13_rxjs@7.6.0/node_modules/@nestjs/core/helpers/external-context-creator.js:74:28)", 
      "    at async Object.enableAndDisableSSO (/usr/src/app/node_modules/.pnpm/@nestjs+core@10.2.7_@nestjs+common@10.2.7_@nestjs+platform-express@10.2.7_reflect-metadata@0.1.13_rxjs@7.6.0/node_modules/@nestjs/core/helpers/external-proxy.js:9:24)" ] } 
   } ], 
  "data": null }
```

### Testing Instruction
1. Test `updateInfraConfigs` mutation to update `MAILER_ADDRESS_FROM`
2. Test `enableAndDisableSSO` mutation


### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
Nil
