### PR TITLE
fix(selfhost-web): perform logout if the silent refresh attempt fails

### DIFF
--- a/packages/hoppscotch-selfhost-web/src/platform/auth/auth.platform.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/auth.platform.ts
@@ -153,7 +153,7 @@ async function refreshToken() {
       {
         withCredentials: true,
       }
-      )
+    )
 
     const isSuccessful = res.status === 200
 

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/auth.platform.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/auth.platform.ts
@@ -114,6 +114,7 @@ async function setInitialUser() {
     } else {
       setUser(null)
       isGettingInitialUser.value = false
+      await logout()
     }
 
     return
@@ -146,22 +147,26 @@ async function setInitialUser() {
 }
 
 async function refreshToken() {
-  const res = await axios.get(
-    `${import.meta.env.VITE_BACKEND_API_URL}/auth/refresh`,
-    {
-      withCredentials: true,
+  try {
+    const res = await axios.get(
+      `${import.meta.env.VITE_BACKEND_API_URL}/auth/refresh`,
+      {
+        withCredentials: true,
+      }
+      )
+
+    const isSuccessful = res.status === 200
+
+    if (isSuccessful) {
+      authEvents$.next({
+        event: "token_refresh",
+      })
     }
-  )
 
-  const isSuccessful = res.status === 200
-
-  if (isSuccessful) {
-    authEvents$.next({
-      event: "token_refresh",
-    })
+    return isSuccessful
+  } catch (error) {
+    return false
   }
-
-  return isSuccessful
 }
 
 async function sendMagicLink(email: string) {


### PR DESCRIPTION
Closes #3701

### Description
This PR fixes the bug found in refresh token feature

- Fix problem with refreshToken method when backend returns 401 code
- When refreshToken returns false then completing the user session

- [ ] Not Completed
- [x] Completed

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
