### PR TITLE
fix: use x-www-form-urlencoded for token exchange requests in oauth

### DIFF
--- a/packages/hoppscotch-common/src/helpers/oauth.ts
+++ b/packages/hoppscotch-common/src/helpers/oauth.ts
@@ -250,19 +250,23 @@ const handleOAuthRedirect = async () => {
     return E.left("NO_CODE_VERIFIER" as const)
   }
 
+  const data = new URLSearchParams({
+    grant_type: "authorization_code",
+    code: queryParams.code,
+    client_id: clientID,
+    client_secret: clientSecret,
+    redirect_uri: redirectUri,
+    code_verifier: codeVerifier,
+  })
+
   // Exchange the authorization code for an access token
   const tokenResponse = await runRequestThroughInterceptor({
     url: tokenEndpoint,
-    data: JSON.stringify({
-      grant_type: "authorization_code",
-      code: queryParams.code,
-      client_id: clientID,
-      client_secret: clientSecret,
-      redirect_uri: redirectUri,
-      code_verifier: codeVerifier,
-    }),
+    data: data.toString(),
     method: "POST",
-    headers: {},
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
   })
 
   // Clean these up since we don't need them anymore


### PR DESCRIPTION
**Before**

In the last oauth update, we used `application/json` as content type for token exchange requests in auth code flow. but most oauth token exchange endpoints works with `application/x-www-form-urlencoded` content type.  

**After**

use `application/x-www-form-urlencoded` content type for token exchange requests.


