### PR TITLE
feat: common changes for site protection

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -994,5 +994,10 @@
     "personal": "My Workspace",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
   }
 }

--- a/packages/hoppscotch-common/src/modules/index.ts
+++ b/packages/hoppscotch-common/src/modules/index.ts
@@ -34,7 +34,7 @@ export type HoppModule = {
     to: RouteLocationNormalized,
     from: RouteLocationNormalized,
     router: Router
-  ) => void
+  ) => void | Promise<void>
 
   /**
    * Called by the router to tell all the modules that a route navigation has completed

--- a/packages/hoppscotch-common/src/modules/router.ts
+++ b/packages/hoppscotch-common/src/modules/router.ts
@@ -47,15 +47,21 @@ export default <HoppModule>{
       routes,
     })
 
-    router.beforeEach((to, from) => {
+    router.beforeEach(async (to, from) => {
       _isLoadingInitialRoute.value = isInitialRoute(from)
 
+      const onBeforeRouteChangePromises: Promise<any>[] = []
+
       HOPP_MODULES.forEach((mod) => {
-        mod.onBeforeRouteChange?.(to, from, router)
+        const res = mod.onBeforeRouteChange?.(to, from, router)
+        if (res) onBeforeRouteChangePromises.push(res)
       })
       platform.addedHoppModules?.forEach((mod) => {
-        mod.onBeforeRouteChange?.(to, from, router)
+        const res = mod.onBeforeRouteChange?.(to, from, router)
+        if (res) onBeforeRouteChangePromises.push(res)
       })
+
+      await Promise.all(onBeforeRouteChangePromises)
     })
 
     // Instead of this a better architecture is for the router

--- a/packages/hoppscotch-common/src/pages/enter.vue
+++ b/packages/hoppscotch-common/src/pages/enter.vue
@@ -44,4 +44,5 @@ export default defineComponent({
 <route lang="yaml">
 meta:
   layout: empty
+  onlyGuest: true
 </route>


### PR DESCRIPTION
Fixs HFE-410

**Changes**

1. make router beforeEach guard wait for the modules returning promises to resolve before going to the target route
2. allow guest only access for enter.vue, this is a requirement to prevent getting redirected to login-required page if site protection is enabled, because we use enter for verifying the magic link
3. add i18n entries for site protection related texts