### PR TITLE
docs: replace CLI url with new docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Help us to translate Hoppscotch. Please read [`TRANSLATIONS`](TRANSLATIONS.md) f
 
 📦 **Add-ons:** Official add-ons for hoppscotch.
 
-- **[Hoppscotch CLI](https://github.com/hoppscotch/hopp-cli)** - Command-line interface for Hoppscotch.
+- **[Hoppscotch CLI](https://docs.hoppscotch.io/documentation/clients/cli)** - Command-line interface for Hoppscotch.
 - **[Proxy](https://github.com/hoppscotch/proxyscotch)** - A simple proxy server created for Hoppscotch.
 - **[Browser Extensions](https://github.com/hoppscotch/hoppscotch-extension)** - Browser extensions that enhance your Hoppscotch experience.
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

### Description
Just replace URL to the [new docs of the CLI](https://docs.hoppscotch.io/documentation/clients/cli) instead of the archived repo 

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed

