### PR TITLE
feat: focus codemirror view when ImportCurl component launched

### DIFF
--- a/packages/hoppscotch-common/src/components/http/ImportCurl.vue
+++ b/packages/hoppscotch-common/src/components/http/ImportCurl.vue
@@ -98,6 +98,7 @@ import { RESTTabService } from "~/services/tab/rest"
 import { useService } from "dioc/vue"
 import { useNestedSetting } from "~/composables/settings"
 import { toggleNestedSetting } from "~/newstore/settings"
+import { EditorView } from "@codemirror/view"
 
 const t = useI18n()
 
@@ -124,8 +125,13 @@ useCodemirror(
     linter: null,
     completer: null,
     environmentHighlights: false,
+    onInit: onInitView,
   })
 )
+
+function onInitView(view: EditorView) {
+  view.focus()
+}
 
 watch(
   () => props.show,

--- a/packages/hoppscotch-common/src/components/http/ImportCurl.vue
+++ b/packages/hoppscotch-common/src/components/http/ImportCurl.vue
@@ -125,13 +125,9 @@ useCodemirror(
     linter: null,
     completer: null,
     environmentHighlights: false,
-    onInit: onInitView,
+    onInit: (view: EditorView) => view.focus(),
   })
 )
-
-function onInitView(view: EditorView) {
-  view.focus()
-}
 
 watch(
   () => props.show,

--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -68,6 +68,9 @@ type CodeMirrorOptions = {
 
   // callback on editor update
   onUpdate?: (view: ViewUpdate) => void
+
+  // callback on view initialization
+  onInit?: (view: EditorView) => void
 }
 
 const hoppCompleterExt = (completer: Completer): Extension => {
@@ -208,7 +211,9 @@ export function useCodemirror(
   el: Ref<any | null>,
   value: Ref<string | undefined>,
   options: CodeMirrorOptions
-): { cursor: Ref<{ line: number; ch: number }> } {
+): {
+  cursor: Ref<{ line: number; ch: number }>
+} {
   const { subscribeToStream } = useStreamSubscriber()
 
   // Set default value for contextMenuEnabled if not provided
@@ -383,6 +388,8 @@ export function useCodemirror(
         extensions,
       }),
     })
+
+    options.onInit?.(view.value)
   }
 
   onMounted(() => {


### PR DESCRIPTION
### Description
This PR introduces new changes to enhance user experience within the ImportCurl component. With this update, when the ImportCurl component is launched, the CodeMirror view automatically receives focus.

- [ ] Not Completed
- [x] Completed

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed