### PR TITLE
feat: secret variables in environments

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -419,6 +419,8 @@
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup lang="ts">
-import { Environment } from "@hoppscotch/data"
+import { Environment, NonSecretEnvironment } from "@hoppscotch/data"
 import * as E from "fp-ts/Either"
 import { ref } from "vue"
 
@@ -340,16 +340,12 @@ const showImportFailedError = () => {
 
 const handleImportToStore = async (
   environments: Environment[],
-  globalEnv?: Environment
+  globalEnv?: NonSecretEnvironment
 ) => {
   // if there's a global env, add them to the store
   if (globalEnv) {
-    globalEnv.variables.map((env) => {
-      if (env.secret) {
-        addGlobalEnvVariable({ key: env.key, secret: true })
-      } else {
-        addGlobalEnvVariable({ key: env.key, value: env.value, secret: false })
-      }
+    globalEnv.variables.map(({ key, value, secret }) => {
+      addGlobalEnvVariable({ key, value, secret })
     })
   }
 

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -344,9 +344,9 @@ const handleImportToStore = async (
 ) => {
   // if there's a global env, add them to the store
   if (globalEnv) {
-    globalEnv.variables.map(({ key, value, secret }) => {
+    globalEnv.variables.forEach(({ key, value, secret }) =>
       addGlobalEnvVariable({ key, value, secret })
-    })
+    )
   }
 
   if (props.environmentType === "MY_ENV") {

--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -497,15 +497,20 @@ const selectedEnv = computed(() => {
         type: "MY_ENV",
         index: props.modelValue.index,
         name: props.modelValue.environment?.name,
+        variables: props.modelValue.environment?.variables,
       }
     } else if (props.modelValue?.type === "team-environment") {
       return {
         type: "TEAM_ENV",
         name: props.modelValue.environment.environment.name,
         teamEnvID: props.modelValue.environment.id,
+        variables: props.modelValue.environment.environment.variables,
       }
     }
-    return { type: "global", name: "Global" }
+    return {
+      type: "global",
+      name: "Global",
+    }
   }
   if (selectedEnvironmentIndex.value.type === "MY_ENV") {
     const environment =

--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -593,9 +593,7 @@ const environmentVariables = computed(() => {
 })
 
 const editGlobalEnv = () => {
-  invokeAction("modals.my.environment.edit", {
-    envName: "Global",
-  })
+  invokeAction("modals.global.environment.update", {})
 }
 
 const editEnv = () => {

--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -209,17 +209,11 @@
                 <span class="min-w-[9rem] w-1/4 truncate text-secondaryLight">
                   {{ variable.key }}
                 </span>
-                <span
-                  v-if="!variable.secret"
-                  class="min-w-[9rem] w-full truncate text-secondaryLight"
-                >
-                  {{ variable.value }}
-                </span>
-                <span
-                  v-else
-                  class="min-w-[9rem] w-full truncate text-secondaryLight"
-                >
-                  ********
+                <span class="min-w-[9rem] w-full truncate text-secondaryLight">
+                  <template v-if="variable.secret"> ******** </template>
+                  <template v-else>
+                    {{ variable.value }}
+                  </template>
                 </span>
               </div>
               <div v-if="globalEnvs.length === 0" class="text-secondaryLight">
@@ -273,17 +267,11 @@
                 <span class="min-w-[9rem] w-1/4 truncate text-secondaryLight">
                   {{ variable.key }}
                 </span>
-                <span
-                  v-if="!variable.secret"
-                  class="min-w-[9rem] w-full truncate text-secondaryLight"
-                >
-                  {{ variable.value }}
-                </span>
-                <span
-                  v-else
-                  class="min-w-[9rem] w-full truncate text-secondaryLight"
-                >
-                  ********
+                <span class="min-w-[9rem] w-full truncate text-secondaryLight">
+                  <template v-if="variable.secret"> ******** </template>
+                  <template v-else>
+                    {{ variable.value }}
+                  </template>
                 </span>
               </div>
               <div

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -25,6 +25,7 @@
       :editing-environment-index="editingEnvironmentIndex"
       :editing-variable-name="editingVariableName"
       :env-vars="envVars"
+      :is-secret-option-selected="secretOptionSelected"
       @hide-modal="displayModalEdit(false)"
     />
     <EnvironmentsAdd
@@ -190,6 +191,7 @@ const action = ref<"new" | "edit">("edit")
 const editingEnvironmentIndex = ref<"Global" | null>(null)
 const editingVariableName = ref("")
 const editingVariableValue = ref("")
+const secretOptionSelected = ref(false)
 
 const position = ref({ top: 0, left: 0 })
 
@@ -250,8 +252,9 @@ defineActionHandler("modals.environment.delete-selected", () => {
 
 defineActionHandler(
   "modals.my.environment.edit",
-  ({ envName, variableName }) => {
+  ({ envName, variableName, isSecret }) => {
     if (variableName) editingVariableName.value = variableName
+    secretOptionSelected.value = isSecret ?? false
     envName === "Global" && editEnvironment("Global")
   }
 )

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -263,13 +263,17 @@ const additionalVars = ref<Environment["variables"]>([])
 
 const envVars = () => [...globalEnv.value, ...additionalVars.value]
 
-defineActionHandler("modals.global.environment.update", ({ variables }) => {
-  if (variables) {
-    additionalVars.value = variables
+defineActionHandler(
+  "modals.global.environment.update",
+  ({ variables, isSecret }) => {
+    if (variables) {
+      additionalVars.value = variables
+    }
+    secretOptionSelected.value = isSecret ?? false
+    editEnvironment("Global")
+    editingVariableName.value = "Global"
   }
-  editEnvironment("Global")
-  editingVariableName.value = "Global"
-})
+)
 
 const selectedEnvironmentIndex = useStream(
   selectedEnvironmentIndex$,

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -239,6 +239,9 @@ const removeSelectedEnvironment = () => {
 
 const resetSelectedData = () => {
   editingEnvironmentIndex.value = null
+  editingVariableName.value = ""
+  editingVariableValue.value = ""
+  secretOptionSelected.value = false
 }
 
 defineActionHandler("modals.environment.new", () => {

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -253,15 +253,6 @@ defineActionHandler("modals.environment.delete-selected", () => {
   showConfirmRemoveEnvModal.value = true
 })
 
-defineActionHandler(
-  "modals.my.environment.edit",
-  ({ envName, variableName, isSecret }) => {
-    if (variableName) editingVariableName.value = variableName
-    secretOptionSelected.value = isSecret ?? false
-    envName === "Global" && editEnvironment("Global")
-  }
-)
-
 const additionalVars = ref<Environment["variables"]>([])
 
 const envVars = () => [...globalEnv.value, ...additionalVars.value]

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -24,6 +24,7 @@
       :action="action"
       :editing-environment-index="editingEnvironmentIndex"
       :editing-variable-name="editingVariableName"
+      :env-vars="envVars"
       @hide-modal="displayModalEdit(false)"
     />
     <EnvironmentsAdd
@@ -67,6 +68,7 @@ import { deleteTeamEnvironment } from "~/helpers/backend/mutations/TeamEnvironme
 import { useToast } from "~/composables/toast"
 import { WorkspaceService } from "~/services/workspace.service"
 import { useService } from "dioc/vue"
+import { Environment } from "@hoppscotch/data"
 
 const t = useI18n()
 const toast = useToast()
@@ -88,6 +90,8 @@ const environmentType = ref<EnvironmentsChooseType>({
 const globalEnv = useReadonlyStream(globalEnv$, [])
 
 const globalEnvironment = computed(() => ({
+  v: 1 as const,
+  id: "Global",
   name: "Global",
   variables: globalEnv.value,
 }))
@@ -203,6 +207,7 @@ const displayModalEdit = (shouldDisplay: boolean) => {
 const editEnvironment = (environmentIndex: "Global") => {
   editingEnvironmentIndex.value = environmentIndex
   action.value = "edit"
+  editingVariableName.value = ""
   displayModalEdit(true)
 }
 
@@ -250,6 +255,18 @@ defineActionHandler(
     envName === "Global" && editEnvironment("Global")
   }
 )
+
+const additionalVars = ref<Environment["variables"]>([])
+
+const envVars = () => [...globalEnv.value, ...additionalVars.value]
+
+defineActionHandler("modals.global.environment.update", ({ variables }) => {
+  if (variables) {
+    additionalVars.value = variables
+  }
+  editEnvironment("Global")
+  editingVariableName.value = "Global"
+})
 
 const selectedEnvironmentIndex = useStream(
   selectedEnvironmentIndex$,

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -37,7 +37,7 @@
 
   <HoppSmartConfirmModal
     :show="showConfirmRemoveEnvModal"
-    :title="t('confirm.remove_team')"
+    :title="`${t('confirm.remove_environment')}`"
     @hide-modal="showConfirmRemoveEnvModal = false"
     @resolve="removeSelectedEnvironment()"
   />

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -47,6 +47,7 @@
                 />
               </div>
             </template>
+
             <HoppSmartTab
               v-for="tab in tabsData"
               :id="tab.id"

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -284,9 +284,13 @@ const selectedEnvOption = ref<SelectedEnv>("variables")
 
 const workingEnv = computed(() => {
   if (props.editingEnvironmentIndex === "Global") {
+    const vars =
+      props.editingVariableName === "Global"
+        ? props.envVars()
+        : getGlobalVariables()
     return {
       name: "Global",
-      variables: getGlobalVariables(),
+      variables: vars,
     } as Environment
   } else if (props.action === "new") {
     return {

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -473,6 +473,7 @@ const saveEnvironment = () => {
 
 const hideModal = () => {
   editingName.value = null
+  selectedEnvOption.value = "variables"
   emit("hide-modal")
 }
 </script>

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -215,14 +215,14 @@ const tabsData: ComputedRef<
     {
       id: "variables",
       label: t("environment.variables"),
-      emptyStateLabel: t("empty.variables"),
+      emptyStateLabel: t("empty.environments"),
       isSecret: false,
       variables: nonSecretVars.value,
     },
     {
       id: "secret",
       label: t("environment.secret"),
-      emptyStateLabel: t("empty.secret"),
+      emptyStateLabel: t("empty.secret_environments"),
       isSecret: true,
       variables: secretVars.value,
     },

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -90,11 +90,13 @@
                     />
                     <SmartEnvInput
                       v-model="env.value"
-                      :select-text-on-mount="env.key === editingVariableName"
                       :placeholder="`${t('count.value', { count: index + 1 })}`"
                       :envs="liveEnvs"
                       :name="'value' + index"
                       :secret="tab.isSecret"
+                      :select-text-on-mount="
+                        env.key ? env.key === editingVariableName : false
+                      "
                     />
                     <div class="flex">
                       <HoppButtonSecondary

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -26,70 +26,41 @@
           <HoppSmartTabs v-model="selectedEnvOption" render-inactive-tabs>
             <template #actions>
               <div class="flex flex-1 items-center justify-between">
-                <div class="flex">
-                  <HoppButtonSecondary
-                    v-tippy="{ theme: 'tooltip' }"
-                    to="https://docs.hoppscotch.io/documentation/features/environments"
-                    blank
-                    :title="t('app.wiki')"
-                    :icon="IconHelpCircle"
-                  />
-                  <HoppButtonSecondary
-                    v-tippy="{ theme: 'tooltip' }"
-                    :title="t('action.clear_all')"
-                    :icon="clearIcon"
-                    @click="clearContent()"
-                  />
-                  <HoppButtonSecondary
-                    v-tippy="{ theme: 'tooltip' }"
-                    :icon="IconPlus"
-                    :title="t('add.new')"
-                    @click="addEnvironmentVariable"
-                  />
-                </div>
+                <HoppButtonSecondary
+                  v-tippy="{ theme: 'tooltip' }"
+                  to="https://docs.hoppscotch.io/documentation/features/environments"
+                  blank
+                  :title="t('app.wiki')"
+                  :icon="IconHelpCircle"
+                />
+                <HoppButtonSecondary
+                  v-tippy="{ theme: 'tooltip' }"
+                  :title="t('action.clear_all')"
+                  :icon="clearIcon"
+                  @click="clearContent()"
+                />
+                <HoppButtonSecondary
+                  v-tippy="{ theme: 'tooltip' }"
+                  :icon="IconPlus"
+                  :title="t('add.new')"
+                  @click="addEnvironmentVariable"
+                />
               </div>
             </template>
-            <HoppSmartTab id="variables" :label="t('environment.variables')">
+            <HoppSmartTab
+              v-for="tab in tabsData"
+              :id="tab.id"
+              :key="tab.id"
+              :label="tab.label"
+            >
               <div
                 class="divide-y divide-dividerLight rounded border border-divider"
               >
-                <div
-                  v-for="({ id, env }, index) in nonSecretVars"
-                  :key="`variable-${id}-${index}`"
-                  class="flex divide-x divide-dividerLight"
-                >
-                  <input
-                    v-model="env.key"
-                    v-focus
-                    class="flex flex-1 bg-transparent px-4 py-2"
-                    :placeholder="`${t('count.variable', {
-                      count: index + 1,
-                    })}`"
-                    :name="'param' + index"
-                  />
-                  <SmartEnvInput
-                    v-model="env.value"
-                    :select-text-on-mount="env.key === editingVariableName"
-                    :placeholder="`${t('count.value', { count: index + 1 })}`"
-                    :envs="liveEnvs"
-                    :name="'value' + index"
-                  />
-                  <div class="flex">
-                    <HoppButtonSecondary
-                      id="variable"
-                      v-tippy="{ theme: 'tooltip' }"
-                      :title="t('action.remove')"
-                      :icon="IconTrash"
-                      color="red"
-                      @click="removeEnvironmentVariable(id)"
-                    />
-                  </div>
-                </div>
                 <HoppSmartPlaceholder
-                  v-if="nonSecretVars.length === 0"
+                  v-if="tab.variables.length === 0"
                   :src="`/images/states/${colorMode.value}/blockchain.svg`"
-                  :alt="`${t('empty.environments')}`"
-                  :text="t('empty.environments')"
+                  :alt="tab.emptyStateLabel"
+                  :text="tab.emptyStateLabel"
                 >
                   <template #body>
                     <HoppButtonSecondary
@@ -100,60 +71,42 @@
                     />
                   </template>
                 </HoppSmartPlaceholder>
-              </div>
-            </HoppSmartTab>
-            <HoppSmartTab id="secret" :label="t('environment.secret')">
-              <div
-                class="divide-y divide-dividerLight rounded border border-divider"
-              >
-                <div
-                  v-for="({ id, env }, index) in secretVars"
-                  :key="`variable-${id}-${index}`"
-                  class="flex divide-x divide-dividerLight"
-                >
-                  <input
-                    v-model="env.key"
-                    v-focus
-                    class="flex flex-1 bg-transparent px-4 py-2"
-                    :placeholder="`${t('count.variable', {
-                      count: index + 1,
-                    })}`"
-                    :name="'param' + index"
-                  />
-                  <SmartEnvInput
-                    v-model="env.value"
-                    :select-text-on-mount="env.key === editingVariableName"
-                    :placeholder="`${t('count.value', { count: index + 1 })}`"
-                    :envs="liveEnvs"
-                    :name="'value' + index"
-                    :secret="true"
-                  />
-                  <div class="flex">
-                    <HoppButtonSecondary
-                      id="variable"
-                      v-tippy="{ theme: 'tooltip' }"
-                      :title="t('action.remove')"
-                      :icon="IconTrash"
-                      color="red"
-                      @click="removeEnvironmentVariable(id)"
+
+                <template v-else>
+                  <div
+                    v-for="({ id, env }, index) in tab.variables"
+                    :key="`variable-${id}-${index}`"
+                    class="flex divide-x divide-dividerLight"
+                  >
+                    <input
+                      v-model="env.key"
+                      v-focus
+                      class="flex flex-1 bg-transparent px-4 py-2"
+                      :placeholder="`${t('count.variable', {
+                        count: index + 1,
+                      })}`"
+                      :name="'param' + index"
                     />
+                    <SmartEnvInput
+                      v-model="env.value"
+                      :select-text-on-mount="env.key === editingVariableName"
+                      :placeholder="`${t('count.value', { count: index + 1 })}`"
+                      :envs="liveEnvs"
+                      :name="'value' + index"
+                      :secret="tab.isSecret"
+                    />
+                    <div class="flex">
+                      <HoppButtonSecondary
+                        id="variable"
+                        v-tippy="{ theme: 'tooltip' }"
+                        :title="t('action.remove')"
+                        :icon="IconTrash"
+                        color="red"
+                        @click="removeEnvironmentVariable(id)"
+                      />
+                    </div>
                   </div>
-                </div>
-                <HoppSmartPlaceholder
-                  v-if="secretVars.length === 0"
-                  :src="`/images/states/${colorMode.value}/blockchain.svg`"
-                  :alt="`${t('empty.secret_environments')}`"
-                  :text="t('empty.secret_environments')"
-                >
-                  <template #body>
-                    <HoppButtonSecondary
-                      :label="`${t('add.new')}`"
-                      filled
-                      :icon="IconPlus"
-                      @click="addEnvironmentVariable"
-                    />
-                  </template>
-                </HoppSmartPlaceholder>
+                </template>
               </div>
             </HoppSmartTab>
           </HoppSmartTabs>
@@ -184,7 +137,7 @@ import IconDone from "~icons/lucide/check"
 import IconPlus from "~icons/lucide/plus"
 import IconTrash from "~icons/lucide/trash"
 import IconHelpCircle from "~icons/lucide/help-circle"
-import { computed, ref, watch } from "vue"
+import { ComputedRef, computed, ref, watch } from "vue"
 import * as E from "fp-ts/Either"
 import * as A from "fp-ts/Array"
 import * as O from "fp-ts/Option"
@@ -248,6 +201,33 @@ const emit = defineEmits<{
 }>()
 
 const idTicker = ref(0)
+
+const tabsData: ComputedRef<
+  {
+    id: string
+    label: string
+    emptyStateLabel: string
+    isSecret: boolean
+    variables: EnvironmentVariable[]
+  }[]
+> = computed(() => {
+  return [
+    {
+      id: "variables",
+      label: t("environment.variables"),
+      emptyStateLabel: t("empty.variables"),
+      isSecret: false,
+      variables: nonSecretVars.value,
+    },
+    {
+      id: "secret",
+      label: t("environment.secret"),
+      emptyStateLabel: t("empty.secret"),
+      isSecret: true,
+      variables: secretVars.value,
+    },
+  ]
+})
 
 const editingName = ref<string | null>(null)
 const editingID = ref<string>("")
@@ -373,9 +353,9 @@ watch(
 )
 
 const clearContent = () => {
-  if (selectedEnvOption.value === "secret")
-    vars.value = vars.value.filter((e) => !e.env.secret)
-  else vars.value = vars.value.filter((e) => e.env.secret)
+  vars.value = vars.value.filter((e) =>
+    selectedEnvOption.value === "secret" ? !e.env.secret : e.env.secret
+  )
 
   clearIcon.value = IconDone
   toast.success(`${t("state.cleared")}`)
@@ -393,19 +373,10 @@ const addEnvironmentVariable = () => {
 }
 
 const removeEnvironmentVariable = (id: number) => {
-  const variable = vars.value
-    .map((e, index) => {
-      if (e.id === id) {
-        return {
-          env: e.env,
-          index,
-        }
-      }
-      return null
-    })
-    .filter((e) => e !== null)[0]
-
-  if (variable) vars.value = vars.value.filter((e) => e.id !== id)
+  const index = vars.value.findIndex((e) => e.id === id)
+  if (index !== -1) {
+    vars.value.splice(index, 1)
+  }
 }
 
 const saveEnvironment = () => {

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -230,6 +230,7 @@ const props = withDefaults(
     action: "edit" | "new"
     editingEnvironmentIndex?: number | "Global" | null
     editingVariableName?: string | null
+    isSecretOptionSelected?: boolean
     envVars?: () => Environment["variables"]
   }>(),
   {
@@ -237,6 +238,7 @@ const props = withDefaults(
     action: "edit",
     editingEnvironmentIndex: null,
     editingVariableName: null,
+    isSecretOptionSelected: false,
     envVars: () => [],
   }
 )
@@ -337,6 +339,9 @@ watch(
   (show) => {
     if (show) {
       editingName.value = workingEnv.value?.name ?? null
+      selectedEnvOption.value = props.isSecretOptionSelected
+        ? "secret"
+        : "variables"
 
       if (props.editingEnvironmentIndex !== "Global") {
         editingID.value = workingEnv.value?.id ?? uniqueId()

--- a/packages/hoppscotch-common/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/index.vue
@@ -67,6 +67,7 @@
       :action="action"
       :editing-environment-index="editingEnvironmentIndex"
       :editing-variable-name="editingVariableName"
+      :is-secret-option-selected="secretOptionSelected"
       @hide-modal="displayModalEdit(false)"
     />
     <EnvironmentsImportExport
@@ -99,6 +100,7 @@ const showModalDetails = ref(false)
 const action = ref<"new" | "edit">("edit")
 const editingEnvironmentIndex = ref<number | null>(null)
 const editingVariableName = ref("")
+const secretOptionSelected = ref(false)
 
 const displayModalAdd = (shouldDisplay: boolean) => {
   action.value = "new"
@@ -124,14 +126,17 @@ const resetSelectedData = () => {
 
 defineActionHandler(
   "modals.my.environment.edit",
-  ({ envName, variableName }) => {
+  ({ envName, variableName, isSecret }) => {
     if (variableName) editingVariableName.value = variableName
     const envIndex: number = environments.value.findIndex(
       (environment: Environment) => {
         return environment.name === envName
       }
     )
-    if (envName !== "Global") editEnvironment(envIndex)
+    if (envName !== "Global") {
+      editEnvironment(envIndex)
+      secretOptionSelected.value = isSecret ?? false
+    }
   }
 )
 </script>

--- a/packages/hoppscotch-common/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/index.vue
@@ -122,6 +122,8 @@ const editEnvironment = (environmentIndex: number) => {
 }
 const resetSelectedData = () => {
   editingEnvironmentIndex.value = null
+  editingVariableName.value = ""
+  secretOptionSelected.value = false
 }
 
 defineActionHandler(

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -26,31 +26,30 @@
           <HoppSmartTabs v-model="selectedEnvOption" render-inactive-tabs>
             <template #actions>
               <div class="flex flex-1 items-center justify-between">
-                <div class="flex">
-                  <HoppButtonSecondary
-                    v-tippy="{ theme: 'tooltip' }"
-                    to="https://docs.hoppscotch.io/documentation/features/environments"
-                    blank
-                    :title="t('app.wiki')"
-                    :icon="IconHelpCircle"
-                  />
-                  <HoppButtonSecondary
-                    v-if="!isViewer"
-                    v-tippy="{ theme: 'tooltip' }"
-                    :title="t('action.clear_all')"
-                    :icon="clearIcon"
-                    @click="clearContent()"
-                  />
-                  <HoppButtonSecondary
-                    v-if="!isViewer"
-                    v-tippy="{ theme: 'tooltip' }"
-                    :icon="IconPlus"
-                    :title="t('add.new')"
-                    @click="addEnvironmentVariable"
-                  />
-                </div>
+                <HoppButtonSecondary
+                  v-tippy="{ theme: 'tooltip' }"
+                  to="https://docs.hoppscotch.io/documentation/features/environments"
+                  blank
+                  :title="t('app.wiki')"
+                  :icon="IconHelpCircle"
+                />
+                <HoppButtonSecondary
+                  v-if="!isViewer"
+                  v-tippy="{ theme: 'tooltip' }"
+                  :title="t('action.clear_all')"
+                  :icon="clearIcon"
+                  @click="clearContent()"
+                />
+                <HoppButtonSecondary
+                  v-if="!isViewer"
+                  v-tippy="{ theme: 'tooltip' }"
+                  :icon="IconPlus"
+                  :title="t('add.new')"
+                  @click="addEnvironmentVariable"
+                />
               </div>
             </template>
+
             <HoppSmartTab
               v-for="tab in tabsData"
               :id="tab.id"
@@ -102,9 +101,8 @@
                       :secret="tab.isSecret"
                       :readonly="isViewer && !tab.isSecret"
                     />
-                    <div class="flex">
+                    <div v-if="!isViewer" class="flex">
                       <HoppButtonSecondary
-                        v-if="!isViewer"
                         id="variable"
                         v-tippy="{ theme: 'tooltip' }"
                         :title="t('action.remove')"

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -68,6 +68,7 @@
                 >
                   <template #body>
                     <HoppButtonSecondary
+                      v-if="!isViewer"
                       :label="`${t('add.new')}`"
                       filled
                       :icon="IconPlus"
@@ -90,6 +91,7 @@
                         count: index + 1,
                       })}`"
                       :name="'param' + index"
+                      :disabled="isViewer"
                     />
                     <SmartEnvInput
                       v-model="env.value"
@@ -98,9 +100,11 @@
                       :envs="liveEnvs"
                       :name="'value' + index"
                       :secret="tab.isSecret"
+                      :readonly="isViewer && !tab.isSecret"
                     />
                     <div class="flex">
                       <HoppButtonSecondary
+                        v-if="!isViewer"
                         id="variable"
                         v-tippy="{ theme: 'tooltip' }"
                         :title="t('action.remove')"
@@ -219,14 +223,14 @@ const tabsData: ComputedRef<
     {
       id: "variables",
       label: t("environment.variables"),
-      emptyStateLabel: t("empty.variables"),
+      emptyStateLabel: t("empty.environments"),
       isSecret: false,
       variables: nonSecretVars.value,
     },
     {
       id: "secret",
       label: t("environment.secret"),
-      emptyStateLabel: t("empty.secret"),
+      emptyStateLabel: t("empty.secret_environments"),
       isSecret: true,
       variables: secretVars.value,
     },

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -386,13 +386,6 @@ const saveEnvironment = async () => {
     )
   )
 
-  const environmentUpdated: Environment = {
-    v: 1,
-    id: editingID.value ?? "",
-    name: editingName.value,
-    variables: filterdVariables,
-  }
-
   const secretVariables = pipe(
     filterdVariables,
     A.filterMapWithIndex((i, e) =>
@@ -400,25 +393,18 @@ const saveEnvironment = async () => {
     )
   )
 
-  if (selectedEnvOption.value === "secret") {
-    const variables = pipe(
-      vars.value,
-      A.map((e) =>
-        e.env.secret
-          ? { key: e.env.key, secret: e.env.secret, value: undefined }
-          : e.env
-      ),
-      A.filterMap(
-        flow(
-          O.fromPredicate((e) => e.key !== ""),
-          O.map((e) => e)
-        )
-      )
+  const variables = pipe(
+    filterdVariables,
+    A.map((e) =>
+      e.secret ? { key: e.key, secret: e.secret, value: undefined } : e
     )
+  )
 
-    environmentUpdated.variables = variables
-  } else {
-    environmentUpdated.variables = filterdVariables
+  const environmentUpdated: Environment = {
+    v: 1,
+    id: editingID.value ?? "",
+    name: editingName.value,
+    variables,
   }
 
   if (props.action === "new") {
@@ -441,7 +427,7 @@ const saveEnvironment = async () => {
         },
         (res) => {
           const envID = res.createTeamEnvironment.id
-          if (selectedEnvOption.value === "secret" && envID) {
+          if (envID) {
             secretEnvironmentService.addSecretEnvironment(
               envID,
               secretVariables
@@ -473,7 +459,7 @@ const saveEnvironment = async () => {
         },
         (res) => {
           const envID = res.updateTeamEnvironment.id
-          if (selectedEnvOption.value === "secret" && envID) {
+          if (envID) {
             secretEnvironmentService.addSecretEnvironment(
               envID,
               secretVariables

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -473,6 +473,7 @@ const saveEnvironment = async () => {
 
 const hideModal = () => {
   editingName.value = null
+  selectedEnvOption.value = "variables"
   emit("hide-modal")
 }
 

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -228,6 +228,7 @@ const props = withDefaults(
     editingTeamId: string | undefined
     editingVariableName?: string | null
     isViewer?: boolean
+    isSecretOptionSelected?: boolean
     envVars?: () => Environment["variables"]
   }>(),
   {
@@ -237,6 +238,7 @@ const props = withDefaults(
     editingTeamId: "",
     editingVariableName: null,
     isViewer: false,
+    isSecretOptionSelected: false,
     envVars: () => [],
   }
 )
@@ -302,6 +304,9 @@ watch(
   (show) => {
     if (show) {
       editingName.value = props.editingEnvironment?.environment.name ?? null
+      selectedEnvOption.value = props.isSecretOptionSelected
+        ? "secret"
+        : "variables"
       if (props.action === "new") {
         vars.value = pipe(
           props.envVars() ?? [],

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -393,21 +393,14 @@ const saveEnvironment = async () => {
     variables: filterdVariables,
   }
 
-  if (selectedEnvOption.value === "secret") {
-    const secretVariables = pipe(
-      filterdVariables,
-      A.filterMapWithIndex((i, e) =>
-        e.secret ? O.some({ key: e.key, value: e.value, varIndex: i }) : O.none
-      )
+  const secretVariables = pipe(
+    filterdVariables,
+    A.filterMapWithIndex((i, e) =>
+      e.secret ? O.some({ key: e.key, value: e.value, varIndex: i }) : O.none
     )
+  )
 
-    if (editingID.value) {
-      secretEnvironmentService.addSecretEnvironment(
-        editingID.value,
-        secretVariables
-      )
-    }
-
+  if (selectedEnvOption.value === "secret") {
     const variables = pipe(
       vars.value,
       A.map((e) =>
@@ -446,7 +439,14 @@ const saveEnvironment = async () => {
           toast.error(`${getErrorMessage(err)}`)
           isLoading.value = false
         },
-        () => {
+        (res) => {
+          const envID = res.createTeamEnvironment.id
+          if (selectedEnvOption.value === "secret" && envID) {
+            secretEnvironmentService.addSecretEnvironment(
+              envID,
+              secretVariables
+            )
+          }
           hideModal()
           toast.success(`${t("environment.created")}`)
           isLoading.value = false
@@ -471,7 +471,14 @@ const saveEnvironment = async () => {
           toast.error(`${getErrorMessage(err)}`)
           isLoading.value = false
         },
-        () => {
+        (res) => {
+          const envID = res.updateTeamEnvironment.id
+          if (selectedEnvOption.value === "secret" && envID) {
+            secretEnvironmentService.addSecretEnvironment(
+              envID,
+              secretVariables
+            )
+          }
           hideModal()
           toast.success(`${t("environment.updated")}`)
           isLoading.value = false

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -94,7 +94,9 @@
                     />
                     <SmartEnvInput
                       v-model="env.value"
-                      :select-text-on-mount="env.key === editingVariableName"
+                      :select-text-on-mount="
+                        env.key ? env.key === editingVariableName : false
+                      "
                       :placeholder="`${t('count.value', { count: index + 1 })}`"
                       :envs="liveEnvs"
                       :name="'value' + index"

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -19,7 +19,6 @@
     </span>
     <span>
       <tippy
-        v-if="!isViewer"
         ref="options"
         interactive
         trigger="click"
@@ -57,6 +56,7 @@
             />
 
             <HoppSmartItem
+              v-if="!isViewer"
               ref="duplicate"
               :icon="IconCopy"
               :label="`${t('action.duplicate')}`"
@@ -69,6 +69,7 @@
               "
             />
             <HoppSmartItem
+              v-if="!isViewer"
               ref="exportAsJsonEl"
               :icon="IconEdit"
               :label="`${t('export.as_json')}`"
@@ -81,6 +82,7 @@
               "
             />
             <HoppSmartItem
+              v-if="!isViewer"
               ref="deleteAction"
               :icon="IconTrash2"
               :label="`${t('action.delete')}`"

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -124,6 +124,8 @@ import IconMoreVertical from "~icons/lucide/more-vertical"
 import { TippyComponent } from "vue-tippy"
 import { HoppSmartItem } from "@hoppscotch/ui"
 import { exportAsJSON } from "~/helpers/import-export/export/environment"
+import { useService } from "dioc/vue"
+import { SecretEnvironmentService } from "~/services/secret-environment.service"
 
 const t = useI18n()
 const toast = useToast()
@@ -136,6 +138,8 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: "edit-environment"): void
 }>()
+
+const secretEnvironmentService = useService(SecretEnvironmentService)
 
 const confirmRemove = ref(false)
 
@@ -161,6 +165,7 @@ const removeEnvironment = () => {
       },
       () => {
         toast.success(`${t("team_environment.deleted")}`)
+        secretEnvironmentService.deleteSecretEnvironment(props.environment.id)
       }
     )
   )()

--- a/packages/hoppscotch-common/src/components/environments/teams/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/index.vue
@@ -105,6 +105,7 @@
       :editing-environment="editingEnvironment"
       :editing-team-id="team?.id"
       :editing-variable-name="editingVariableName"
+      :is-secret-option-selected="secretOptionSelected"
       :is-viewer="team?.myRole === 'VIEWER'"
       @hide-modal="displayModalEdit(false)"
     />
@@ -148,6 +149,7 @@ const showModalDetails = ref(false)
 const action = ref<"new" | "edit">("edit")
 const editingEnvironment = ref<TeamEnvironment | null>(null)
 const editingVariableName = ref("")
+const secretOptionSelected = ref(false)
 
 const isTeamViewer = computed(() => props.team?.myRole === "VIEWER")
 
@@ -187,12 +189,15 @@ const getErrorMessage = (err: GQLError<string>) => {
 
 defineActionHandler(
   "modals.team.environment.edit",
-  ({ envName, variableName }) => {
+  ({ envName, variableName, isSecret }) => {
     if (variableName) editingVariableName.value = variableName
     const teamEnvToEdit = props.teamEnvironments.find(
       (environment) => environment.environment.name === envName
     )
-    if (teamEnvToEdit) editEnvironment(teamEnvToEdit)
+    if (teamEnvToEdit) {
+      editEnvironment(teamEnvToEdit)
+      secretOptionSelected.value = isSecret ?? false
+    }
   }
 )
 </script>

--- a/packages/hoppscotch-common/src/components/environments/teams/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/index.vue
@@ -173,6 +173,8 @@ const editEnvironment = (environment: TeamEnvironment | null) => {
 }
 const resetSelectedData = () => {
   editingEnvironment.value = null
+  editingVariableName.value = ""
+  secretOptionSelected.value = false
 }
 
 const getErrorMessage = (err: GQLError<string>) => {

--- a/packages/hoppscotch-common/src/components/http/CodegenModal.vue
+++ b/packages/hoppscotch-common/src/components/http/CodegenModal.vue
@@ -187,6 +187,8 @@ const copyCodeIcon = refAutoReset<typeof IconCopy | typeof IconCheck>(
 const requestCode = computed(() => {
   const aggregateEnvs = getAggregateEnvs()
   const env: Environment = {
+    v: 1,
+    id: "env",
     name: "Env",
     variables: aggregateEnvs,
   }

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -553,7 +553,7 @@ const clearContent = () => {
 const aggregateEnvs = useReadonlyStream(aggregateEnvs$, getAggregateEnvs())
 
 const computedHeaders = computed(() =>
-  getComputedHeaders(request.value, aggregateEnvs.value).map(
+  getComputedHeaders(request.value, aggregateEnvs.value, false).map(
     (header, index) => ({
       id: `header-${index}`,
       ...header,
@@ -606,7 +606,8 @@ const inheritedProperties = computed(() => {
   const computedAuthHeader = getComputedAuthHeaders(
     aggregateEnvs.value,
     request.value,
-    props.inheritedProperties.auth.inheritedAuth
+    props.inheritedProperties.auth.inheritedAuth,
+    false
   )[0]
 
   if (

--- a/packages/hoppscotch-common/src/components/http/TabHead.vue
+++ b/packages/hoppscotch-common/src/components/http/TabHead.vue
@@ -64,7 +64,6 @@
             :icon="IconShare2"
             :label="t('tab.share_tab_request')"
             :shortcut="['S']"
-            :new="true"
             @click="
               () => {
                 emit('share-tab-request')

--- a/packages/hoppscotch-common/src/components/http/TestResult.vue
+++ b/packages/hoppscotch-common/src/components/http/TestResult.vue
@@ -225,6 +225,7 @@ import { useColorMode } from "~/composables/theming"
 import { useVModel } from "@vueuse/core"
 import { useService } from "dioc/vue"
 import { WorkspaceService } from "~/services/workspace.service"
+import { invokeAction } from "~/helpers/actions"
 
 const props = defineProps<{
   modelValue: HoppTestResult | null | undefined
@@ -304,9 +305,16 @@ const globalHasAdditions = computed(() => {
 
 const addEnvToGlobal = () => {
   if (!testResults.value?.envDiff.selected.additions) return
+
   setGlobalEnvVariables([
     ...globalEnvVars.value,
     ...testResults.value.envDiff.selected.additions,
   ])
+
+  invokeAction("modals.my.environment.edit", {
+    envName: "Global",
+    variableName: testResults.value.envDiff.selected.additions[0].key,
+    isSecret: false,
+  })
 }
 </script>

--- a/packages/hoppscotch-common/src/components/http/TestResult.vue
+++ b/packages/hoppscotch-common/src/components/http/TestResult.vue
@@ -211,7 +211,6 @@ import { useI18n } from "@composables/i18n"
 import {
   globalEnv$,
   selectedEnvironmentIndex$,
-  setGlobalEnvVariables,
   setSelectedEnvironmentIndex,
 } from "~/newstore/environments"
 import { HoppTestResult } from "~/helpers/types/HoppTestResult"
@@ -306,14 +305,8 @@ const globalHasAdditions = computed(() => {
 const addEnvToGlobal = () => {
   if (!testResults.value?.envDiff.selected.additions) return
 
-  setGlobalEnvVariables([
-    ...globalEnvVars.value,
-    ...testResults.value.envDiff.selected.additions,
-  ])
-
-  invokeAction("modals.my.environment.edit", {
-    envName: "Global",
-    variableName: testResults.value.envDiff.selected.additions[0].key,
+  invokeAction("modals.global.environment.update", {
+    variables: testResults.value.envDiff.selected.additions,
     isSecret: false,
   })
 }

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -161,26 +161,11 @@ onClickOutside(autoCompleteWrapper, () => {
 })
 
 const toggleSecret = () => {
-  if (isSecret.value) {
-    asterikedText.value = props.modelValue
-    isSecret.value = false
-  } else {
-    asterikedText.value = getAsterikedText(props.modelValue)
-    isSecret.value = true
-  }
+  asterikedText.value = isSecret.value
+    ? props.modelValue
+    : getAsterikedText(props.modelValue)
+  isSecret.value = !isSecret.value
 }
-watch(
-  () => isSecret.value,
-  (newVal) => {
-    if (newVal) {
-      asterikedText.value = getAsterikedText(props.modelValue)
-      isSecret.value = true
-    } else {
-      asterikedText.value = props.modelValue
-      isSecret.value = false
-    }
-  }
-)
 
 //filter autocompleteSource with unique values
 const uniqueAutoCompleteSource = computed(() => {

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -229,8 +229,6 @@ watch(
 )
 
 const handleKeystroke = (ev: KeyboardEvent) => {
-  if (!props.autoCompleteSource) return
-
   if (["ArrowDown", "ArrowUp", "Enter", "Escape"].includes(ev.key)) {
     ev.preventDefault()
   }

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -79,7 +79,10 @@ import { history, historyKeymap } from "@codemirror/commands"
 import { inputTheme } from "~/helpers/editor/themes/baseTheme"
 import { HoppReactiveEnvPlugin } from "~/helpers/editor/extensions/HoppEnvironment"
 import { useReadonlyStream } from "@composables/stream"
-import { AggregateEnvironment, aggregateEnvs$ } from "~/newstore/environments"
+import {
+  AggregateEnvironment,
+  aggregateEnvsWithSecrets$,
+} from "~/newstore/environments"
 import { platform } from "~/platform"
 import { onClickOutside, useDebounceFn } from "@vueuse/core"
 import { InspectorResult } from "~/services/inspection"
@@ -364,7 +367,7 @@ watch(
 let clipboardEv: ClipboardEvent | null = null
 let pastedValue: string | null = null
 
-const aggregateEnvs = useReadonlyStream(aggregateEnvs$, []) as Ref<
+const aggregateEnvs = useReadonlyStream(aggregateEnvsWithSecrets$, []) as Ref<
   AggregateEnvironment[]
 >
 

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -3,8 +3,18 @@
     <div
       class="no-scrollbar absolute inset-0 flex flex-1 divide-x divide-dividerLight overflow-x-auto"
     >
+      <input
+        v-if="isSecret"
+        id="secret"
+        v-model="asteriskedText"
+        name="secret"
+        disabled
+        :placeholder="t('environment.secret_value')"
+        class="flex flex-1 bg-transparent px-4 opacity-50"
+        :class="styles"
+      />
       <div
-        v-if="!isSecret"
+        v-else
         ref="editor"
         :placeholder="placeholder"
         class="flex flex-1"
@@ -12,16 +22,6 @@
         @click="emit('click', $event)"
         @keydown="handleKeystroke"
         @focusin="showSuggestionPopover = true"
-      ></div>
-      <input
-        v-if="isSecret"
-        id="secret"
-        v-model="asterikedText"
-        name="secret"
-        disabled
-        :placeholder="t('environment.secret_value')"
-        class="flex flex-1 bg-transparent px-4 opacity-50"
-        :class="styles"
       />
       <HoppButtonSecondary
         v-if="secret"
@@ -151,19 +151,19 @@ const autoCompleteWrapper = ref<any | null>(null)
 
 const isSecret = ref(props.secret)
 
-const getAsterikedText = (text: string) => {
+const getAsteriskedText = (text: string) => {
   return "*".repeat(text.length)
 }
-const asterikedText = ref(getAsterikedText(props.modelValue))
+const asteriskedText = ref(getAsteriskedText(props.modelValue))
 
 onClickOutside(autoCompleteWrapper, () => {
   showSuggestionPopover.value = false
 })
 
 const toggleSecret = () => {
-  asterikedText.value = isSecret.value
+  asteriskedText.value = isSecret.value
     ? props.modelValue
-    : getAsterikedText(props.modelValue)
+    : getAsteriskedText(props.modelValue)
   isSecret.value = !isSecret.value
 }
 
@@ -416,7 +416,7 @@ const initView = (el: any) => {
   }
 
   if (isSecret.value) {
-    emit("update:modelValue", asterikedText.value)
+    emit("update:modelValue", asteriskedText.value)
   }
   const extensions: Extension = getExtensions(props.readonly || isSecret.value)
   view.value = new EditorView({
@@ -486,7 +486,7 @@ const getExtensions = (readonly: boolean): Extension => {
             const value = clone(cachedValue.value).replaceAll("\n", "")
 
             if (isSecret.value) {
-              const asterikedValue = "*".repeat(value.length)
+              const asterikedValue = getAsteriskedText(value)
               emit("update:modelValue", asterikedValue)
               emit("change", asterikedValue)
             } else {

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -466,6 +466,7 @@ const getExtensions = (readonly: boolean): Extension => {
         })
       : EditorView.theme({}),
     tooltips({
+      parent: document.body,
       position: "absolute",
     }),
     props.environmentHighlights ? envTooltipPlugin : [],

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -94,14 +94,14 @@ import IconUnlock from "~icons/lucide/unlock"
 
 const t = useI18n()
 
-type Env = Environment["variables"] & { source: string }
+type Env = Environment["variables"][number] & { source: string }
 
 const props = withDefaults(
   defineProps<{
     modelValue?: string
     placeholder?: string
     styles?: string
-    envs?: Env | null
+    envs?: Env[] | null
     focus?: boolean
     selectTextOnMount?: boolean
     environmentHighlights?: boolean
@@ -541,11 +541,11 @@ const triggerTextSelection = () => {
     })
   })
 }
-
 onMounted(() => {
   if (editor.value) {
     if (!view.value) initView(editor.value)
     if (props.selectTextOnMount) triggerTextSelection()
+    if (props.focus) view.value?.focus()
     platform.ui?.onCodemirrorInstanceMount?.(editor.value)
   }
 })

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -378,6 +378,7 @@ const envVars = computed(() => {
           return {
             key: x.key,
             sourceEnv: "source" in x ? x.source : null,
+            value: "********",
           }
         }
         return {

--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -4,6 +4,7 @@ import {
   ViewPlugin,
   ViewUpdate,
   placeholder,
+  tooltips,
 } from "@codemirror/view"
 import {
   Extension,
@@ -269,6 +270,7 @@ export function useCodemirror(
       basicSetup,
       baseTheme,
       syntaxHighlighting(baseHighlightStyle, { fallback: true }),
+
       ViewPlugin.fromClass(
         class {
           update(update: ViewUpdate) {
@@ -318,6 +320,7 @@ export function useCodemirror(
           }
         }
       ),
+
       EditorView.domEventHandlers({
         scroll(event) {
           if (event.target && options.contextMenuEnabled) {
@@ -359,6 +362,10 @@ export function useCodemirror(
           run: indentLess,
         },
       ]),
+      tooltips({
+        parent: document.body,
+        position: "absolute",
+      }),
       EditorView.contentAttributes.of({ "data-enable-grammarly": "false" }),
       additionalExts.of(options.additionalExts ?? []),
     ]

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -113,10 +113,12 @@ const updateEnvironmentsWithSecret = (
       return e
     })
   )
-  secretEnvironmentService.addSecretEnvironment(
-    currentEnvID,
-    updatedSecretEnvironments
-  )
+  if (currentEnvID) {
+    secretEnvironmentService.addSecretEnvironment(
+      currentEnvID,
+      updatedSecretEnvironments
+    )
+  }
   return updatedEnv
 }
 

--- a/packages/hoppscotch-common/src/helpers/actions.ts
+++ b/packages/hoppscotch-common/src/helpers/actions.ts
@@ -5,7 +5,7 @@
 import { Ref, onBeforeUnmount, onMounted, reactive, watch } from "vue"
 import { BehaviorSubject } from "rxjs"
 import { HoppRESTDocument } from "./rest/document"
-import { HoppGQLRequest, HoppRESTRequest } from "@hoppscotch/data"
+import { Environment, HoppGQLRequest, HoppRESTRequest } from "@hoppscotch/data"
 import { RESTOptionTabs } from "~/components/http/RequestOptions.vue"
 import { HoppGQLSaveContext } from "./graphql/document"
 import { GQLOptionTabs } from "~/components/graphql/RequestOptions.vue"
@@ -43,6 +43,7 @@ export type HoppAction =
   | "modals.environment.new" // Add new environment
   | "modals.environment.delete-selected" // Delete Selected Environment
   | "modals.my.environment.edit" // Edit current personal environment
+  | "modals.global.environment.update" // Update global environment
   | "modals.team.environment.edit" // Edit current team environment
   | "modals.team.new" // Add new team
   | "modals.team.edit" // Edit selected team
@@ -92,6 +93,10 @@ type HoppActionArgsMap = {
       left: number
     }
     text: string | null
+  }
+  "modals.global.environment.update": {
+    variables?: Environment["variables"]
+    isSecret?: boolean
   }
   "modals.my.environment.edit": {
     envName: string

--- a/packages/hoppscotch-common/src/helpers/actions.ts
+++ b/packages/hoppscotch-common/src/helpers/actions.ts
@@ -96,6 +96,7 @@ type HoppActionArgsMap = {
   "modals.my.environment.edit": {
     envName: string
     variableName?: string
+    isSecret?: boolean
   }
   "modals.team.environment.edit": {
     envName: string

--- a/packages/hoppscotch-common/src/helpers/actions.ts
+++ b/packages/hoppscotch-common/src/helpers/actions.ts
@@ -100,6 +100,7 @@ type HoppActionArgsMap = {
   "modals.team.environment.edit": {
     envName: string
     variableName?: string
+    isSecret?: boolean
   }
   "modals.team.delete": {
     teamId: string

--- a/packages/hoppscotch-common/src/helpers/backend/gql/mutations/CreateTeamEnvironment.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/mutations/CreateTeamEnvironment.graphql
@@ -1,7 +1,12 @@
-mutation CreateTeamEnvironment($variables: String!,$teamID: ID!,$name: String!){
-  createTeamEnvironment( variables: $variables ,teamID: $teamID ,name: $name){
+mutation CreateTeamEnvironment(
+  $variables: String!
+  $teamID: ID!
+  $name: String!
+) {
+  createTeamEnvironment(variables: $variables, teamID: $teamID, name: $name) {
     variables
     name
     teamID
+    id
   }
 }

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -68,11 +68,10 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
 
       let envValue = "Not Found"
 
-      if (tooltipEnv?.secret && tooltipEnv.value) {
+      if (!tooltipEnv?.secret && tooltipEnv?.value) envValue = tooltipEnv.value
+      else if (tooltipEnv?.secret && tooltipEnv.value) {
         envValue = "******"
-      }
-
-      if (!tooltipEnv?.sourceEnv) {
+      } else if (!tooltipEnv?.sourceEnv) {
         envValue = "Not Found"
       } else if (!tooltipEnv?.value) {
         envValue = "Empty"

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -13,7 +13,7 @@ import { StreamSubscriberFunc } from "@composables/stream"
 import {
   AggregateEnvironment,
   aggregateEnvs$,
-  getAggregateEnvs,
+  getAggregateEnvsWithSecrets,
   getSelectedEnvironmentType,
 } from "~/newstore/environments"
 import { invokeAction } from "~/helpers/actions"
@@ -68,8 +68,12 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
 
       let envValue = tooltipEnv?.value ?? "Not found"
 
-      if (tooltipEnv?.secret) {
+      if (tooltipEnv?.secret && tooltipEnv.value) {
         envValue = "******"
+      }
+
+      if (!tooltipEnv?.value) {
+        envValue = "Not found"
       }
 
       const result = parseTemplateStringE(envValue, aggregateEnvs)
@@ -175,7 +179,7 @@ export class HoppEnvironmentPlugin {
     subscribeToStream: StreamSubscriberFunc,
     private editorView: Ref<EditorView | undefined>
   ) {
-    this.envs = getAggregateEnvs()
+    this.envs = getAggregateEnvsWithSecrets()
 
     subscribeToStream(aggregateEnvs$, (envs) => {
       this.envs = envs

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -97,6 +97,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
           invokeAction(`modals.${action}.environment.edit`, {
             envName,
             variableName: parsedEnvKey,
+            isSecret: tooltipEnv?.secret,
           })
         })
         editIcon.innerHTML = `<span class="inline-flex items-center justify-center my-1">${IconEdit}</span>`

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -12,7 +12,7 @@ import { parseTemplateStringE } from "@hoppscotch/data"
 import { StreamSubscriberFunc } from "@composables/stream"
 import {
   AggregateEnvironment,
-  aggregateEnvs$,
+  aggregateEnvsWithSecrets$,
   getAggregateEnvsWithSecrets,
   getSelectedEnvironmentType,
 } from "~/newstore/environments"
@@ -182,7 +182,7 @@ export class HoppEnvironmentPlugin {
   ) {
     this.envs = getAggregateEnvsWithSecrets()
 
-    subscribeToStream(aggregateEnvs$, (envs) => {
+    subscribeToStream(aggregateEnvsWithSecrets$, (envs) => {
       this.envs = envs
 
       this.editorView.value?.dispatch({

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -66,7 +66,11 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
 
       const envName = tooltipEnv?.sourceEnv ?? "Choose an Environment"
 
-      const envValue = tooltipEnv?.value ?? "Not found"
+      let envValue = tooltipEnv?.value ?? "Not found"
+
+      if (tooltipEnv?.secret) {
+        envValue = "******"
+      }
 
       const result = parseTemplateStringE(envValue, aggregateEnvs)
 

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -66,14 +66,16 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
 
       const envName = tooltipEnv?.sourceEnv ?? "Choose an Environment"
 
-      let envValue = tooltipEnv?.value ?? "Not found"
+      let envValue = "Not Found"
 
       if (tooltipEnv?.secret && tooltipEnv.value) {
         envValue = "******"
       }
 
-      if (!tooltipEnv?.value) {
-        envValue = "Not found"
+      if (!tooltipEnv?.sourceEnv) {
+        envValue = "Not Found"
+      } else if (!tooltipEnv?.value) {
+        envValue = "Empty"
       }
 
       const result = parseTemplateStringE(envValue, aggregateEnvs)

--- a/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
@@ -12,8 +12,6 @@ const getEnvironmentJson = (
       ? cloneDeep(environmentObj.environment)
       : cloneDeep(environmentObj)
 
-  delete newEnvironment.id
-
   const environmentId =
     environmentIndex || environmentIndex === 0
       ? environmentIndex

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
@@ -1,30 +1,50 @@
 import * as TE from "fp-ts/TaskEither"
 import * as O from "fp-ts/Option"
+import * as RA from "fp-ts/ReadonlyArray"
+import { pipe, flow } from "fp-ts/function"
 
 import { IMPORTER_INVALID_FILE_FORMAT } from "."
 import { safeParseJSON } from "~/helpers/functional/json"
 
-import { z } from "zod"
-import { entityReference } from "verzod"
-import { Environment } from "@hoppscotch/data"
+import { Environment, translateToNewEnvironment } from "@hoppscotch/data"
+import { isPlainObject as _isPlainObject } from "lodash-es"
 
-const hoppEnvSchema = entityReference(Environment)
+const isPlainObject = (value: any): value is object => _isPlainObject(value)
 
-export const hoppEnvImporter = (content: string) => {
-  const parsedContent = safeParseJSON(content, true)
+/**
+ * checks if a environment matches the schema for a hoppscotch environment.
+ * here 1 is the latest version of the schema.
+ */
+const isValidEnvironment = (environment: unknown): environment is Environment =>
+  isPlainObject(environment) && "v" in environment && environment.v === 1
 
-  // parse json from the environments string
-  if (O.isNone(parsedContent)) {
-    return TE.left(IMPORTER_INVALID_FILE_FORMAT)
+/**
+ * checks if a environment is a valid hoppscotch environment.
+ * else translate it into one.
+ */
+const validateEnviroment = (env: unknown) => {
+  if (isValidEnvironment(env)) {
+    return O.some(env)
   }
-
-  const validationResult = z.array(hoppEnvSchema).safeParse(parsedContent.value)
-
-  if (!validationResult.success) {
-    return TE.left(IMPORTER_INVALID_FILE_FORMAT)
-  }
-
-  const environments = validationResult.data
-
-  return TE.right(environments)
+  return O.some(translateToNewEnvironment(env))
 }
+
+/**
+ * convert single environment object into an array so it can be handled the same as multiple environments
+ */
+const makeEnvironmentsArray = (environments: unknown | unknown[]): unknown[] =>
+  Array.isArray(environments) ? environments : [environments]
+
+export const hoppEnvImporter = (content: string) =>
+  pipe(
+    safeParseJSON(content),
+    O.chain(
+      flow(
+        makeEnvironmentsArray,
+        RA.map(validateEnviroment),
+        O.sequenceArray,
+        O.map(RA.toArray)
+      )
+    ),
+    TE.fromOption(() => IMPORTER_INVALID_FILE_FORMAT)
+  )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
@@ -1,50 +1,30 @@
-import * as TE from "fp-ts/TaskEither"
 import * as O from "fp-ts/Option"
-import * as RA from "fp-ts/ReadonlyArray"
-import { pipe, flow } from "fp-ts/function"
+import * as TE from "fp-ts/TaskEither"
+import { entityReference } from "verzod"
 
-import { IMPORTER_INVALID_FILE_FORMAT } from "."
 import { safeParseJSON } from "~/helpers/functional/json"
+import { IMPORTER_INVALID_FILE_FORMAT } from "."
 
-import { Environment, translateToNewEnvironment } from "@hoppscotch/data"
-import { isPlainObject as _isPlainObject } from "lodash-es"
+import { Environment } from "@hoppscotch/data"
+import { z } from "zod"
 
-const isPlainObject = (value: any): value is object => _isPlainObject(value)
+export const hoppEnvImporter = (content: string) => {
+  const parsedContent = safeParseJSON(content, true)
 
-/**
- * checks if a environment matches the schema for a hoppscotch environment.
- * here 1 is the latest version of the schema.
- */
-const isValidEnvironment = (environment: unknown): environment is Environment =>
-  isPlainObject(environment) && "v" in environment && environment.v === 1
-
-/**
- * checks if a environment is a valid hoppscotch environment.
- * else translate it into one.
- */
-const validateEnviroment = (env: unknown) => {
-  if (isValidEnvironment(env)) {
-    return O.some(env)
+  // parse json from the environments string
+  if (O.isNone(parsedContent)) {
+    return TE.left(IMPORTER_INVALID_FILE_FORMAT)
   }
-  return O.some(translateToNewEnvironment(env))
+
+  const validationResult = z
+    .array(entityReference(Environment))
+    .safeParse(parsedContent.value)
+
+  if (!validationResult.success) {
+    return TE.left(IMPORTER_INVALID_FILE_FORMAT)
+  }
+
+  const environments = validationResult.data
+
+  return TE.right(environments)
 }
-
-/**
- * convert single environment object into an array so it can be handled the same as multiple environments
- */
-const makeEnvironmentsArray = (environments: unknown | unknown[]): unknown[] =>
-  Array.isArray(environments) ? environments : [environments]
-
-export const hoppEnvImporter = (content: string) =>
-  pipe(
-    safeParseJSON(content),
-    O.chain(
-      flow(
-        makeEnvironmentsArray,
-        RA.map(validateEnviroment),
-        O.sequenceArray,
-        O.map(RA.toArray)
-      )
-    ),
-    TE.fromOption(() => IMPORTER_INVALID_FILE_FORMAT)
-  )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
@@ -5,17 +5,10 @@ import { IMPORTER_INVALID_FILE_FORMAT } from "."
 import { safeParseJSON } from "~/helpers/functional/json"
 
 import { z } from "zod"
+import { entityReference } from "verzod"
+import { Environment } from "@hoppscotch/data"
 
-const hoppEnvSchema = z.object({
-  id: z.string().optional(),
-  name: z.string(),
-  variables: z.array(
-    z.object({
-      key: z.string(),
-      value: z.string(),
-    })
-  ),
-})
+const hoppEnvSchema = entityReference(Environment)
 
 export const hoppEnvImporter = (content: string) => {
   const parsedContent = safeParseJSON(content, true)

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
@@ -4,7 +4,7 @@ import * as O from "fp-ts/Option"
 import { IMPORTER_INVALID_FILE_FORMAT } from "."
 
 import { z } from "zod"
-import { Environment, NonSecretEnvironment } from "@hoppscotch/data"
+import { NonSecretEnvironment } from "@hoppscotch/data"
 import { safeParseJSONOrYAML } from "~/helpers/functional/yaml"
 import { uniqueId } from "lodash-es"
 

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
@@ -6,6 +6,7 @@ import { IMPORTER_INVALID_FILE_FORMAT } from "."
 import { z } from "zod"
 import { Environment } from "@hoppscotch/data"
 import { safeParseJSONOrYAML } from "~/helpers/functional/yaml"
+import { uniqueId } from "lodash-es"
 
 const insomniaResourcesSchema = z.object({
   resources: z.array(
@@ -63,9 +64,11 @@ export const insomniaEnvImporter = (content: string) => {
 
     if (parsedInsomniaEnv.success) {
       const environment: Environment = {
+        id: uniqueId(),
+        v: 1,
         name: parsedInsomniaEnv.data.name,
         variables: Object.entries(parsedInsomniaEnv.data.data).map(
-          ([key, value]) => ({ key, value })
+          ([key, value]) => ({ key, value, secret: false })
         ),
       }
 
@@ -77,7 +80,15 @@ export const insomniaEnvImporter = (content: string) => {
     ...env,
     variables: env.variables.map((variable) => ({
       ...variable,
-      value: replaceInsomniaTemplating(variable.value),
+      value: replaceInsomniaTemplating(
+        (
+          variable as {
+            key: string
+            value: string
+            secret: false
+          }
+        ).value
+      ),
     })),
   }))
 

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
@@ -4,7 +4,7 @@ import * as O from "fp-ts/Option"
 import { IMPORTER_INVALID_FILE_FORMAT } from "."
 
 import { z } from "zod"
-import { Environment } from "@hoppscotch/data"
+import { Environment, NonSecretEnvironment } from "@hoppscotch/data"
 import { safeParseJSONOrYAML } from "~/helpers/functional/yaml"
 import { uniqueId } from "lodash-es"
 
@@ -57,13 +57,13 @@ export const insomniaEnvImporter = (content: string) => {
       return { ...envResource, data: stringifiedData }
     })
 
-  const environments: Environment[] = []
+  const environments: NonSecretEnvironment[] = []
 
   insomniaEnvs.forEach((insomniaEnv) => {
     const parsedInsomniaEnv = insomniaEnvSchema.safeParse(insomniaEnv)
 
     if (parsedInsomniaEnv.success) {
-      const environment: Environment = {
+      const environment: NonSecretEnvironment = {
         id: uniqueId(),
         v: 1,
         name: parsedInsomniaEnv.data.name,
@@ -80,15 +80,7 @@ export const insomniaEnvImporter = (content: string) => {
     ...env,
     variables: env.variables.map((variable) => ({
       ...variable,
-      value: replaceInsomniaTemplating(
-        (
-          variable as {
-            key: string
-            value: string
-            secret: false
-          }
-        ).value
-      ),
+      value: replaceInsomniaTemplating(variable.value),
     })),
   }))
 

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
@@ -6,6 +6,7 @@ import { safeParseJSON } from "~/helpers/functional/json"
 
 import { z } from "zod"
 import { Environment } from "@hoppscotch/data"
+import { uniqueId } from "lodash-es"
 
 const postmanEnvSchema = z.object({
   name: z.string(),
@@ -34,12 +35,14 @@ export const postmanEnvImporter = (content: string) => {
   const postmanEnv = validationResult.data
 
   const environment: Environment = {
+    id: uniqueId(),
+    v: 1,
     name: postmanEnv.name,
     variables: [],
   }
 
   postmanEnv.values.forEach(({ key, value }) =>
-    environment.variables.push({ key, value })
+    environment.variables.push({ key, value, secret: false })
   )
 
   return TE.right(environment)

--- a/packages/hoppscotch-common/src/helpers/preRequest.ts
+++ b/packages/hoppscotch-common/src/helpers/preRequest.ts
@@ -25,7 +25,6 @@ const unsecretEnvironments = (
     if (secretVar) {
       return {
         ...globalVar,
-        secret: false,
         value: secretVar.value,
       }
     }
@@ -41,7 +40,6 @@ const unsecretEnvironments = (
       if (secretVar) {
         return {
           ...selectedVar,
-          secret: false,
           value: secretVar.value,
         }
       }

--- a/packages/hoppscotch-common/src/helpers/preRequest.ts
+++ b/packages/hoppscotch-common/src/helpers/preRequest.ts
@@ -27,6 +27,11 @@ const unsecretEnvironments = (
         ...globalVar,
         value: secretVar.value,
       }
+    } else if (!("value" in globalVar) || !globalVar.value) {
+      return {
+        ...globalVar,
+        value: "",
+      }
     }
     return globalVar
   })

--- a/packages/hoppscotch-common/src/helpers/preRequest.ts
+++ b/packages/hoppscotch-common/src/helpers/preRequest.ts
@@ -7,7 +7,15 @@ import {
   getCurrentEnvironment,
   getGlobalVariables,
 } from "~/newstore/environments"
-import { TestResult } from "@hoppscotch/js-sandbox"
+import { TestDescriptor } from "@hoppscotch/js-sandbox"
+
+type TestResultWithSelectedEnv = {
+  tests: TestDescriptor[]
+  envs: {
+    global: Environment["variables"]
+    selected: Environment
+  }
+}
 
 export const getCombinedEnvVariables = () => ({
   global: cloneDeep(getGlobalVariables()),
@@ -20,5 +28,5 @@ export const getFinalEnvsFromPreRequest = (
     global: Environment["variables"]
     selected: Environment
   }
-): Promise<E.Either<string, TestResult["envs"]>> =>
+): Promise<E.Either<string, TestResultWithSelectedEnv["envs"]>> =>
   runPreRequestScript(script, envs)

--- a/packages/hoppscotch-common/src/helpers/preRequest.ts
+++ b/packages/hoppscotch-common/src/helpers/preRequest.ts
@@ -42,6 +42,11 @@ const unsecretEnvironments = (
           ...selectedVar,
           value: secretVar.value,
         }
+      } else if (!("value" in selectedVar) || !selectedVar.value) {
+        return {
+          ...selectedVar,
+          value: "",
+        }
       }
       return selectedVar
     }

--- a/packages/hoppscotch-common/src/helpers/preRequest.ts
+++ b/packages/hoppscotch-common/src/helpers/preRequest.ts
@@ -11,14 +11,14 @@ import { TestResult } from "@hoppscotch/js-sandbox"
 
 export const getCombinedEnvVariables = () => ({
   global: cloneDeep(getGlobalVariables()),
-  selected: cloneDeep(getCurrentEnvironment().variables),
+  selected: cloneDeep(getCurrentEnvironment()),
 })
 
 export const getFinalEnvsFromPreRequest = (
   script: string,
   envs: {
     global: Environment["variables"]
-    selected: Environment["variables"]
+    selected: Environment
   }
 ): Promise<E.Either<string, TestResult["envs"]>> =>
   runPreRequestScript(script, envs)

--- a/packages/hoppscotch-common/src/helpers/teams/TeamEnvironmentAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamEnvironmentAdapter.ts
@@ -118,6 +118,8 @@ export default class TeamEnvironmentAdapter {
               id: x.id,
               teamID: x.teamID,
               environment: {
+                v: 1,
+                id: x.id,
                 name: x.name,
                 variables: JSON.parse(x.variables),
               },
@@ -196,6 +198,8 @@ export default class TeamEnvironmentAdapter {
                 id: x.id,
                 teamID: x.teamID,
                 environment: {
+                  v: 1,
+                  id: x.id,
                   name: x.name,
                   variables: JSON.parse(x.variables),
                 },
@@ -249,6 +253,8 @@ export default class TeamEnvironmentAdapter {
                 id: x.id,
                 teamID: x.teamID,
                 environment: {
+                  v: 1,
+                  id: x.id,
                   name: x.name,
                   variables: JSON.parse(x.variables),
                 },

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -82,7 +82,7 @@ export const getComputedAuthHeaders = (
       key: "Authorization",
       value: `Bearer ${
         parse
-          ? parseTemplateString(request.auth.token, envVars, true)
+          ? parseTemplateString(request.auth.token, envVars)
           : request.auth.token
       }`,
     })
@@ -314,6 +314,8 @@ export function getEffectiveRESTRequest(
   environment: Environment
 ): EffectiveHoppRESTRequest {
   const envVariables = [...environment.variables, ...getGlobalVariables()]
+
+  console.log("cobuned", getComputedHeaders(request, envVariables))
 
   const effectiveFinalHeaders = pipe(
     getComputedHeaders(request, envVariables).map((h) => h.header),

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -315,8 +315,6 @@ export function getEffectiveRESTRequest(
 ): EffectiveHoppRESTRequest {
   const envVariables = [...environment.variables, ...getGlobalVariables()]
 
-  console.log("cobuned", getComputedHeaders(request, envVariables))
-
   const effectiveFinalHeaders = pipe(
     getComputedHeaders(request, envVariables).map((h) => h.header),
     A.concat(request.headers),

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -45,7 +45,8 @@ export interface EffectiveHoppRESTRequest extends HoppRESTRequest {
 export const getComputedAuthHeaders = (
   envVars: Environment["variables"],
   req?: HoppRESTRequest,
-  auth?: HoppRESTRequest["auth"]
+  auth?: HoppRESTRequest["auth"],
+  parse = true
 ) => {
   const request = auth ? { auth: auth ?? { authActive: false } } : req
   // If Authorization header is also being user-defined, that takes priority
@@ -60,8 +61,12 @@ export const getComputedAuthHeaders = (
 
   // TODO: Support a better b64 implementation than btoa ?
   if (request.auth.authType === "basic") {
-    const username = parseTemplateString(request.auth.username, envVars)
-    const password = parseTemplateString(request.auth.password, envVars)
+    const username = parse
+      ? parseTemplateString(request.auth.username, envVars)
+      : request.auth.username
+    const password = parse
+      ? parseTemplateString(request.auth.password, envVars)
+      : request.auth.password
 
     headers.push({
       active: true,
@@ -75,7 +80,11 @@ export const getComputedAuthHeaders = (
     headers.push({
       active: true,
       key: "Authorization",
-      value: `Bearer ${parseTemplateString(request.auth.token, envVars)}`,
+      value: `Bearer ${
+        parse
+          ? parseTemplateString(request.auth.token, envVars, true)
+          : request.auth.token
+      }`,
     })
   } else if (request.auth.authType === "api-key") {
     const { key, addTo } = request.auth
@@ -83,7 +92,9 @@ export const getComputedAuthHeaders = (
       headers.push({
         active: true,
         key: parseTemplateString(key, envVars),
-        value: parseTemplateString(request.auth.value ?? "", envVars),
+        value: parse
+          ? parseTemplateString(request.auth.value ?? "", envVars)
+          : request.auth.value ?? "",
       })
     }
   }
@@ -133,10 +144,11 @@ export type ComputedHeader = {
  */
 export const getComputedHeaders = (
   req: HoppRESTRequest,
-  envVars: Environment["variables"]
+  envVars: Environment["variables"],
+  parse = true
 ): ComputedHeader[] => {
   return [
-    ...getComputedAuthHeaders(envVars, req).map((header) => ({
+    ...getComputedAuthHeaders(envVars, req, undefined, parse).map((header) => ({
       source: "auth" as const,
       header,
     })),

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -22,6 +22,7 @@ import {
 import { arrayFlatMap, arraySort } from "../functional/array"
 import { toFormData } from "../functional/formData"
 import { tupleWithSameKeysToRecord } from "../functional/record"
+import { getGlobalVariables } from "~/newstore/environments"
 
 export interface EffectiveHoppRESTRequest extends HoppRESTRequest {
   /**
@@ -300,7 +301,7 @@ export function getEffectiveRESTRequest(
   request: HoppRESTRequest,
   environment: Environment
 ): EffectiveHoppRESTRequest {
-  const envVariables = environment.variables
+  const envVariables = [...environment.variables, ...getGlobalVariables()]
 
   const effectiveFinalHeaders = pipe(
     getComputedHeaders(request, envVariables).map((h) => h.header),

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -22,7 +22,6 @@ import {
 import { arrayFlatMap, arraySort } from "../functional/array"
 import { toFormData } from "../functional/formData"
 import { tupleWithSameKeysToRecord } from "../functional/record"
-import { getGlobalVariables } from "~/newstore/environments"
 
 export interface EffectiveHoppRESTRequest extends HoppRESTRequest {
   /**
@@ -301,7 +300,7 @@ export function getEffectiveRESTRequest(
   request: HoppRESTRequest,
   environment: Environment
 ): EffectiveHoppRESTRequest {
-  const envVariables = [...environment.variables, ...getGlobalVariables()]
+  const envVariables = environment.variables
 
   const effectiveFinalHeaders = pipe(
     getComputedHeaders(request, envVariables).map((h) => h.header),

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -118,13 +118,12 @@ const dispatchers = defineDispatchers({
       }
     }
 
-    newEnvironment.id = uniqueId()
-
     return {
       environments: [
         ...environments,
         {
           ...cloneDeep(newEnvironment),
+          id: uniqueId(),
           name: `${newEnvironment.name} - Duplicate`,
         },
       ],

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -37,8 +37,6 @@ const defaultEnvironmentsState = {
 
 type EnvironmentStore = typeof defaultEnvironmentsState
 
-// const secretEnvironmentService = getService(SecretEnvironmentService)
-
 const dispatchers = defineDispatchers({
   setSelectedEnvironmentIndex(
     store: EnvironmentStore,
@@ -116,8 +114,7 @@ const dispatchers = defineDispatchers({
       }
     }
 
-    // remove the id, because this is a new environment & it will get its own id when syncing
-    delete newEnvironment["id"]
+    newEnvironment.id = uniqueId()
 
     return {
       environments: [
@@ -395,40 +392,6 @@ export const aggregateEnvs$: Observable<AggregateEnvironment[]> = combineLatest(
       results.push({ key, value, secret, sourceEnv: "Global" })
     )
 
-    // selectedEnv?.variables.map((x, index) => {
-    //   let value
-    //   if (x.secret) {
-    //     value = secretEnvironmentService.getSecretEnvironmentVariableValue(
-    //       selectedEnv.id,
-    //       index
-    //     )
-    //   } else {
-    //     value = x.value
-    //   }
-    //   results.push({
-    //     key: x.key,
-    //     value,
-    //     sourceEnv: selectedEnv.name,
-    //   })
-    // })
-
-    // globalVars.map((x, index) => {
-    //   let value
-    //   if (x.secret) {
-    //     value = secretEnvironmentService.getSecretEnvironmentVariableValue(
-    //       "Global",
-    //       index
-    //     )
-    //   } else {
-    //     value = x.value
-    //   }
-    //   results.push({
-    //     key: x.key,
-    //     value,
-    //     sourceEnv: "Global",
-    //   })
-    // })
-
     return results
   }),
   distinctUntilChanged(isEqual)
@@ -463,51 +426,6 @@ export function getAggregateEnvs() {
       }
     }),
   ]
-  // return [
-  //   ...currentEnv.variables.map((x, index) => {
-  //     let value
-  //     if (x.secret) {
-  //       value = secretEnvironmentService.getSecretEnvironmentVariableValue(
-  //         currentEnv.id,
-  //         index
-  //       )
-  //     } else {
-  //       value = x.value
-  //     }
-  //     console.log("set-agrre", {
-  //       key: x.key,
-  //       value,
-  //       sourceEnv: currentEnv.name,
-  //     })
-  //     return <AggregateEnvironment>{
-  //       key: x.key,
-  //       value,
-  //       sourceEnv: currentEnv.name,
-  //     }
-  //   }),
-  //   ...getGlobalVariables().map((x, index) => {
-  //     let value
-  //     if (x.secret) {
-  //       value = secretEnvironmentService.getSecretEnvironmentVariableValue(
-  //         "Global",
-  //         index
-  //       )
-  //     } else {
-  //       value = x.value
-  //     }
-  //     console.log("set-agrre-global", {
-  //       key: x.key,
-  //       value,
-  //       sourceEnv: currentEnv.name,
-  //     })
-
-  //     return <AggregateEnvironment>{
-  //       key: x.key,
-  //       value,
-  //       sourceEnv: "Global",
-  //     }
-  //   }),
-  // ]
 }
 
 export function getCurrentEnvironment(): Environment {

--- a/packages/hoppscotch-common/src/services/__tests__/secret-environment.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/secret-environment.service.spec.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, beforeEach } from "vitest"
+import { TestContainer } from "dioc/testing"
+import { SecretEnvironmentService } from "../secret-environment.service"
+
+describe("SecretEnvironmentService", () => {
+  let container: TestContainer
+  let service: SecretEnvironmentService
+
+  beforeEach(() => {
+    container = new TestContainer()
+    service = container.bind(SecretEnvironmentService)
+  })
+
+  describe("addSecretEnvironment", () => {
+    it("should add a new secret environment with the provided ID and secret variables", () => {
+      const id = "testEnvironment"
+      const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
+
+      service.addSecretEnvironment(id, secretVars)
+
+      expect(service.secretEnvironments.get(id)).toEqual(secretVars)
+    })
+  })
+
+  describe("getSecretEnvironment", () => {
+    it("should return the secret variables of the specified environment", () => {
+      const id = "testEnvironment"
+      const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
+
+      service.secretEnvironments.set(id, secretVars)
+
+      expect(service.getSecretEnvironment(id)).toEqual(secretVars)
+    })
+
+    it("should return undefined if the specified environment does not exist", () => {
+      const id = "nonExistentEnvironment"
+
+      expect(service.getSecretEnvironment(id)).toBeUndefined()
+    })
+  })
+
+  describe("getSecretEnvironmentVariable", () => {
+    it("should return the specified secret environment variable", () => {
+      const id = "testEnvironment"
+      const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
+
+      service.secretEnvironments.set(id, secretVars)
+
+      const result = service.getSecretEnvironmentVariable(id, 1)
+
+      expect(result).toEqual(secretVars[0])
+    })
+
+    it("should return undefined if the specified variable does not exist", () => {
+      const id = "testEnvironment"
+      const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
+
+      service.secretEnvironments.set(id, secretVars)
+
+      const result = service.getSecretEnvironmentVariable(id, 2)
+
+      expect(result).toBeUndefined()
+    })
+
+    it("should return undefined if the specified environment does not exist", () => {
+      const id = "nonExistentEnvironment"
+
+      const result = service.getSecretEnvironmentVariable(id, 1)
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("getSecretEnvironmentVariableValue", () => {
+    it("should return the value of the specified secret environment variable", () => {
+      const id = "testEnvironment"
+      const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
+
+      service.secretEnvironments.set(id, secretVars)
+
+      const result = service.getSecretEnvironmentVariableValue(id, 1)
+
+      expect(result).toEqual(secretVars[0].value)
+    })
+
+    it("should return undefined if the specified variable does not exist", () => {
+      const id = "testEnvironment"
+      const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
+
+      service.secretEnvironments.set(id, secretVars)
+
+      const result = service.getSecretEnvironmentVariableValue(id, 2)
+
+      expect(result).toBeUndefined()
+    })
+
+    it("should return undefined if the specified environment does not exist", () => {
+      const id = "nonExistentEnvironment"
+
+      const result = service.getSecretEnvironmentVariableValue(id, 1)
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("loadSecretEnvironmentsFromPersistedState", () => {
+    it("should load secret environments from the persisted state", () => {
+      const persistedState = {
+        testEnvironment: [{ key: "key1", value: "value1", varIndex: 1 }],
+      }
+
+      service.loadSecretEnvironmentsFromPersistedState(persistedState)
+
+      expect(service.secretEnvironments.size).toBe(1)
+      expect(service.secretEnvironments.get("testEnvironment")).toEqual([
+        { key: "key1", value: "value1", varIndex: 1 },
+      ])
+    })
+  })
+
+  describe("deleteSecretEnvironment", () => {
+    it("should delete the specified secret environment", () => {
+      const id = "testEnvironment"
+      const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
+
+      service.secretEnvironments.set(id, secretVars)
+
+      service.deleteSecretEnvironment(id)
+
+      expect(service.secretEnvironments.has(id)).toBe(false)
+    })
+  })
+
+  describe("removeSecretEnvironmentVariable", () => {
+    it("should remove the specified secret environment variable", () => {
+      const id = "testEnvironment"
+      const secretVars = [
+        { key: "key1", value: "value1", varIndex: 1 },
+        { key: "key2", value: "value2", varIndex: 2 },
+      ]
+
+      service.secretEnvironments.set(id, secretVars)
+
+      service.removeSecretEnvironmentVariable(id, 1)
+
+      expect(service.secretEnvironments.get(id)).toEqual([
+        { key: "key2", value: "value2", varIndex: 2 },
+      ])
+    })
+
+    it("should do nothing if the specified variable does not exist", () => {
+      const id = "testEnvironment"
+      const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
+
+      service.secretEnvironments.set(id, secretVars)
+
+      service.removeSecretEnvironmentVariable(id, 2)
+
+      expect(service.secretEnvironments.get(id)).toEqual(secretVars)
+    })
+  })
+
+  describe("updateSecretEnvironmentID", () => {
+    it("should update the ID of the specified secret environment", () => {
+      const oldID = "oldEnvironment"
+      const newID = "newEnvironment"
+      const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
+
+      service.secretEnvironments.set(oldID, secretVars)
+
+      service.updateSecretEnvironmentID(oldID, newID)
+
+      expect(service.secretEnvironments.has(oldID)).toBe(false)
+      expect(service.secretEnvironments.get(newID)).toEqual(secretVars)
+    })
+  })
+
+  describe("persistableSecretEnvironments", () => {
+    it("should return a record of secret environments suitable for persistence", () => {
+      const secretVars = [
+        { key: "key1", value: "value1", varIndex: 1 },
+        { key: "key2", value: "value2", varIndex: 2 },
+      ]
+
+      service.secretEnvironments.set("environment1", secretVars)
+
+      const persistedState = service.persistableSecretEnvironments.value
+
+      expect(persistedState).toEqual({
+        environment1: secretVars,
+      })
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/__tests__/environment.inspector.spec.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/__tests__/environment.inspector.spec.ts
@@ -15,9 +15,20 @@ vi.mock("~/newstore/environments", async () => {
 
   return {
     __esModule: true,
-    aggregateEnvs$: new BehaviorSubject([
-      { key: "EXISTING_ENV_VAR", value: "test_value" },
+    aggregateEnvsWithSecrets$: new BehaviorSubject([
+      { key: "EXISTING_ENV_VAR", value: "test_value", secret: false },
+      { key: "EXISTING_ENV_VAR_2", value: "", secret: false },
     ]),
+    getCurrentEnvironment: () => ({
+      id: "1",
+      name: "some-env",
+      v: 1,
+      variables: {
+        key: "EXISTING_ENV_VAR",
+        value: "test_value",
+        secret: false,
+      },
+    }),
   }
 })
 
@@ -51,7 +62,7 @@ describe("EnvironmentInspectorService", () => {
 
       expect(result.value).toContainEqual(
         expect.objectContaining({
-          id: "environment",
+          id: "environment-not-found-0",
           isApplicable: true,
           text: {
             type: "text",
@@ -91,7 +102,7 @@ describe("EnvironmentInspectorService", () => {
 
       expect(result.value).toContainEqual(
         expect.objectContaining({
-          id: "environment",
+          id: "environment-not-found-0",
           isApplicable: true,
           text: {
             type: "text",
@@ -134,7 +145,7 @@ describe("EnvironmentInspectorService", () => {
 
       expect(result.value).toContainEqual(
         expect.objectContaining({
-          id: "environment",
+          id: "environment-not-found-0",
           isApplicable: true,
           text: {
             type: "text",
@@ -145,6 +156,104 @@ describe("EnvironmentInspectorService", () => {
     })
 
     it("should not return an inspector result when the params contain defined environment variables", () => {
+      const container = new TestContainer()
+      const envInspector = container.bind(EnvironmentInspectorService)
+
+      const req = ref({
+        ...getDefaultRESTRequest(),
+        endpoint: "http://example.com/api/data",
+        headers: [],
+        params: [
+          { key: "<<EXISTING_ENV_VAR>>", value: "some-value", active: true },
+        ],
+      })
+
+      const result = envInspector.getInspections(req)
+
+      expect(result.value).toHaveLength(0)
+    })
+
+    it("should return an inspector result when the URL contains empty value in a environment variable", () => {
+      const container = new TestContainer()
+      const envInspector = container.bind(EnvironmentInspectorService)
+
+      const req = ref({
+        ...getDefaultRESTRequest(),
+        endpoint: "<<EXISTING_ENV_VAR_2>>",
+      })
+
+      const result = envInspector.getInspections(req)
+
+      expect(result.value).toHaveLength(1)
+    })
+
+    it("should not return an inspector result when the URL contains non empty value in a environemnt variable", () => {
+      const container = new TestContainer()
+      const envInspector = container.bind(EnvironmentInspectorService)
+
+      const req = ref({
+        ...getDefaultRESTRequest(),
+        endpoint: "<<EXISTING_ENV_VAR>>",
+      })
+
+      const result = envInspector.getInspections(req)
+
+      expect(result.value).toHaveLength(0)
+    })
+
+    it("should return an inspector result when the headers contain empty value in a environment variable", () => {
+      const container = new TestContainer()
+      const envInspector = container.bind(EnvironmentInspectorService)
+
+      const req = ref({
+        ...getDefaultRESTRequest(),
+        endpoint: "http://example.com/api/data",
+        headers: [
+          { key: "<<EXISTING_ENV_VAR_2>>", value: "some-value", active: true },
+        ],
+      })
+
+      const result = envInspector.getInspections(req)
+
+      expect(result.value).toHaveLength(1)
+    })
+
+    it("should not return an inspector result when the headers contain non empty value in a environemnt variable", () => {
+      const container = new TestContainer()
+      const envInspector = container.bind(EnvironmentInspectorService)
+
+      const req = ref({
+        ...getDefaultRESTRequest(),
+        endpoint: "http://example.com/api/data",
+        headers: [
+          { key: "<<EXISTING_ENV_VAR>>", value: "some-value", active: true },
+        ],
+      })
+
+      const result = envInspector.getInspections(req)
+
+      expect(result.value).toHaveLength(0)
+    })
+
+    it("should return an inspector result when the params contain empty value in a environment variable", () => {
+      const container = new TestContainer()
+      const envInspector = container.bind(EnvironmentInspectorService)
+
+      const req = ref({
+        ...getDefaultRESTRequest(),
+        endpoint: "http://example.com/api/data",
+        headers: [],
+        params: [
+          { key: "<<EXISTING_ENV_VAR_2>>", value: "some-value", active: true },
+        ],
+      })
+
+      const result = envInspector.getInspections(req)
+
+      expect(result.value).toHaveLength(1)
+    })
+
+    it("should not return an inspector result when the params contain non empty value in a environemnt variable", () => {
       const container = new TestContainer()
       const envInspector = container.bind(EnvironmentInspectorService)
 

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/__tests__/environment.inspector.spec.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/__tests__/environment.inspector.spec.ts
@@ -29,6 +29,7 @@ vi.mock("~/newstore/environments", async () => {
         secret: false,
       },
     }),
+    getSelectedEnvironmentType: () => "MY_ENV",
   }
 })
 

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -12,6 +12,7 @@ import { HoppRESTRequest } from "@hoppscotch/data"
 import {
   aggregateEnvsWithSecrets$,
   getCurrentEnvironment,
+  getSelectedEnvironmentType,
 } from "~/newstore/environments"
 import { invokeAction } from "~/helpers/actions"
 import { computed } from "vue"
@@ -157,6 +158,11 @@ export class EnvironmentInspectorService extends Service implements Inspector {
                   }
 
                   const currentSelectedEnvironment = getCurrentEnvironment()
+                  const currentEnvironmentType = getSelectedEnvironmentType()
+                  const invokeActionType =
+                    currentEnvironmentType === "TEAM_ENV"
+                      ? "modals.team.environment.edit"
+                      : "modals.my.environment.edit"
                   newErrors.push({
                     id: `environment-empty-${newErrors.length}`,
                     text: {
@@ -171,7 +177,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
                         "inspections.environment.add_environment_value"
                       ),
                       apply: () => {
-                        invokeAction("modals.team.environment.edit", {
+                        invokeAction(invokeActionType, {
                           envName: currentSelectedEnvironment.name,
                           variableName: formattedExEnv,
                           isSecret: env.secret,

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -110,7 +110,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
                 locations: itemLocation,
                 doc: {
                   text: this.t("action.learn_more"),
-                  link: "https://docs.hoppscotch.io/",
+                  link: "https://docs.hoppscotch.io/documentation/features/inspections",
                 },
               })
             }
@@ -201,7 +201,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
                     locations: itemLocation,
                     doc: {
                       text: this.t("action.learn_more"),
-                      link: "https://docs.hoppscotch.io/",
+                      link: "https://docs.hoppscotch.io/documentation/features/inspections",
                     },
                   })
                 }

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -52,9 +52,8 @@ export class EnvironmentInspectorService extends Service implements Inspector {
   /**
    * Validates the environment variables in the target array
    * @param target The target array to validate
-   * @param results The results array to push the results to
    * @param locations The location where results are to be displayed
-   * @returns The results array
+   * @returns The results array containing the results of the validation
    */
   private validateEnvironmentVariables = (
     target: any[],
@@ -118,6 +117,12 @@ export class EnvironmentInspectorService extends Service implements Inspector {
     return newErrors
   }
 
+  /**
+   * Checks if the environment variables in the target array are empty
+   * @param target The target array to validate
+   * @param locations The location where results are to be displayed
+   * @returns The results array containing the results of the validation
+   */
   private validateEmptyEnvironmentVariables = (
     target: any[],
     locations: InspectorLocation
@@ -169,7 +174,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
                         })
                       },
                     },
-                    severity: 3,
+                    severity: 2,
                     isApplicable: true,
                     locations: itemLocation,
                     doc: {

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -39,9 +39,13 @@ export class EnvironmentInspectorService extends Service implements Inspector {
 
   private readonly inspection = this.bind(InspectionService)
 
-  private aggregateEnvs = useStreamStatic(aggregateEnvsWithSecrets$, [], () => {
-    /* noop */
-  })[0]
+  private aggregateEnvsWithSecrets = useStreamStatic(
+    aggregateEnvsWithSecrets$,
+    [],
+    () => {
+      /* noop */
+    }
+  )[0]
 
   constructor() {
     super()
@@ -61,7 +65,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
   ) => {
     const newErrors: InspectorResult[] = []
 
-    const envKeys = this.aggregateEnvs.value.map((e) => e.key)
+    const envKeys = this.aggregateEnvsWithSecrets.value.map((e) => e.key)
 
     target.forEach((element, index) => {
       if (isENVInString(element)) {
@@ -83,7 +87,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
             }
             if (!envKeys.includes(formattedExEnv)) {
               newErrors.push({
-                id: `environment-not-foud-${newErrors.length}`,
+                id: `environment-not-found-${newErrors.length}`,
                 text: {
                   type: "text",
                   text: this.t("inspections.environment.not_found", {
@@ -137,7 +141,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
           extractedEnv.forEach((exEnv: string) => {
             const formattedExEnv = exEnv.slice(2, -2)
 
-            this.aggregateEnvs.value.forEach((env) => {
+            this.aggregateEnvsWithSecrets.value.forEach((env) => {
               if (env.key === formattedExEnv) {
                 if (env.value === "") {
                   const itemLocation: InspectorLocation = {

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -162,9 +162,13 @@ export class EnvironmentInspectorService extends Service implements Inspector {
 
                   let invokeActionType:
                     | "modals.my.environment.edit"
-                    | "modals.team.environment.edit" =
+                    | "modals.team.environment.edit"
+                    | "modals.global.environment.update" =
                     "modals.my.environment.edit"
-                  if (currentEnvironmentType === "MY_ENV") {
+
+                  if (env.sourceEnv === "Global") {
+                    invokeActionType = "modals.global.environment.update"
+                  } else if (currentEnvironmentType === "MY_ENV") {
                     invokeActionType = "modals.my.environment.edit"
                   } else if (currentEnvironmentType === "TEAM_ENV") {
                     invokeActionType = "modals.team.environment.edit"

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -159,10 +159,19 @@ export class EnvironmentInspectorService extends Service implements Inspector {
 
                   const currentSelectedEnvironment = getCurrentEnvironment()
                   const currentEnvironmentType = getSelectedEnvironmentType()
-                  const invokeActionType =
-                    currentEnvironmentType === "TEAM_ENV"
-                      ? "modals.team.environment.edit"
-                      : "modals.my.environment.edit"
+
+                  let invokeActionType:
+                    | "modals.my.environment.edit"
+                    | "modals.team.environment.edit" =
+                    "modals.my.environment.edit"
+                  if (currentEnvironmentType === "MY_ENV") {
+                    invokeActionType = "modals.my.environment.edit"
+                  } else if (currentEnvironmentType === "TEAM_ENV") {
+                    invokeActionType = "modals.team.environment.edit"
+                  } else {
+                    invokeActionType = "modals.my.environment.edit"
+                  }
+
                   newErrors.push({
                     id: `environment-empty-${newErrors.length}`,
                     text: {
@@ -178,7 +187,10 @@ export class EnvironmentInspectorService extends Service implements Inspector {
                       ),
                       apply: () => {
                         invokeAction(invokeActionType, {
-                          envName: currentSelectedEnvironment.name,
+                          envName:
+                            env.sourceEnv !== "Global"
+                              ? currentSelectedEnvironment.name
+                              : "Global",
                           variableName: formattedExEnv,
                           isSecret: env.secret,
                         })

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/header.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/header.inspector.ts
@@ -67,7 +67,7 @@ export class HeaderInspectorService extends Service implements Inspector {
               },
               doc: {
                 text: this.t("action.learn_more"),
-                link: "https://docs.hoppscotch.io/",
+                link: "https://docs.hoppscotch.io/documentation/features/inspections",
               },
             })
           }

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/response.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/response.inspector.ts
@@ -67,7 +67,7 @@ export class ResponseInspectorService extends Service implements Inspector {
           },
           doc: {
             text: this.t("action.learn_more"),
-            link: "https://docs.hoppscotch.io/",
+            link: "https://docs.hoppscotch.io/documentation/features/inspections",
           },
         })
       }

--- a/packages/hoppscotch-common/src/services/persistence/__tests__/__mocks__/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/__tests__/__mocks__/index.ts
@@ -4,6 +4,7 @@ import { HoppGQLDocument } from "~/helpers/graphql/document"
 import { HoppRESTDocument } from "~/helpers/rest/document"
 import { GQLHistoryEntry, RESTHistoryEntry } from "~/newstore/history"
 import { SettingsDef, getDefaultSettings } from "~/newstore/settings"
+import { SecretVariable } from "~/services/secret-environment.service"
 import { PersistableTabState } from "~/services/tab"
 
 type VUEX_DATA = {
@@ -19,7 +20,7 @@ const DEFAULT_SETTINGS = getDefaultSettings()
 
 export const REST_COLLECTIONS_MOCK: HoppCollection[] = [
   {
-    v: 1,
+    v: 2,
     name: "Echo",
     folders: [],
     requests: [
@@ -36,12 +37,14 @@ export const REST_COLLECTIONS_MOCK: HoppCollection[] = [
         body: { contentType: null, body: null },
       },
     ],
+    auth: { authType: "none", authActive: true },
+    headers: [],
   },
 ]
 
 export const GQL_COLLECTIONS_MOCK: HoppCollection[] = [
   {
-    v: 1,
+    v: 2,
     name: "Echo",
     folders: [],
     requests: [
@@ -55,20 +58,30 @@ export const GQL_COLLECTIONS_MOCK: HoppCollection[] = [
         auth: { authType: "none", authActive: true },
       },
     ],
+    auth: { authType: "none", authActive: true },
+    headers: [],
   },
 ]
 
 export const ENVIRONMENTS_MOCK: Environment[] = [
   {
+    v: 1,
+    id: "ENV_1",
     name: "globals",
     variables: [
       {
         key: "test-global-key",
         value: "test-global-value",
+        secret: false,
       },
     ],
   },
-  { name: "Test", variables: [{ key: "test-key", value: "test-value" }] },
+  {
+    v: 1,
+    id: "ENV_2",
+    name: "Test",
+    variables: [{ key: "test-key", value: "test-value", secret: false }],
+  },
 ]
 
 export const SELECTED_ENV_INDEX_MOCK = {
@@ -98,7 +111,7 @@ export const MQTT_REQUEST_MOCK = {
 }
 
 export const GLOBAL_ENV_MOCK: Environment["variables"] = [
-  { key: "test-key", value: "test-value" },
+  { key: "test-key", value: "test-value", secret: false },
 ]
 
 export const VUEX_DATA_MOCK: VUEX_DATA = {
@@ -200,4 +213,12 @@ export const REST_TAB_STATE_MOCK: PersistableTabState<HoppRESTDocument> = {
       },
     },
   ],
+}
+
+export const SECRET_ENVIRONMENTS_MOCK: Record<string, SecretVariable> = {
+  clryz7ir7002al4162bsj0azg: {
+    key: "test-key",
+    value: "test-value",
+    varIndex: 1,
+  },
 }

--- a/packages/hoppscotch-common/src/services/persistence/__tests__/index.spec.ts
+++ b/packages/hoppscotch-common/src/services/persistence/__tests__/index.spec.ts
@@ -1121,7 +1121,7 @@ describe("PersistenceService", () => {
         expect(watchDebounced).toHaveBeenCalledWith(
           expect.any(Object),
           expect.any(Function),
-          { debounce: 200 }
+          { debounce: 500 }
         )
       })
 
@@ -1165,7 +1165,7 @@ describe("PersistenceService", () => {
         expect(watchDebounced).toHaveBeenCalledWith(
           expect.any(Object),
           expect.any(Function),
-          { debounce: 200 }
+          { debounce: 500 }
         )
       })
     })

--- a/packages/hoppscotch-common/src/services/persistence/__tests__/index.spec.ts
+++ b/packages/hoppscotch-common/src/services/persistence/__tests__/index.spec.ts
@@ -56,12 +56,14 @@ import {
   REST_COLLECTIONS_MOCK,
   REST_HISTORY_MOCK,
   REST_TAB_STATE_MOCK,
+  SECRET_ENVIRONMENTS_MOCK,
   SELECTED_ENV_INDEX_MOCK,
   SOCKET_IO_REQUEST_MOCK,
   SSE_REQUEST_MOCK,
   VUEX_DATA_MOCK,
   WEBSOCKET_REQUEST_MOCK,
 } from "./__mocks__"
+import { SecretEnvironmentService } from "~/services/secret-environment.service"
 
 vi.mock("~/modules/i18n", () => {
   return {
@@ -122,10 +124,12 @@ const spyOnSetItem = () => vi.spyOn(Storage.prototype, "setItem")
 const bindPersistenceService = ({
   mockGQLTabService = false,
   mockRESTTabService = false,
+  mockSecretEnvironmentsService = false,
   mock = {},
 }: {
   mockGQLTabService?: boolean
   mockRESTTabService?: boolean
+  mockSecretEnvironmentsService?: boolean
   mock?: Record<string, unknown>
 } = {}) => {
   const container = new TestContainer()
@@ -136,6 +140,10 @@ const bindPersistenceService = ({
 
   if (mockRESTTabService) {
     container.bindMock(RESTTabService, mock)
+  }
+
+  if (mockSecretEnvironmentsService) {
+    container.bindMock(SecretEnvironmentService, mock)
   }
 
   container.bind(PersistenceService)
@@ -893,7 +901,12 @@ describe("PersistenceService", () => {
         // Invalid shape for `environments`
         const environments = [
           // `entries` -> `variables`
-          { name: "Test", entries: [{ key: "test-key", value: "test-value" }] },
+          {
+            v: 1,
+            id: "ENV_1",
+            name: "Test",
+            entries: [{ key: "test-key", value: "test-value", secret: false }],
+          },
         ]
 
         window.localStorage.setItem(
@@ -1040,6 +1053,119 @@ describe("PersistenceService", () => {
         })
         expect(selectedEnvironmentIndex$.subscribe).toHaveBeenCalledWith(
           expect.any(Function)
+        )
+      })
+    })
+
+    describe("Setup secret Environments persistence", () => {
+      // Key read from localStorage across test cases
+      const secretEnvironmentsKey = "secretEnvironments"
+
+      const loadSecretEnvironmentsFromPersistedStateFn = vi.fn()
+      const mock = {
+        loadSecretEnvironmentsFromPersistedState:
+          loadSecretEnvironmentsFromPersistedStateFn,
+      }
+
+      it(`shows an error and sets the entry as a backup in localStorage if "${secretEnvironmentsKey}" read from localStorage doesn't match the schema`, () => {
+        // Invalid shape for `secretEnvironments`
+        const secretEnvironments = {
+          clryz7ir7002al4162bsj0azg: {
+            key: "ENV_KEY",
+            value: "ENV_VALUE",
+          },
+        }
+
+        window.localStorage.setItem(
+          secretEnvironmentsKey,
+          JSON.stringify(secretEnvironments)
+        )
+
+        const getItemSpy = spyOnGetItem()
+        const setItemSpy = spyOnSetItem()
+
+        invokeSetupLocalPersistence()
+
+        expect(getItemSpy).toHaveBeenCalledWith(secretEnvironmentsKey)
+
+        expect(toastErrorFn).toHaveBeenCalledWith(
+          expect.stringContaining(secretEnvironmentsKey)
+        )
+        expect(setItemSpy).toHaveBeenCalledWith(
+          `${secretEnvironmentsKey}-backup`,
+          JSON.stringify(secretEnvironments)
+        )
+      })
+
+      it("loads secret environments from the state persisted in localStorage and sets watcher for `persistableSecretEnvironment`", () => {
+        const secretEnvironment = SECRET_ENVIRONMENTS_MOCK
+        window.localStorage.setItem(
+          secretEnvironmentsKey,
+          JSON.stringify(secretEnvironment)
+        )
+
+        const getItemSpy = spyOnGetItem()
+
+        invokeSetupLocalPersistence({
+          mockSecretEnvironmentsService: true,
+          mock,
+        })
+
+        expect(getItemSpy).toHaveBeenCalledWith(secretEnvironmentsKey)
+
+        expect(toastErrorFn).not.toHaveBeenCalledWith(secretEnvironmentsKey)
+
+        expect(loadSecretEnvironmentsFromPersistedStateFn).toHaveBeenCalledWith(
+          secretEnvironment
+        )
+        expect(watchDebounced).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.any(Function),
+          { debounce: 200 }
+        )
+      })
+
+      it(`skips schema parsing and the loading of persisted secret environments if there is no "${secretEnvironmentsKey}" key present in localStorage`, () => {
+        window.localStorage.removeItem(secretEnvironmentsKey)
+
+        const getItemSpy = spyOnGetItem()
+        const setItemSpy = spyOnSetItem()
+
+        invokeSetupLocalPersistence({
+          mockSecretEnvironmentsService: true,
+          mock,
+        })
+
+        expect(getItemSpy).toHaveBeenCalledWith(secretEnvironmentsKey)
+
+        expect(toastErrorFn).not.toHaveBeenCalledWith(secretEnvironmentsKey)
+        expect(setItemSpy).not.toHaveBeenCalled()
+
+        expect(watchDebounced).toHaveBeenCalled()
+      })
+
+      it("logs an error to the console on failing to parse persisted secret environments", () => {
+        window.localStorage.setItem(secretEnvironmentsKey, "invalid-json")
+
+        console.error = vi.fn()
+        const getItemSpy = spyOnGetItem()
+        const setItemSpy = spyOnSetItem()
+
+        invokeSetupLocalPersistence()
+
+        expect(getItemSpy).toHaveBeenCalledWith(secretEnvironmentsKey)
+
+        expect(toastErrorFn).not.toHaveBeenCalledWith(secretEnvironmentsKey)
+        expect(setItemSpy).not.toHaveBeenCalled()
+
+        expect(console.error).toHaveBeenCalledWith(
+          `Failed parsing persisted secret environment, state:`,
+          window.localStorage.getItem(secretEnvironmentsKey)
+        )
+        expect(watchDebounced).toHaveBeenCalledWith(
+          expect.any(Object),
+          expect.any(Function),
+          { debounce: 200 }
         )
       })
     })

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -73,7 +73,6 @@ import {
   WEBSOCKET_REQUEST_SCHEMA,
 } from "./validation-schemas"
 import { SecretEnvironmentService } from "../secret-environment.service"
-import { watch } from "vue"
 
 /**
  * This service compiles persistence logic across the codebase
@@ -476,12 +475,12 @@ export class PersistenceService extends Service {
       }
     } catch (e) {
       console.error(
-        `Failed parsing persisted tab state, state:`,
+        `Failed parsing persisted secret environment, state:`,
         secretEnvironmentsData
       )
     }
 
-    watch(
+    watchDebounced(
       this.secretEnvironmentService.persistableSecretEnvironments,
       (newSecretEnvironment) => {
         window.localStorage.setItem(
@@ -490,7 +489,7 @@ export class PersistenceService extends Service {
         )
       },
       {
-        immediate: true,
+        debounce: 200,
       }
     )
   }

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -67,7 +67,7 @@ import {
   SETTINGS_SCHEMA,
   SOCKET_IO_REQUEST_SCHEMA,
   SSE_REQUEST_SCHEMA,
-  SecretEnvironmentVariable,
+  SECRET_ENVIRONMENT_VARIABLE_SCHEMA,
   THEME_COLOR_SCHEMA,
   VUEX_SCHEMA,
   WEBSOCKET_REQUEST_SCHEMA,
@@ -455,7 +455,7 @@ export class PersistenceService extends Service {
         let parsedSecretEnvironmentsData = JSON.parse(secretEnvironmentsData)
 
         // Validate data read from localStorage
-        const result = SecretEnvironmentVariable.safeParse(
+        const result = SECRET_ENVIRONMENT_VARIABLE_SCHEMA.safeParse(
           parsedSecretEnvironmentsData
         )
 
@@ -489,7 +489,7 @@ export class PersistenceService extends Service {
         )
       },
       {
-        debounce: 200,
+        debounce: 500,
       }
     )
   }

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -385,7 +385,7 @@ const HoppTestResultSchema = z
           .object({
             additions: z.array(EnvironmentVariablesSchema),
             updations: z.array(
-              EnvironmentVariablesSchema.and(
+              EnvironmentVariablesSchema.refine((x) => !x.secret).and(
                 z.object({
                   previousValue: z.string(),
                 })
@@ -398,7 +398,7 @@ const HoppTestResultSchema = z
           .object({
             additions: z.array(EnvironmentVariablesSchema),
             updations: z.array(
-              EnvironmentVariablesSchema.and(
+              EnvironmentVariablesSchema.refine((x) => !x.secret).and(
                 z.object({
                   previousValue: z.string(),
                 })

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -214,19 +214,15 @@ export const GLOBAL_ENV_SCHEMA = z.union([
 
   z.array(
     z.union([
-      z
-        .object({
-          key: z.string(),
-          secret: z.literal(true),
-        })
-        .strict(),
-      z
-        .object({
-          key: z.string(),
-          value: z.string(),
-          secret: z.literal(false),
-        })
-        .strict(),
+      z.object({
+        key: z.string(),
+        secret: z.literal(true),
+      }),
+      z.object({
+        key: z.string(),
+        value: z.string(),
+        secret: z.literal(false),
+      }),
     ])
   ),
 ])
@@ -349,22 +345,18 @@ const HoppTestDataSchema = z.lazy(() =>
 )
 
 const EnvironmentVariablesSchema = z.union([
-  z
-    .object({
-      key: z.string(),
-      value: z.string(),
-      secret: z.literal(false),
-    })
-    .strict(),
-  z
-    .object({
-      key: z.string(),
-      secret: z.literal(true),
-    })
-    .strict(),
+  z.object({
+    key: z.string(),
+    value: z.string(),
+    secret: z.literal(false),
+  }),
+  z.object({
+    key: z.string(),
+    secret: z.literal(true),
+  }),
 ])
 
-export const SecretEnvironmentVariable = z.union([
+export const SECRET_ENVIRONMENT_VARIABLE_SCHEMA = z.union([
   z.object({}).strict(),
 
   z.record(

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -160,16 +160,7 @@ export const SELECTED_ENV_INDEX_SCHEMA = z.nullable(
       type: z.literal("TEAM_ENV"),
       teamID: z.string(),
       teamEnvID: z.string(),
-      environment: z.object({
-        name: z.string(),
-        variables: z.array(
-          z.object({
-            key: z.string(),
-            value: z.string(),
-            secret: z.boolean(),
-          })
-        ),
-      }),
+      environment: entityReference(Environment),
     }),
   ])
 )

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -393,7 +393,11 @@ const HoppTestResultSchema = z
           .object({
             additions: z.array(EnvironmentVariablesSchema),
             updations: z.array(
-              EnvironmentVariablesSchema.refine((val) => !val.secret)
+              EnvironmentVariablesSchema.and(
+                z.object({
+                  previousValue: z.string(),
+                })
+              )
             ),
             deletions: z.array(EnvironmentVariablesSchema),
           })
@@ -402,7 +406,11 @@ const HoppTestResultSchema = z
           .object({
             additions: z.array(EnvironmentVariablesSchema),
             updations: z.array(
-              EnvironmentVariablesSchema.refine((val) => !val.secret)
+              EnvironmentVariablesSchema.and(
+                z.object({
+                  previousValue: z.string(),
+                })
+              )
             ),
             deletions: z.array(EnvironmentVariablesSchema),
           })

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -59,6 +59,12 @@ export class SecretEnvironmentService extends Service {
     this.secretEnvironments.set(id, newSecretVars || [])
   }
 
+  public updateSecretEnvironmentID(oldID: string, newID: string) {
+    const secretVars = this.getSecretEnvironment(oldID)
+    this.secretEnvironments.set(newID, secretVars || [])
+    this.secretEnvironments.delete(oldID)
+  }
+
   public persistableSecretEnvironments = computed(() => {
     const secretEnvironments: Record<string, SecretVariable[]> = {}
     this.secretEnvironments.forEach((secretVars, id) => {

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -2,39 +2,76 @@ import { Service } from "dioc"
 import { reactive } from "vue"
 import { computed } from "vue"
 
+/**
+ * Defines a secret environment variable.
+ */
 type SecretVariable = {
   key: string
   value: string
   varIndex: number
 }
 
+/**
+ * This service is used to store and manage secret environments.
+ * The secret environments are not synced with the server.
+ * hence they are not persisted in the database. They are stored
+ * in the local storage of the browser.
+ */
 export class SecretEnvironmentService extends Service {
   public static readonly ID = "SECRET_ENVIRONMENT_SERVICE"
 
+  /**
+   * Map of secret environments.
+   * The key is the ID of the secret environment.
+   * The value is the list of secret variables.
+   */
   public secretEnvironments = reactive(new Map<string, SecretVariable[]>())
 
   constructor() {
     super()
   }
 
+  /**
+   * Add a new secret environment.
+   * @param id ID of the environment
+   * @param secretVars List of secret variables
+   */
   public addSecretEnvironment(id: string, secretVars: SecretVariable[]) {
     this.secretEnvironments.set(id, secretVars)
   }
 
+  /**
+   * Get a secret environment.
+   * @param id ID of the environment
+   */
   public getSecretEnvironment(id: string) {
     return this.secretEnvironments.get(id)
   }
 
+  /**
+   * Get a secret environment variable.
+   * @param id ID of the environment
+   * @param varIndex Index of the variable in the environment
+   */
   public getSecretEnvironmentVariable(id: string, varIndex: number) {
     const secretVars = this.getSecretEnvironment(id)
     return secretVars?.find((secretVar) => secretVar.varIndex === varIndex)
   }
 
+  /**
+   * Used to get the value of a secret environment variable.
+   * @param id ID of the environment
+   * @param varIndex Index of the variable in the environment
+=   */
   public getSecretEnvironmentVariableValue(id: string, varIndex: number) {
     const secretVar = this.getSecretEnvironmentVariable(id, varIndex)
     return secretVar?.value
   }
 
+  /**
+   *
+   * @param secretEnvironments Used to load secret environments from persisted state.
+   */
   public loadSecretEnvironmentsFromPersistedState(
     secretEnvironments: Record<string, SecretVariable[]>
   ) {
@@ -47,10 +84,19 @@ export class SecretEnvironmentService extends Service {
     }
   }
 
+  /**
+   * Delete a secret environment.
+   * @param id ID of the environment
+   */
   public deleteSecretEnvironment(id: string) {
     this.secretEnvironments.delete(id)
   }
 
+  /**
+   * Delete a secret environment variable.
+   * @param id ID of the environment
+   * @param varIndex Index of the variable in the environment
+   */
   public removeSecretEnvironmentVariable(id: string, varIndex: number) {
     const secretVars = this.getSecretEnvironment(id)
     const newSecretVars = secretVars?.filter(
@@ -59,12 +105,21 @@ export class SecretEnvironmentService extends Service {
     this.secretEnvironments.set(id, newSecretVars || [])
   }
 
+  /**
+   * Used to update thye ID of a secret environment.
+   * Used while syncing with the server.
+   * @param oldID old ID of the environment
+   * @param newID new ID of the environment
+   */
   public updateSecretEnvironmentID(oldID: string, newID: string) {
     const secretVars = this.getSecretEnvironment(oldID)
     this.secretEnvironments.set(newID, secretVars || [])
     this.secretEnvironments.delete(oldID)
   }
 
+  /**
+   * Used to update the value of a secret environment variable.
+   */
   public persistableSecretEnvironments = computed(() => {
     const secretEnvironments: Record<string, SecretVariable[]> = {}
     this.secretEnvironments.forEach((secretVars, id) => {

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -5,7 +5,7 @@ import { computed } from "vue"
 /**
  * Defines a secret environment variable.
  */
-type SecretVariable = {
+export type SecretVariable = {
   key: string
   value: string
   varIndex: number

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/environment.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/environment.searcher.ts
@@ -248,9 +248,7 @@ export class EnvironmentsSpotlightSearcherService extends StaticSpotlightSearche
         this.duplicateSelectedEnv()
         break
       case "edit_global_env":
-        invokeAction(`modals.my.environment.edit`, {
-          envName: "Global",
-        })
+        invokeAction(`modals.global.environment.update`, {})
         break
       case "duplicate_global_env":
         this.duplicateGlobalEnv()

--- a/packages/hoppscotch-data/src/environment/index.ts
+++ b/packages/hoppscotch-data/src/environment/index.ts
@@ -126,6 +126,15 @@ export function parseTemplateStringE(
     : E.right(result)
 }
 
+export type NonSecretEnvironmentVariable = Extract<
+  EnvironmentVariable,
+  { secret: false }
+>
+
+export type NonSecretEnvironment = Omit<Environment, "variables"> & {
+  variables: NonSecretEnvironmentVariable[]
+}
+
 /**
  * @deprecated Use `parseTemplateStringE` instead
  */

--- a/packages/hoppscotch-data/src/environment/index.ts
+++ b/packages/hoppscotch-data/src/environment/index.ts
@@ -62,7 +62,7 @@ export function parseBodyEnvVariablesE(
         (envVar) => envVar.key === key.replace(/[<>]/g, "")
       )
 
-      if (found && !found.secret) {
+      if (found && "value" in found) {
         return found.value
       }
       return key

--- a/packages/hoppscotch-data/src/environment/index.ts
+++ b/packages/hoppscotch-data/src/environment/index.ts
@@ -131,14 +131,12 @@ export const parseTemplateString = (
 
 export const translateToNewEnvironmentVariables = (
   x: any
-): Environment["variables"] => {
-  return x.variables.map((variable: any) => {
-    return {
-      key: variable.key,
-      value: variable.value,
-      secret: false,
-    }
-  })
+): Environment["variables"][number] => {
+  return {
+    key: x.key,
+    value: x.value,
+    secret: false,
+  }
 }
 
 export const translateToNewEnvironment = (x: any): Environment => {

--- a/packages/hoppscotch-data/src/environment/v/0.ts
+++ b/packages/hoppscotch-data/src/environment/v/0.ts
@@ -2,7 +2,6 @@ import { z } from "zod"
 import { defineVersion } from "verzod"
 
 export const V0_SCHEMA = z.object({
-  v: z.literal(0),
   id: z.optional(z.string()),
   name: z.string(),
   variables: z.array(

--- a/packages/hoppscotch-data/src/environment/v/1.ts
+++ b/packages/hoppscotch-data/src/environment/v/1.ts
@@ -37,8 +37,6 @@ export default defineVersion({
       }),
     }
 
-    if (old.id) result.id = old.id
-
     return result
   },
 })

--- a/packages/hoppscotch-js-sandbox/src/__tests__/preRequest.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/preRequest.spec.ts
@@ -12,16 +12,16 @@ describe("runPreRequestScript", () => {
         {
           global: [],
           selected: [
-            { key: "bob", value: "oldbob" },
-            { key: "foo", value: "bar" },
+            { key: "bob", value: "oldbob", secret: false },
+            { key: "foo", value: "bar", secret: false },
           ],
         }
       )()
     ).resolves.toEqualRight({
       global: [],
       selected: [
-        { key: "bob", value: "newbob" },
-        { key: "foo", value: "bar" },
+        { key: "bob", value: "newbob", secret: false },
+        { key: "foo", value: "bar", secret: false },
       ],
     })
   })
@@ -35,8 +35,8 @@ describe("runPreRequestScript", () => {
         {
           global: [],
           selected: [
-            { key: "bob", value: "oldbob" },
-            { key: "foo", value: "bar" },
+            { key: "bob", value: "oldbob", secret: false },
+            { key: "foo", value: "bar", secret: false },
           ],
         }
       )()
@@ -52,8 +52,8 @@ describe("runPreRequestScript", () => {
         {
           global: [],
           selected: [
-            { key: "bob", value: "oldbob" },
-            { key: "foo", value: "bar" },
+            { key: "bob", value: "oldbob", secret: false },
+            { key: "foo", value: "bar", secret: false },
           ],
         }
       )()
@@ -69,8 +69,8 @@ describe("runPreRequestScript", () => {
         {
           global: [],
           selected: [
-            { key: "bob", value: "oldbob" },
-            { key: "foo", value: "bar" },
+            { key: "bob", value: "oldbob", secret: false },
+            { key: "foo", value: "bar", secret: false },
           ],
         }
       )()
@@ -87,7 +87,7 @@ describe("runPreRequestScript", () => {
       )()
     ).resolves.toEqualRight({
       global: [],
-      selected: [{ key: "foo", value: "bar" }],
+      selected: [{ key: "foo", value: "bar", secret: false }],
     })
   })
 })

--- a/packages/hoppscotch-js-sandbox/src/__tests__/testing/base64-helper-functions.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/testing/base64-helper-functions.spec.ts
@@ -10,13 +10,13 @@ describe("Base64 helper functions", () => {
     atob: {
       script: `pw.env.set("atob", atob("SGVsbG8gV29ybGQ="))`,
       environment: {
-        selected: [{ key: "atob", value: "Hello World" }],
+        selected: [{ key: "atob", value: "Hello World", secret: false }],
       },
     },
     btoa: {
       script: `pw.env.set("btoa", btoa("Hello World"))`,
       environment: {
-        selected: [{ key: "btoa", value: "SGVsbG8gV29ybGQ=" }],
+        selected: [{ key: "btoa", value: "SGVsbG8gV29ybGQ=", secret: false }],
       },
     },
   }

--- a/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/get.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/get.spec.ts
@@ -31,6 +31,7 @@ describe("pw.env.get", () => {
             {
               key: "a",
               value: "b",
+              secret: false,
             },
           ],
         }
@@ -59,6 +60,7 @@ describe("pw.env.get", () => {
             {
               key: "a",
               value: "b",
+              secret: false,
             },
           ],
           selected: [],
@@ -112,12 +114,14 @@ describe("pw.env.get", () => {
             {
               key: "a",
               value: "global val",
+              secret: false,
             },
           ],
           selected: [
             {
               key: "a",
               value: "selected val",
+              secret: false,
             },
           ],
         }
@@ -147,6 +151,7 @@ describe("pw.env.get", () => {
             {
               key: "a",
               value: "<<hello>>",
+              secret: false,
             },
           ],
         }

--- a/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/getResolve.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/getResolve.spec.ts
@@ -31,6 +31,7 @@ describe("pw.env.getResolve", () => {
             {
               key: "a",
               value: "b",
+              secret: false,
             },
           ],
         }
@@ -59,6 +60,7 @@ describe("pw.env.getResolve", () => {
             {
               key: "a",
               value: "b",
+              secret: false,
             },
           ],
           selected: [],
@@ -112,12 +114,14 @@ describe("pw.env.getResolve", () => {
             {
               key: "a",
               value: "global val",
+              secret: false,
             },
           ],
           selected: [
             {
               key: "a",
               value: "selected val",
+              secret: false,
             },
           ],
         }
@@ -147,10 +151,12 @@ describe("pw.env.getResolve", () => {
             {
               key: "a",
               value: "<<hello>>",
+              secret: false,
             },
             {
               key: "hello",
               value: "there",
+              secret: false,
             },
           ],
         }
@@ -180,10 +186,12 @@ describe("pw.env.getResolve", () => {
             {
               key: "a",
               value: "<<hello>>",
+              secret: false,
             },
             {
               key: "hello",
               value: "<<a>>",
+              secret: false,
             },
           ],
         }

--- a/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/resolve.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/resolve.spec.ts
@@ -43,6 +43,7 @@ describe("pw.env.resolve", () => {
             {
               key: "hello",
               value: "there",
+              secret: false,
             },
           ],
           selected: [],
@@ -73,6 +74,7 @@ describe("pw.env.resolve", () => {
             {
               key: "hello",
               value: "there",
+              secret: false,
             },
           ],
         }
@@ -101,12 +103,14 @@ describe("pw.env.resolve", () => {
             {
               key: "hello",
               value: "yo",
+              secret: false,
             },
           ],
           selected: [
             {
               key: "hello",
               value: "there",
+              secret: false,
             },
           ],
         }
@@ -136,10 +140,12 @@ describe("pw.env.resolve", () => {
             {
               key: "hello",
               value: "<<there>>",
+              secret: false,
             },
             {
               key: "there",
               value: "<<hello>>",
+              secret: false,
             },
           ],
         }

--- a/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/set.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/set.spec.ts
@@ -35,6 +35,7 @@ describe("pw.env.set", () => {
             {
               key: "a",
               value: "b",
+              secret: false,
             },
           ],
         }
@@ -45,6 +46,7 @@ describe("pw.env.set", () => {
           {
             key: "a",
             value: "c",
+            secret: false,
           },
         ],
       })
@@ -62,6 +64,7 @@ describe("pw.env.set", () => {
             {
               key: "a",
               value: "b",
+              secret: false,
             },
           ],
           selected: [],
@@ -73,6 +76,7 @@ describe("pw.env.set", () => {
           {
             key: "a",
             value: "c",
+            secret: false,
           },
         ],
       })
@@ -90,12 +94,14 @@ describe("pw.env.set", () => {
             {
               key: "a",
               value: "b",
+              secret: false,
             },
           ],
           selected: [
             {
               key: "a",
               value: "d",
+              secret: false,
             },
           ],
         }
@@ -106,12 +112,14 @@ describe("pw.env.set", () => {
           {
             key: "a",
             value: "b",
+            secret: false,
           },
         ],
         selected: [
           {
             key: "a",
             value: "c",
+            secret: false,
           },
         ],
       })
@@ -136,6 +144,7 @@ describe("pw.env.set", () => {
           {
             key: "a",
             value: "c",
+            secret: false,
           },
         ],
       })

--- a/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/unset.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/testing/envs/unset.spec.ts
@@ -35,6 +35,7 @@ describe("pw.env.unset", () => {
             {
               key: "baseUrl",
               value: "https://echo.hoppscotch.io",
+              secret: false,
             },
           ],
         }
@@ -57,6 +58,7 @@ describe("pw.env.unset", () => {
             {
               key: "baseUrl",
               value: "https://echo.hoppscotch.io",
+              secret: false,
             },
           ],
           selected: [],
@@ -80,12 +82,14 @@ describe("pw.env.unset", () => {
             {
               key: "baseUrl",
               value: "https://httpbin.org",
+              secret: false,
             },
           ],
           selected: [
             {
               key: "baseUrl",
               value: "https://echo.hoppscotch.io",
+              secret: false,
             },
           ],
         }
@@ -96,6 +100,7 @@ describe("pw.env.unset", () => {
           {
             key: "baseUrl",
             value: "https://httpbin.org",
+            secret: false,
           },
         ],
         selected: [],
@@ -114,16 +119,19 @@ describe("pw.env.unset", () => {
             {
               key: "baseUrl",
               value: "https://echo.hoppscotch.io",
+              secret: false,
             },
           ],
           selected: [
             {
               key: "baseUrl",
               value: "https://httpbin.org",
+              secret: false,
             },
             {
               key: "baseUrl",
               value: "https://echo.hoppscotch.io",
+              secret: false,
             },
           ],
         }
@@ -134,12 +142,14 @@ describe("pw.env.unset", () => {
           {
             key: "baseUrl",
             value: "https://echo.hoppscotch.io",
+            secret: false,
           },
         ],
         selected: [
           {
             key: "baseUrl",
             value: "https://echo.hoppscotch.io",
+            secret: false,
           },
         ],
       })
@@ -157,10 +167,12 @@ describe("pw.env.unset", () => {
             {
               key: "baseUrl",
               value: "https://httpbin.org/",
+              secret: false,
             },
             {
               key: "baseUrl",
               value: "https://echo.hoppscotch.io",
+              secret: false,
             },
           ],
           selected: [],
@@ -172,6 +184,7 @@ describe("pw.env.unset", () => {
           {
             key: "baseUrl",
             value: "https://echo.hoppscotch.io",
+            secret: false,
           },
         ],
         selected: [],
@@ -225,6 +238,7 @@ describe("pw.env.unset", () => {
             {
               key: "baseUrl",
               value: "https://echo.hoppscotch.io",
+              secret: false,
             },
           ],
         }

--- a/packages/hoppscotch-js-sandbox/src/test-runner/web-worker/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/test-runner/web-worker/index.ts
@@ -17,10 +17,15 @@ export const runTestScript = (
       resolve(event.data.results)
     )
 
+    const environments = {
+      global: envs.global,
+      selected: envs.selected.variables,
+    }
+
     // Send the script to the web worker
     worker.postMessage({
       testScript,
-      envs,
+      environments,
       response,
     })
   })

--- a/packages/hoppscotch-js-sandbox/src/test-runner/web-worker/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/test-runner/web-worker/index.ts
@@ -17,15 +17,10 @@ export const runTestScript = (
       resolve(event.data.results)
     )
 
-    const environments = {
-      global: envs.global,
-      selected: envs.selected.variables,
-    }
-
     // Send the script to the web worker
     worker.postMessage({
       testScript,
-      environments,
+      envs,
       response,
     })
   })

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -51,12 +51,11 @@ export type TestResult = {
   tests: TestDescriptor[]
   envs: {
     global: Environment["variables"]
-    selected: Environment
+    selected: Environment["variables"]
   }
 }
 
 export type GlobalEnvItem = TestResult["envs"]["global"][number]
-export type SelectedEnvItem =
-  TestResult["envs"]["selected"]["variables"][number]
+export type SelectedEnvItem = TestResult["envs"]["selected"][number]
 
 export type SandboxTestResult = TestResult & { tests: TestDescriptor }

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -62,6 +62,6 @@ export type SandboxTestResult = TestResult & { tests: TestDescriptor }
 
 export type EnvironmentVariable = {
   key: string
-  value: string | undefined
+  value: string
   secret: boolean
 }

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -51,11 +51,12 @@ export type TestResult = {
   tests: TestDescriptor[]
   envs: {
     global: Environment["variables"]
-    selected: Environment["variables"]
+    selected: Environment
   }
 }
 
 export type GlobalEnvItem = TestResult["envs"]["global"][number]
-export type SelectedEnvItem = TestResult["envs"]["selected"][number]
+export type SelectedEnvItem =
+  TestResult["envs"]["selected"]["variables"][number]
 
 export type SandboxTestResult = TestResult & { tests: TestDescriptor }

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -1,5 +1,3 @@
-import { Environment } from "@hoppscotch/data"
-
 /**
  * The response object structure exposed to the test script
  */
@@ -43,6 +41,13 @@ export type TestDescriptor = {
   children: TestDescriptor[]
 }
 
+// Representation of a transformed state for environment variables in the sandbox
+type TransformedEnvironmentVariable = {
+  key: string
+  value: string
+  secret: boolean
+}
+
 /**
  * Defines the result of a test script execution
  */
@@ -50,8 +55,8 @@ export type TestDescriptor = {
 export type TestResult = {
   tests: TestDescriptor[]
   envs: {
-    global: Environment["variables"]
-    selected: Environment["variables"]
+    global: TransformedEnvironmentVariable[]
+    selected: TransformedEnvironmentVariable[]
   }
 }
 
@@ -59,9 +64,3 @@ export type GlobalEnvItem = TestResult["envs"]["global"][number]
 export type SelectedEnvItem = TestResult["envs"]["selected"][number]
 
 export type SandboxTestResult = TestResult & { tests: TestDescriptor }
-
-export type EnvironmentVariable = {
-  key: string
-  value: string
-  secret: boolean
-}

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -59,3 +59,9 @@ export type GlobalEnvItem = TestResult["envs"]["global"][number]
 export type SelectedEnvItem = TestResult["envs"]["selected"][number]
 
 export type SandboxTestResult = TestResult & { tests: TestDescriptor }
+
+export type EnvironmentVariable = {
+  key: string
+  value: string | undefined
+  secret: boolean
+}

--- a/packages/hoppscotch-js-sandbox/src/utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils.ts
@@ -5,6 +5,7 @@ import { pipe } from "fp-ts/lib/function"
 import { cloneDeep } from "lodash-es"
 
 import {
+  EnvironmentVariable,
   GlobalEnvItem,
   SelectedEnvItem,
   TestDescriptor,
@@ -95,16 +96,7 @@ const getSharedMethods = (envs: TestResult["envs"]) => {
       getEnv(key, updatedEnvs),
       O.fold(
         () => undefined,
-        (env) =>
-          String(
-            (
-              env as {
-                key: string
-                value: string | undefined
-                secret: boolean
-              }
-            ).value
-          )
+        (env) => String((env as EnvironmentVariable).value)
       )
     )
 
@@ -122,26 +114,11 @@ const getSharedMethods = (envs: TestResult["envs"]) => {
 
       E.map((e) =>
         pipe(
-          parseTemplateStringE(
-            (
-              e as {
-                key: string
-                value: string | undefined
-                secret: boolean
-              }
-            ).value ?? "",
-            [...updatedEnvs.selected, ...updatedEnvs.global]
-          ), // If the recursive resolution failed, return the unresolved value
-          E.getOrElse(
-            () =>
-              (
-                e as {
-                  key: string
-                  value: string | undefined
-                  secret: boolean
-                }
-              ).value ?? ""
-          )
+          parseTemplateStringE((e as EnvironmentVariable).value ?? "", [
+            ...updatedEnvs.selected,
+            ...updatedEnvs.global,
+          ]), // If the recursive resolution failed, return the unresolved value
+          E.getOrElse(() => (e as EnvironmentVariable).value ?? "")
         )
       ),
       E.map((x) => String(x)),

--- a/packages/hoppscotch-js-sandbox/src/utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils.ts
@@ -5,7 +5,6 @@ import { pipe } from "fp-ts/lib/function"
 import { cloneDeep } from "lodash-es"
 
 import {
-  EnvironmentVariable,
   GlobalEnvItem,
   SelectedEnvItem,
   TestDescriptor,
@@ -96,7 +95,7 @@ const getSharedMethods = (envs: TestResult["envs"]) => {
       getEnv(key, updatedEnvs),
       O.fold(
         () => undefined,
-        (env) => String((env as EnvironmentVariable).value)
+        (env) => String(env.value)
       )
     )
 
@@ -114,11 +113,11 @@ const getSharedMethods = (envs: TestResult["envs"]) => {
 
       E.map((e) =>
         pipe(
-          parseTemplateStringE((e as EnvironmentVariable).value ?? "", [
+          parseTemplateStringE(e.value, [
             ...updatedEnvs.selected,
             ...updatedEnvs.global,
           ]), // If the recursive resolution failed, return the unresolved value
-          E.getOrElse(() => (e as EnvironmentVariable).value ?? "")
+          E.getOrElse(() => e.value)
         )
       ),
       E.map((x) => String(x)),

--- a/packages/hoppscotch-js-sandbox/src/utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils.ts
@@ -43,7 +43,7 @@ const setEnv = (
       selectedEnv.value = envValue
     }
   } else if (indexInGlobal >= 0) {
-    if (!global[indexInGlobal].secret && "value" in global[indexInGlobal]) {
+    if ("value" in global[indexInGlobal]) {
       // eslint-disable-next-line @typescript-eslint/no-extra-semi
       ;(global[indexInGlobal] as { value: string }).value = envValue
     }

--- a/packages/hoppscotch-js-sandbox/src/utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils.ts
@@ -120,19 +120,27 @@ const getSharedMethods = (envs: TestResult["envs"]) => {
       getEnv(key, updatedEnvs),
       E.fromOption(() => "INVALID_KEY" as const),
 
-      E.map((env) =>
+      E.map((e) =>
         pipe(
-          env,
-          E.fromNullable(undefined),
-          E.map((e) =>
-            pipe(
-              parseTemplateStringE(!e.secret ? e.value?.toString() : "", [
-                ...updatedEnvs.selected,
-                ...updatedEnvs.global,
-              ]),
-              // If the recursive resolution failed, return the unresolved value
-              E.getOrElse(() => (!e.secret ? e.value?.toString() : ""))
-            )
+          parseTemplateStringE(
+            (
+              e as {
+                key: string
+                value: string | undefined
+                secret: boolean
+              }
+            ).value ?? "",
+            [...updatedEnvs.selected, ...updatedEnvs.global]
+          ), // If the recursive resolution failed, return the unresolved value
+          E.getOrElse(
+            () =>
+              (
+                e as {
+                  key: string
+                  value: string | undefined
+                  secret: boolean
+                }
+              ).value ?? ""
           )
         )
       ),

--- a/packages/hoppscotch-js-sandbox/src/utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils.ts
@@ -95,7 +95,16 @@ const getSharedMethods = (envs: TestResult["envs"]) => {
       getEnv(key, updatedEnvs),
       O.fold(
         () => undefined,
-        (env) => (env.secret ? "" : String(env.value))
+        (env) =>
+          String(
+            (
+              env as {
+                key: string
+                value: string | undefined
+                secret: boolean
+              }
+            ).value
+          )
       )
     )
 

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/environments.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/environments.sync.ts
@@ -20,9 +20,13 @@ import {
   deleteUserEnvironment,
   updateUserEnvironment,
 } from "./environments.api"
+import { SecretEnvironmentService } from "@hoppscotch/common/services/secret-environment.service"
+import { getService } from "@hoppscotch/common/modules/dioc"
 
 export const environmentsMapper = createMapper<number, string>()
 export const globalEnvironmentMapper = createMapper<number, string>()
+
+const secretEnvironmentService = getService(SecretEnvironmentService)
 
 export const storeSyncDefinition: StoreSyncDefinitionOf<
   typeof environmentsStore
@@ -34,6 +38,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
 
     if (E.isRight(res)) {
       const id = res.right.createUserEnvironment.id
+
+      secretEnvironmentService.updateSecretEnvironmentID(
+        environmentsStore.value.environments[lastCreatedEnvIndex].id,
+        id
+      )
+
       environmentsStore.value.environments[lastCreatedEnvIndex].id = id
       removeDuplicateEntry(id)
     }
@@ -84,7 +94,6 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   },
   updateEnvironment({ envIndex, updatedEnv }) {
     const backendId = environmentsStore.value.environments[envIndex].id
-
     if (backendId) {
       updateUserEnvironment(backendId, updatedEnv)()
     }


### PR DESCRIPTION
Closes HFE-220 HFE-393 HFE-358

### Description
**A user** will now be able to create a secret variable in the **personal environment**;
**Any owner or editor** will now be able to create a “**secret**” variable. in a **team environment**;

1. A normal environment variable: This is the current implementation of environment variables. Normal variables in team environments are shared across the team workspace.
2. A secret environment variable: The value of the secret environment variable will be masked and never synced to servers/DB.

This PR also add a additional check in the environment inspector which alerts the user if a environment variable has empty value.

### Checks
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
