### PR TITLE
chore(cli): emit bundle in ESM format

### DIFF
--- a/packages/hoppscotch-cli/bin/hopp
+++ b/packages/hoppscotch-cli/bin/hopp
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-// * The entry point of the CLI
-require("../dist").cli(process.argv);

--- a/packages/hoppscotch-cli/bin/hopp.js
+++ b/packages/hoppscotch-cli/bin/hopp.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// * The entry point of the CLI
+
+import { cli } from "../dist/index.js";
+
+cli(process.argv);

--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@hoppscotch/cli",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "A CLI to run Hoppscotch test scripts in CI environments.",
   "homepage": "https://hoppscotch.io",
+  "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "hopp": "bin/hopp"
+    "hopp": "bin/hopp.js"
   },
   "publishConfig": {
     "access": "public"
@@ -39,27 +40,27 @@
   },
   "license": "MIT",
   "private": false,
+  "dependencies": {
+    "axios": "^1.6.6",
+    "chalk": "^5.3.0",
+    "commander": "^11.1.0",
+    "lodash-es": "^4.17.21",
+    "qs": "^6.11.2",
+    "zod": "^3.22.4"
+  },
   "devDependencies": {
     "@hoppscotch/data": "workspace:^",
     "@hoppscotch/js-sandbox": "workspace:^",
     "@relmify/jest-fp-ts": "^2.1.1",
-    "@swc/core": "^1.3.92",
-    "@types/jest": "^29.5.5",
-    "@types/lodash": "^4.14.199",
-    "@types/qs": "^6.9.8",
-    "axios": "^0.21.4",
-    "chalk": "^4.1.2",
-    "commander": "^11.0.0",
-    "esm": "^3.2.25",
-    "fp-ts": "^2.16.1",
-    "io-ts": "^2.2.20",
+    "@swc/core": "^1.3.105",
+    "@types/jest": "^29.5.11",
+    "@types/lodash-es": "^4.17.12",
+    "@types/qs": "^6.9.11",
+    "fp-ts": "^2.16.2",
     "jest": "^29.7.0",
-    "lodash": "^4.17.21",
-    "prettier": "^3.0.3",
-    "qs": "^6.11.2",
-    "ts-jest": "^29.1.1",
-    "tsup": "^7.2.0",
-    "typescript": "^5.2.2",
-    "zod": "^3.22.4"
+    "prettier": "^3.2.4",
+    "ts-jest": "^29.1.2",
+    "tsup": "^8.0.1",
+    "typescript": "^5.3.3"
   }
 }

--- a/packages/hoppscotch-cli/src/index.ts
+++ b/packages/hoppscotch-cli/src/index.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { program } from "commander";
+import { Command } from "commander";
 import * as E from "fp-ts/Either";
 import { version } from "../package.json";
 import { test } from "./commands/test";
@@ -19,6 +19,8 @@ const CLI_BEFORE_ALL_TXT = `hopp: The ${accent(
 const CLI_AFTER_ALL_TXT = `\nFor more help, head on to ${accent(
   "https://docs.hoppscotch.io/documentation/clients/cli"
 )}`;
+
+const program = new Command()
 
 program
   .name("hopp")

--- a/packages/hoppscotch-cli/src/utils/collections.ts
+++ b/packages/hoppscotch-cli/src/utils/collections.ts
@@ -1,9 +1,9 @@
 import { HoppCollection, HoppRESTRequest } from "@hoppscotch/data";
-import { bold } from "chalk";
+import chalk from "chalk";
 import { log } from "console";
 import * as A from "fp-ts/Array";
 import { pipe } from "fp-ts/function";
-import round from "lodash/round";
+import { round } from "lodash-es";
 
 import { CollectionRunnerParam } from "../types/collections";
 import {
@@ -68,7 +68,7 @@ export const collectionsRunner = async (
         };
 
         // Request processing initiated message.
-        log(WARN(`\nRunning: ${bold(requestPath)}`));
+        log(WARN(`\nRunning: ${chalk.bold(requestPath)}`));
 
       // Processing current request.
       const result = await processRequest(processRequestParams)();

--- a/packages/hoppscotch-cli/src/utils/display.ts
+++ b/packages/hoppscotch-cli/src/utils/display.ts
@@ -1,4 +1,4 @@
-import { bold } from "chalk";
+import chalk from "chalk";
 import { groupEnd, group, log } from "console";
 import { handleError } from "../handlers/error";
 import { RequestConfig } from "../interfaces/request";
@@ -120,7 +120,7 @@ export const printErrorsReport = (
   errorsReport: HoppCLIError[]
 ) => {
   if (errorsReport.length > 0) {
-    const REPORTED_ERRORS_TITLE = FAIL(`\n${bold(path)} reported errors:`);
+    const REPORTED_ERRORS_TITLE = FAIL(`\n${chalk.bold(path)} reported errors:`);
 
     group(REPORTED_ERRORS_TITLE);
     for (const errorReport of errorsReport) {
@@ -143,7 +143,7 @@ export const printFailedTestsReport = (
 
   // Only printing test-reports with failed test-cases.
   if (failedTestsReport.length > 0) {
-    const FAILED_TESTS_PATH = FAIL(`\n${bold(path)} failed tests:`);
+    const FAILED_TESTS_PATH = FAIL(`\n${chalk.bold(path)} failed tests:`);
     group(FAILED_TESTS_PATH);
 
     for (const failedTestReport of failedTestsReport) {

--- a/packages/hoppscotch-cli/src/utils/functions/array.ts
+++ b/packages/hoppscotch-cli/src/utils/functions/array.ts
@@ -1,4 +1,4 @@
-import { clone } from "lodash";
+import { clone } from "lodash-es";
 
 /**
  * Sorts the array based on the sort func.

--- a/packages/hoppscotch-cli/src/utils/getters.ts
+++ b/packages/hoppscotch-cli/src/utils/getters.ts
@@ -11,7 +11,7 @@ import * as E from "fp-ts/Either";
 import * as S from "fp-ts/string";
 import * as O from "fp-ts/Option";
 import { error } from "../types/errors";
-import round from "lodash/round";
+import { round } from "lodash-es";
 import { DEFAULT_DURATION_PRECISION } from "./constants";
 
 /**

--- a/packages/hoppscotch-cli/tsconfig.json
+++ b/packages/hoppscotch-cli/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES6",
-    "module": "commonjs",
+    "target": "ESNext",
+    "module": "ESNext",
     "outDir": ".",
     "rootDir": ".",
     "strict": true,

--- a/packages/hoppscotch-cli/tsup.config.ts
+++ b/packages/hoppscotch-cli/tsup.config.ts
@@ -3,17 +3,14 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: [ "./src/index.ts" ],
   outDir: "./dist/",
-  format: ["cjs"],
+  format: ["esm"],
   platform: "node",
   sourcemap: true,
   bundle: true,
-  target: "node12",
+  target: "esnext",
   skipNodeModulesBundle: false,
   esbuildOptions(options) {
     options.bundle = true
   },
-  noExternal:  [
-    /\w+/
-  ],
   clean: true,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,25 @@ importers:
         version: 4.9.3
 
   packages/hoppscotch-cli:
+    dependencies:
+      axios:
+        specifier: ^1.6.6
+        version: 1.6.7
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
+      commander:
+        specifier: ^11.1.0
+        version: 11.1.0
+      lodash-es:
+        specifier: ^4.17.21
+        version: 4.17.21
+      qs:
+        specifier: ^6.11.2
+        version: 6.11.2
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
     devDependencies:
       '@hoppscotch/data':
         specifier: workspace:^
@@ -299,61 +318,37 @@ importers:
         version: link:../hoppscotch-js-sandbox
       '@relmify/jest-fp-ts':
         specifier: ^2.1.1
-        version: 2.1.1(fp-ts@2.16.1)(io-ts@2.2.20)
+        version: 2.1.1(fp-ts@2.16.2)(io-ts@2.2.20)
       '@swc/core':
-        specifier: ^1.3.92
-        version: 1.3.100
+        specifier: ^1.3.105
+        version: 1.3.107
       '@types/jest':
-        specifier: ^29.5.5
-        version: 29.5.10
-      '@types/lodash':
-        specifier: ^4.14.199
-        version: 4.14.200
+        specifier: ^29.5.11
+        version: 29.5.12
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/qs':
-        specifier: ^6.9.8
-        version: 6.9.10
-      axios:
-        specifier: ^0.21.4
-        version: 0.21.4
-      chalk:
-        specifier: ^4.1.2
-        version: 4.1.2
-      commander:
-        specifier: ^11.0.0
-        version: 11.1.0
-      esm:
-        specifier: ^3.2.25
-        version: 3.2.25
+        specifier: ^6.9.11
+        version: 6.9.11
       fp-ts:
-        specifier: ^2.16.1
-        version: 2.16.1
-      io-ts:
-        specifier: ^2.2.20
-        version: 2.2.20(fp-ts@2.16.1)
+        specifier: ^2.16.2
+        version: 2.16.2
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@17.0.27)
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
       prettier:
-        specifier: ^3.0.3
-        version: 3.0.3
-      qs:
-        specifier: ^6.11.2
-        version: 6.11.2
+        specifier: ^3.2.4
+        version: 3.2.4
       ts-jest:
-        specifier: ^29.1.1
-        version: 29.1.1(@babel/core@7.23.2)(esbuild@0.19.5)(jest@29.7.0)(typescript@5.2.2)
+        specifier: ^29.1.2
+        version: 29.1.2(@babel/core@7.23.2)(esbuild@0.19.5)(jest@29.7.0)(typescript@5.3.3)
       tsup:
-        specifier: ^7.2.0
-        version: 7.3.0(@swc/core@1.3.100)(typescript@5.2.2)
+        specifier: ^8.0.1
+        version: 8.0.1(@swc/core@1.3.107)(typescript@5.3.3)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
-      zod:
-        specifier: ^3.22.4
-        version: 3.22.4
+        specifier: ^5.3.3
+        version: 5.3.3
 
   packages/hoppscotch-common:
     dependencies:
@@ -7522,7 +7517,7 @@ packages:
       '@hoppscotch/vue-toasted': 0.1.0(vue@3.3.9)
       '@vitejs/plugin-legacy': 2.3.0(terser@5.27.0)(vite@4.5.0)
       '@vueuse/core': 8.7.5(vue@3.3.9)
-      fp-ts: 2.16.1
+      fp-ts: 2.16.2
       lodash-es: 4.17.21
       path: 0.12.7
       vite-plugin-eslint: 1.8.1(eslint@8.55.0)(vite@4.5.0)
@@ -7548,7 +7543,7 @@ packages:
       '@hoppscotch/vue-toasted': 0.1.0(vue@3.3.9)
       '@vitejs/plugin-legacy': 2.3.0(terser@5.27.0)(vite@3.2.4)
       '@vueuse/core': 8.7.5(vue@3.3.9)
-      fp-ts: 2.16.1
+      fp-ts: 2.16.2
       lodash-es: 4.17.21
       path: 0.12.7
       vite-plugin-eslint: 1.8.1(eslint@8.56.0)(vite@3.2.4)
@@ -7574,7 +7569,7 @@ packages:
       '@hoppscotch/vue-toasted': 0.1.0(vue@3.3.9)
       '@vitejs/plugin-legacy': 2.3.0(terser@5.27.0)(vite@3.2.8)
       '@vueuse/core': 8.7.5(vue@3.3.9)
-      fp-ts: 2.16.1
+      fp-ts: 2.16.2
       lodash-es: 4.17.21
       path: 0.12.7
       vite-plugin-eslint: 1.8.1(eslint@8.56.0)(vite@3.2.8)
@@ -8038,7 +8033,7 @@ packages:
       '@types/node': 18.18.8
       chalk: 4.1.2
       jest-message-util: 29.5.0
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       slash: 3.0.0
     dev: true
 
@@ -8246,7 +8241,7 @@ packages:
     resolution: {integrity: sha512-ZxKJP5DTUNF2XkpJeZIzvnzF1KkfrhEF6Rz0HGG69fHl6Bgx5/GoU3XyaeFYEjuuKSOOsbqD/k72wFvFxc3iTw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      expect: 29.5.0
+      expect: 29.7.0
       jest-snapshot: 29.4.1
     transitivePeerDependencies:
       - supports-color
@@ -8283,7 +8278,7 @@ packages:
       '@types/node': 18.18.8
       jest-message-util: 29.5.0
       jest-mock: 29.4.1
-      jest-util: 29.5.0
+      jest-util: 29.7.0
     dev: true
 
   /@jest/fake-timers@29.7.0:
@@ -8396,7 +8391,7 @@ packages:
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.1.4
       jest-message-util: 29.5.0
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       jest-worker: 29.4.1
       slash: 3.0.0
       string-length: 4.0.2
@@ -8604,7 +8599,7 @@ packages:
       graceful-fs: 4.2.10
       jest-haste-map: 29.4.1
       jest-regex-util: 29.2.0
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       micromatch: 4.0.5
       pirates: 4.0.5
       slash: 3.0.0
@@ -9441,6 +9436,20 @@ packages:
       jest-matcher-utils: 29.5.0
     dev: true
 
+  /@relmify/jest-fp-ts@2.1.1(fp-ts@2.16.2)(io-ts@2.2.20):
+    resolution: {integrity: sha512-ljNGMAINGa8YjIjbkufx6qV0+1HRoX3yNJi92A/RSZifYJpaztqjNtYm9jvKPBmQuZtnkWv+Vik+zMa2rZI0TQ==}
+    peerDependencies:
+      fp-ts: 2.x
+      io-ts: 2.x
+    dependencies:
+      '@jest/expect-utils': 29.5.0
+      expect: 29.5.0
+      fp-ts: 2.16.2
+      io-ts: 2.2.20(fp-ts@2.16.2)
+      jest-get-type: 29.4.3
+      jest-matcher-utils: 29.5.0
+    dev: true
+
   /@repeaterjs/repeater@3.0.4:
     resolution: {integrity: sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==}
 
@@ -9743,8 +9752,8 @@ packages:
       string.prototype.matchall: 4.0.10
     dev: true
 
-  /@swc/core-darwin-arm64@1.3.100:
-    resolution: {integrity: sha512-XVWFsKe6ei+SsDbwmsuRkYck1SXRpO60Hioa4hoLwR8fxbA9eVp6enZtMxzVVMBi8ej5seZ4HZQeAWepbukiBw==}
+  /@swc/core-darwin-arm64@1.3.107:
+    resolution: {integrity: sha512-47tD/5vSXWxPd0j/ZllyQUg4bqalbQTsmqSw0J4dDdS82MWqCAwUErUrAZPRjBkjNQ6Kmrf5rpCWaGTtPw+ngw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
@@ -9752,8 +9761,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-darwin-x64@1.3.100:
-    resolution: {integrity: sha512-KF/MXrnH1nakm1wbt4XV8FS7kvqD9TGmVxeJ0U4bbvxXMvzeYUurzg3AJUTXYmXDhH/VXOYJE5N5RkwZZPs5iA==}
+  /@swc/core-darwin-x64@1.3.107:
+    resolution: {integrity: sha512-hwiLJ2ulNkBGAh1m1eTfeY1417OAYbRGcb/iGsJ+LuVLvKAhU/itzsl535CvcwAlt2LayeCFfcI8gdeOLeZa9A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
@@ -9761,8 +9770,17 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-gnu@1.3.100:
-    resolution: {integrity: sha512-p8hikNnAEJrw5vHCtKiFT4hdlQxk1V7vqPmvUDgL/qe2menQDK/i12tbz7/3BEQ4UqUPnvwpmVn2d19RdEMNxw==}
+  /@swc/core-linux-arm-gnueabihf@1.3.107:
+    resolution: {integrity: sha512-I2wzcC0KXqh0OwymCmYwNRgZ9nxX7DWnOOStJXV3pS0uB83TXAkmqd7wvMBuIl9qu4Hfomi9aDM7IlEEn9tumQ==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@swc/core-linux-arm64-gnu@1.3.107:
+    resolution: {integrity: sha512-HWgnn7JORYlOYnGsdunpSF8A+BCZKPLzLtEUA27/M/ZuANcMZabKL9Zurt7XQXq888uJFAt98Gy+59PU90aHKg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -9770,8 +9788,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-arm64-musl@1.3.100:
-    resolution: {integrity: sha512-BWx/0EeY89WC4q3AaIaBSGfQxkYxIlS3mX19dwy2FWJs/O+fMvF9oLk/CyJPOZzbp+1DjGeeoGFuDYpiNO91JA==}
+  /@swc/core-linux-arm64-musl@1.3.107:
+    resolution: {integrity: sha512-vfPF74cWfAm8hyhS8yvYI94ucMHIo8xIYU+oFOW9uvDlGQRgnUf/6DEVbLyt/3yfX5723Ln57U8uiMALbX5Pyw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
@@ -9779,8 +9797,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-gnu@1.3.100:
-    resolution: {integrity: sha512-XUdGu3dxAkjsahLYnm8WijPfKebo+jHgHphDxaW0ovI6sTdmEGFDew7QzKZRlbYL2jRkUuuKuDGvD6lO5frmhA==}
+  /@swc/core-linux-x64-gnu@1.3.107:
+    resolution: {integrity: sha512-uBVNhIg0ip8rH9OnOsCARUFZ3Mq3tbPHxtmWk9uAa5u8jQwGWeBx5+nTHpDOVd3YxKb6+5xDEI/edeeLpha/9g==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -9788,8 +9806,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-linux-x64-musl@1.3.100:
-    resolution: {integrity: sha512-PhoXKf+f0OaNW/GCuXjJ0/KfK9EJX7z2gko+7nVnEA0p3aaPtbP6cq1Ubbl6CMoPL+Ci3gZ7nYumDqXNc3CtLQ==}
+  /@swc/core-linux-x64-musl@1.3.107:
+    resolution: {integrity: sha512-mvACkUvzSIB12q1H5JtabWATbk3AG+pQgXEN95AmEX2ZA5gbP9+B+mijsg7Sd/3tboHr7ZHLz/q3SHTvdFJrEw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
@@ -9797,8 +9815,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-arm64-msvc@1.3.100:
-    resolution: {integrity: sha512-PwLADZN6F9cXn4Jw52FeP/MCLVHm8vwouZZSOoOScDtihjY495SSjdPnlosMaRSR4wJQssGwiD/4MbpgQPqbAw==}
+  /@swc/core-win32-arm64-msvc@1.3.107:
+    resolution: {integrity: sha512-J3P14Ngy/1qtapzbguEH41kY109t6DFxfbK4Ntz9dOWNuVY3o9/RTB841ctnJk0ZHEG+BjfCJjsD2n8H5HcaOA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
@@ -9806,8 +9824,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-ia32-msvc@1.3.100:
-    resolution: {integrity: sha512-0f6nicKSLlDKlyPRl2JEmkpBV4aeDfRQg6n8mPqgL7bliZIcDahG0ej+HxgNjZfS3e0yjDxsNRa6sAqWU2Z60A==}
+  /@swc/core-win32-ia32-msvc@1.3.107:
+    resolution: {integrity: sha512-ZBUtgyjTHlz8TPJh7kfwwwFma+ktr6OccB1oXC8fMSopD0AxVnQasgun3l3099wIsAB9eEsJDQ/3lDkOLs1gBA==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
@@ -9815,8 +9833,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core-win32-x64-msvc@1.3.100:
-    resolution: {integrity: sha512-b7J0rPoMkRTa3XyUGt8PwCaIBuYWsL2DqbirrQKRESzgCvif5iNpqaM6kjIjI/5y5q1Ycv564CB51YDpiS8EtQ==}
+  /@swc/core-win32-x64-msvc@1.3.107:
+    resolution: {integrity: sha512-Eyzo2XRqWOxqhE1gk9h7LWmUf4Bp4Xn2Ttb0ayAXFp6YSTxQIThXcT9kipXZqcpxcmDwoq8iWbbf2P8XL743EA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
@@ -9824,8 +9842,8 @@ packages:
     dev: true
     optional: true
 
-  /@swc/core@1.3.100:
-    resolution: {integrity: sha512-7dKgTyxJjlrMwFZYb1auj3Xq0D8ZBe+5oeIgfMlRU05doXZypYJe0LAk0yjj3WdbwYzpF+T1PLxwTWizI0pckw==}
+  /@swc/core@1.3.107:
+    resolution: {integrity: sha512-zKhqDyFcTsyLIYK1iEmavljZnf4CCor5pF52UzLAz4B6Nu/4GLU+2LQVAf+oRHjusG39PTPjd2AlRT3f3QWfsQ==}
     engines: {node: '>=10'}
     requiresBuild: true
     peerDependencies:
@@ -9837,15 +9855,16 @@ packages:
       '@swc/counter': 0.1.2
       '@swc/types': 0.1.5
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.3.100
-      '@swc/core-darwin-x64': 1.3.100
-      '@swc/core-linux-arm64-gnu': 1.3.100
-      '@swc/core-linux-arm64-musl': 1.3.100
-      '@swc/core-linux-x64-gnu': 1.3.100
-      '@swc/core-linux-x64-musl': 1.3.100
-      '@swc/core-win32-arm64-msvc': 1.3.100
-      '@swc/core-win32-ia32-msvc': 1.3.100
-      '@swc/core-win32-x64-msvc': 1.3.100
+      '@swc/core-darwin-arm64': 1.3.107
+      '@swc/core-darwin-x64': 1.3.107
+      '@swc/core-linux-arm-gnueabihf': 1.3.107
+      '@swc/core-linux-arm64-gnu': 1.3.107
+      '@swc/core-linux-arm64-musl': 1.3.107
+      '@swc/core-linux-x64-gnu': 1.3.107
+      '@swc/core-linux-x64-musl': 1.3.107
+      '@swc/core-win32-arm64-msvc': 1.3.107
+      '@swc/core-win32-ia32-msvc': 1.3.107
+      '@swc/core-win32-x64-msvc': 1.3.107
     dev: true
 
   /@swc/counter@0.1.2:
@@ -10137,7 +10156,7 @@ packages:
     resolution: {integrity: sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==}
     dependencies:
       '@types/node': 18.18.8
-      '@types/qs': 6.9.10
+      '@types/qs': 6.9.11
       '@types/range-parser': 1.2.4
 
   /@types/express@4.17.14:
@@ -10154,7 +10173,7 @@ packages:
     dependencies:
       '@types/body-parser': 1.19.2
       '@types/express-serve-static-core': 4.17.31
-      '@types/qs': 6.9.10
+      '@types/qs': 6.9.11
       '@types/serve-static': 1.15.0
     dev: false
 
@@ -10198,11 +10217,11 @@ packages:
       pretty-format: 29.3.1
     dev: true
 
-  /@types/jest@29.5.10:
-    resolution: {integrity: sha512-tE4yxKEphEyxj9s4inideLHktW/x6DwesIwWZ9NN1FKf9zbJYsnhBoA9vrHA/IuIOKwPa5PcFBNV4lpMIOEzyQ==}
+  /@types/jest@29.5.12:
+    resolution: {integrity: sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==}
     dependencies:
-      expect: 29.5.0
-      pretty-format: 29.5.0
+      expect: 29.7.0
+      pretty-format: 29.7.0
     dev: true
 
   /@types/js-yaml@4.0.9:
@@ -10412,8 +10431,8 @@ packages:
     dev: false
     optional: true
 
-  /@types/qs@6.9.10:
-    resolution: {integrity: sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==}
+  /@types/qs@6.9.11:
+    resolution: {integrity: sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ==}
 
   /@types/qs@6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
@@ -12503,11 +12522,22 @@ packages:
       follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
+    dev: false
 
   /axios@1.6.2:
     resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
     dependencies:
       follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /axios@1.6.7:
+    resolution: {integrity: sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==}
+    dependencies:
+      follow-redirects: 1.15.5
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -13173,6 +13203,11 @@ packages:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false
+
   /change-case-all@1.0.14:
     resolution: {integrity: sha512-CWVm2uT7dmSHdO/z1CXT/n47mWonyypzBbuCy5tN7uMg22BsfkhwT6oHmFCAk+gL1LOOxhdbB9SZz3J1KTY3gA==}
     dependencies:
@@ -13449,7 +13484,7 @@ packages:
   /commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
-    dev: true
+    dev: false
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -15852,11 +15887,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /esm@3.2.25:
-    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
-    engines: {node: '>=6'}
-    dev: true
-
   /espree@6.2.1:
     resolution: {integrity: sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==}
     engines: {node: '>=6.0.0'}
@@ -16431,6 +16461,16 @@ packages:
       debug:
         optional: true
 
+  /follow-redirects@1.15.5:
+    resolution: {integrity: sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
@@ -16513,6 +16553,9 @@ packages:
 
   /fp-ts@2.16.1:
     resolution: {integrity: sha512-by7U5W8dkIzcvDofUcO42yl9JbnHTEDBrzu3pt5fKT+Z4Oy85I21K80EYJYdjQGC2qum4Vo55Ag57iiIK4FYuA==}
+
+  /fp-ts@2.16.2:
+    resolution: {integrity: sha512-CkqAjnIKFqvo3sCyoBTqgJvF+bHrSik584S9nhTjtBESLx26cbtVMR/T9a6ApChOcSDAaM3JydDmWDUn4EEXng==}
 
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
@@ -17777,6 +17820,14 @@ packages:
     dependencies:
       fp-ts: 2.16.1
 
+  /io-ts@2.2.20(fp-ts@2.16.2):
+    resolution: {integrity: sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA==}
+    peerDependencies:
+      fp-ts: ^2.5.0
+    dependencies:
+      fp-ts: 2.16.2
+    dev: true
+
   /ioredis@5.3.2:
     resolution: {integrity: sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==}
     engines: {node: '>=12.22.0'}
@@ -18356,9 +18407,9 @@ packages:
       jest-message-util: 29.5.0
       jest-runtime: 29.4.1
       jest-snapshot: 29.4.1
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       p-limit: 3.1.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.5
     transitivePeerDependencies:
@@ -18548,11 +18599,11 @@ packages:
       jest-regex-util: 29.2.0
       jest-resolve: 29.4.1
       jest-runner: 29.4.1
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       jest-validate: 29.4.1
       micromatch: 4.0.5
       parse-json: 5.2.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
       ts-node: 10.9.1(@types/node@18.11.10)(typescript@4.9.3)
@@ -18588,11 +18639,11 @@ packages:
       jest-regex-util: 29.2.0
       jest-resolve: 29.4.1
       jest-runner: 29.4.1
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       jest-validate: 29.4.1
       micromatch: 4.0.5
       parse-json: 5.2.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
       ts-node: 10.9.1(@types/node@18.11.10)(typescript@4.9.3)
@@ -18707,7 +18758,7 @@ packages:
       chalk: 4.1.2
       diff-sequences: 29.4.3
       jest-get-type: 29.4.3
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
     dev: true
 
   /jest-diff@29.7.0:
@@ -18759,7 +18810,7 @@ packages:
       '@jest/types': 29.5.0
       chalk: 4.1.2
       jest-get-type: 29.4.3
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       pretty-format: 29.7.0
     dev: true
 
@@ -18813,7 +18864,7 @@ packages:
       '@jest/types': 29.5.0
       '@types/node': 18.18.8
       jest-mock: 29.4.1
-      jest-util: 29.5.0
+      jest-util: 29.7.0
     dev: true
 
   /jest-environment-node@29.7.0:
@@ -18884,7 +18935,7 @@ packages:
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
       jest-regex-util: 29.2.0
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       jest-worker: 29.4.1
       micromatch: 4.0.5
       walker: 1.0.8
@@ -18949,7 +19000,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       jest-get-type: 29.4.3
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
     dev: true
 
   /jest-leak-detector@29.7.0:
@@ -18987,7 +19038,7 @@ packages:
       chalk: 4.1.2
       jest-diff: 29.5.0
       jest-get-type: 29.4.3
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
     dev: true
 
   /jest-matcher-utils@29.5.0:
@@ -19050,7 +19101,7 @@ packages:
       chalk: 4.1.2
       graceful-fs: 4.2.11
       micromatch: 4.0.5
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.5
     dev: true
@@ -19065,7 +19116,7 @@ packages:
       chalk: 4.1.2
       graceful-fs: 4.2.10
       micromatch: 4.0.5
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.5
     dev: true
@@ -19080,7 +19131,7 @@ packages:
       chalk: 4.1.2
       graceful-fs: 4.2.11
       micromatch: 4.0.5
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       slash: 3.0.0
       stack-utils: 2.0.5
     dev: true
@@ -19125,7 +19176,7 @@ packages:
     dependencies:
       '@jest/types': 29.5.0
       '@types/node': 18.18.8
-      jest-util: 29.5.0
+      jest-util: 29.7.0
     dev: true
 
   /jest-mock@29.7.0:
@@ -19243,7 +19294,7 @@ packages:
       graceful-fs: 4.2.10
       jest-haste-map: 29.4.1
       jest-pnp-resolver: 1.2.2(jest-resolve@29.4.1)
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       jest-validate: 29.4.1
       resolve: 1.22.8
       resolve.exports: 2.0.0
@@ -19317,7 +19368,7 @@ packages:
       jest-message-util: 29.5.0
       jest-resolve: 29.4.1
       jest-runtime: 29.4.1
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       jest-watcher: 29.4.1
       jest-worker: 29.4.1
       p-limit: 3.1.0
@@ -19408,7 +19459,7 @@ packages:
       jest-regex-util: 29.2.0
       jest-resolve: 29.4.1
       jest-snapshot: 29.4.1
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       semver: 7.5.4
       slash: 3.0.0
       strip-bom: 4.0.0
@@ -19501,16 +19552,16 @@ packages:
       '@types/prettier': 2.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.22.10)
       chalk: 4.1.2
-      expect: 29.5.0
+      expect: 29.7.0
       graceful-fs: 4.2.10
       jest-diff: 29.5.0
       jest-get-type: 29.4.3
       jest-haste-map: 29.4.1
       jest-matcher-utils: 29.5.0
       jest-message-util: 29.5.0
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       natural-compare: 1.4.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -19637,7 +19688,7 @@ packages:
       chalk: 4.1.2
       jest-get-type: 29.4.3
       leven: 3.1.0
-      pretty-format: 29.5.0
+      pretty-format: 29.7.0
     dev: true
 
   /jest-validate@29.7.0:
@@ -19675,7 +19726,7 @@ packages:
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       string-length: 4.0.2
     dev: true
 
@@ -19716,7 +19767,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@types/node': 18.18.8
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
@@ -22292,12 +22343,6 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier@3.0.3:
-    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
-    engines: {node: '>=14'}
-    hasBin: true
-    dev: true
-
   /prettier@3.1.0:
     resolution: {integrity: sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==}
     engines: {node: '>=14'}
@@ -24032,19 +24077,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /sucrase@3.23.0:
-    resolution: {integrity: sha512-xgC1xboStzGhCnRywlBf/DLmkC+SkdAKqrNCDsxGrzM0phR5oUxoFKiQNrsc2D8wDdAm03iLbSZqjHDddo3IzQ==}
-    engines: {node: '>=8'}
-    hasBin: true
-    dependencies:
-      commander: 4.1.1
-      glob: 7.1.6
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.5
-      ts-interface-checker: 0.1.13
-    dev: true
-
   /sucrase@3.34.0:
     resolution: {integrity: sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==}
     engines: {node: '>=8'}
@@ -24653,9 +24685,9 @@ packages:
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-jest@29.1.1(@babel/core@7.23.2)(esbuild@0.19.5)(jest@29.7.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+  /ts-jest@29.1.2(@babel/core@7.23.2)(esbuild@0.19.5)(jest@29.7.0)(typescript@5.3.3):
+    resolution: {integrity: sha512-br6GJoH/WUX4pu7FbZXuWGKGNDuU7b8Uj77g/Sp7puZV6EXzuByl6JrECvm0MzVzSTkSHWTihsXt+5XYER5b+g==}
+    engines: {node: ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@babel/core': '>=7.0.0-beta.0 <8'
@@ -24679,12 +24711,12 @@ packages:
       esbuild: 0.19.5
       fast-json-stable-stringify: 2.1.0
       jest: 29.7.0(@types/node@17.0.27)
-      jest-util: 29.5.0
+      jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 5.2.2
+      typescript: 5.3.3
       yargs-parser: 21.1.1
     dev: true
 
@@ -24887,16 +24919,18 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsup@7.3.0(@swc/core@1.3.100)(typescript@5.2.2):
-    resolution: {integrity: sha512-Ja1eaSRrE+QarmATlNO5fse2aOACYMBX+IZRKy1T+gpyH+jXgRrl5l4nHIQJQ1DoDgEjHDTw8cpE085UdBZuWQ==}
+  /tsup@8.0.1(@swc/core@1.3.107)(typescript@5.3.3):
+    resolution: {integrity: sha512-hvW7gUSG96j53ZTSlT4j/KL0q1Q2l6TqGBFc6/mu/L46IoNWqLLUzLRLP1R8Q7xrJTmkDxxDoojV5uCVs1sVOg==}
     engines: {node: '>=18'}
-    deprecated: Breaking node 16
     hasBin: true
     peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
       postcss: ^8.4.12
       typescript: '>=4.5.0'
     peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
       '@swc/core':
         optional: true
       postcss:
@@ -24904,7 +24938,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@swc/core': 1.3.100
+      '@swc/core': 1.3.107
       bundle-require: 4.0.2(esbuild@0.19.5)
       cac: 6.7.14
       chokidar: 3.5.3
@@ -24917,9 +24951,9 @@ packages:
       resolve-from: 5.0.0
       rollup: 4.6.1
       source-map: 0.8.0-beta.0
-      sucrase: 3.23.0
+      sucrase: 3.34.0
       tree-kill: 1.2.2
-      typescript: 5.2.2
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -25066,6 +25100,12 @@ packages:
     resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
 
   /ua-parser-js@0.7.31:
     resolution: {integrity: sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==}
@@ -27828,6 +27868,7 @@ packages:
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false
 
   github.com/tauri-apps/tauri-plugin-store/3367248b2661abcb73d2a89f30df780c387fb57d:
     resolution: {tarball: https://codeload.github.com/tauri-apps/tauri-plugin-store/tar.gz/3367248b2661abcb73d2a89f30df780c387fb57d}


### PR DESCRIPTION
### Description

This PR brings the necessary updates to the build system for the CLI to emit an ESM-only bundle. Along with that, the dependencies are bumped, and the following are removed:
  - [esm](https://www.npmjs.com/package/esm)
  - [io-ts](https://www.npmjs.com/package/io-ts)

Follow up of #3441.

Closes HFE-278.

### Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed

### Note to reviewers

The dependencies, while inlined in the bundle, caused issues relating to the usage of `require` in the ESM context; hence they're no longer inlined ([officially recommended](https://tsup.egoist.dev/#excluding-all-packages)) and moved under `dependencies`. For `fp-ts`, it's inlined as part of the bundle and kept under `devDependencies` since the import paths were expected to specify the extensions `import * as TE from fp-ts/lib/TaskEither.js`.