### PR TITLE
fix(common): prevent exception with `ShortcodeListAdapter` initialization

### DIFF
--- a/packages/hoppscotch-common/src/components/share/index.vue
+++ b/packages/hoppscotch-common/src/components/share/index.vue
@@ -273,6 +273,10 @@ const loading = computed(
 )
 
 onLoggedIn(() => {
+  if (adapter.isInitialized()) {
+    return
+  }
+
   try {
     // wait for a bit to let the auth token to be set
     // because in some race conditions, the token is not set this fixes that


### PR DESCRIPTION
### Description

This PR aims at adding a safeguard to prevent an exception that can arise while attempting to initialize the `ShortCodeListAdapter` where the adapter is already initialized. This can happen while logging in on cloud with `Shared Requests` as the active tab.

Closes HFE-454.

### Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed