### PR TITLE
fix: request failing on change content type to multipart-formdata

### DIFF
--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -274,7 +274,7 @@ function getFinalBodyFromRequest(
 
   if (request.body.contentType === "application/x-www-form-urlencoded") {
     const parsedBodyRecord = pipe(
-      request.body.body,
+      request.body.body ?? "",
       parseRawKeyValueEntriesE,
       E.map(
         flow(
@@ -311,7 +311,7 @@ function getFinalBodyFromRequest(
 
   if (request.body.contentType === "multipart/form-data") {
     return pipe(
-      request.body.body,
+      request.body.body ?? "",
       A.filter((x) => (x.key !== "" || x.isFile) && x.active), // Remove empty keys
 
       // Sort files down

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -311,7 +311,7 @@ function getFinalBodyFromRequest(
 
   if (request.body.contentType === "multipart/form-data") {
     return pipe(
-      request.body.body ?? "",
+      request.body.body ?? [],
       A.filter((x) => (x.key !== "" || x.isFile) && x.active), // Remove empty keys
 
       // Sort files down

--- a/packages/hoppscotch-data/package.json
+++ b/packages/hoppscotch-data/package.json
@@ -10,6 +10,7 @@
     "dist/*"
   ],
   "scripts": {
+    "dev": "vite build --watch",
     "build:code": "vite build",
     "build:decl": "tsc --project tsconfig.decl.json",
     "build": "pnpm run build:code && pnpm run build:decl",


### PR DESCRIPTION
### Description
When choosing the content-type as `application/x-www-form-urlencoded`, `application/multipart-formdata` and sending the request, an error appears in the console. This PR fixes the issue

- [ ] Not Completed
- [x] Completed