### PR TITLE
fix(common): ensure requests are translated to the latest version during import and search actions

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/hopp.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hopp.ts
@@ -37,6 +37,7 @@ export const hoppRESTImporter = (content: string[]) =>
  */
 const validateCollection = (collection: unknown) => {
   const collectionSchemaParsedResult = HoppCollection.safeParse(collection)
+
   if (collectionSchemaParsedResult.type === "ok") {
     const requests = collectionSchemaParsedResult.value.requests.map(
       (request) => {
@@ -83,19 +84,24 @@ export const hoppGQLImporter = (content: string) =>
  * @returns the collection if it is valid, else a translated version of the collection
  */
 export const validateGQLCollection = (collection: unknown) => {
-  const result = HoppCollection.safeParse(collection)
+  const collectionSchemaParsedResult = HoppCollection.safeParse(collection)
 
-  if (result.type === "ok")
-    return O.some({
-      ...result.value,
-      requests: result.value.requests.map((request) => {
+  if (collectionSchemaParsedResult.type === "ok") {
+    const requests = collectionSchemaParsedResult.value.requests.map(
+      (request) => {
         const requestSchemaParsedResult = HoppRESTRequest.safeParse(request)
 
         return requestSchemaParsedResult.type === "ok"
           ? requestSchemaParsedResult.value
           : getDefaultGQLRequest()
-      }),
+      }
+    )
+
+    return O.some({
+      ...collectionSchemaParsedResult.value,
+      requests,
     })
+  }
 
   return O.some(translateToNewGQLCollection(collection))
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hopp.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hopp.ts
@@ -1,15 +1,19 @@
-import { pipe, flow } from "fp-ts/function"
-import * as TE from "fp-ts/TaskEither"
+import {
+  HoppCollection,
+  HoppRESTRequest,
+  getDefaultGQLRequest,
+  getDefaultRESTRequest,
+  translateToNewRESTCollection,
+} from "@hoppscotch/data"
+import * as A from "fp-ts/Array"
 import * as O from "fp-ts/Option"
 import * as RA from "fp-ts/ReadonlyArray"
-import * as A from "fp-ts/Array"
-import { translateToNewRESTCollection, HoppCollection } from "@hoppscotch/data"
+import * as TE from "fp-ts/TaskEither"
+import { flow, pipe } from "fp-ts/function"
 
-import { IMPORTER_INVALID_FILE_FORMAT } from "."
-import { safeParseJSON } from "~/helpers/functional/json"
 import { translateToNewGQLCollection } from "@hoppscotch/data"
-import { entityReference } from "verzod"
-import { z } from "zod"
+import { safeParseJSON } from "~/helpers/functional/json"
+import { IMPORTER_INVALID_FILE_FORMAT } from "."
 
 export const hoppRESTImporter = (content: string[]) =>
   pipe(
@@ -32,8 +36,23 @@ export const hoppRESTImporter = (content: string[]) =>
  * else translate it into one.
  */
 const validateCollection = (collection: unknown) => {
-  const result = entityReference(HoppCollection).safeParse(collection)
-  if (result.success) return O.some(result.data)
+  const collectionSchemaParsedResult = HoppCollection.safeParse(collection)
+  if (collectionSchemaParsedResult.type === "ok") {
+    const requests = collectionSchemaParsedResult.value.requests.map(
+      (request) => {
+        const requestSchemaParsedResult = HoppRESTRequest.safeParse(request)
+
+        return requestSchemaParsedResult.type === "ok"
+          ? requestSchemaParsedResult.value
+          : getDefaultRESTRequest()
+      }
+    )
+
+    return O.some({
+      ...collectionSchemaParsedResult.value,
+      requests,
+    })
+  }
 
   return O.some(translateToNewRESTCollection(collection))
 }
@@ -64,9 +83,19 @@ export const hoppGQLImporter = (content: string) =>
  * @returns the collection if it is valid, else a translated version of the collection
  */
 export const validateGQLCollection = (collection: unknown) => {
-  const result = z.array(entityReference(HoppCollection)).safeParse(collection)
+  const result = HoppCollection.safeParse(collection)
 
-  if (result.success) return O.some(result.data)
+  if (result.type === "ok")
+    return O.some({
+      ...result.value,
+      requests: result.value.requests.map((request) => {
+        const requestSchemaParsedResult = HoppRESTRequest.safeParse(request)
+
+        return requestSchemaParsedResult.type === "ok"
+          ? requestSchemaParsedResult.value
+          : getDefaultGQLRequest()
+      }),
+    })
 
   return O.some(translateToNewGQLCollection(collection))
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hopp.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hopp.ts
@@ -11,7 +11,7 @@ import * as RA from "fp-ts/ReadonlyArray"
 import * as TE from "fp-ts/TaskEither"
 import { flow, pipe } from "fp-ts/function"
 
-import { translateToNewGQLCollection } from "@hoppscotch/data"
+import { HoppGQLRequest, translateToNewGQLCollection } from "@hoppscotch/data"
 import { safeParseJSON } from "~/helpers/functional/json"
 import { IMPORTER_INVALID_FILE_FORMAT } from "."
 
@@ -89,7 +89,7 @@ export const validateGQLCollection = (collection: unknown) => {
   if (collectionSchemaParsedResult.type === "ok") {
     const requests = collectionSchemaParsedResult.value.requests.map(
       (request) => {
-        const requestSchemaParsedResult = HoppRESTRequest.safeParse(request)
+        const requestSchemaParsedResult = HoppGQLRequest.safeParse(request)
 
         return requestSchemaParsedResult.type === "ok"
           ? requestSchemaParsedResult.value

--- a/packages/hoppscotch-common/src/helpers/teams/TeamsSearch.service.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamsSearch.service.ts
@@ -1,4 +1,14 @@
-import { ref } from "vue"
+import {
+  HoppRESTAuth,
+  HoppRESTHeader,
+  HoppRESTRequest,
+  getDefaultRESTRequest,
+} from "@hoppscotch/data"
+import axios from "axios"
+import { Service } from "dioc"
+import * as E from "fp-ts/Either"
+import { Ref, ref } from "vue"
+
 import { runGQLQuery } from "../backend/GQLClient"
 import {
   GetCollectionChildrenDocument,
@@ -7,15 +17,10 @@ import {
   GetSingleRequestDocument,
 } from "../backend/graphql"
 import { TeamCollection } from "./TeamCollection"
-import { HoppRESTAuth, HoppRESTHeader } from "@hoppscotch/data"
 
-import * as E from "fp-ts/Either"
+import { platform } from "~/platform"
 import { HoppInheritedProperty } from "../types/HoppInheritedProperties"
 import { TeamRequest } from "./TeamRequest"
-import { Service } from "dioc"
-import axios from "axios"
-import { Ref } from "vue"
-import { platform } from "~/platform"
 
 type CollectionSearchMeta = {
   isSearchResult?: boolean
@@ -150,12 +155,21 @@ function convertToTeamTree(
     if (isAlreadyInserted) return
 
     if (parentCollection) {
+      const requestSchemaParsedResult = HoppRESTRequest.safeParse(
+        request.request
+      )
+
+      const effectiveRequest =
+        requestSchemaParsedResult.type === "ok"
+          ? requestSchemaParsedResult.value
+          : getDefaultRESTRequest()
+
       parentCollection.requests = parentCollection.requests || []
       parentCollection.requests.push({
         id: request.id,
         collectionID: request.collectionID,
         title: request.title,
-        request: request.request,
+        request: effectiveRequest,
       })
     }
   })


### PR DESCRIPTION
### Description

This PR ensures requests are validated against the `HoppRESTRequest` versioned entity and translated to the latest version before consuming preventing any exceptions under the following scenarios.

- Importing a collection with requests conforming to an old schema followed by an attempt to open one among them via spotlight.
- Searching for a request in the collection tree with the above state (one or more requests not as per the latest schema) and selecting the request from the search results.

Fixes HFE-461.

### Checks

- [x] My pull request adheres to the code style of this project
- [x] All the tests have passed