### PR TITLE
make rm in docker file ignore nonexistent files

### DIFF
--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -19,7 +19,7 @@ RUN pnpm exec prisma generate
 RUN pnpm run build
 COPY --from=base_builder /usr/src/app/packages/hoppscotch-backend/backend.Caddyfile /etc/caddy/backend.Caddyfile
 # Remove the env file to avoid backend copying it in and using it
-RUN rm "../../.env"
+RUN rm -f "../../.env"
 ENV PRODUCTION="true"
 ENV PORT=8080
 ENV APP_PORT=${PORT}


### PR DESCRIPTION
added -f to rm .env to ignore nonexistent files

without this change my docker backend builds fail with "0.556 rm: can't remove '../../.env': No such file or directory"