### PR TITLE
fix: use proper values for `addTo` field when auth type is `api-key`

### DIFF
--- a/packages/hoppscotch-cli/src/utils/pre-request.ts
+++ b/packages/hoppscotch-cli/src/utils/pre-request.ts
@@ -136,13 +136,13 @@ export function getEffectiveRESTRequest(
       }
     } else if (request.auth.authType === "api-key") {
       const { key, value, addTo } = request.auth;
-      if (addTo === "Headers") {
+      if (addTo === "HEADERS") {
         effectiveFinalHeaders.push({
           active: true,
           key: parseTemplateString(key, envVariables),
           value: parseTemplateString(value, envVariables),
         });
-      } else if (addTo === "Query params") {
+      } else if (addTo === "QUERY_PARAMS") {
         effectiveFinalParams.push({
           active: true,
           key: parseTemplateString(key, envVariables),

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -162,6 +162,8 @@
       "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Password",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Token",

--- a/packages/hoppscotch-common/src/components/graphql/Headers.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Headers.vue
@@ -595,7 +595,7 @@ const getComputedAuthHeaders = (
   } else if (request.auth.authType === "api-key") {
     const { key, addTo } = request.auth
 
-    if (addTo === "Headers" && key) {
+    if (addTo === "HEADERS" && key) {
       headers.push({
         active: true,
         key,

--- a/packages/hoppscotch-common/src/components/http/authorization/ApiKey.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/ApiKey.vue
@@ -40,23 +40,23 @@
             @keyup.escape="hide()"
           >
             <HoppSmartItem
-              :icon="auth.addTo === 'Headers' ? IconCircleDot : IconCircle"
-              :active="auth.addTo === 'Headers'"
+              :icon="auth.addTo === 'HEADERS' ? IconCircleDot : IconCircle"
+              :active="auth.addTo === 'HEADERS'"
               :label="'Headers'"
               @click="
                 () => {
-                  auth.addTo = 'Headers'
+                  auth.addTo = 'HEADERS'
                   hide()
                 }
               "
             />
             <HoppSmartItem
-              :icon="auth.addTo === 'Query params' ? IconCircleDot : IconCircle"
-              :active="auth.addTo === 'Query params'"
+              :icon="auth.addTo === 'QUERY_PARAMS' ? IconCircleDot : IconCircle"
+              :active="auth.addTo === 'QUERY_PARAMS'"
               :label="'Query params'"
               @click="
                 () => {
-                  auth.addTo = 'Query params'
+                  auth.addTo = 'QUERY_PARAMS'
                   hide()
                 }
               "

--- a/packages/hoppscotch-common/src/components/http/authorization/ApiKey.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/ApiKey.vue
@@ -28,7 +28,13 @@
       >
         <HoppSmartSelectWrapper>
           <HoppButtonSecondary
-            :label="auth.addTo || t('state.none')"
+            :label="
+              auth.addTo
+                ? auth.addTo === 'HEADERS'
+                  ? t('authorization.pass_by_headers_label')
+                  : t('authorization.pass_by_query_params_label')
+                : t('state.none')
+            "
             class="ml-2 rounded-none pr-8"
           />
         </HoppSmartSelectWrapper>
@@ -42,7 +48,7 @@
             <HoppSmartItem
               :icon="auth.addTo === 'HEADERS' ? IconCircleDot : IconCircle"
               :active="auth.addTo === 'HEADERS'"
-              :label="'Headers'"
+              :label="t('authorization.pass_by_headers_label')"
               @click="
                 () => {
                   auth.addTo = 'HEADERS'
@@ -53,7 +59,7 @@
             <HoppSmartItem
               :icon="auth.addTo === 'QUERY_PARAMS' ? IconCircleDot : IconCircle"
               :active="auth.addTo === 'QUERY_PARAMS'"
-              :label="'Query params'"
+              :label="t('authorization.pass_by_query_params_label')"
               @click="
                 () => {
                   auth.addTo = 'QUERY_PARAMS'

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -281,9 +281,9 @@ export const runGQLOperation = async (options: RunQueryOptions) => {
       }
     } else if (auth.authType === "api-key") {
       const { key, value, addTo } = auth
-      if (addTo === "Headers") {
+      if (addTo === "HEADERS") {
         finalHeaders[key] = value
-      } else if (addTo === "Query params") {
+      } else if (addTo === "QUERY_PARAMS") {
         params[key] = value
       }
     }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
@@ -260,7 +260,7 @@ const resolveOpenAPIV3SecurityObj = (
       return {
         authType: "api-key",
         authActive: true,
-        addTo: "Headers",
+        addTo: "HEADERS",
         key: scheme.name,
         value: "",
       }
@@ -268,7 +268,7 @@ const resolveOpenAPIV3SecurityObj = (
       return {
         authType: "api-key",
         authActive: true,
-        addTo: "Query params",
+        addTo: "QUERY_PARAMS",
         key: scheme.in,
         value: "",
       }
@@ -430,7 +430,7 @@ const resolveOpenAPIV2SecurityScheme = (
     // V2 only supports in: header and in: query
     return {
       authType: "api-key",
-      addTo: scheme.in === "header" ? "Headers" : "Query params",
+      addTo: scheme.in === "header" ? "HEADERS" : "QUERY_PARAMS",
       authActive: true,
       key: scheme.name,
       value: "",

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -150,8 +150,8 @@ const getHoppReqAuth = (item: Item): HoppRESTAuth => {
       ),
       addTo:
         (getVariableValue(auth.apikey, "in") ?? "query") === "query"
-          ? "Query params"
-          : "Headers",
+          ? "QUERY_PARAMS"
+          : "HEADERS",
     }
   } else if (auth.type === "bearer") {
     return {

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -96,7 +96,7 @@ export const getComputedAuthHeaders = (
     })
   } else if (request.auth.authType === "api-key") {
     const { key, addTo } = request.auth
-    if (addTo === "Headers" && key) {
+    if (addTo === "HEADERS" && key) {
       headers.push({
         active: true,
         key: parseTemplateString(key, envVars),

--- a/packages/hoppscotch-data/src/graphql/index.ts
+++ b/packages/hoppscotch-data/src/graphql/index.ts
@@ -3,31 +3,33 @@ import { z } from "zod"
 import V1_VERSION from "./v/1"
 import V2_VERSION from "./v/2"
 import V3_VERSION from "./v/3"
+import V4_VERSION from "./v/4"
 
 export { GQLHeader } from "./v/1"
 export {
-  HoppGQLAuthAPIKey,
   HoppGQLAuthBasic,
   HoppGQLAuthBearer,
   HoppGQLAuthNone,
   HoppGQLAuthInherit,
 } from "./v/2"
 
-export { HoppGQLAuth } from "./v/3"
+export { HoppGQLAuth } from "./v/4"
 export { HoppGQLAuthOAuth2 } from "./v/3"
+export { HoppGQLAuthAPIKey } from "./v/4"
 
-export const GQL_REQ_SCHEMA_VERSION = 3
+export const GQL_REQ_SCHEMA_VERSION = 4
 
 const versionedObject = z.object({
   v: z.number(),
 })
 
 export const HoppGQLRequest = createVersionedEntity({
-  latestVersion: 3,
+  latestVersion: 4,
   versionMap: {
     1: V1_VERSION,
     2: V2_VERSION,
     3: V3_VERSION,
+    4: V4_VERSION,
   },
   getVersion(x) {
     const result = versionedObject.safeParse(x)

--- a/packages/hoppscotch-data/src/graphql/v/4.ts
+++ b/packages/hoppscotch-data/src/graphql/v/4.ts
@@ -1,0 +1,71 @@
+import { z } from "zod"
+
+import { defineVersion } from "verzod"
+
+import { HoppRESTAuthOAuth2 } from "../../rest"
+import {
+  HoppGQLAuthAPIKey as HoppGQLAuthAPIKeyOld,
+  HoppGQLAuthBasic,
+  HoppGQLAuthBearer,
+  HoppGQLAuthInherit,
+  HoppGQLAuthNone,
+} from "./2"
+import { V3_SCHEMA } from "./3"
+
+export { HoppRESTAuthOAuth2 as HoppGQLAuthOAuth2 } from "../../rest"
+
+export const HoppGQLAuthAPIKey = HoppGQLAuthAPIKeyOld.extend({
+  addTo: z.enum(["HEADERS", "QUERY_PARAMS"]).catch("HEADERS"),
+})
+
+export type HoppGqlAuthOAuth2 = z.infer<typeof HoppRESTAuthOAuth2>
+
+export const HoppGQLAuth = z
+  .discriminatedUnion("authType", [
+    HoppGQLAuthNone,
+    HoppGQLAuthInherit,
+    HoppGQLAuthBasic,
+    HoppGQLAuthBearer,
+    HoppGQLAuthAPIKey,
+    HoppRESTAuthOAuth2, // both rest and gql have the same auth type for oauth2
+  ])
+  .and(
+    z.object({
+      authActive: z.boolean(),
+    })
+  )
+
+export type HoppGQLAuth = z.infer<typeof HoppGQLAuth>
+
+export const V4_SCHEMA = V3_SCHEMA.extend({
+  v: z.literal(4),
+  auth: HoppGQLAuth,
+})
+
+export default defineVersion({
+  initial: false,
+  schema: V4_SCHEMA,
+  up(old: z.infer<typeof V3_SCHEMA>) {
+    if (old.auth.authType === "api-key") {
+      return {
+        ...old,
+        v: 4 as const,
+        auth: {
+          ...old.auth,
+          addTo:
+            old.auth.addTo === "Query params"
+              ? ("QUERY_PARAMS" as const)
+              : ("HEADERS" as const),
+        },
+      }
+    }
+
+    return {
+      ...old,
+      v: 4 as const,
+      auth: {
+        ...old.auth,
+      },
+    }
+  },
+})

--- a/packages/hoppscotch-data/src/rest/index.ts
+++ b/packages/hoppscotch-data/src/rest/index.ts
@@ -5,12 +5,13 @@ import V0_VERSION from "./v/0"
 import V1_VERSION from "./v/1"
 import V2_VERSION from "./v/2"
 import V3_VERSION from "./v/3"
+import V4_VERSION from "./v/4"
 import { createVersionedEntity, InferredEntity } from "verzod"
 import { lodashIsEqualEq, mapThenEq, undefinedEq } from "../utils/eq"
 
 import { HoppRESTReqBody, HoppRESTHeaders, HoppRESTParams } from "./v/1"
 
-import { HoppRESTAuth } from "./v/3"
+import { HoppRESTAuth } from "./v/4"
 import { HoppRESTRequestVariables } from "./v/2"
 import { z } from "zod"
 
@@ -19,7 +20,6 @@ export * from "./content-types"
 export {
   FormDataKeyValue,
   HoppRESTReqBodyFormData,
-  HoppRESTAuthAPIKey,
   HoppRESTAuthBasic,
   HoppRESTAuthInherit,
   HoppRESTAuthBearer,
@@ -29,13 +29,14 @@ export {
 } from "./v/1"
 
 export {
-  HoppRESTAuth,
   HoppRESTAuthOAuth2,
   AuthCodeGrantTypeParams,
   ClientCredentialsGrantTypeParams,
   ImplicitOauthFlowParams,
   PasswordGrantTypeParams,
 } from "./v/3"
+
+export { HoppRESTAuth, HoppRESTAuthAPIKey } from "./v/4"
 
 export { HoppRESTRequestVariables } from "./v/2"
 
@@ -45,12 +46,13 @@ const versionedObject = z.object({
 })
 
 export const HoppRESTRequest = createVersionedEntity({
-  latestVersion: 3,
+  latestVersion: 4,
   versionMap: {
     0: V0_VERSION,
     1: V1_VERSION,
     2: V2_VERSION,
     3: V3_VERSION,
+    4: V4_VERSION,
   },
   getVersion(data) {
     // For V1 onwards we have the v string storing the number
@@ -92,7 +94,7 @@ const HoppRESTRequestEq = Eq.struct<HoppRESTRequest>({
   ),
 })
 
-export const RESTReqSchemaVersion = "3"
+export const RESTReqSchemaVersion = "4"
 
 export type HoppRESTParam = HoppRESTRequest["params"][number]
 export type HoppRESTHeader = HoppRESTRequest["headers"][number]
@@ -187,7 +189,7 @@ export function makeRESTRequest(
 
 export function getDefaultRESTRequest(): HoppRESTRequest {
   return {
-    v: "3",
+    v: "4",
     endpoint: "https://echo.hoppscotch.io",
     name: "Untitled",
     params: [],

--- a/packages/hoppscotch-data/src/rest/v/4.ts
+++ b/packages/hoppscotch-data/src/rest/v/4.ts
@@ -1,0 +1,69 @@
+import { z } from "zod"
+import { defineVersion } from "verzod"
+import { HoppRESTAuthOAuth2, V3_SCHEMA } from "./3"
+import {
+  HoppRESTAuthAPIKey as HoppRESTAuthAPIKeyOld,
+  HoppRESTAuthBasic,
+  HoppRESTAuthBearer,
+  HoppRESTAuthInherit,
+  HoppRESTAuthNone,
+} from "./1"
+
+// in this new version, we update the old 'Headers' and 'Query params' to be more consistent with OAuth addTo values
+// also in the previous version addTo was a string, which prevented some bugs from being caught by the type system
+// this version uses an enum, so we get the values as literals in the type system
+export const HoppRESTAuthAPIKey = HoppRESTAuthAPIKeyOld.extend({
+  addTo: z.enum(["HEADERS", "QUERY_PARAMS"]).catch("HEADERS"),
+})
+
+export type HoppRESTAuthAPIKey = z.infer<typeof HoppRESTAuthAPIKey>
+
+export const HoppRESTAuth = z
+  .discriminatedUnion("authType", [
+    HoppRESTAuthNone,
+    HoppRESTAuthInherit,
+    HoppRESTAuthBasic,
+    HoppRESTAuthBearer,
+    HoppRESTAuthOAuth2,
+    HoppRESTAuthAPIKey,
+  ])
+  .and(
+    z.object({
+      authActive: z.boolean(),
+    })
+  )
+
+export type HoppRESTAuth = z.infer<typeof HoppRESTAuth>
+
+export const V4_SCHEMA = V3_SCHEMA.extend({
+  v: z.literal("4"),
+  auth: HoppRESTAuth,
+})
+
+export default defineVersion({
+  schema: V4_SCHEMA,
+  initial: false,
+  up(old: z.infer<typeof V3_SCHEMA>) {
+    if (old.auth.authType === "api-key") {
+      return {
+        ...old,
+        v: "4" as const,
+        auth: {
+          ...old.auth,
+          addTo:
+            old.auth.addTo === "Query params"
+              ? ("QUERY_PARAMS" as const)
+              : ("HEADERS" as const),
+        },
+      }
+    }
+
+    return {
+      ...old,
+      auth: {
+        ...old.auth,
+      },
+      v: "4" as const,
+    }
+  },
+})


### PR DESCRIPTION
FIXES HFE-466
Closes #3963

**Changes**

Previously when the auth type was `api-key`, the `addTo` field values where "Headers" or "Query params", and the type was a string.

This PR updates the `addTo` field to be an enum with the values `HEADERS` and `QUERY_PARAMS`. this is consistent with the OAuth `addTo` values, and also allows the type system to catch bugs that were previously not caught because any string value was accepted as a valid `addTo` value.

The issue [#3963](https://github.com/hoppscotch/hoppscotch/issues/3963) is coming from this inconsistency, and this PR fixes it.

We could have kept the "Headers" and "Query params" and updated some checks. but i think this is a good time to make the values consistent and better typed, hence this PR.
