### PR TITLE
fix(sh-admin): persist active selection in the sidebar

### DIFF
--- a/packages/hoppscotch-sh-admin/src/components/app/Sidebar.vue
+++ b/packages/hoppscotch-sh-admin/src/components/app/Sidebar.vue
@@ -43,12 +43,11 @@
                 ? 'flex items-center justify-center'
                 : 'flex items-center'
             "
-            @click="setActiveTab(navigation.label)"
           >
             <div
               class="flex p-5 w-full font-bold"
               :class="
-                activeTab === navigation.label
+                  currentRouteName.startsWith(navigation.baseRouteName)
                   ? 'bg-primaryDark text-secondaryDark border-l-2 border-l-emerald-600'
                   : 'bg-primary hover:bg-primaryLight hover:text-secondaryDark focus-visible:text-secondaryDark focus-visible:bg-primaryLight focus-visible:outline-none'
               "
@@ -72,7 +71,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, type Component } from 'vue';
+import { computed, type Component } from 'vue';
+import { useRoute } from 'vue-router';
 
 import { useI18n } from '~/composables/i18n';
 import { useSidebar } from '~/composables/useSidebar';
@@ -81,6 +81,7 @@ import IconSettings from '~icons/lucide/settings';
 import IconUser from '~icons/lucide/user';
 import IconUsers from '~icons/lucide/users';
 
+const route = useRoute()
 const t = useI18n();
 
 const { isOpen, isExpanded } = useSidebar();
@@ -90,6 +91,7 @@ type NavigationItem = {
   icon: Component;
   to: string;
   exact: boolean;
+  baseRouteName: string;
 };
 
 const primaryNavigations: NavigationItem[] = [
@@ -98,32 +100,32 @@ const primaryNavigations: NavigationItem[] = [
     icon: IconDashboard,
     to: '/dashboard',
     exact: true,
+    baseRouteName: 'dashboard',
   },
   {
     label: t('users.users'),
     icon: IconUser,
     to: '/users',
     exact: false,
+    baseRouteName: 'users'
   },
   {
     label: t('teams.teams'),
     icon: IconUsers,
     to: '/teams',
     exact: false,
+    baseRouteName: 'teams'
   },
   {
     label: t('settings.settings'),
     icon: IconSettings,
     to: '/settings',
     exact: true,
+    baseRouteName: 'settings',
   },
 ];
 
-const activeTab = ref('Dashboard');
-
-const setActiveTab = (tab: string) => {
-  activeTab.value = tab;
-};
+const currentRouteName = computed(() => route.name as string);
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
### Description

This PR ensures the active selection in the sidebar for the Admin dashboard is persisted across page reloads. A new property, `baseRouteName` is introduced under `primaryNavigations` in the `AppSidebar` component that defines the base route names corresponding to each nav item and checks against the route name to decide whether to apply the classes for active selection or not.

Closes HFE-424.

### Preview

https://github.com/hoppscotch/hoppscotch/assets/25279263/790ed666-d5a0-405d-8bb2-bd5a9a3cc10d

### Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed