### PR TITLE
chore: spotlight improvements for team requests search

### DIFF
--- a/packages/hoppscotch-common/src/services/spotlight/searchers/collections.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/collections.searcher.ts
@@ -169,7 +169,16 @@ export class CollectionsSpotlightSearcherService
     }
 
     scopeHandle.run(() => {
+      const isPersonalWorkspace = computed(
+        () => this.workspaceService.currentWorkspace.value.type === "personal"
+      )
+
       watch(query, (query) => {
+        if (!isPersonalWorkspace.value) {
+          results.value = []
+          return
+        }
+
         if (pageCategory === "other") {
           results.value = []
           return

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/teamRequest.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/teamRequest.searcher.ts
@@ -65,6 +65,25 @@ export class TeamsSpotlightSearcherService
           immediate: true,
         }
       )
+
+      // set the search section title based on the current workspace
+      const teamName = computed(() => {
+        return (
+          (this.workspaceService.currentWorkspace.value.type === "team" &&
+            this.workspaceService.currentWorkspace.value.teamName) ||
+          this.t("team.search_title")
+        )
+      })
+
+      watch(
+        teamName,
+        (teamName) => {
+          this.searcherSectionTitle = teamName
+        },
+        {
+          immediate: true,
+        }
+      )
     })
 
     const onSessionEnd = () => {

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/teamRequest.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/teamRequest.searcher.ts
@@ -58,7 +58,7 @@ export class TeamsSpotlightSearcherService
         (query) => {
           if (this.workspaceService.currentWorkspace.value.type === "team") {
             const teamID = this.workspaceService.currentWorkspace.value.teamID
-            debouncedSearch(query, teamID)?.catch((_) => {})
+            debouncedSearch(query, teamID)?.catch(() => {})
           }
         },
         {
@@ -77,8 +77,8 @@ export class TeamsSpotlightSearcherService
 
       watch(
         teamName,
-        (teamName) => {
-          this.searcherSectionTitle = teamName
+        (newTeamName) => {
+          this.searcherSectionTitle = newTeamName
         },
         {
           immediate: true,


### PR DESCRIPTION
Fixs HFE-460

**Changes**

1. Results from the personal workspace are not shown when searching from team workspaces
2. Instead of `Team Requests`, spotlight section title will be the name of the Team Workspace