### PR TITLE
fix(common): update global environment variables schema

### DIFF
--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -628,7 +628,7 @@ export class PersistenceService extends Service {
 
   private setupGlobalEnvsPersistence() {
     const globalEnvKey = "globalEnv"
-    let globalEnvData: Environment["variables"] = JSON.parse(
+    let globalEnvData: z.infer<typeof GLOBAL_ENV_SCHEMA> = JSON.parse(
       window.localStorage.getItem(globalEnvKey) || "[]"
     )
 
@@ -644,7 +644,7 @@ export class PersistenceService extends Service {
       )
     }
 
-    setGlobalEnvVariables(globalEnvData)
+    setGlobalEnvVariables(globalEnvData as Environment["variables"])
 
     globalEnv$.subscribe((vars) => {
       window.localStorage.setItem(globalEnvKey, JSON.stringify(vars))

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -229,23 +229,25 @@ export const MQTT_REQUEST_SCHEMA = z.nullable(
     .strict()
 )
 
-export const GLOBAL_ENV_SCHEMA = z.union([
-  z.array(z.never()),
-
-  z.array(
-    z.union([
-      z.object({
-        key: z.string(),
-        secret: z.literal(true),
-      }),
-      z.object({
-        key: z.string(),
-        value: z.string(),
-        secret: z.literal(false),
-      }),
-    ])
-  ),
+const EnvironmentVariablesSchema = z.union([
+  z.object({
+    key: z.string(),
+    value: z.string(),
+    secret: z.literal(false),
+  }),
+  z.object({
+    key: z.string(),
+    secret: z.literal(true),
+  }),
+  z.object({
+    key: z.string(),
+    value: z.string(),
+  }),
 ])
+
+export const GLOBAL_ENV_SCHEMA = z.array(
+  z.union([z.never(), EnvironmentVariablesSchema])
+)
 
 const OperationTypeSchema = z.enum([
   "subscription",
@@ -363,22 +365,6 @@ const HoppTestDataSchema = z.lazy(() =>
     })
     .strict()
 )
-
-const EnvironmentVariablesSchema = z.union([
-  z.object({
-    key: z.string(),
-    value: z.string(),
-    secret: z.literal(false),
-  }),
-  z.object({
-    key: z.string(),
-    secret: z.literal(true),
-  }),
-  z.object({
-    key: z.string(),
-    value: z.string(),
-  }),
-])
 
 export const SECRET_ENVIRONMENT_VARIABLE_SCHEMA = z.union([
   z.object({}).strict(),


### PR DESCRIPTION
### Description

This PR ensures the schema for global environment variables maintains backward compatibility while checking against the data read from `localStorage` (for the key `globalEnv`) via the persistence service.

### Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed