### PR TITLE
fix: fix typo in team search url

### DIFF
--- a/packages/hoppscotch-common/src/helpers/teams/TeamsSearch.service.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamsSearch.service.ts
@@ -205,7 +205,7 @@ export class TeamSearchService extends Service {
           this.endpoint
         }/team-collection/search/${teamID}?searchQuery=${encodeURIComponent(
           query
-        )}}`,
+        )}`,
         {
           withCredentials: true,
         }


### PR DESCRIPTION
**Before**

The url for the team search endpoint had an extra '}'

**After**

The typo is fixed.