### PR TITLE
fix: perfomance in safari

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -429,6 +429,11 @@ pre.ace_editor {
   }
 }
 
+.splitpanes__pane {
+  @apply will-change-auto;
+  transform: translateZ(0);
+}
+
 .smart-splitter .splitpanes__splitter {
   @apply relative;
   @apply before:absolute;

--- a/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex h-full flex-1 flex-col">
+  <div class="h-full">
     <HoppSmartTabs
       v-model="selectedOptionTab"
       styles="sticky top-0 bg-primary z-10 border-b-0"

--- a/packages/hoppscotch-common/src/components/graphql/Response.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Response.vue
@@ -4,7 +4,7 @@
       v-if="
         response && response.length === 1 && response[0].type === 'response'
       "
-      class="flex flex-1 flex-col"
+      class="flex flex-1 flex-col relative"
     >
       <div
         class="sticky top-0 z-10 flex flex-shrink-0 items-center justify-between overflow-x-auto border-b border-dividerLight bg-primary pl-4"
@@ -72,7 +72,10 @@
           </tippy>
         </div>
       </div>
-      <div ref="schemaEditor" class="flex flex-1 flex-col"></div>
+      <div
+        ref="schemaEditor"
+        class="flex flex-1 flex-col absolute inset-0 top-10"
+      ></div>
     </div>
     <component
       :is="response[0].error.component"

--- a/packages/hoppscotch-common/src/components/graphql/Response.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Response.vue
@@ -72,7 +72,7 @@
           </tippy>
         </div>
       </div>
-      <div class="relative h-full">
+      <div class="h-full">
         <div ref="schemaEditor"></div>
       </div>
     </div>

--- a/packages/hoppscotch-common/src/components/graphql/Response.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Response.vue
@@ -4,7 +4,7 @@
       v-if="
         response && response.length === 1 && response[0].type === 'response'
       "
-      class="flex flex-1 flex-col relative"
+      class="flex flex-1 flex-col"
     >
       <div
         class="sticky top-0 z-10 flex flex-shrink-0 items-center justify-between overflow-x-auto border-b border-dividerLight bg-primary pl-4"
@@ -72,10 +72,9 @@
           </tippy>
         </div>
       </div>
-      <div
-        ref="schemaEditor"
-        class="flex flex-1 flex-col absolute inset-0 top-10"
-      ></div>
+      <div class="relative h-full">
+        <div ref="schemaEditor"></div>
+      </div>
     </div>
     <component
       :is="response[0].error.component"

--- a/packages/hoppscotch-common/src/components/graphql/Sidebar.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Sidebar.vue
@@ -145,11 +145,9 @@
           />
         </div>
       </div>
-      <div
-        v-if="schemaString"
-        ref="schemaEditor"
-        class="flex flex-1 flex-col"
-      ></div>
+      <div v-if="schemaString" class="h-full">
+        <div ref="schemaEditor" class="flex flex-1 flex-col"></div>
+      </div>
       <HoppSmartPlaceholder
         v-else
         :src="`/images/states/${colorMode.value}/blockchain.svg`"

--- a/packages/hoppscotch-common/src/components/graphql/Sidebar.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Sidebar.vue
@@ -145,8 +145,8 @@
           />
         </div>
       </div>
-      <div v-if="schemaString" class="h-full">
-        <div ref="schemaEditor" class="flex flex-1 flex-col"></div>
+      <div v-if="schemaString" class="h-full relative w-full">
+        <div ref="schemaEditor" class="absolute inset-0"></div>
       </div>
       <HoppSmartPlaceholder
         v-else

--- a/packages/hoppscotch-common/src/components/graphql/Variable.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Variable.vue
@@ -67,7 +67,9 @@
       />
     </div>
   </div>
-  <div ref="variableEditor" class="flex flex-1 flex-col"></div>
+  <div class="h-full relative">
+    <div ref="variableEditor" class="flex flex-1 flex-col"></div>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -49,7 +49,9 @@
         />
       </div>
     </div>
-    <div v-if="bulkMode" ref="bulkEditor" class="flex flex-1 flex-col"></div>
+    <div v-if="bulkMode" class="h-full relative w-full">
+      <div ref="bulkEditor" class="absolute inset-0"></div>
+    </div>
     <div v-else>
       <draggable
         v-model="workingHeaders"

--- a/packages/hoppscotch-common/src/components/http/Parameters.vue
+++ b/packages/hoppscotch-common/src/components/http/Parameters.vue
@@ -44,7 +44,9 @@
         />
       </div>
     </div>
-    <div v-if="bulkMode" ref="bulkEditor" class="flex flex-1 flex-col"></div>
+    <div v-if="bulkMode" class="h-full relative">
+      <div ref="bulkEditor" class="absolute inset-0"></div>
+    </div>
     <div v-else>
       <draggable
         v-model="workingParams"

--- a/packages/hoppscotch-common/src/components/http/PreRequestScript.vue
+++ b/packages/hoppscotch-common/src/components/http/PreRequestScript.vue
@@ -30,8 +30,8 @@
       </div>
     </div>
     <div class="flex flex-1 border-b border-dividerLight">
-      <div class="w-2/3 border-r border-dividerLight">
-        <div ref="preRequestEditor" class="h-full"></div>
+      <div class="w-2/3 border-r border-dividerLight h-full relative">
+        <div ref="preRequestEditor" class="h-full absolute inset-0"></div>
       </div>
       <div
         class="z-[9] sticky top-upperTertiaryStickyFold h-full min-w-[12rem] max-w-1/3 flex-shrink-0 overflow-auto overflow-x-auto bg-primary p-4"

--- a/packages/hoppscotch-common/src/components/http/RawBody.vue
+++ b/packages/hoppscotch-common/src/components/http/RawBody.vue
@@ -59,7 +59,9 @@
         />
       </div>
     </div>
-    <div ref="rawBodyParameters" class="flex flex-1 flex-col"></div>
+    <div class="h-full relative">
+      <div ref="rawBodyParameters" class="absolute inset-0"></div>
+    </div>
   </div>
 </template>
 

--- a/packages/hoppscotch-common/src/components/http/RequestTab.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestTab.vue
@@ -9,7 +9,7 @@
       />
     </template>
     <template #secondary>
-      <HttpResponse v-model:document="tab.document" />
+      <HttpResponse v-model:document="tab.document" :is-embed="false" />
     </template>
   </AppPaneLayout>
 </template>

--- a/packages/hoppscotch-common/src/components/http/Tests.vue
+++ b/packages/hoppscotch-common/src/components/http/Tests.vue
@@ -30,8 +30,8 @@
       </div>
     </div>
     <div class="flex flex-1 border-b border-dividerLight">
-      <div class="w-2/3 border-r border-dividerLight">
-        <div ref="testScriptEditor" class="h-full"></div>
+      <div class="w-2/3 border-r border-dividerLight h-full relative">
+        <div ref="testScriptEditor" class="h-full absolute inset-0"></div>
       </div>
       <div
         class="z-[9] sticky top-upperTertiaryStickyFold h-full min-w-[12rem] max-w-1/3 flex-shrink-0 overflow-auto overflow-x-auto bg-primary p-4"

--- a/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
+++ b/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
@@ -44,7 +44,9 @@
         />
       </div>
     </div>
-    <div v-if="bulkMode" ref="bulkEditor" class="flex flex-1 flex-col"></div>
+    <div v-if="bulkMode" class="h-full relative">
+      <div ref="bulkEditor" class="absolute inset-0"></div>
+    </div>
     <div v-else>
       <draggable
         v-model="workingUrlEncodedParams"

--- a/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
@@ -44,11 +44,9 @@
         />
       </div>
     </div>
-    <div
-      v-show="!previewEnabled"
-      ref="htmlResponse"
-      class="flex flex-1 flex-col"
-    ></div>
+    <div v-show="!previewEnabled" class="h-full">
+      <div ref="htmlResponse" class="flex flex-1 flex-col"></div>
+    </div>
     <iframe
       v-show="previewEnabled"
       ref="previewFrame"

--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -119,11 +119,12 @@
         />
       </div>
     </div>
-    <div
-      ref="jsonResponse"
-      class="flex h-auto h-full flex-1 flex-col"
-      :class="toggleFilter ? 'responseToggleOn' : 'responseToggleOff'"
-    ></div>
+    <div class="relative h-full">
+      <div
+        ref="jsonResponse"
+        :class="toggleFilter ? 'responseToggleOn' : 'responseToggleOff'"
+      ></div>
+    </div>
     <div
       v-if="outlinePath"
       class="sticky bottom-0 z-10 flex flex-shrink-0 flex-nowrap overflow-auto overflow-x-auto border-t border-dividerLight bg-primaryLight px-2"

--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -119,7 +119,7 @@
         />
       </div>
     </div>
-    <div class="relative h-full">
+    <div class="h-full">
       <div
         ref="jsonResponse"
         :class="toggleFilter ? 'responseToggleOn' : 'responseToggleOff'"

--- a/packages/hoppscotch-common/src/components/lenses/renderers/RawLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/RawLensRenderer.vue
@@ -35,7 +35,9 @@
         />
       </div>
     </div>
-    <div ref="rawResponse" class="flex flex-1 flex-col"></div>
+    <div class="h-full">
+      <div ref="rawResponse" class="flex flex-1 flex-col"></div>
+    </div>
   </div>
 </template>
 

--- a/packages/hoppscotch-common/src/components/lenses/renderers/XMLLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/XMLLensRenderer.vue
@@ -35,7 +35,9 @@
         />
       </div>
     </div>
-    <div ref="xmlResponse" class="flex flex-1 flex-col"></div>
+    <div class="h-full">
+      <div ref="xmlResponse" class="flex flex-1 flex-col"></div>
+    </div>
   </div>
 </template>
 

--- a/packages/hoppscotch-common/src/components/realtime/Communication.vue
+++ b/packages/hoppscotch-common/src/components/realtime/Communication.vue
@@ -130,7 +130,9 @@
         />
       </div>
     </div>
-    <div ref="wsCommunicationBody" class="flex flex-1 flex-col"></div>
+    <div class="h-full">
+      <div ref="wsCommunicationBody" class="flex flex-1 flex-col"></div>
+    </div>
   </div>
 </template>
 <script setup lang="ts">

--- a/packages/hoppscotch-common/src/helpers/editor/themes/baseTheme.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/themes/baseTheme.ts
@@ -171,9 +171,6 @@ export const baseTheme = EditorView.theme({
   ".cm-activeLineGutter": {
     backgroundColor: "transparent",
   },
-  ".cm-scroller::-webkit-scrollbar": {
-    display: "none",
-  },
   ".cm-foldPlaceholder": {
     backgroundColor: "var(--divider-light-color)",
     color: "var(--secondary-dark-color)",
@@ -319,9 +316,6 @@ export const inputTheme = EditorView.theme({
   },
   ".cm-activeLineGutter": {
     backgroundColor: "transparent",
-  },
-  ".cm-scroller::-webkit-scrollbar": {
-    display: "none",
   },
   ".cm-foldPlaceholder": {
     backgroundColor: "var(--divider-light-color)",


### PR DESCRIPTION
Closes HFE-433

### Description

The overall performance in Safari especially when the response section is rendered was bad and laggy.

The performance of the app in safari was bad for the following reasons

- The codemirror didn't have a parent container which leads to attain the height of the next parent element which inherited the height of the splitpanes which lead to lag while changing the height of the splitpanes

- The browser was unaware (mostly safari) of the layout paint areas due to splitpanes height/width changes rapidly, adding will-change property and changing the splitpanes to a new layer reduced the Cumulative Layout Shift and Total Blocking Time to half



### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

