### PR TITLE
HBE-348 feature: user invitation revoke from admin dashboard

### DIFF
--- a/packages/hoppscotch-backend/src/admin/admin.resolver.ts
+++ b/packages/hoppscotch-backend/src/admin/admin.resolver.ts
@@ -282,7 +282,7 @@ export class AdminResolver {
   ): Promise<boolean> {
     const invite = await this.adminService.revokeUserInvite(
       inviteeEmail,
-      adminUser,
+      adminUser.uid,
     );
     if (E.isLeft(invite)) throwErr(invite.left);
     return invite.right;

--- a/packages/hoppscotch-backend/src/admin/admin.resolver.ts
+++ b/packages/hoppscotch-backend/src/admin/admin.resolver.ts
@@ -271,7 +271,7 @@ export class AdminResolver {
 
   @Mutation(() => Boolean, { description: 'Revoke a user invite by ID' })
   @UseGuards(GqlAuthGuard, GqlAdminGuard)
-  async revokeUserInviteByAdmin(
+  async revokeUserInvitationByAdmin(
     @GqlAdmin() adminUser: Admin,
     @Args({
       name: 'inviteeEmail',

--- a/packages/hoppscotch-backend/src/admin/admin.service.ts
+++ b/packages/hoppscotch-backend/src/admin/admin.service.ts
@@ -117,7 +117,7 @@ export class AdminService {
    * @param adminUser Admin object
    * @returns an Either of array of `InvitedUser` object or error string
    */
-  async revokeUserInvite(inviteeEmail: string, adminUser: Admin) {
+  async revokeUserInvite(inviteeEmail: string, adminUid: string) {
     try {
       const deletedInvitee = await this.prisma.invitedUsers.delete({
         where: {
@@ -132,7 +132,7 @@ export class AdminService {
         invitedOn: deletedInvitee.invitedOn,
       };
 
-      this.pubsub.publish(`admin/${adminUser.uid}/revoked`, invitedUser);
+      this.pubsub.publish(`admin/${adminUid}/revoked`, invitedUser);
 
       return E.right(true);
     } catch (error) {

--- a/packages/hoppscotch-backend/src/admin/invited-user.model.ts
+++ b/packages/hoppscotch-backend/src/admin/invited-user.model.ts
@@ -21,4 +21,10 @@ export class InvitedUser {
     description: 'Date when the user invitation was sent',
   })
   invitedOn: Date;
+
+  @Field({
+    description: 'Boolean status if invitation was accepted or not',
+    defaultValue: false,
+  })
+  isInvitationAccepted: boolean;
 }

--- a/packages/hoppscotch-backend/src/errors.ts
+++ b/packages/hoppscotch-backend/src/errors.ts
@@ -66,6 +66,11 @@ export const USER_FB_DOCUMENT_DELETION_FAILED =
 export const USER_NOT_FOUND = 'user/not_found' as const;
 
 /**
+ * User is not invited by admin
+ */
+export const USER_NOT_INVITED = 'admin/user_not_invited' as const;
+
+/**
  * User is already invited by admin
  */
 export const USER_ALREADY_INVITED = 'admin/user_already_invited' as const;

--- a/packages/hoppscotch-backend/src/pubsub/topicsDefs.ts
+++ b/packages/hoppscotch-backend/src/pubsub/topicsDefs.ts
@@ -31,7 +31,7 @@ import { Shortcode } from 'src/shortcode/shortcode.model';
 // A custom message type that defines the topic and the corresponding payload.
 // For every module that publishes a subscription add its type def and the possible subscription type.
 export type TopicDef = {
-  [topic: `admin/${string}/${'invited'}`]: InvitedUser;
+  [topic: `admin/${string}/${'invited' | 'revoked'}`]: InvitedUser;
   [topic: `user/${string}/${'updated' | 'deleted'}`]: User;
   [topic: `user_settings/${string}/${'created' | 'updated'}`]: UserSettings;
   [


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HSB-350

### Description
<!-- Add a brief description of the pull request -->
This PR introduces a mutation in `hoppscotch-backend` that can revoke a user invitation from the admin dashboard.

* If an admin invites a person, but the person **does not accept the invitation**, only in that case, the person's invitation can be revocable. 
* Once the **person accepts the invitation**, then that invitation should not be revocable. To delete that person, admin should follow the delete_user flow.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### How to Test:
```
mutation {
  revokeUserInviteByAdmin(inviteeEmail: "test@gmail.com")
}

subscription {
  userInvited {
    adminUid
    adminEmail
    inviteeEmail
    invitedOn
    isInvitationAccepted
  }
}
```

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
Nil