### PR TITLE
chore: add workspace type property in request run analytics event

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -341,6 +341,10 @@ const newSendRequest = async () => {
     type: "HOPP_REQUEST_RUN",
     platform: "rest",
     strategy: interceptorService.currentInterceptorID.value!,
+    workspaceType:
+      tab.value.document.saveContext?.originLocation === "team-collection"
+        ? "team"
+        : "personal",
   })
 
   const [cancel, streamPromise] = runRESTRequest$(tab)

--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -263,6 +263,7 @@ import { HoppTab } from "~/services/tab"
 import { HoppRESTDocument } from "~/helpers/rest/document"
 import { RESTTabService } from "~/services/tab/rest"
 import { getMethodLabelColor } from "~/helpers/rest/labelColoring"
+import { WorkspaceService } from "~/services/workspace.service"
 
 const t = useI18n()
 const interceptorService = useService(InterceptorService)
@@ -326,6 +327,8 @@ const inspectionService = useService(InspectionService)
 
 const tabs = useService(RESTTabService)
 
+const workspaceService = useService(WorkspaceService)
+
 const newSendRequest = async () => {
   if (newEndpoint.value === "" || /^\s+$/.test(newEndpoint.value)) {
     toast.error(`${t("empty.endpoint")}`)
@@ -341,10 +344,7 @@ const newSendRequest = async () => {
     type: "HOPP_REQUEST_RUN",
     platform: "rest",
     strategy: interceptorService.currentInterceptorID.value!,
-    workspaceType:
-      tab.value.document.saveContext?.originLocation === "team-collection"
-        ? "team"
-        : "personal",
+    workspaceType: workspaceService.currentWorkspace.value.type,
   })
 
   const [cancel, streamPromise] = runRESTRequest$(tab)

--- a/packages/hoppscotch-common/src/platform/analytics.ts
+++ b/packages/hoppscotch-common/src/platform/analytics.ts
@@ -1,6 +1,11 @@
 export type HoppRequestEvent =
   | {
-      platform: "rest" | "graphql-query" | "graphql-schema"
+      platform: "rest"
+      strategy: string
+      workspaceType: "personal" | "team"
+    }
+  | {
+      platform: "graphql-query" | "graphql-schema"
       strategy: string
     }
   | { platform: "wss" | "sse" | "socketio" | "mqtt" }


### PR DESCRIPTION
Fixes HFE-427

**Changes**

This PR adds the `workspaceType` property in `HOPP_REQUEST_RUN` event. the possible values are `team` and `personal`. 