### PR TITLE
feat: full text search for `TeamCollections` and `TeamRequests`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,17 +112,17 @@ services:
     build:
       dockerfile: packages/hoppscotch-backend/Dockerfile
       context: .
-      target: prod
+      target: dev
     env_file:
       - ./.env
     restart: always
     environment:
       # Edit the below line to match your PostgresDB URL if you have an outside DB (make sure to update the .env file as well)
-      # - DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch?connect_timeout=300
+      - DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch?connect_timeout=300
       - PORT=3000
     volumes:
       # Uncomment the line below when modifying code. Only applicable when using the "dev" target.
-      # - ./packages/hoppscotch-backend/:/usr/src/app
+      - ./packages/hoppscotch-backend/:/usr/src/app
       - /usr/src/app/node_modules/
     depends_on:
       hoppscotch-db:

--- a/packages/hoppscotch-backend/prisma/migrations/20240226053141_full_text_search_additions/migration.sql
+++ b/packages/hoppscotch-backend/prisma/migrations/20240226053141_full_text_search_additions/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE
+  "TeamCollection"
+ADD
+  titleSearch tsvector GENERATED ALWAYS AS (to_tsvector('english', title)) STORED;
+
+-- AlterTable
+ALTER TABLE
+  "TeamRequest"
+ADD
+  titleSearch tsvector GENERATED ALWAYS AS (to_tsvector('english', title)) STORED;
+
+-- CreateIndex
+CREATE INDEX "TeamCollection_textSearch_idx" ON "TeamCollection" USING GIN (titleSearch);
+
+-- CreateIndex
+CREATE INDEX "TeamRequest_textSearch_idx" ON "TeamRequest" USING GIN (titleSearch);

--- a/packages/hoppscotch-backend/prisma/schema.prisma
+++ b/packages/hoppscotch-backend/prisma/schema.prisma
@@ -41,31 +41,31 @@ model TeamInvitation {
 }
 
 model TeamCollection {
-  id         String           @id @default(cuid())
+  id         String                   @id @default(cuid())
   parentID   String?
   data       Json?
-  parent     TeamCollection?  @relation("TeamCollectionChildParent", fields: [parentID], references: [id])
-  children   TeamCollection[] @relation("TeamCollectionChildParent")
+  parent     TeamCollection?          @relation("TeamCollectionChildParent", fields: [parentID], references: [id])
+  children   TeamCollection[]         @relation("TeamCollectionChildParent")
   requests   TeamRequest[]
   teamID     String
-  team       Team             @relation(fields: [teamID], references: [id], onDelete: Cascade)
+  team       Team                     @relation(fields: [teamID], references: [id], onDelete: Cascade)
   title      String
   orderIndex Int
-  createdOn  DateTime         @default(now()) @db.Timestamp(3)
-  updatedOn  DateTime         @updatedAt @db.Timestamp(3)
+  createdOn  DateTime                 @default(now()) @db.Timestamp(3)
+  updatedOn  DateTime                 @updatedAt @db.Timestamp(3)
 }
 
 model TeamRequest {
-  id           String         @id @default(cuid())
+  id           String                   @id @default(cuid())
   collectionID String
-  collection   TeamCollection @relation(fields: [collectionID], references: [id], onDelete: Cascade)
+  collection   TeamCollection           @relation(fields: [collectionID], references: [id], onDelete: Cascade)
   teamID       String
-  team         Team           @relation(fields: [teamID], references: [id], onDelete: Cascade)
+  team         Team                     @relation(fields: [teamID], references: [id], onDelete: Cascade)
   title        String
   request      Json
   orderIndex   Int
-  createdOn    DateTime       @default(now()) @db.Timestamp(3)
-  updatedOn    DateTime       @updatedAt @db.Timestamp(3)
+  createdOn    DateTime                 @default(now()) @db.Timestamp(3)
+  updatedOn    DateTime                 @updatedAt @db.Timestamp(3)
 }
 
 model Shortcode {

--- a/packages/hoppscotch-backend/src/auth/auth.controller.ts
+++ b/packages/hoppscotch-backend/src/auth/auth.controller.ts
@@ -18,12 +18,7 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { GqlUser } from 'src/decorators/gql-user.decorator';
 import { AuthUser } from 'src/types/AuthUser';
 import { RTCookie } from 'src/decorators/rt-cookie.decorator';
-import {
-  AuthProvider,
-  authCookieHandler,
-  authProviderCheck,
-  throwHTTPErr,
-} from './helper';
+import { AuthProvider, authCookieHandler, authProviderCheck } from './helper';
 import { GoogleSSOGuard } from './guards/google-sso.guard';
 import { GithubSSOGuard } from './guards/github-sso.guard';
 import { MicrosoftSSOGuard } from './guards/microsoft-sso-.guard';
@@ -31,6 +26,7 @@ import { ThrottlerBehindProxyGuard } from 'src/guards/throttler-behind-proxy.gua
 import { SkipThrottle } from '@nestjs/throttler';
 import { AUTH_PROVIDER_NOT_SPECIFIED } from 'src/errors';
 import { ConfigService } from '@nestjs/config';
+import { throwHTTPErr } from 'src/utils';
 
 @UseGuards(ThrottlerBehindProxyGuard)
 @Controller({ path: 'auth', version: '1' })

--- a/packages/hoppscotch-backend/src/auth/auth.service.ts
+++ b/packages/hoppscotch-backend/src/auth/auth.service.ts
@@ -24,7 +24,7 @@ import {
   RefreshTokenPayload,
 } from 'src/types/AuthTokens';
 import { JwtService } from '@nestjs/jwt';
-import { AuthError } from 'src/types/AuthError';
+import { RESTError } from 'src/types/RESTError';
 import { AuthUser, IsAdmin } from 'src/types/AuthUser';
 import { VerificationToken } from '@prisma/client';
 import { Origin } from './helper';
@@ -117,7 +117,7 @@ export class AuthService {
       userUid,
     );
     if (E.isLeft(updatedUser))
-      return E.left(<AuthError>{
+      return E.left(<RESTError>{
         message: updatedUser.left,
         statusCode: HttpStatus.NOT_FOUND,
       });
@@ -255,7 +255,7 @@ export class AuthService {
    */
   async verifyMagicLinkTokens(
     magicLinkIDTokens: VerifyMagicDto,
-  ): Promise<E.Right<AuthTokens> | E.Left<AuthError>> {
+  ): Promise<E.Right<AuthTokens> | E.Left<RESTError>> {
     const passwordlessTokens = await this.validatePasswordlessTokens(
       magicLinkIDTokens,
     );
@@ -373,7 +373,7 @@ export class AuthService {
     if (usersCount === 1) {
       const elevatedUser = await this.usersService.makeAdmin(user.uid);
       if (E.isLeft(elevatedUser))
-        return E.left(<AuthError>{
+        return E.left(<RESTError>{
           message: elevatedUser.left,
           statusCode: HttpStatus.NOT_FOUND,
         });

--- a/packages/hoppscotch-backend/src/auth/guards/github-sso.guard.ts
+++ b/packages/hoppscotch-backend/src/auth/guards/github-sso.guard.ts
@@ -1,9 +1,10 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { AuthProvider, authProviderCheck, throwHTTPErr } from '../helper';
+import { AuthProvider, authProviderCheck } from '../helper';
 import { Observable } from 'rxjs';
 import { AUTH_PROVIDER_NOT_SPECIFIED } from 'src/errors';
 import { ConfigService } from '@nestjs/config';
+import { throwHTTPErr } from 'src/utils';
 
 @Injectable()
 export class GithubSSOGuard extends AuthGuard('github') implements CanActivate {

--- a/packages/hoppscotch-backend/src/auth/guards/google-sso.guard.ts
+++ b/packages/hoppscotch-backend/src/auth/guards/google-sso.guard.ts
@@ -1,9 +1,10 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { AuthProvider, authProviderCheck, throwHTTPErr } from '../helper';
+import { AuthProvider, authProviderCheck } from '../helper';
 import { Observable } from 'rxjs';
 import { AUTH_PROVIDER_NOT_SPECIFIED } from 'src/errors';
 import { ConfigService } from '@nestjs/config';
+import { throwHTTPErr } from 'src/utils';
 
 @Injectable()
 export class GoogleSSOGuard extends AuthGuard('google') implements CanActivate {

--- a/packages/hoppscotch-backend/src/auth/guards/microsoft-sso-.guard.ts
+++ b/packages/hoppscotch-backend/src/auth/guards/microsoft-sso-.guard.ts
@@ -1,9 +1,10 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { AuthProvider, authProviderCheck, throwHTTPErr } from '../helper';
+import { AuthProvider, authProviderCheck } from '../helper';
 import { Observable } from 'rxjs';
 import { AUTH_PROVIDER_NOT_SPECIFIED } from 'src/errors';
 import { ConfigService } from '@nestjs/config';
+import { throwHTTPErr } from 'src/utils';
 
 @Injectable()
 export class MicrosoftSSOGuard

--- a/packages/hoppscotch-backend/src/auth/helper.ts
+++ b/packages/hoppscotch-backend/src/auth/helper.ts
@@ -1,6 +1,5 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { DateTime } from 'luxon';
-import { AuthError } from 'src/types/AuthError';
 import { AuthTokens } from 'src/types/AuthTokens';
 import { Response } from 'express';
 import * as cookie from 'cookie';
@@ -23,15 +22,6 @@ export enum AuthProvider {
   GITHUB = 'GITHUB',
   MICROSOFT = 'MICROSOFT',
   EMAIL = 'EMAIL',
-}
-
-/**
- * This function allows throw to be used as an expression
- * @param errMessage Message present in the error message
- */
-export function throwHTTPErr(errorData: AuthError): never {
-  const { message, statusCode } = errorData;
-  throw new HttpException(message, statusCode);
 }
 
 /**

--- a/packages/hoppscotch-backend/src/errors.ts
+++ b/packages/hoppscotch-backend/src/errors.ts
@@ -229,6 +229,12 @@ export const TEAM_COL_SAME_NEXT_COLL =
   'team_coll/collection_and_next_collection_are_same';
 
 /**
+ * Team Collection search failed
+ * (TeamCollectionService)
+ */
+export const TEAM_COL_SEARCH_FAILED = 'team_coll/team_collection_search_failed';
+
+/**
  * Team Collection Re-Ordering Failed
  * (TeamCollectionService)
  */
@@ -284,6 +290,13 @@ export const TEAM_COLL_DATA_INVALID =
   'team_coll/team_coll_data_invalid' as const;
 
 /**
+ * Team Collection parent tree generation failed
+ * (TeamCollectionService)
+ */
+export const TEAM_COLL_PARENT_TREE_GEN_FAILED =
+  'team_coll/team_coll_parent_tree_generation_failed';
+
+/**
  * Tried to perform an action on a request that doesn't accept their member role level
  * (GqlRequestTeamMemberGuard)
  */
@@ -307,6 +320,19 @@ export const TEAM_REQ_INVALID_TARGET_COLL_ID =
  * (TeamRequestService)
  */
 export const TEAM_REQ_REORDERING_FAILED = 'team_req/reordering_failed' as const;
+
+/**
+ * Team Request search failed
+ * (TeamRequestService)
+ */
+export const TEAM_REQ_SEARCH_FAILED = 'team_req/team_request_search_failed';
+
+/**
+ * Team Request parent tree generation failed
+ * (TeamRequestService)
+ */
+export const TEAM_REQ_PARENT_TREE_GEN_FAILED =
+  'team_req/team_req_parent_tree_generation_failed';
 
 /**
  * No Postmark Sender Email defined

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.controller.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.controller.ts
@@ -4,9 +4,9 @@ import { InfraConfigService } from './infra-config.service';
 import * as E from 'fp-ts/Either';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RESTAdminGuard } from 'src/admin/guards/rest-admin.guard';
-import { throwHTTPErr } from 'src/auth/helper';
-import { AuthError } from 'src/types/AuthError';
+import { RESTError } from 'src/types/RESTError';
 import { InfraConfigEnumForClient } from 'src/types/InfraConfig';
+import { throwHTTPErr } from 'src/utils';
 
 @UseGuards(ThrottlerBehindProxyGuard)
 @Controller({ path: 'site', version: '1' })
@@ -21,7 +21,7 @@ export class SiteController {
     );
 
     if (E.isLeft(status))
-      throwHTTPErr(<AuthError>{
+      throwHTTPErr(<RESTError>{
         message: status.left,
         statusCode: HttpStatus.NOT_FOUND,
       });
@@ -38,7 +38,7 @@ export class SiteController {
     );
 
     if (E.isLeft(res))
-      throwHTTPErr(<AuthError>{
+      throwHTTPErr(<RESTError>{
         message: res.left,
         statusCode: HttpStatus.FORBIDDEN,
       });

--- a/packages/hoppscotch-backend/src/team-collection/helper.ts
+++ b/packages/hoppscotch-backend/src/team-collection/helper.ts
@@ -1,6 +1,14 @@
+// Type of data returned from the query to obtain all search results
 export type SearchQueryReturnType = {
   id: string;
   title: string;
   type: 'collection' | 'request';
   method?: string;
+};
+
+// Type of data returned from the query to obtain all parents
+export type ParentTreeQueryReturnType = {
+  id: string;
+  parentID: string;
+  title: string;
 };

--- a/packages/hoppscotch-backend/src/team-collection/helper.ts
+++ b/packages/hoppscotch-backend/src/team-collection/helper.ts
@@ -1,0 +1,6 @@
+export type SearchQueryReturnType = {
+  id: string;
+  title: string;
+  type: 'collection' | 'request';
+  method?: string;
+};

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
@@ -1,12 +1,12 @@
 import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { TeamCollectionService } from './team-collection.service';
-import { throwHTTPErr } from 'src/auth/helper';
 import * as E from 'fp-ts/Either';
 import { ThrottlerBehindProxyGuard } from 'src/guards/throttler-behind-proxy.guard';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RequiresTeamRole } from 'src/team/decorators/requires-team-role.decorator';
 import { TeamMemberRole } from '@prisma/client';
 import { RESTTeamMemberGuard } from 'src/team/guards/rest-team-member.guard';
+import { throwHTTPErr } from 'src/utils';
 
 @UseGuards(ThrottlerBehindProxyGuard)
 @Controller({ path: 'team-collection', version: '1' })

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
@@ -22,11 +22,13 @@ export class TeamCollectionController {
   @UseGuards(JwtAuthGuard, RESTTeamMemberGuard)
   async searchByTitle(
     @Param('searchQuery') searchQuery: string,
+    @Param('teamID') teamID: string,
     @Query('take') take: string,
     @Query('skip') skip: string,
   ) {
     const res = await this.teamCollectionService.searchByTitle(
       searchQuery,
+      teamID,
       parseInt(take),
       parseInt(skip),
     );

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
@@ -3,6 +3,10 @@ import { TeamCollectionService } from './team-collection.service';
 import { throwHTTPErr } from 'src/auth/helper';
 import * as E from 'fp-ts/Either';
 import { ThrottlerBehindProxyGuard } from 'src/guards/throttler-behind-proxy.guard';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { RequiresTeamRole } from 'src/team/decorators/requires-team-role.decorator';
+import { TeamMemberRole } from '@prisma/client';
+import { RESTTeamMemberGuard } from 'src/team/guards/rest-team-member.guard';
 
 @UseGuards(ThrottlerBehindProxyGuard)
 @Controller({ path: 'team-collection', version: '1' })
@@ -10,6 +14,12 @@ export class TeamCollectionController {
   constructor(private readonly teamCollectionService: TeamCollectionService) {}
 
   @Get('search/:teamID/:searchQuery')
+  @RequiresTeamRole(
+    TeamMemberRole.VIEWER,
+    TeamMemberRole.EDITOR,
+    TeamMemberRole.OWNER,
+  )
+  @UseGuards(JwtAuthGuard, RESTTeamMemberGuard)
   async searchByTitle(@Param('searchQuery') searchQuery: string) {
     const res = await this.teamCollectionService.searchByTitle(searchQuery);
     if (E.isLeft(res)) throwHTTPErr(res.left);

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { TeamCollectionService } from './team-collection.service';
 import { throwHTTPErr } from 'src/auth/helper';
 import * as E from 'fp-ts/Either';
@@ -7,6 +7,7 @@ import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RequiresTeamRole } from 'src/team/decorators/requires-team-role.decorator';
 import { TeamMemberRole } from '@prisma/client';
 import { RESTTeamMemberGuard } from 'src/team/guards/rest-team-member.guard';
+import { take } from 'rxjs';
 
 @UseGuards(ThrottlerBehindProxyGuard)
 @Controller({ path: 'team-collection', version: '1' })
@@ -20,8 +21,16 @@ export class TeamCollectionController {
     TeamMemberRole.OWNER,
   )
   @UseGuards(JwtAuthGuard, RESTTeamMemberGuard)
-  async searchByTitle(@Param('searchQuery') searchQuery: string) {
-    const res = await this.teamCollectionService.searchByTitle(searchQuery);
+  async searchByTitle(
+    @Param('searchQuery') searchQuery: string,
+    @Query('take') take: string,
+    @Query('skip') skip: string,
+  ) {
+    const res = await this.teamCollectionService.searchByTitle(
+      searchQuery,
+      parseInt(take),
+      parseInt(skip),
+    );
     if (E.isLeft(res)) throwHTTPErr(res.left);
     return res.right;
   }

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
@@ -7,7 +7,6 @@ import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RequiresTeamRole } from 'src/team/decorators/requires-team-role.decorator';
 import { TeamMemberRole } from '@prisma/client';
 import { RESTTeamMemberGuard } from 'src/team/guards/rest-team-member.guard';
-import { take } from 'rxjs';
 
 @UseGuards(ThrottlerBehindProxyGuard)
 @Controller({ path: 'team-collection', version: '1' })

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { TeamCollectionService } from './team-collection.service';
+import { throwHTTPErr } from 'src/auth/helper';
+import * as E from 'fp-ts/Either';
+import { ThrottlerBehindProxyGuard } from 'src/guards/throttler-behind-proxy.guard';
+
+@UseGuards(ThrottlerBehindProxyGuard)
+@Controller({ path: 'team-collection', version: '1' })
+export class TeamCollectionController {
+  constructor(private readonly teamCollectionService: TeamCollectionService) {}
+
+  @Get('search/:teamID/:searchQuery')
+  async searchByTitle(@Param('searchQuery') searchQuery: string) {
+    const res = await this.teamCollectionService.searchByTitle(searchQuery);
+    if (E.isLeft(res)) throwHTTPErr(res.left);
+    return res.right;
+  }
+}

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.module.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.module.ts
@@ -6,6 +6,7 @@ import { GqlCollectionTeamMemberGuard } from './guards/gql-collection-team-membe
 import { TeamModule } from '../team/team.module';
 import { UserModule } from '../user/user.module';
 import { PubSubModule } from '../pubsub/pubsub.module';
+import { TeamCollectionController } from './team-collection.controller';
 
 @Module({
   imports: [PrismaModule, TeamModule, UserModule, PubSubModule],
@@ -15,5 +16,6 @@ import { PubSubModule } from '../pubsub/pubsub.module';
     GqlCollectionTeamMemberGuard,
   ],
   exports: [TeamCollectionService, GqlCollectionTeamMemberGuard],
+  controllers: [TeamCollectionController],
 })
 export class TeamCollectionModule {}

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -28,7 +28,7 @@ import { CollectionFolder } from 'src/types/CollectionFolder';
 import { stringToJson } from 'src/utils';
 import { CollectionSearchNode } from 'src/types/CollectionSearchNode';
 import { ParentTreeQueryReturnType, SearchQueryReturnType } from './helper';
-import { AuthError } from 'src/types/AuthError';
+import { RESTError } from 'src/types/RESTError';
 
 @Injectable()
 export class TeamCollectionService {
@@ -1089,7 +1089,7 @@ export class TeamCollectionService {
       skip,
     );
     if (E.isLeft(matchedCollections))
-      return E.left(<AuthError>{
+      return E.left(<RESTError>{
         message: matchedCollections.left,
         statusCode: HttpStatus.NOT_FOUND,
       });
@@ -1102,7 +1102,7 @@ export class TeamCollectionService {
       skip,
     );
     if (E.isLeft(matchedRequests))
-      return E.left(<AuthError>{
+      return E.left(<RESTError>{
         message: matchedRequests.left,
         statusCode: HttpStatus.NOT_FOUND,
       });
@@ -1114,7 +1114,7 @@ export class TeamCollectionService {
     for (let i = 0; i < searchResults.length; i++) {
       const fetchedParentTree = await this.fetchParentTree(searchResults[i]);
       if (E.isLeft(fetchedParentTree))
-        return E.left(<AuthError>{
+        return E.left(<RESTError>{
           message: fetchedParentTree.left,
           statusCode: HttpStatus.NOT_FOUND,
         });

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1065,6 +1065,7 @@ export class TeamCollectionService {
     }
   }
 
+  // TODO: Implement Pagination for search results
   /**
    * Search for TeamCollections and TeamRequests by title
    *
@@ -1072,6 +1073,7 @@ export class TeamCollectionService {
    * @returns An Either of the search results
    */
   async searchByTitle(searchQuery: string) {
+    const start = performance.now();
     // Fetch all collections and requests that match the search query
     const searchResults: SearchQueryReturnType[] = [];
 
@@ -1082,6 +1084,7 @@ export class TeamCollectionService {
         statusCode: HttpStatus.NOT_FOUND,
       });
     searchResults.push(...matchedCollections.right);
+    console.log('Collections were fetched in', performance.now() - start, 'ms');
 
     const matchedRequests = await this.searchRequests(searchQuery);
     if (E.isLeft(matchedRequests))
@@ -1090,6 +1093,7 @@ export class TeamCollectionService {
         statusCode: HttpStatus.NOT_FOUND,
       });
     searchResults.push(...matchedRequests.right);
+    console.log('Requests were fetched in', performance.now() - start, 'ms');
 
     // Generate the parent tree for searchResults
     const searchResultsWithTree: CollectionSearchNode[] = [];
@@ -1108,9 +1112,11 @@ export class TeamCollectionService {
         id: searchResults[i].id,
         path: !fetchedParentTree
           ? []
-          : ([fetchedParentTree] as CollectionSearchNode[]),
+          : ([fetchedParentTree.right] as CollectionSearchNode[]),
       });
     }
+    console.log('Tree Generation Complete in', performance.now() - start, 'ms');
+
     return E.right({ data: searchResultsWithTree });
   }
 

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1124,9 +1124,15 @@ export class TeamCollectionService {
    * Search for TeamCollections by title
    *
    * @param searchQuery The search query
+   * @param take Number of items we want returned
+   * @param skip Number of items we want to skip
    * @returns An Either of the search results
    */
-  private async searchCollections(searchQuery, take, skip) {
+  private async searchCollections(
+    searchQuery: string,
+    take: number,
+    skip: number,
+  ) {
     const query = Prisma.sql`
     select id,title,'collection' AS type
     from "TeamCollection"
@@ -1147,9 +1153,15 @@ export class TeamCollectionService {
    * Search for TeamRequests by title
    *
    * @param searchQuery The search query
+   * @param take Number of items we want returned
+   * @param skip Number of items we want to skip
    * @returns An Either of the search results
    */
-  private async searchRequests(searchQuery, take, skip) {
+  private async searchRequests(
+    searchQuery: string,
+    take: number,
+    skip: number,
+  ) {
     const query = Prisma.sql`
     select id,title,request->>'method' as method,'request' AS type
     from "TeamRequest"
@@ -1185,7 +1197,7 @@ export class TeamCollectionService {
    * @param id The ID of the collection
    * @returns The parent tree of the collection
    */
-  private async fetchCollectionParentTree(id) {
+  private async fetchCollectionParentTree(id: string) {
     try {
       const query = Prisma.sql`
       WITH RECURSIVE collection_tree AS (
@@ -1203,7 +1215,7 @@ export class TeamCollectionService {
       SELECT * FROM collection_tree;
       `;
       const res = await this.prisma.$queryRaw(query);
-
+      console.log('fetchCollectionParentTree', res);
       const collectionParentTree = this.generateParentTree(res);
       return E.right(collectionParentTree);
     } catch (error) {
@@ -1265,7 +1277,7 @@ export class TeamCollectionService {
    * @param id The ID of the request
    * @returns The parent tree of the request
    */
-  private async fetchRequestParentTree(id) {
+  private async fetchRequestParentTree(id: string) {
     try {
       const query = Prisma.sql`
       WITH RECURSIVE request_collection_tree AS (
@@ -1284,7 +1296,7 @@ export class TeamCollectionService {
 
       `;
       const res = await this.prisma.$queryRaw(query);
-
+      console.log('fetchRequestParentTree', res);
       const requestParentTree = this.generateParentTree(res);
       return E.right(requestParentTree);
     } catch (error) {

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -27,7 +27,7 @@ import { Prisma, TeamCollection as DBTeamCollection } from '@prisma/client';
 import { CollectionFolder } from 'src/types/CollectionFolder';
 import { stringToJson } from 'src/utils';
 import { CollectionSearchNode } from 'src/types/CollectionSearchNode';
-import { SearchQueryReturnType } from './helper';
+import { ParentTreeQueryReturnType, SearchQueryReturnType } from './helper';
 import { AuthError } from 'src/types/AuthError';
 
 @Injectable()
@@ -1214,8 +1214,10 @@ export class TeamCollectionService {
       )
       SELECT * FROM collection_tree;
       `;
-      const res = await this.prisma.$queryRaw(query);
-      console.log('fetchCollectionParentTree', res);
+      const res = await this.prisma.$queryRaw<ParentTreeQueryReturnType[]>(
+        query,
+      );
+
       const collectionParentTree = this.generateParentTree(res);
       return E.right(collectionParentTree);
     } catch (error) {
@@ -1229,7 +1231,7 @@ export class TeamCollectionService {
    * @param parentCollections The parent collections
    * @returns The parent tree of the parent collections
    */
-  private generateParentTree(parentCollections) {
+  private generateParentTree(parentCollections: ParentTreeQueryReturnType[]) {
     function findChildren(id) {
       const collection = parentCollections.filter((item) => item.id === id)[0];
       if (collection.parentID == null) {
@@ -1295,8 +1297,10 @@ export class TeamCollectionService {
       SELECT * FROM request_collection_tree;
 
       `;
-      const res = await this.prisma.$queryRaw(query);
-      console.log('fetchRequestParentTree', res);
+      const res = await this.prisma.$queryRaw<ParentTreeQueryReturnType[]>(
+        query,
+      );
+
       const requestParentTree = this.generateParentTree(res);
       return E.right(requestParentTree);
     } catch (error) {

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1142,11 +1142,11 @@ export class TeamCollectionService {
     `;
     const res = await this.prisma.$queryRaw(query);
 
-    const transformedData = this.buildHierarchy(res);
-    return transformedData;
+    const collectionParentTree = this.generateParentTree(res);
+    return collectionParentTree;
   }
 
-  private buildHierarchy(parentCollections) {
+  private generateParentTree(parentCollections) {
     function findChildren(id) {
       const collection = parentCollections.filter((item) => item.id === id)[0];
       if (collection.parentID == null) {
@@ -1205,9 +1205,9 @@ export class TeamCollectionService {
     SELECT * FROM request_collection_tree;
 
     `;
-    const res = await this.prisma.$queryRaw<CollectionSearchNode[]>(query);
+    const res = await this.prisma.$queryRaw(query);
 
-    const transformedData = this.buildHierarchy(res);
-    return transformedData;
+    const requestParentTree = this.generateParentTree(res);
+    return requestParentTree;
   }
 }

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1092,7 +1092,7 @@ export class TeamCollectionService {
     return E.right(searchResultsWithTree);
   }
 
-  async searchCollections(searchQuery) {
+  private async searchCollections(searchQuery) {
     const query = Prisma.sql`
     select id,title,'collection' AS type
     from "TeamCollection"
@@ -1105,7 +1105,7 @@ export class TeamCollectionService {
     return res;
   }
 
-  async searchRequests(searchQuery) {
+  private async searchRequests(searchQuery) {
     const query = Prisma.sql`
     select id,title,request->>'method' as method,'request' AS type
     from "TeamRequest"
@@ -1118,13 +1118,13 @@ export class TeamCollectionService {
     return res;
   }
 
-  async fetchParentTree(searchResult: SearchQueryReturnType) {
+  private async fetchParentTree(searchResult: SearchQueryReturnType) {
     return searchResult.type === 'collection'
       ? await this.fetchCollectionParentTree(searchResult.id)
       : await this.fetchRequestParentTree(searchResult.id);
   }
 
-  async fetchCollectionParentTree(id) {
+  private async fetchCollectionParentTree(id) {
     const query = Prisma.sql`
     WITH RECURSIVE collection_tree AS (
       SELECT tc.id, tc."parentID", tc.title
@@ -1188,7 +1188,7 @@ export class TeamCollectionService {
     return null;
   }
 
-  async fetchRequestParentTree(id) {
+  private async fetchRequestParentTree(id) {
     const query = Prisma.sql`
     WITH RECURSIVE request_collection_tree AS (
       SELECT tc.id, tc."parentID", tc.title

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1056,4 +1056,8 @@ export class TeamCollectionService {
       return E.left(TEAM_COLL_NOT_FOUND);
     }
   }
+
+  async searchByTitle(searchQuery: string) {
+    return E.right('Hello! World');
+  }
 }

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1057,6 +1057,12 @@ export class TeamCollectionService {
     }
   }
 
+  /**
+   * Search for TeamCollections and TeamRequests by title
+   *
+   * @param searchQuery The search query
+   * @returns An Either of the search results
+   */
   async searchByTitle(searchQuery: string) {
     return E.right('Hello! World');
   }

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -28,7 +28,6 @@ import { CollectionFolder } from 'src/types/CollectionFolder';
 import { stringToJson } from 'src/utils';
 import { CollectionSearchNode } from 'src/types/CollectionSearchNode';
 import { SearchQueryReturnType } from './helper';
-import { cons } from 'fp-ts/lib/ReadonlyNonEmptyArray';
 import { AuthError } from 'src/types/AuthError';
 
 @Injectable()

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1068,6 +1068,7 @@ export class TeamCollectionService {
    * Search for TeamCollections and TeamRequests by title
    *
    * @param searchQuery The search query
+   * @param teamID The Team ID
    * @param take Number of items we want returned
    * @param skip Number of items we want to skip
    * @returns An Either of the search results

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1073,6 +1073,7 @@ export class TeamCollectionService {
    * @returns An Either of the search results
    */
   async searchByTitle(searchQuery: string) {
+    console.log('Search Query:', searchQuery);
     const start = performance.now();
     // Fetch all collections and requests that match the search query
     const searchResults: SearchQueryReturnType[] = [];
@@ -1130,8 +1131,8 @@ export class TeamCollectionService {
     const query = Prisma.sql`
     select id,title,'collection' AS type
     from "TeamCollection"
-    where to_tsvector(title) @@ to_tsquery(${searchQuery})
-    order by ts_rank(to_tsvector(title),to_tsquery(${searchQuery}))
+    where titlesearch @@ to_tsquery(${searchQuery})
+    order by ts_rank(titlesearch,to_tsquery(${searchQuery}))
     limit 10
     OFFSET 10;
   `;
@@ -1153,8 +1154,8 @@ export class TeamCollectionService {
     const query = Prisma.sql`
     select id,title,request->>'method' as method,'request' AS type
     from "TeamRequest"
-    where to_tsvector(title) @@ to_tsquery(${searchQuery})
-    order by ts_rank(to_tsvector(title),to_tsquery(${searchQuery}))
+    where titlesearch @@ to_tsquery(${searchQuery})
+    order by ts_rank(titlesearch,to_tsquery(${searchQuery}))
     limit 10
     OFFSET 10;
   `;

--- a/packages/hoppscotch-backend/src/team/guards/rest-team-member.guard.ts
+++ b/packages/hoppscotch-backend/src/team/guards/rest-team-member.guard.ts
@@ -1,0 +1,42 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { TeamService } from '../../team/team.service';
+import { TeamMemberRole } from '../../team/team.model';
+import {
+  BUG_TEAM_NO_REQUIRE_TEAM_ROLE,
+  BUG_AUTH_NO_USER_CTX,
+  BUG_TEAM_NO_TEAM_ID,
+  TEAM_MEMBER_NOT_FOUND,
+  TEAM_NOT_REQUIRED_ROLE,
+} from 'src/errors';
+
+@Injectable()
+export class RESTTeamMemberGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly teamService: TeamService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const requireRoles = this.reflector.get<TeamMemberRole[]>(
+      'requiresTeamRole',
+      context.getHandler(),
+    );
+    if (!requireRoles) throw new Error(BUG_TEAM_NO_REQUIRE_TEAM_ROLE);
+
+    const request = context.switchToHttp().getRequest();
+
+    const { user } = request;
+    if (user == undefined) throw new Error(BUG_AUTH_NO_USER_CTX);
+
+    const teamID = request.params.teamID;
+    if (!teamID) throw new Error(BUG_TEAM_NO_TEAM_ID);
+
+    const teamMember = await this.teamService.getTeamMember(teamID, user.uid);
+    if (!teamMember) throw new Error(TEAM_MEMBER_NOT_FOUND);
+
+    if (requireRoles.includes(teamMember.role)) return true;
+
+    throw new Error(TEAM_NOT_REQUIRED_ROLE);
+  }
+}

--- a/packages/hoppscotch-backend/src/team/guards/rest-team-member.guard.ts
+++ b/packages/hoppscotch-backend/src/team/guards/rest-team-member.guard.ts
@@ -9,6 +9,7 @@ import {
   TEAM_MEMBER_NOT_FOUND,
   TEAM_NOT_REQUIRED_ROLE,
 } from 'src/errors';
+import { throwHTTPErr } from 'src/utils';
 
 @Injectable()
 export class RESTTeamMemberGuard implements CanActivate {
@@ -22,21 +23,25 @@ export class RESTTeamMemberGuard implements CanActivate {
       'requiresTeamRole',
       context.getHandler(),
     );
-    if (!requireRoles) throw new Error(BUG_TEAM_NO_REQUIRE_TEAM_ROLE);
+    if (!requireRoles)
+      throwHTTPErr({ message: BUG_TEAM_NO_REQUIRE_TEAM_ROLE, statusCode: 400 });
 
     const request = context.switchToHttp().getRequest();
 
     const { user } = request;
-    if (user == undefined) throw new Error(BUG_AUTH_NO_USER_CTX);
+    if (user == undefined)
+      throwHTTPErr({ message: BUG_AUTH_NO_USER_CTX, statusCode: 400 });
 
     const teamID = request.params.teamID;
-    if (!teamID) throw new Error(BUG_TEAM_NO_TEAM_ID);
+    if (!teamID)
+      throwHTTPErr({ message: BUG_TEAM_NO_TEAM_ID, statusCode: 400 });
 
     const teamMember = await this.teamService.getTeamMember(teamID, user.uid);
-    if (!teamMember) throw new Error(TEAM_MEMBER_NOT_FOUND);
+    if (!teamMember)
+      throwHTTPErr({ message: TEAM_MEMBER_NOT_FOUND, statusCode: 404 });
 
     if (requireRoles.includes(teamMember.role)) return true;
 
-    throw new Error(TEAM_NOT_REQUIRED_ROLE);
+    throwHTTPErr({ message: TEAM_NOT_REQUIRED_ROLE, statusCode: 403 });
   }
 }

--- a/packages/hoppscotch-backend/src/types/CollectionSearchNode.ts
+++ b/packages/hoppscotch-backend/src/types/CollectionSearchNode.ts
@@ -1,0 +1,17 @@
+// Response type of results from the search query
+export type CollectionSearchNode = {
+  /** Encodes the hierarchy of where the node is **/
+  path: CollectionSearchNode[];
+} & (
+  | {
+      type: 'request';
+      title: string;
+      method: string;
+      id: string;
+    }
+  | {
+      type: 'collection';
+      title: string;
+      id: string;
+    }
+);

--- a/packages/hoppscotch-backend/src/types/RESTError.ts
+++ b/packages/hoppscotch-backend/src/types/RESTError.ts
@@ -1,10 +1,10 @@
 import { HttpStatus } from '@nestjs/common';
 
 /**
- ** Custom interface to handle errors specific to Auth module
+ ** Custom interface to handle errors for REST modules such as Auth, Admin modules
  ** Since its REST we need to return the HTTP status code along with the error message
  */
-export type AuthError = {
+export type RESTError = {
   message: string;
   statusCode: HttpStatus;
 };

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext } from '@nestjs/common';
+import { ExecutionContext, HttpException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { pipe } from 'fp-ts/lib/function';
@@ -16,6 +16,7 @@ import {
   JSON_INVALID,
 } from './errors';
 import { AuthProvider } from './auth/helper';
+import { RESTError } from './types/RESTError';
 
 /**
  * A workaround to throw an exception in an expression.
@@ -25,6 +26,15 @@ import { AuthProvider } from './auth/helper';
  */
 export function throwErr(errMessage: string): never {
   throw new Error(errMessage);
+}
+
+/**
+ * This function allows throw to be used as an expression
+ * @param errMessage Message present in the error message
+ */
+export function throwHTTPErr(errorData: RESTError): never {
+  const { message, statusCode } = errorData;
+  throw new HttpException(message, statusCode);
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes HSB-322

### Description
<!-- Add a brief description of the pull request -->
In this PR we introduce a new route that allows for full-text search to be performed over saved team collections and requests. 

`GET http://localhost:3170/v1/team-collection/search/:teamID/:searchQuery?take=5&skip=2`

We also have simple offset pagination available using the `take` and `skip` query params.

An example response to the above query may be like the following:

```
{
  "data": [
   .........,
    {
      "type": "collection",
      "title": "Get Started for BSPs",
      "id": "clt1k7d6u02h9ioerkkia6b7h",
      "path": [
        {
          "id": "clt1k7d6p02goioeri3f85nju",
          "title": "Cloud API",
          "type": "collection",
          "path": []
        }
      ]
    },
   .........,
    {
      "type": "request",
      "title": "get request",
      "method": "GET",
      "id": "clt1k7cm9000hioerpzpfpmb0",
      "path": [
        {
          "id": "clt1k7cm9000fioer57bl0n9d",
          "title": "child collection",
          "type": "collection",
          "path": {
            "id": "clt1k7cm70006ioer65sc2xsb",
            "title": "Currency Rates API",
            "type": "collection",
            "path": []
          }
        }
      ]
    },
   .........,
  ]
}
```


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
