### PR TITLE
refactor(sh-admin): updated data sharing doc links + remove disabled property from all inputs in configurations

### DIFF
--- a/packages/hoppscotch-sh-admin/src/components.d.ts
+++ b/packages/hoppscotch-sh-admin/src/components.d.ts
@@ -17,7 +17,6 @@ declare module '@vue/runtime-core' {
     HoppButtonPrimary: typeof import('@hoppscotch/ui')['HoppButtonPrimary']
     HoppButtonSecondary: typeof import('@hoppscotch/ui')['HoppButtonSecondary']
     HoppSmartAnchor: typeof import('@hoppscotch/ui')['HoppSmartAnchor']
-    HoppSmartAutoComplete: typeof import('@hoppscotch/ui')['HoppSmartAutoComplete']
     HoppSmartConfirmModal: typeof import('@hoppscotch/ui')['HoppSmartConfirmModal']
     HoppSmartInput: typeof import('@hoppscotch/ui')['HoppSmartInput']
     HoppSmartItem: typeof import('@hoppscotch/ui')['HoppSmartItem']

--- a/packages/hoppscotch-sh-admin/src/components.d.ts
+++ b/packages/hoppscotch-sh-admin/src/components.d.ts
@@ -17,6 +17,7 @@ declare module '@vue/runtime-core' {
     HoppButtonPrimary: typeof import('@hoppscotch/ui')['HoppButtonPrimary']
     HoppButtonSecondary: typeof import('@hoppscotch/ui')['HoppButtonSecondary']
     HoppSmartAnchor: typeof import('@hoppscotch/ui')['HoppSmartAnchor']
+    HoppSmartAutoComplete: typeof import('@hoppscotch/ui')['HoppSmartAutoComplete']
     HoppSmartConfirmModal: typeof import('@hoppscotch/ui')['HoppSmartConfirmModal']
     HoppSmartInput: typeof import('@hoppscotch/ui')['HoppSmartInput']
     HoppSmartItem: typeof import('@hoppscotch/ui')['HoppSmartItem']

--- a/packages/hoppscotch-sh-admin/src/components/settings/AuthProvider.vue
+++ b/packages/hoppscotch-sh-admin/src/components/settings/AuthProvider.vue
@@ -45,7 +45,6 @@
                     :type="
                       isMasked(provider.name, field.key) ? 'password' : 'text'
                     "
-                    :disabled="isMasked(provider.name, field.key)"
                     :autofocus="false"
                     class="!my-2 !bg-primaryLight flex-1"
                   />

--- a/packages/hoppscotch-sh-admin/src/components/settings/DataSharing.vue
+++ b/packages/hoppscotch-sh-admin/src/components/settings/DataSharing.vue
@@ -21,7 +21,6 @@
         </HoppSmartToggle>
       </div>
 
-      <!-- TODO: Update the link below -->
       <HoppButtonSecondary
         outline
         filled

--- a/packages/hoppscotch-sh-admin/src/components/settings/DataSharing.vue
+++ b/packages/hoppscotch-sh-admin/src/components/settings/DataSharing.vue
@@ -27,7 +27,7 @@
         filled
         :icon="IconShieldQuestion"
         :label="t('configs.data_sharing.see_shared')"
-        to="http://docs.hoppscotch.io"
+        to="https://docs.hoppscotch.io/documentation/self-host/community-edition/telemetry"
         blank
         class="w-min my-2"
       />

--- a/packages/hoppscotch-sh-admin/src/components/settings/SmtpConfiguration.vue
+++ b/packages/hoppscotch-sh-admin/src/components/settings/SmtpConfiguration.vue
@@ -37,7 +37,6 @@
                 <HoppSmartInput
                   v-model="smtpConfigs.fields[field.key]"
                   :type="isMasked(field.key) ? 'password' : 'text'"
-                  :disabled="isMasked(field.key)"
                   :autofocus="false"
                   class="!my-2 !bg-primaryLight flex-1"
                 />

--- a/packages/hoppscotch-sh-admin/src/components/setup/DataSharingAndNewsletter.vue
+++ b/packages/hoppscotch-sh-admin/src/components/setup/DataSharingAndNewsletter.vue
@@ -31,7 +31,7 @@
         <!-- TODO: Update link -->
         <HoppSmartAnchor
           blank
-          to="http://docs.hoppscotch.io"
+          to="https://docs.hoppscotch.io/documentation/self-host/community-edition/telemetry"
           :label="t('data_sharing.see_shared')"
           class="underline"
         />

--- a/packages/hoppscotch-sh-admin/src/components/setup/DataSharingAndNewsletter.vue
+++ b/packages/hoppscotch-sh-admin/src/components/setup/DataSharingAndNewsletter.vue
@@ -28,7 +28,6 @@
         >
           {{ t('data_sharing.toggle_description') }}
         </HoppSmartToggle>
-        <!-- TODO: Update link -->
         <HoppSmartAnchor
           blank
           to="https://docs.hoppscotch.io/documentation/self-host/community-edition/telemetry"


### PR DESCRIPTION
### Ticket
Closes HFE-445

### Description
This PR updates the documentation links related to Data Sharing in the Admin Dashboard. It also introduces a refactor where all inputs in configurations tab under settings page will not be disabled by default. Admins can update the input-boxes without unmasking the inputs.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed