### PR TITLE
fix: environment tooltip update bug

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -380,7 +380,7 @@ const saveEnvironment = async () => {
   const variables = pipe(
     filterdVariables,
     A.map((e) =>
-      e.secret ? { key: e.key, secret: e.secret ?? false, value: undefined } : e
+      e.secret ? { key: e.key, secret: e.secret, value: undefined } : e
     )
   )
 

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -380,7 +380,7 @@ const saveEnvironment = async () => {
   const variables = pipe(
     filterdVariables,
     A.map((e) =>
-      e.secret ? { key: e.key, secret: e.secret, value: undefined } : e
+      e.secret ? { key: e.key, secret: e.secret ?? false, value: undefined } : e
     )
   )
 

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -83,9 +83,9 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
       )
 
       if (!tooltipEnv?.secret && tooltipEnv?.value) envValue = tooltipEnv.value
-      else if (tooltipEnv?.secret && !tooltipEnv.value && hasSecretEnv) {
+      else if (tooltipEnv?.secret && hasSecretEnv) {
         envValue = "******"
-      } else if (tooltipEnv?.secret && !tooltipEnv.value && !hasSecretEnv) {
+      } else if (tooltipEnv?.secret && !hasSecretEnv) {
         envValue = "Empty"
       } else if (!tooltipEnv?.sourceEnv) {
         envValue = "Not Found"

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -14,12 +14,15 @@ import {
   AggregateEnvironment,
   aggregateEnvsWithSecrets$,
   getAggregateEnvsWithSecrets,
+  getCurrentEnvironment,
   getSelectedEnvironmentType,
 } from "~/newstore/environments"
 import { invokeAction } from "~/helpers/actions"
 import IconUser from "~icons/lucide/user?raw"
 import IconUsers from "~icons/lucide/users?raw"
 import IconEdit from "~icons/lucide/edit?raw"
+import { SecretEnvironmentService } from "~/services/secret-environment.service"
+import { getService } from "~/modules/dioc"
 
 const HOPP_ENVIRONMENT_REGEX = /(<<[a-zA-Z0-9-_]+>>)/g
 
@@ -27,6 +30,8 @@ const HOPP_ENV_HIGHLIGHT =
   "cursor-help transition rounded px-1 focus:outline-none mx-0.5 env-highlight"
 const HOPP_ENV_HIGHLIGHT_FOUND = "env-found"
 const HOPP_ENV_HIGHLIGHT_NOT_FOUND = "env-not-found"
+
+const secretEnvironmentService = getService(SecretEnvironmentService)
 
 const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
   hoverTooltip(
@@ -67,9 +72,21 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
       const envName = tooltipEnv?.sourceEnv ?? "Choose an Environment"
 
       let envValue = "Not Found"
+
+      const currentSelectedEnvironment = getCurrentEnvironment()
+
+      const hasSecretEnv = secretEnvironmentService.hasSecretValue(
+        tooltipEnv?.sourceEnv !== "Global"
+          ? currentSelectedEnvironment.id
+          : "Global",
+        tooltipEnv?.key ?? ""
+      )
+
       if (!tooltipEnv?.secret && tooltipEnv?.value) envValue = tooltipEnv.value
-      else if (tooltipEnv?.secret && tooltipEnv.value) {
+      else if (tooltipEnv?.secret && !tooltipEnv.value && hasSecretEnv) {
         envValue = "******"
+      } else if (tooltipEnv?.secret && !tooltipEnv.value && !hasSecretEnv) {
+        envValue = "Empty"
       } else if (!tooltipEnv?.sourceEnv) {
         envValue = "Not Found"
       } else if (!tooltipEnv?.value) {

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -374,6 +374,10 @@ const EnvironmentVariablesSchema = z.union([
     key: z.string(),
     secret: z.literal(true),
   }),
+  z.object({
+    key: z.string(),
+    value: z.string(),
+  }),
 ])
 
 export const SECRET_ENVIRONMENT_VARIABLE_SCHEMA = z.union([
@@ -405,7 +409,9 @@ const HoppTestResultSchema = z
           .object({
             additions: z.array(EnvironmentVariablesSchema),
             updations: z.array(
-              EnvironmentVariablesSchema.refine((x) => !x.secret).and(
+              EnvironmentVariablesSchema.refine(
+                (x) => "secret" in x && !x.secret
+              ).and(
                 z.object({
                   previousValue: z.string(),
                 })
@@ -418,7 +424,9 @@ const HoppTestResultSchema = z
           .object({
             additions: z.array(EnvironmentVariablesSchema),
             updations: z.array(
-              EnvironmentVariablesSchema.refine((x) => !x.secret).and(
+              EnvironmentVariablesSchema.refine(
+                (x) => "secret" in x && !x.secret
+              ).and(
                 z.object({
                   previousValue: z.string(),
                 })


### PR DESCRIPTION
Closes HFE-426

### Description
This PR fixes a bug where a hovered environment tooltip failed to update its state when a secret environment is updated.
Also fixes a issue in schema validation for restTab testResult type.

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
