### PR TITLE
fix: fix accessing undefined property `variables`

### DIFF
--- a/packages/hoppscotch-common/src/components/http/OAuth2Authorization.vue
+++ b/packages/hoppscotch-common/src/components/http/OAuth2Authorization.vue
@@ -112,7 +112,7 @@ const handleAccessTokenRequest = async () => {
   }
 
   const envs = getCombinedEnvVariables()
-  const envVars = [...envs.selected.variables, ...envs.global]
+  const envVars = [...envs.selected, ...envs.global]
 
   try {
     const tokenReqParams = {


### PR DESCRIPTION
Fixes HFE-428

**Changes**

Fix accessing undefined property `selected.variables`. `selected` is already the list of variables, we do not need to access the `variables` property.