### PR TITLE
fix: documentation is not being generated on GQL

### DIFF
--- a/packages/hoppscotch-common/src/components/graphql/Sidebar.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Sidebar.vue
@@ -187,7 +187,7 @@ import IconClock from "~icons/lucide/clock"
 import IconCopy from "~icons/lucide/copy"
 import IconBox from "~icons/lucide/box"
 import { computed, nextTick, reactive, ref } from "vue"
-import { GraphQLField, GraphQLType } from "graphql"
+import { GraphQLField, GraphQLType, getNamedType } from "graphql"
 import { refAutoReset } from "@vueuse/core"
 import { useCodemirror } from "@composables/codemirror"
 import { copyToClipboard } from "@helpers/utils/clipboard"
@@ -200,7 +200,6 @@ import {
   queryFields,
   schemaString,
   subscriptionFields,
-  resolveRootType,
 } from "~/helpers/graphql/connection"
 import { platform } from "~/platform"
 
@@ -326,7 +325,7 @@ const handleJumpToType = async (type: GraphQLType) => {
   selectedGqlTab.value = "types"
   await nextTick()
 
-  const rootTypeName = resolveRootType(type).name
+  const rootTypeName = getNamedType(type).name
   const target = document.getElementById(`type_${rootTypeName}`)
   if (target) {
     target.scrollIntoView({ block: "center", behavior: "smooth" })

--- a/packages/hoppscotch-common/src/components/graphql/Sidebar.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Sidebar.vue
@@ -200,6 +200,7 @@ import {
   queryFields,
   schemaString,
   subscriptionFields,
+  resolveRootType,
 } from "~/helpers/graphql/connection"
 import { platform } from "~/platform"
 
@@ -258,12 +259,6 @@ function getFilteredGraphqlTypes(filterText: string, types: GraphQLType[]) {
 
     return isFilterTextMatchingAtLeastOneField
   })
-}
-
-function resolveRootType(type: GraphQLType) {
-  let t: any = type
-  while (t.ofType) t = t.ofType
-  return t
 }
 
 const toast = useToast()

--- a/packages/hoppscotch-common/src/components/graphql/TypeLink.vue
+++ b/packages/hoppscotch-common/src/components/graphql/TypeLink.vue
@@ -10,6 +10,7 @@
 <script setup lang="ts">
 import { GraphQLScalarType, GraphQLType } from "graphql"
 import { computed } from "vue"
+import { resolveRootType } from "~/helpers/graphql/connection"
 
 const props = defineProps<{
   gqlType: GraphQLType
@@ -23,13 +24,6 @@ const typeString = computed(() => `${props.gqlType}`)
 const isScalar = computed(() => {
   return resolveRootType(props.gqlType) instanceof GraphQLScalarType
 })
-
-function resolveRootType(type: GraphQLType) {
-  let t = type as any
-  // We can't do !== here because it's possible to have a type that is not null or undefined but still not have an ofType property
-  while (t.ofType != null) t = t.ofType
-  return t
-}
 
 function jumpToType() {
   if (isScalar.value) return

--- a/packages/hoppscotch-common/src/components/graphql/TypeLink.vue
+++ b/packages/hoppscotch-common/src/components/graphql/TypeLink.vue
@@ -8,9 +8,8 @@
 </template>
 
 <script setup lang="ts">
-import { GraphQLScalarType, GraphQLType } from "graphql"
+import { GraphQLScalarType, GraphQLType, getNamedType } from "graphql"
 import { computed } from "vue"
-import { resolveRootType } from "~/helpers/graphql/connection"
 
 const props = defineProps<{
   gqlType: GraphQLType
@@ -22,7 +21,7 @@ const emit = defineEmits<{
 
 const typeString = computed(() => `${props.gqlType}`)
 const isScalar = computed(() => {
-  return resolveRootType(props.gqlType) instanceof GraphQLScalarType
+  return getNamedType(props.gqlType) instanceof GraphQLScalarType
 })
 
 function jumpToType() {

--- a/packages/hoppscotch-common/src/components/graphql/TypeLink.vue
+++ b/packages/hoppscotch-common/src/components/graphql/TypeLink.vue
@@ -26,7 +26,8 @@ const isScalar = computed(() => {
 
 function resolveRootType(type: GraphQLType) {
   let t = type as any
-  while (t.ofType !== null) t = t.ofType
+  // We can't do !== here because it's possible to have a type that is not null or undefined but still not have an ofType property
+  while (t.ofType != null) t = t.ofType
   return t
 }
 

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -7,6 +7,7 @@ import {
   GraphQLInterfaceType,
   GraphQLObjectType,
   GraphQLSchema,
+  GraphQLType,
   buildClientSchema,
   getIntrospectionQuery,
   printSchema,
@@ -443,4 +444,10 @@ const addQueryToHistory = (options: RunQueryOptions, response: string) => {
       star: false,
     })
   )
+}
+
+export function resolveRootType(type: GraphQLType) {
+  let t: any = type
+  while (t.ofType) t = t.ofType
+  return t
 }

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -7,7 +7,6 @@ import {
   GraphQLInterfaceType,
   GraphQLObjectType,
   GraphQLSchema,
-  GraphQLType,
   buildClientSchema,
   getIntrospectionQuery,
   printSchema,
@@ -444,10 +443,4 @@ const addQueryToHistory = (options: RunQueryOptions, response: string) => {
       star: false,
     })
   )
-}
-
-export function resolveRootType(type: GraphQLType) {
-  let t: any = type
-  while (t.ofType) t = t.ofType
-  return t
 }


### PR DESCRIPTION
Closes HFE-380

### Description
Updated the `resolveRootType` function to correctly handle GraphQL types that do not have an `ofType` property. The function now uses a while loop to traverse the `ofType` chain until it reaches a type that does not contain any other types (i.e., its ofType property is null). This ensures that the function always returns the correct root type for any given GraphQL type.

- [ ] Not Completed
- [x] Completed