### PR TITLE
feat(common): support simultaneous imports of collections and environment files

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -416,7 +416,8 @@
     "postman_environment_description": "Import Postman Environment from a JSON file",
     "title": "Import",
     "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
-    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file."
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -315,7 +315,8 @@
     "proxy_error": "Proxy error",
     "script_fail": "Could not execute pre-request script",
     "something_went_wrong": "Something went wrong",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files."
   },
   "export": {
     "as_json": "Export as JSON",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -414,7 +414,9 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Import"
+    "title": "Import",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file."
   },
   "inspections": {
     "description": "Inspect possible errors",

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -263,7 +263,7 @@ const HoppOpenAPIImporter: ImporterOrExporter = {
       step: UrlSource({
         caption: "import.from_url",
         onImportFromURL: async (content) => {
-          const res = await hoppOpenAPIImporter(content)()
+          const res = await hoppOpenAPIImporter([content])()
 
           if (E.isRight(res)) {
             handleImportToStore(res.right)

--- a/packages/hoppscotch-common/src/components/collections/MyCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/MyCollections.vue
@@ -694,7 +694,7 @@ class MyCollectionsAdapter implements SmartTreeAdapter<MyCollectionNode> {
     let target = collections[indexPaths.shift() as number]
 
     while (indexPaths.length > 0)
-      target = target.folders[indexPaths.shift() as number]
+      target = target?.folders[indexPaths.shift() as number]
 
     return target !== undefined ? target : null
   }

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -133,7 +133,7 @@ const PostmanEnvironmentsImport: ImporterOrExporter = {
         return
       }
 
-      handleImportToStore([res.right])
+      handleImportToStore(res.right)
 
       platform.analytics?.logEvent({
         type: "HOPP_IMPORT_ENVIRONMENT",

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -166,19 +166,14 @@ const insomniaEnvironmentsImport: ImporterOrExporter = {
         return
       }
 
-      const globalEnvIndex = res.right.findIndex(
+      const globalEnvs = res.right.filter(
         (env) => env.name === "Base Environment"
       )
+      const otherEnvs = res.right.filter(
+        (env) => env.name !== "Base Environment"
+      )
 
-      const globalEnv =
-        globalEnvIndex !== -1 ? res.right[globalEnvIndex] : undefined
-
-      // remove the global env from the environments array to prevent it from being imported twice
-      if (globalEnvIndex !== -1) {
-        res.right.splice(globalEnvIndex, 1)
-      }
-
-      handleImportToStore(res.right, globalEnv)
+      handleImportToStore(otherEnvs, globalEnvs)
 
       platform.analytics?.logEvent({
         type: "HOPP_IMPORT_ENVIRONMENT",
@@ -340,14 +335,14 @@ const showImportFailedError = () => {
 
 const handleImportToStore = async (
   environments: Environment[],
-  globalEnv?: NonSecretEnvironment
+  globalEnvs: NonSecretEnvironment[] = []
 ) => {
-  // if there's a global env, add them to the store
-  if (globalEnv) {
-    globalEnv.variables.forEach(({ key, value, secret }) =>
+  // Add global envs to the store
+  globalEnvs.forEach(({ variables }) => {
+    variables.forEach(({ key, value, secret }) => {
       addGlobalEnvVariable({ key, value, secret })
-    )
-  }
+    })
+  })
 
   if (props.environmentType === "MY_ENV") {
     appendEnvironments(environments)

--- a/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
@@ -67,6 +67,8 @@ defineProps<{
 const t = useI18n()
 const toast = useToast()
 
+const ALLOWED_FILE_SIZE_LIMIT = 10 // 10 MB
+
 const importFilesCount = ref(0)
 
 const hasFile = ref(false)
@@ -80,6 +82,7 @@ const emit = defineEmits<{
 }>()
 
 const onFileChange = async () => {
+  // Reset the state on entering the handler to avoid any stale state
   if (showFileSizeLimitExceededWarning.value) {
     showFileSizeLimitExceededWarning.value = false
   }
@@ -104,14 +107,14 @@ const onFileChange = async () => {
 
   const readerPromises: Promise<string | null>[] = []
 
-  let totalFilesSize = 0
+  let totalFileSize = 0
 
   for (let i = 0; i < inputFileToImport.files.length; i++) {
     const file = inputFileToImport.files[i]
 
-    totalFilesSize += file.size / 1024 / 1024
+    totalFileSize += file.size / 1024 / 1024
 
-    if (totalFilesSize > 10) {
+    if (totalFileSize > ALLOWED_FILE_SIZE_LIMIT) {
       showFileSizeLimitExceededWarning.value = true
       break
     }

--- a/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
@@ -70,7 +70,7 @@ const onFileChange = async () => {
   }
 
   if (!inputFileToImport.files || inputFileToImport.files.length === 0) {
-    inputChooseFileToImportFrom.value[0].value = ""
+    inputChooseFileToImportFrom.value = ""
     hasFile.value = false
     toast.show(t("action.choose_file").toString())
     return

--- a/packages/hoppscotch-common/src/helpers/functional/json.ts
+++ b/packages/hoppscotch-common/src/helpers/functional/json.ts
@@ -11,10 +11,7 @@ type SafeParseJSON = {
  * @param str Raw JSON data to be parsed
  * @returns Option type with some(JSON data) or none
  */
-export const safeParseJSON: SafeParseJSON = (
-  str: string,
-  convertToArray = false
-) =>
+export const safeParseJSON: SafeParseJSON = (str, convertToArray = false) =>
   O.tryCatch(() => {
     const data = JSON.parse(str)
     if (convertToArray) {

--- a/packages/hoppscotch-common/src/helpers/functional/json.ts
+++ b/packages/hoppscotch-common/src/helpers/functional/json.ts
@@ -11,7 +11,10 @@ type SafeParseJSON = {
  * @param str Raw JSON data to be parsed
  * @returns Option type with some(JSON data) or none
  */
-export const safeParseJSON: SafeParseJSON = (str, convertToArray = false) =>
+export const safeParseJSON: SafeParseJSON = (
+  str: string,
+  convertToArray = false
+) =>
   O.tryCatch(() => {
     const data = JSON.parse(str)
     if (convertToArray) {

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hopp.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hopp.ts
@@ -9,7 +9,6 @@ import { isPlainObject as _isPlainObject } from "lodash-es"
 import { IMPORTER_INVALID_FILE_FORMAT } from "."
 import { safeParseJSON } from "~/helpers/functional/json"
 import { translateToNewGQLCollection } from "@hoppscotch/data"
-import { trace } from "~/helpers/functional/debug"
 
 export const hoppRESTImporter = (content: string[]) =>
   pipe(
@@ -17,11 +16,8 @@ export const hoppRESTImporter = (content: string[]) =>
     A.traverse(O.Applicative)((str) => safeParseJSON(str, true)),
     O.chain(
       flow(
-        makeCollectionsArray,
-        trace,
-        // @ts-expect-error Todo: Investigate this
         A.flatten,
-        trace,
+        makeCollectionsArray,
         RA.map(validateCollection),
         O.sequenceArray,
         O.map(RA.toArray)

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hopp.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hopp.ts
@@ -2,19 +2,26 @@ import { pipe, flow } from "fp-ts/function"
 import * as TE from "fp-ts/TaskEither"
 import * as O from "fp-ts/Option"
 import * as RA from "fp-ts/ReadonlyArray"
+import * as A from "fp-ts/Array"
 import { translateToNewRESTCollection, HoppCollection } from "@hoppscotch/data"
 import { isPlainObject as _isPlainObject } from "lodash-es"
 
 import { IMPORTER_INVALID_FILE_FORMAT } from "."
 import { safeParseJSON } from "~/helpers/functional/json"
 import { translateToNewGQLCollection } from "@hoppscotch/data"
+import { trace } from "~/helpers/functional/debug"
 
-export const hoppRESTImporter = (content: string) =>
+export const hoppRESTImporter = (content: string[]) =>
   pipe(
-    safeParseJSON(content),
+    content,
+    A.traverse(O.Applicative)((str) => safeParseJSON(str, true)),
     O.chain(
       flow(
         makeCollectionsArray,
+        trace,
+        // @ts-expect-error Todo: Investigate this
+        A.flatten,
+        trace,
         RA.map(validateCollection),
         O.sequenceArray,
         O.map(RA.toArray)

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
@@ -8,17 +8,19 @@ import { IMPORTER_INVALID_FILE_FORMAT } from "."
 import { Environment } from "@hoppscotch/data"
 import { z } from "zod"
 
-export const hoppEnvImporter = (content: string) => {
-  const parsedContent = safeParseJSON(content, true)
+export const hoppEnvImporter = (contents: string[]) => {
+  const parsedContents = contents.map((str) => safeParseJSON(str))
 
-  // parse json from the environments string
-  if (O.isNone(parsedContent)) {
+  // check if any of the JSON parse results is None
+  if (parsedContents.some((parsed) => O.isNone(parsed))) {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)
   }
 
+  const parsedValues = parsedContents.flatMap((parsed) => O.toNullable(parsed))
+
   const validationResult = z
     .array(entityReference(Environment))
-    .safeParse(parsedContent.value)
+    .safeParse(parsedValues)
 
   if (!validationResult.success) {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
@@ -9,14 +9,14 @@ import { Environment } from "@hoppscotch/data"
 import { z } from "zod"
 
 export const hoppEnvImporter = (contents: string[]) => {
-  const parsedContents = contents.map((str) => safeParseJSON(str))
+  const parsedContents = contents.map((str) => safeParseJSON(str, true))
 
   if (parsedContents.some((parsed) => O.isNone(parsed))) {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)
   }
 
   const parsedValues = parsedContents.flatMap((content) => {
-    const unwrappedContent = O.toNullable(content) as HoppEnv[] | null
+    const unwrappedContent = O.toNullable(content) as Environment[] | null
 
     if (unwrappedContent) {
       return unwrappedContent.map((contentEntry) => {
@@ -24,7 +24,9 @@ export const hoppEnvImporter = (contents: string[]) => {
           ...contentEntry,
           variables: contentEntry.variables?.map((valueEntry) => ({
             ...valueEntry,
-            value: String(valueEntry.value),
+            ...("value" in valueEntry
+              ? { value: String(valueEntry.value) }
+              : {}),
           })),
         }
       })

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
@@ -16,17 +16,20 @@ export const hoppEnvImporter = (contents: string[]) => {
   }
 
   const parsedValues = parsedContents.flatMap((content) => {
-    const unwrappedContent = O.toNullable(content) as HoppEnv[]
+    const unwrappedContent = O.toNullable(content) as HoppEnv[] | null
 
-    return unwrappedContent.map((contentEntry) => {
-      return {
-        ...contentEntry,
-        variables: contentEntry.variables.map((valueEntry) => ({
-          ...valueEntry,
-          value: String(valueEntry.value),
-        })),
-      }
-    })
+    if (unwrappedContent) {
+      return unwrappedContent.map((contentEntry) => {
+        return {
+          ...contentEntry,
+          variables: contentEntry.variables?.map((valueEntry) => ({
+            ...valueEntry,
+            value: String(valueEntry.value),
+          })),
+        }
+      })
+    }
+    return null
   })
 
   const validationResult = z

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppGql.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppGql.ts
@@ -6,12 +6,7 @@ export const hoppGqlCollectionsImporter = (
   contents: string[]
 ): E.Either<"INVALID_JSON", HoppCollection[]> => {
   return E.tryCatch(
-    () =>
-      contents.flatMap((content) => {
-        const data = JSON.parse(content)
-        const result = Array.isArray(data) ? data : [data]
-        return result
-      }) as HoppCollection[],
+    () => contents.flatMap((content) => JSON.parse(content)),
     () => "INVALID_JSON"
   )
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppGql.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppGql.ts
@@ -3,10 +3,15 @@ import * as E from "fp-ts/Either"
 
 // TODO: add zod validation
 export const hoppGqlCollectionsImporter = (
-  content: string
+  contents: string[]
 ): E.Either<"INVALID_JSON", HoppCollection[]> => {
   return E.tryCatch(
-    () => JSON.parse(content) as HoppCollection[],
+    () =>
+      contents.flatMap((content) => {
+        const data = JSON.parse(content)
+        const result = Array.isArray(data) ? data : [data]
+        return result
+      }) as HoppCollection[],
     () => "INVALID_JSON"
   )
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/FileSource.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/FileSource.ts
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from "uuid"
 export function FileSource(metadata: {
   acceptedFileTypes: string
   caption: string
-  onImportFromFile: (content: string) => any | Promise<any>
+  onImportFromFile: (content: string[]) => any | Promise<any>
 }) {
   const stepID = uuidv4()
 

--- a/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/GistSource.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/GistSource.ts
@@ -10,7 +10,7 @@ import { v4 as uuidv4 } from "uuid"
 export function GistSource(metadata: {
   caption: string
   onImportFromGist: (
-    importResult: E.Either<string, string>
+    importResult: E.Either<string, string[]>
   ) => any | Promise<any>
 }) {
   const stepID = uuidv4()
@@ -29,9 +29,11 @@ export function GistSource(metadata: {
         return
       }
 
-      const content = Object.values(parseResult.data.files)[0].content
+      const contents = Object.values(parseResult.data.files).map(
+        ({ content }) => content
+      )
 
-      metadata.onImportFromGist(E.right(content))
+      metadata.onImportFromGist(E.right(contents))
     },
     fetchLogic: fetchGistFromUrl,
   }))

--- a/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/GistSource.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/GistSource.ts
@@ -17,7 +17,7 @@ export function GistSource(metadata: {
 
   return defineStep(stepID, UrlImport, () => ({
     caption: metadata.caption,
-    onImportFromURL: (gistResponse) => {
+    onImportFromURL: (gistResponse: Record<string, unknown>) => {
       const fileSchema = z.object({
         files: z.record(z.object({ content: z.string() })),
       })

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
@@ -1,4 +1,3 @@
-import * as A from "fp-ts/Array"
 import * as TE from "fp-ts/TaskEither"
 import * as O from "fp-ts/Option"
 

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
@@ -35,7 +35,7 @@ export const insomniaEnvImporter = (contents: string[]) => {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)
   }
 
-  const parsedValues = parsedContents.flatMap((parsed) => O.toNullable(parsed))
+  const parsedValues = parsedContents.map((parsed) => O.toNullable(parsed))
 
   const validationResult = z
     .array(insomniaResourcesSchema)

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
@@ -618,11 +618,11 @@ const parseOpenAPIDocContent = (str: string) =>
     )
   )
 
-export const hoppOpenAPIImporter = (fileContent: string) =>
+export const hoppOpenAPIImporter = (fileContents: string[]) =>
   pipe(
     // See if we can parse JSON properly
-    fileContent,
-    parseOpenAPIDocContent,
+    fileContents,
+    A.traverse(O.Applicative)(parseOpenAPIDocContent),
     TE.fromOption(() => {
       return IMPORTER_INVALID_FILE_FORMAT
     }),

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -58,9 +58,7 @@ const readPMCollection = (def: string) => {
     safeParseJSON,
     O.chain((data) =>
       O.tryCatch(() => {
-        return data.map((item: CollectionDefinition) => {
-          return new PMCollection(item)
-        })
+        return new PMCollection(data)
       })
     )
   )
@@ -304,17 +302,17 @@ const getHoppFolder = (ig: ItemGroup<Item>): HoppCollection =>
     headers: [],
   })
 
-export const getHoppCollection = (collections: PMCollection[]) => {
+export const getHoppCollections = (collections: PMCollection[]) => {
   return collections.map(getHoppFolder)
 }
 
-export const hoppPostmanImporter = (fileContent: string) => {
+export const hoppPostmanImporter = (fileContents: string[]) => {
   return pipe(
     // Try reading
-    fileContent,
-    readPMCollection,
+    fileContents,
+    A.traverse(O.Applicative)(readPMCollection),
 
-    O.map(flow(getHoppCollection)),
+    O.map(flow(getHoppCollections)),
 
     TE.fromOption(() => IMPORTER_INVALID_FILE_FORMAT)
   )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -5,7 +5,6 @@ import {
   QueryParam,
   RequestAuthDefinition,
   VariableDefinition,
-  CollectionDefinition,
 } from "postman-collection"
 import {
   HoppRESTAuth,
@@ -52,8 +51,8 @@ const PMRawLanguageOptionsToContentTypeMap: Record<
 const isPMItemGroup = (x: unknown): x is ItemGroup<Item> =>
   ItemGroup.isItemGroup(x)
 
-const readPMCollection = (def: string) => {
-  return pipe(
+const readPMCollection = (def: string) =>
+  pipe(
     def,
     safeParseJSON,
     O.chain((data) =>
@@ -62,7 +61,6 @@ const readPMCollection = (def: string) => {
       })
     )
   )
-}
 
 const getHoppReqHeaders = (item: Item): HoppRESTHeader[] =>
   pipe(
@@ -306,8 +304,8 @@ export const getHoppCollections = (collections: PMCollection[]) => {
   return collections.map(getHoppFolder)
 }
 
-export const hoppPostmanImporter = (fileContents: string[]) => {
-  return pipe(
+export const hoppPostmanImporter = (fileContents: string[]) =>
+  pipe(
     // Try reading
     fileContents,
     A.traverse(O.Applicative)(readPMCollection),
@@ -316,4 +314,3 @@ export const hoppPostmanImporter = (fileContents: string[]) => {
 
     TE.fromOption(() => IMPORTER_INVALID_FILE_FORMAT)
   )
-}

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
@@ -1,12 +1,11 @@
-import * as TE from "fp-ts/TaskEither"
-import * as O from "fp-ts/Option"
-
-import { IMPORTER_INVALID_FILE_FORMAT } from "."
-import { safeParseJSON } from "~/helpers/functional/json"
-
-import { z } from "zod"
 import { Environment } from "@hoppscotch/data"
+import * as O from "fp-ts/Option"
+import * as TE from "fp-ts/TaskEither"
 import { uniqueId } from "lodash-es"
+import { z } from "zod"
+
+import { safeParseJSON } from "~/helpers/functional/json"
+import { IMPORTER_INVALID_FILE_FORMAT } from "."
 
 const postmanEnvSchema = z.object({
   name: z.string(),
@@ -26,24 +25,23 @@ export const postmanEnvImporter = (content: string) => {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)
   }
 
-  const validationResult = postmanEnvSchema.safeParse(parsedContent.value)
+  const validationResult = z
+    .array(postmanEnvSchema)
+    .safeParse(parsedContent.value)
 
   if (!validationResult.success) {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)
   }
 
-  const postmanEnv = validationResult.data
-
-  const environment: Environment = {
-    id: uniqueId(),
-    v: 1,
-    name: postmanEnv.name,
-    variables: [],
-  }
-
-  postmanEnv.values.forEach(({ key, value }) =>
-    environment.variables.push({ key, value, secret: false })
+  // Convert `values` to `variables` to match the format expected by the system
+  const environments: Environment[] = validationResult.data.map(
+    ({ name, values }) => ({
+      id: uniqueId(),
+      v: 1,
+      name,
+      variables: values.map((entires) => ({ ...entires, secret: false })),
+    })
   )
 
-  return TE.right(environment)
+  return TE.right(environments)
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
@@ -17,17 +17,15 @@ const postmanEnvSchema = z.object({
   ),
 })
 
-export const postmanEnvImporter = (content: string) => {
-  const parsedContent = safeParseJSON(content)
-
-  // parse json from the environments string
-  if (O.isNone(parsedContent)) {
+export const postmanEnvImporter = (contents: string[]) => {
+  const parsedContents = contents.map((str) => safeParseJSON(str))
+  if (parsedContents.some((parsed) => O.isNone(parsed))) {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)
   }
 
-  const validationResult = z
-    .array(postmanEnvSchema)
-    .safeParse(parsedContent.value)
+  const parsedValues = parsedContents.flatMap((parsed) => O.toNullable(parsed))
+
+  const validationResult = z.array(postmanEnvSchema).safeParse(parsedValues)
 
   if (!validationResult.success) {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
@@ -20,21 +20,22 @@ const postmanEnvSchema = z.object({
 type PostmanEnv = z.infer<typeof postmanEnvSchema>
 
 export const postmanEnvImporter = (contents: string[]) => {
-  const parsedContents = contents.map((str) => safeParseJSON(str))
+  const parsedContents = contents.map((str) => safeParseJSON(str, true))
   if (parsedContents.some((parsed) => O.isNone(parsed))) {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)
   }
 
   const parsedValues = parsedContents.flatMap((parsed) => {
-    const unwrappedEntry = O.toNullable(parsed) as PostmanEnv | null
+    const unwrappedEntry = O.toNullable(parsed) as PostmanEnv[] | null
+
     if (unwrappedEntry) {
-      return {
-        ...unwrappedEntry,
-        values: unwrappedEntry.values.map((valueEntry) => ({
+      return unwrappedEntry.map((entry) => ({
+        ...entry,
+        values: entry.values?.map((valueEntry) => ({
           ...valueEntry,
           value: String(valueEntry.value),
         })),
-      }
+      }))
     }
     return null
   })

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -61,8 +61,8 @@ export function navigateToFolderWithIndexPath(
 
   let target = collections[indexPaths.shift() as number]
 
-  while (indexPaths.length > 0)
-    target = target?.folders[indexPaths.shift() as number]
+  while (indexPaths.length > 0 && target)
+    target = target.folders[indexPaths.shift() as number]
 
   return target !== undefined ? target : null
 }

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -62,7 +62,7 @@ export function navigateToFolderWithIndexPath(
   let target = collections[indexPaths.shift() as number]
 
   while (indexPaths.length > 0)
-    target = target.folders[indexPaths.shift() as number]
+    target = target?.folders[indexPaths.shift() as number]
 
   return target !== undefined ? target : null
 }


### PR DESCRIPTION
### Description

This PR adds support for importing multiple collection and environment files simultaneously for all import formats, including import from Gist. Also, the environment values are converted to strings while importing from Hoppscotch (via Gist/file) & Postman. We're also introducing a file size limit of `10 MB`.

Closes HFE-386 HFE-389.

### Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed

### Note to reviewers

- The collection tree appears broken while importing REST/GQL collections in the personal workspace, with the requests appearing outside folders where they should reside. This is an issue that already exists related to syncing tracked separately. Safeguards are added with this PR to prevent exceptions observed while importing collections with many requests.
- If the user mixes files of other types while importing, it will result in an error toast if the importer has validation logic for other file types but prevents importing other valid file types. Otherwise, it will result in importing all the files with the invalid file types in a broken state (empty folders, etc). Ideally, the invalid files should be filtered out, and the user should be notified via a toast. To be revisited in an overhaul.