### PR TITLE
chore: split axios request options into platform

### DIFF
--- a/packages/hoppscotch-common/src/helpers/teams/TeamsSearch.service.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamsSearch.service.ts
@@ -200,9 +200,7 @@ export class TeamSearchService extends Service {
     this.searchResultsRequests = {}
     this.expandedCollections.value = []
 
-    const axiosPlatformConfig = platform.auth.axiosPlatformConfig
-      ? platform.auth.axiosPlatformConfig()
-      : {}
+    const axiosPlatformConfig = platform.auth.axiosPlatformConfig?.() ?? {}
 
     try {
       const searchResponse = await axios.get(
@@ -211,9 +209,7 @@ export class TeamSearchService extends Service {
         }/team-collection/search/${teamID}?searchQuery=${encodeURIComponent(
           query
         )}`,
-        {
-          ...axiosPlatformConfig,
-        }
+        axiosPlatformConfig
       )
 
       if (searchResponse.status !== 200) {

--- a/packages/hoppscotch-common/src/helpers/teams/TeamsSearch.service.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamsSearch.service.ts
@@ -15,6 +15,7 @@ import { TeamRequest } from "./TeamRequest"
 import { Service } from "dioc"
 import axios from "axios"
 import { Ref } from "vue"
+import { platform } from "~/platform"
 
 type CollectionSearchMeta = {
   isSearchResult?: boolean
@@ -207,6 +208,7 @@ export class TeamSearchService extends Service {
           query
         )}`,
         {
+          headers: platform.auth.getBackendHeaders(),
           withCredentials: true,
         }
       )

--- a/packages/hoppscotch-common/src/helpers/teams/TeamsSearch.service.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamsSearch.service.ts
@@ -200,6 +200,10 @@ export class TeamSearchService extends Service {
     this.searchResultsRequests = {}
     this.expandedCollections.value = []
 
+    const axiosPlatformConfig = platform.auth.axiosPlatformConfig
+      ? platform.auth.axiosPlatformConfig()
+      : {}
+
     try {
       const searchResponse = await axios.get(
         `${
@@ -208,8 +212,7 @@ export class TeamSearchService extends Service {
           query
         )}`,
         {
-          headers: platform.auth.getBackendHeaders(),
-          withCredentials: true,
+          ...axiosPlatformConfig,
         }
       )
 

--- a/packages/hoppscotch-common/src/platform/auth.ts
+++ b/packages/hoppscotch-common/src/platform/auth.ts
@@ -3,6 +3,7 @@ import { Observable } from "rxjs"
 import { Component } from "vue"
 import { getI18n } from "~/modules/i18n"
 import * as E from "fp-ts/Either"
+import { AxiosRequestConfig } from "axios"
 
 /**
  * A common (and required) set of fields that describe a user.
@@ -134,6 +135,15 @@ export type AuthPlatformDef = {
    * @returns
    */
   getGQLClientOptions?: () => Partial<ClientOptions>
+
+  /**
+   * called by the platform to provide additional/different config options when
+   * sending requests with axios
+   * eg: SH needs to include cookies in the request, while Central doesn't and throws a cors error if it does
+   *
+   * @returns AxiosRequestConfig
+   */
+  axiosPlatformConfig?: () => AxiosRequestConfig
 
   /**
    * Returns the string content that should be returned when the user selects to

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/auth.platform.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/auth.platform.ts
@@ -211,6 +211,13 @@ export const def: AuthPlatformDef = {
     }
   },
 
+  axiosPlatformConfig() {
+    return {
+      // for including cookies in the request
+      withCredentials: true,
+    }
+  },
+
   /**
    * it is not possible for us to know if the current cookie is expired because we cannot access http-only cookies from js
    * hence just returning if the currentUser$ has a value associated with it


### PR DESCRIPTION
**Changes**

This PR introduces a new property `axiosPlatformConfig` to auth platform definition. this allows us to pass different axios configs based on the platform.

eg: Central uses Bearer Token to authenticate with the backend, while the SH uses Cookies, the configs for these can now belong in the respective platforms. 

we already do this for our Gql Client, this PR adds the same for axios configs to be used for requests sent outside of the graphql client. 