### PR TITLE
chore: update copy for header inspection

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -27,7 +27,7 @@
     "hide_secret": "Hide secret",
     "label": "Label",
     "learn_more": "Learn more",
-    "download_now": "Download now",
+    "download_here": "Download here",
     "less": "Less",
     "more": "More",
     "new": "New",
@@ -428,7 +428,7 @@
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
-      "cookie": "Download our Hopscotch Desktop App for seamless usage. The browser doesn't allow Hopscotch to set the Cookie Header, use the Authorization Header instead on the browser."
+      "cookie": "The browser doesn't allow Hoppscotch to set Cookie Headers. Please use Authorization Headers instead. However, our Hoppscotch Desktop App is live now and support Cookies."
     },
     "response": {
       "401_error": "Please check your authentication credentials.",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -428,7 +428,7 @@
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
-      "cookie": "The browser doesn't allow Hoppscotch to set Cookie Headers. Please use Authorization Headers instead. However, our Hoppscotch Desktop App is live now and support Cookies."
+      "cookie": "The browser doesn't allow Hoppscotch to set Cookie Headers. Please use Authorization Headers instead. However, our Hoppscotch Desktop App is live now and supports Cookies."
     },
     "response": {
       "401_error": "Please check your authentication credentials.",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -428,7 +428,7 @@
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
-      "cookie": "Download now our Hopscotch Desktop App for seamless usage. The browser doesn't allow Hopscotch to set the Cookie Header, use the Authorization Header instead on browser."
+      "cookie": "Download our Hopscotch Desktop App for seamless usage. The browser doesn't allow Hopscotch to set the Cookie Header, use the Authorization Header instead on the browser."
     },
     "response": {
       "401_error": "Please check your authentication credentials.",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -27,6 +27,7 @@
     "hide_secret": "Hide secret",
     "label": "Label",
     "learn_more": "Learn more",
+    "download_now": "Download now",
     "less": "Less",
     "more": "More",
     "new": "New",
@@ -281,7 +282,7 @@
     "updated": "Environment updated",
     "value": "Value",
     "variable": "Variable",
-    "variables":"Variables",
+    "variables": "Variables",
     "variable_list": "Variable List"
   },
   "error": {
@@ -427,7 +428,7 @@
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
-      "cookie": "The browser doesn't allow Hoppscotch to set the Cookie Header. While we're working on the Hoppscotch Desktop App (coming soon), please use the Authorization Header instead."
+      "cookie": "Download now our Hopscotch Desktop App for seamless usage. The browser doesn't allow Hopscotch to set the Cookie Header, use the Authorization Header instead on browser."
     },
     "response": {
       "401_error": "Please check your authentication credentials.",

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/header.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/header.inspector.ts
@@ -66,7 +66,7 @@ export class HeaderInspectorService extends Service implements Inspector {
                 index: index,
               },
               doc: {
-                text: this.t("action.download_now"),
+                text: this.t("action.download_here"),
                 link: "https://hoppscotch.com/download",
               },
             })

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/header.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/header.inspector.ts
@@ -66,8 +66,8 @@ export class HeaderInspectorService extends Service implements Inspector {
                 index: index,
               },
               doc: {
-                text: this.t("action.learn_more"),
-                link: "https://docs.hoppscotch.io/documentation/features/inspections",
+                text: this.t("action.download_now"),
+                link: "https://hoppscotch.com/download",
               },
             })
           }


### PR DESCRIPTION
### Description
Changed copy for header inspection as the Hoppscotch Desktop app is now available

Before: The browser doesn't allow Hoppscotch to set the Cookie Header. While we're working on the Hoppscotch Desktop App (coming soon), please use the Authorization Header instead.

After: The browser doesn't allow Hoppscotch to set Cookie Headers. Please use Authorization Headers instead. However, our Hoppscotch Desktop App is live now and supports Cookies.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
