### PR TITLE
fix: fix direct import from url failing

### DIFF
--- a/packages/hoppscotch-common/src/pages/import.vue
+++ b/packages/hoppscotch-common/src/pages/import.vue
@@ -79,7 +79,7 @@ const importCollections = (url: unknown, type: unknown) =>
         content.data,
         TO.fromPredicate(isOfType("string")),
         TE.fromTaskOption(() => IMPORTER_INVALID_FILE_FORMAT),
-        TE.chain((data) => importer.importer(data))
+        TE.chain((data) => importer.importer([data]))
       )
     )
   )


### PR DESCRIPTION
**Before**

The importers now takes an array instead of just the import content. this update was not made in the `import.vue` file. because of this imports will fail. (test in staging server to repro.)

`https://hoppscotch.io/import?url=https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml&type=openapi`

**After**

Imports from `import.vue` also passes the contents as an array.
