### PR TITLE
chore: update escaping for special characters in `key:value` string

### DIFF
--- a/packages/hoppscotch-data/package.json
+++ b/packages/hoppscotch-data/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build:code": "vite build",
+    "build:watch": "vite build --watch",
     "build:decl": "tsc --project tsconfig.decl.json",
     "build": "pnpm run build:code && pnpm run build:decl",
     "prepare": "pnpm run build:code && pnpm run build:decl",


### PR DESCRIPTION
Closes HFE-399

### Description
In parameters, headers, or any other key value type input places if you write backslash `\` you will see a bug that it's replacing that backslash with `"\\"`. This PR is to address that bug by removing escaping for all the special characters. Rather, inform the user not to use reserved character as string