### PR TITLE
refactor: personal workspace nomenclature update

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -988,7 +988,6 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "Personal Workspace",
-    "personal_workspace": "{name}'s Workspace",
     "other_workspaces": "My Workspaces",
     "team": "Workspace",
     "title": "Workspaces"

--- a/packages/hoppscotch-common/src/components/app/Header.vue
+++ b/packages/hoppscotch-common/src/components/app/Header.vue
@@ -331,8 +331,9 @@ const myTeams = useReadonlyStream(teamListAdapter.teamList$, null)
 const workspace = workspaceService.currentWorkspace
 
 const workspaceName = computed(() => {
-  if (workspace.value.type === "personal") return t("workspace.personal")
-  return workspace.value.teamName
+  return workspace.value.type === "personal"
+    ? t("workspace.personal")
+    : workspace.value.teamName
 })
 
 const refetchTeams = () => {

--- a/packages/hoppscotch-common/src/components/app/Header.vue
+++ b/packages/hoppscotch-common/src/components/app/Header.vue
@@ -331,13 +331,7 @@ const myTeams = useReadonlyStream(teamListAdapter.teamList$, null)
 const workspace = workspaceService.currentWorkspace
 
 const workspaceName = computed(() => {
-  if (workspace.value.type === "personal") {
-    return currentUser.value?.displayName
-      ? t("workspace.personal_workspace", {
-          name: currentUser.value.displayName,
-        })
-      : t("workspace.personal")
-  }
+  if (workspace.value.type === "personal") return t("workspace.personal")
   return workspace.value.teamName
 })
 

--- a/packages/hoppscotch-common/src/components/workspace/Current.vue
+++ b/packages/hoppscotch-common/src/components/workspace/Current.vue
@@ -15,8 +15,6 @@ import { computed } from "vue"
 import { useI18n } from "~/composables/i18n"
 import { useService } from "dioc/vue"
 import { WorkspaceService } from "~/services/workspace.service"
-import { useReadonlyStream } from "~/composables/stream"
-import { platform } from "~/platform"
 
 const props = defineProps<{
   section?: string
@@ -28,23 +26,11 @@ const t = useI18n()
 const workspaceService = useService(WorkspaceService)
 const workspace = workspaceService.currentWorkspace
 
-const currentUser = useReadonlyStream(
-  platform.auth.getProbableUserStream(),
-  platform.auth.getProbableUser()
-)
-
 const currentWorkspace = computed(() => {
-  const personalWorkspaceName = currentUser.value?.displayName
-    ? t("workspace.personal_workspace", { name: currentUser.value.displayName })
-    : t("workspace.personal")
-
-  if (props.isOnlyPersonal) {
-    return personalWorkspaceName
+  if (props.isOnlyPersonal || workspace.value.type === "personal") {
+    return t("workspace.personal")
   }
-  if (workspace.value.type === "team") {
-    return teamWorkspaceName.value
-  }
-  return personalWorkspaceName
+  return teamWorkspaceName.value
 })
 
 const teamWorkspaceName = computed(() => {

--- a/packages/hoppscotch-common/src/components/workspace/Selector.vue
+++ b/packages/hoppscotch-common/src/components/workspace/Selector.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-col">
       <div class="flex flex-col">
         <HoppSmartItem
-          :label="personalWorkspaceName"
+          :label="t('workspace.personal')"
           :icon="IconUser"
           :info-icon="workspace.type === 'personal' ? IconDone : undefined"
           :active-info-icon="workspace.type === 'personal'"
@@ -94,12 +94,6 @@ const showModalAdd = ref(false)
 const currentUser = useReadonlyStream(
   platform.auth.getProbableUserStream(),
   platform.auth.getProbableUser()
-)
-
-const personalWorkspaceName = computed(() =>
-  currentUser.value?.displayName
-    ? t("workspace.personal_workspace", { name: currentUser.value.displayName })
-    : t("workspace.personal")
 )
 
 const workspaceService = useService(WorkspaceService)


### PR DESCRIPTION
Closes HFE-444

### Description
Show `personal workspace` as workspace selector text even if the user has provided their name.

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

