### PR TITLE
fix(common): prevent exceptions with open shared requests in new tab action

### DIFF
--- a/packages/hoppscotch-common/src/components/share/Request.vue
+++ b/packages/hoppscotch-common/src/components/share/Request.vue
@@ -62,7 +62,7 @@
                 :shortcut="['T']"
                 @click="
                   () => {
-                    openInNewTab()
+                    emit('open-shared-request', parseRequest)
                     hide()
                   }
                 "
@@ -128,6 +128,7 @@ const emit = defineEmits<{
     embedProperties?: string | null
   ): void
   (e: "delete-shared-request", codeID: string): void
+  (e: "open-shared-request", request: HoppRESTRequest): void
 }>()
 
 const tippyActions = ref<TippyComponent | null>(null)

--- a/packages/hoppscotch-common/src/components/share/index.vue
+++ b/packages/hoppscotch-common/src/components/share/index.vue
@@ -53,6 +53,7 @@
           :request="request"
           @customize-shared-request="customizeSharedRequest"
           @delete-shared-request="deleteSharedRequest"
+          @open-shared-request="openRequestInNewTab"
         />
         <HoppSmartIntersection
           v-if="hasMoreSharedRequests"
@@ -481,6 +482,13 @@ const getErrorMessage = (err: GQLError<string>) => {
     default:
       return t("error.something_went_wrong")
   }
+}
+
+const openRequestInNewTab = (request: HoppRESTRequest) => {
+  restTab.createNewTab({
+    isDirty: false,
+    request,
+  })
 }
 
 defineActionHandler("share.request", ({ request }) => {


### PR DESCRIPTION
### Description

This PR fixes an exception with the open shared request in a new tab action where the handler was not in place previously, leading to exceptions.

Fixes HFE-431.

### Preview

https://github.com/hoppscotch/hoppscotch/assets/25279263/2b62ad20-3197-4167-ad7a-557723858498

### Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed