### PR TITLE
fix: collection level authorization inheritance issue

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -614,8 +614,8 @@ const addNewRootCollection = (name: string) => {
         requests: [],
         headers: [],
         auth: {
-          authType: "inherit",
-          authActive: false,
+          authType: "none",
+          authActive: true,
         },
       })
     )

--- a/packages/hoppscotch-common/src/components/graphql/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Authorization.vue
@@ -32,17 +32,6 @@
               @keyup.escape="hide()"
             >
               <HoppSmartItem
-                label="None"
-                :icon="authName === 'None' ? IconCircleDot : IconCircle"
-                :active="authName === 'None'"
-                @click="
-                  () => {
-                    auth.authType = 'none'
-                    hide()
-                  }
-                "
-              />
-              <HoppSmartItem
                 v-if="!isRootCollection"
                 label="Inherit"
                 :icon="authName === 'Inherit' ? IconCircleDot : IconCircle"
@@ -50,6 +39,17 @@
                 @click="
                   () => {
                     auth.authType = 'inherit'
+                    hide()
+                  }
+                "
+              />
+              <HoppSmartItem
+                label="None"
+                :icon="authName === 'None' ? IconCircleDot : IconCircle"
+                :active="authName === 'None'"
+                @click="
+                  () => {
+                    auth.authType = 'none'
                     hide()
                   }
                 "
@@ -284,7 +284,7 @@ const authActive = pluckRef(auth, "authActive")
 
 const clearContent = () => {
   auth.value = {
-    authType: "none",
+    authType: "inherit",
     authActive: true,
   }
 }

--- a/packages/hoppscotch-common/src/components/graphql/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Authorization.vue
@@ -232,6 +232,7 @@ import { useI18n } from "@composables/i18n"
 import { useColorMode } from "@composables/theming"
 import { useVModel } from "@vueuse/core"
 import { HoppInheritedProperty } from "~/helpers/types/HoppInheritedProperties"
+import { onMounted } from "vue"
 
 const t = useI18n()
 
@@ -247,6 +248,15 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: "update:modelValue", value: HoppGQLAuth): void
 }>()
+
+onMounted(() => {
+  if (props.isRootCollection && auth.value.authType === "inherit") {
+    auth.value = {
+      authType: "none",
+      authActive: true,
+    }
+  }
+})
 
 const auth = useVModel(props, "modelValue", emit)
 

--- a/packages/hoppscotch-common/src/components/graphql/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Authorization.vue
@@ -232,7 +232,6 @@ import { useI18n } from "@composables/i18n"
 import { useColorMode } from "@composables/theming"
 import { useVModel } from "@vueuse/core"
 import { HoppInheritedProperty } from "~/helpers/types/HoppInheritedProperties"
-import { onMounted } from "vue"
 
 const t = useI18n()
 
@@ -248,15 +247,6 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: "update:modelValue", value: HoppGQLAuth): void
 }>()
-
-onMounted(() => {
-  if (props.isRootCollection && auth.value.authType === "inherit") {
-    auth.value = {
-      authType: "none",
-      authActive: true,
-    }
-  }
-})
 
 const auth = useVModel(props, "modelValue", emit)
 

--- a/packages/hoppscotch-common/src/components/http/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/http/Authorization.vue
@@ -213,6 +213,7 @@ import { pluckRef } from "@composables/ref"
 import { useI18n } from "@composables/i18n"
 import { useColorMode } from "@composables/theming"
 import { useVModel } from "@vueuse/core"
+import { onMounted } from "vue"
 import { HoppInheritedProperty } from "~/helpers/types/HoppInheritedProperties"
 
 const t = useI18n()
@@ -231,6 +232,15 @@ const emit = defineEmits<{
 }>()
 
 const auth = useVModel(props, "modelValue", emit)
+
+onMounted(() => {
+  if (props.isRootCollection && auth.value.authType === "inherit") {
+    auth.value = {
+      authType: "none",
+      authActive: true,
+    }
+  }
+})
 
 const AUTH_KEY_NAME = {
   basic: "Basic Auth",

--- a/packages/hoppscotch-common/src/components/http/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/http/Authorization.vue
@@ -32,17 +32,6 @@
               @keyup.escape="hide()"
             >
               <HoppSmartItem
-                label="None"
-                :icon="authName === 'None' ? IconCircleDot : IconCircle"
-                :active="authName === 'None'"
-                @click="
-                  () => {
-                    auth.authType = 'none'
-                    hide()
-                  }
-                "
-              />
-              <HoppSmartItem
                 v-if="!isRootCollection"
                 label="Inherit"
                 :icon="authName === 'Inherit' ? IconCircleDot : IconCircle"
@@ -50,6 +39,17 @@
                 @click="
                   () => {
                     auth.authType = 'inherit'
+                    hide()
+                  }
+                "
+              />
+              <HoppSmartItem
+                label="None"
+                :icon="authName === 'None' ? IconCircleDot : IconCircle"
+                :active="authName === 'None'"
+                @click="
+                  () => {
+                    auth.authType = 'none'
                     hide()
                   }
                 "
@@ -213,7 +213,6 @@ import { pluckRef } from "@composables/ref"
 import { useI18n } from "@composables/i18n"
 import { useColorMode } from "@composables/theming"
 import { useVModel } from "@vueuse/core"
-import { onMounted } from "vue"
 import { HoppInheritedProperty } from "~/helpers/types/HoppInheritedProperties"
 
 const t = useI18n()
@@ -232,15 +231,6 @@ const emit = defineEmits<{
 }>()
 
 const auth = useVModel(props, "modelValue", emit)
-
-onMounted(() => {
-  if (props.isRootCollection && auth.value.authType === "inherit") {
-    auth.value = {
-      authType: "none",
-      authActive: true,
-    }
-  }
-})
 
 const AUTH_KEY_NAME = {
   basic: "Basic Auth",
@@ -265,7 +255,7 @@ const authActive = pluckRef(auth, "authActive")
 
 const clearContent = () => {
   auth.value = {
-    authType: "none",
+    authType: "inherit",
     authActive: true,
   }
 }

--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -18,7 +18,7 @@ const samples = [
       method: "GET",
       name: "Untitled",
       endpoint: "https://echo.hoppscotch.io/",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       body: {
         contentType: "application/x-www-form-urlencoded",
         body: rawKeyValueEntriesToString([
@@ -149,7 +149,7 @@ const samples = [
       method: "GET",
       name: "Untitled",
       endpoint: "https://google.com/",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       body: {
         contentType: null,
         body: null,
@@ -166,7 +166,7 @@ const samples = [
       method: "POST",
       name: "Untitled",
       endpoint: "http://localhost:1111/hello/world/?buzz",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       body: {
         contentType: "application/json",
         body: `{\n  "foo": "bar"\n}`,
@@ -189,7 +189,7 @@ const samples = [
       method: "GET",
       name: "Untitled",
       endpoint: "https://example.com/",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       body: {
         contentType: null,
         body: null,
@@ -217,7 +217,7 @@ const samples = [
       method: "POST",
       name: "Untitled",
       endpoint: "https://bing.com/",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       body: {
         contentType: "multipart/form-data",
         body: [
@@ -301,7 +301,7 @@ const samples = [
       name: "Untitled",
       endpoint: "http://localhost:9900/",
       auth: {
-        authType: "none",
+        authType: "inherit",
         authActive: true,
       },
       body: {
@@ -345,7 +345,7 @@ const samples = [
       endpoint: "https://hoppscotch.io/?io",
       auth: {
         authActive: true,
-        authType: "none",
+        authType: "inherit",
       },
       body: {
         contentType: null,
@@ -380,7 +380,7 @@ const samples = [
       endpoint: "https://someshadywebsite.com/questionable/path/?so",
       auth: {
         authActive: true,
-        authType: "none",
+        authType: "inherit",
       },
       body: {
         contentType: "multipart/form-data",
@@ -441,7 +441,7 @@ const samples = [
       endpoint: "http://localhost/",
       auth: {
         authActive: true,
-        authType: "none",
+        authType: "inherit",
       },
       body: {
         contentType: "multipart/form-data",
@@ -473,7 +473,7 @@ const samples = [
       method: "GET",
       name: "Untitled",
       endpoint: "https://hoppscotch.io/",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       body: {
         contentType: null,
         body: null,
@@ -528,7 +528,7 @@ const samples = [
       method: "GET",
       name: "Untitled",
       endpoint: "https://echo.hoppscotch.io/",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       body: {
         contentType: "application/x-www-form-urlencoded",
         body: rawKeyValueEntriesToString([
@@ -573,7 +573,7 @@ const samples = [
       name: "Untitled",
       endpoint: "https://echo.hoppscotch.io/",
       method: "POST",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       headers: [
         {
           active: true,
@@ -615,7 +615,7 @@ const samples = [
       name: "Untitled",
       endpoint: "https://muxueqz.top/skybook.html",
       method: "GET",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       headers: [],
       body: { contentType: null, body: null },
       params: [],
@@ -629,7 +629,7 @@ const samples = [
       name: "Untitled",
       endpoint: "https://echo.hoppscotch.io/",
       method: "POST",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       headers: [],
       body: {
         contentType: "multipart/form-data",
@@ -653,7 +653,7 @@ const samples = [
       name: "Untitled",
       endpoint: "http://127.0.0.1/",
       method: "CUSTOMMETHOD",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       headers: [],
       body: {
         contentType: null,
@@ -670,7 +670,7 @@ const samples = [
       name: "Untitled",
       endpoint: "https://echo.hoppscotch.io/",
       method: "GET",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       headers: [
         {
           active: true,
@@ -693,7 +693,7 @@ const samples = [
       name: "Untitled",
       endpoint: "https://echo.hoppscotch.io/",
       method: "GET",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       headers: [],
       body: {
         contentType: null,
@@ -710,7 +710,7 @@ const samples = [
       name: "Untitled",
       endpoint: "https://example.org/",
       method: "HEAD",
-      auth: { authType: "none", authActive: true },
+      auth: { authType: "inherit", authActive: true },
       headers: [],
       body: {
         contentType: null,
@@ -756,7 +756,7 @@ const samples = [
       name: "Untitled",
       endpoint: "https://google.com/",
       auth: {
-        authType: "none",
+        authType: "inherit",
         authActive: true,
       },
       body: {
@@ -777,7 +777,7 @@ const samples = [
       name: "Untitled",
       endpoint: "https://google.com/",
       auth: {
-        authType: "none",
+        authType: "inherit",
         authActive: true,
       },
       body: {
@@ -797,7 +797,7 @@ const samples = [
       name: "Untitled",
       endpoint: "http://192.168.0.24:8080/ping",
       auth: {
-        authType: "none",
+        authType: "inherit",
         authActive: true,
       },
       body: {
@@ -817,7 +817,7 @@ const samples = [
       name: "Untitled",
       endpoint: "https://example.com/",
       auth: {
-        authType: "none",
+        authType: "inherit",
         authActive: true,
       },
       body: {

--- a/packages/hoppscotch-common/src/helpers/graphql/default.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/default.ts
@@ -27,7 +27,7 @@ export const getDefaultGQLRequest = (): HoppGQLRequest => ({
 }`,
   query: DEFAULT_QUERY,
   auth: {
-    authType: "none",
+    authType: "inherit",
     authActive: true,
   },
 })

--- a/packages/hoppscotch-common/src/helpers/rest/default.ts
+++ b/packages/hoppscotch-common/src/helpers/rest/default.ts
@@ -8,7 +8,7 @@ export const getDefaultRESTRequest = (): HoppRESTRequest => ({
   headers: [],
   method: "GET",
   auth: {
-    authType: "none",
+    authType: "inherit",
     authActive: true,
   },
   preRequestScript: "",

--- a/packages/hoppscotch-data/src/graphql/index.ts
+++ b/packages/hoppscotch-data/src/graphql/index.ts
@@ -57,7 +57,7 @@ export function getDefaultGQLRequest(): HoppGQLRequest {
 }`.trim(),
     query: DEFAULT_QUERY,
     auth: {
-      authType: "none",
+      authType: "inherit",
       authActive: true,
     },
   }

--- a/packages/hoppscotch-data/src/rest/index.ts
+++ b/packages/hoppscotch-data/src/rest/index.ts
@@ -167,7 +167,7 @@ export function getDefaultRESTRequest(): HoppRESTRequest {
     headers: [],
     method: "GET",
     auth: {
-      authType: "none",
+      authType: "inherit",
       authActive: true,
     },
     preRequestScript: "",


### PR DESCRIPTION
Closes HFE-422 #3713

### Description
This pull request resolves the issue of collection-level authorization inheritance in its requests. Currently, when we create a request in a collection that is supposed to inherit the auth from collection properties, we have to manually choose an auth-type called "inherit" to inherit authorization from the collection. 

Although it works when we select the option manually, it should by default inherit the auth options from the collection and prioritize request auth over collection auth without creating or selecting any auth-type called "inherit". This PR addresses the issue and changes the flow to achieve this.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed