### PR TITLE
fix: minor updation for shared request and auth-headers features

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -262,6 +262,7 @@ const emit = defineEmits<{
   (event: "select", payload: Picked | null): void
   (event: "update-team", team: SelectedTeam): void
   (event: "update-collection-type", type: CollectionType["type"]): void
+  (event: "set-team-collection-adapter", adapter: TeamCollectionAdapter): void
 }>()
 
 type SelectedTeam = GetMyTeamsQuery["myTeams"][number] | undefined
@@ -354,6 +355,7 @@ watch(
   (newTeam) => {
     if (newTeam) {
       teamCollectionAdapter.changeTeamID(newTeam.id)
+      emit("set-team-collection-adapter", teamCollectionAdapter)
     }
   }
 )

--- a/packages/hoppscotch-common/src/components/share/index.vue
+++ b/packages/hoppscotch-common/src/components/share/index.vue
@@ -451,7 +451,7 @@ const getErrorMessage = (err: GQLError<string>) => {
   }
   switch (err.error) {
     case "shortcode/not_found":
-      return t("shared_request.not_found")
+      return t("shared_requests.not_found")
     default:
       return t("error.something_went_wrong")
   }

--- a/packages/hoppscotch-common/src/components/share/index.vue
+++ b/packages/hoppscotch-common/src/components/share/index.vue
@@ -21,7 +21,7 @@
       />
     </div>
     <div class="flex flex-col">
-      <div v-if="loading" class="flex flex-col items-center justify-center">
+      <div v-if="loading" class="flex flex-col items-center justify-center p-4">
         <HoppSmartSpinner class="mb-4" />
         <span class="text-secondaryLight">{{ t("state.loading") }}</span>
       </div>

--- a/packages/hoppscotch-common/src/helpers/backend/gql/mutations/UpdateRequest.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/mutations/UpdateRequest.graphql
@@ -2,5 +2,6 @@ mutation UpdateRequest($data: UpdateTeamRequestInput!, $requestID: ID!) {
   updateRequest(data: $data, requestID: $requestID) {
     id
     title
+    collectionID
   }
 }

--- a/packages/hoppscotch-common/src/helpers/shortcode/ShortcodeListAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/shortcode/ShortcodeListAdapter.ts
@@ -156,6 +156,7 @@ export default class ShortcodeListAdapter {
     const [shortcodeCreated$, shortcodeCreatedSub] = runAuthOnlyGQLSubscription(
       {
         query: ShortcodeCreatedDocument,
+        variables: {},
       }
     )
 
@@ -172,6 +173,7 @@ export default class ShortcodeListAdapter {
     const [shortcodeRevoked$, shortcodeRevokedSub] = runAuthOnlyGQLSubscription(
       {
         query: ShortcodeDeletedDocument,
+        variables: {},
       }
     )
 
@@ -188,6 +190,7 @@ export default class ShortcodeListAdapter {
     const [shortcodeUpdated$, shortcodeUpdatedSub] = runAuthOnlyGQLSubscription(
       {
         query: ShortcodeUpdatedDocument,
+        variables: {},
       }
     )
 

--- a/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
@@ -1034,6 +1034,11 @@ export default class NewTeamCollectionAdapter {
     }
   }
 
+  /**
+   * Used to obtain the inherited auth and headers for a given folder path, used for both REST and GraphQL team collections
+   * @param folderPath the path of the folder to cascade the auth from
+   * @returns the inherited auth and headers for the given folder path
+   */
   public cascadeParentCollectionForHeaderAuth(folderPath: string) {
     let auth: HoppInheritedProperty["auth"] = {
       parentID: folderPath ?? "",
@@ -1089,7 +1094,10 @@ export default class NewTeamCollectionAdapter {
       const parentFolderAuth = data.auth
       const parentFolderHeaders = data.headers
 
-      if (parentFolderAuth?.authType === "inherit" && path.length === 1) {
+      if (
+        parentFolderAuth?.authType === "inherit" &&
+        [...path.slice(0, i + 1)].length === 1
+      ) {
         auth = {
           parentID: [...path.slice(0, i + 1)].join("/"),
           parentName: parentFolder.title,

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -68,7 +68,7 @@ export function navigateToFolderWithIndexPath(
 }
 
 /**
- * Used to obtain the inherited auth and headers for a given folder path, used for both REST and GraphQL
+ * Used to obtain the inherited auth and headers for a given folder path, used for both REST and GraphQL personal collections
  * @param folderPath the path of the folder to cascade the auth from
  * @param type the type of collection
  * @returns the inherited auth and headers for the given folder path

--- a/packages/hoppscotch-common/src/pages/e/_id.vue
+++ b/packages/hoppscotch-common/src/pages/e/_id.vue
@@ -18,6 +18,41 @@
       :properties="properties"
       :shared-request-i-d="sharedRequestID"
     />
+    <div v-else class="flex flex-1 flex-col items-center justify-center p-4">
+      <div
+        v-if="sharedRequestDetails.loading"
+        class="flex flex-1 flex-col items-center justify-center p-4"
+      >
+        <HoppSmartSpinner />
+      </div>
+      <div v-else>
+        <div
+          v-if="
+            !sharedRequestDetails.loading && E.isLeft(sharedRequestDetails.data)
+          "
+          class="flex flex-col items-center p-4"
+        >
+          <icon-lucide-alert-triangle class="svg-icons mb-2 opacity-75" />
+          <h1 class="heading text-center">
+            {{ t("error.invalid_link") }}
+          </h1>
+          <p class="mt-2 text-center">
+            {{ t("error.invalid_embed_link") }}
+          </p>
+        </div>
+        <div
+          v-if="
+            !sharedRequestDetails.loading &&
+            E.isRight(sharedRequestDetails.data)
+          "
+          class="flex flex-1 flex-col items-center justify-center p-4"
+        >
+          <h1 class="heading">
+            {{ t("state.loading") }}
+          </h1>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
Closes HFE-367

### Description
This PR fixes some of the minor bugs in the shared request and auth-headers in collection features.
 - Added loading state in embeds
 - fixed i18n string when deleting a already deleted shared request
 - minor code update on team auth-header cascading folder path
 - Saving team request failed to inherit property.
 
### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

