### PR TITLE
Added new button to save request modal

### DIFF
--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -65,11 +65,11 @@
       @hide-modal="showRenamingReqNameModal = false"
     />
     <HoppSmartConfirmModal
-      :show="confirmingCloseForTabID !== null"
+      :show="confirmingCloseAllTabs"
       :confirm="t('modal.close_unsaved_tab')"
-      :title="t('confirm.save_unsaved_tab')"
-      @hide-modal="onCloseConfirmSaveTab"
-      @resolve="onResolveConfirmSaveTab"
+      :title="t('confirm.close_unsaved_tabs', { count: unsavedTabsCount })"
+      @hide-modal="confirmingCloseAllTabs = false"
+      @resolve="onResolveConfirmCloseAllTabs"
     />
     <HoppSmartModal
       v-if="confirmingCloseForTabID !== null"
@@ -85,12 +85,12 @@
         <span class="flex space-x-2">
           <HoppButtonPrimary
             v-focus
-            :label="t?.('action.save')"
+            :label="t?.('action.yes')"
             outline
             @click="onResolveConfirmSaveTab"
           />
           <HoppButtonSecondary
-            :label="t?.('action.dont_save')"
+            :label="t?.('action.no')"
             filled
             outline
             @click="onCloseConfirmSaveTab"

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -73,6 +73,9 @@
     />
     <HoppSmartModal
       v-if="confirmingCloseForTabID !== null"
+      dialog
+      role="dialog"
+      aria-modal="true"
       :title="t('modal.close_unsaved_tab')"
       @close="confirmingCloseForTabID = null"
     >

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -71,13 +71,41 @@
       @hide-modal="onCloseConfirmSaveTab"
       @resolve="onResolveConfirmSaveTab"
     />
-    <HoppSmartConfirmModal
-      :show="confirmingCloseAllTabs"
-      :confirm="t('modal.close_unsaved_tab')"
-      :title="t('confirm.close_unsaved_tabs', { count: unsavedTabsCount })"
-      @hide-modal="confirmingCloseAllTabs = false"
-      @resolve="onResolveConfirmCloseAllTabs"
-    />
+    <HoppSmartModal
+      v-if="confirmingCloseForTabID !== null"
+      :title="t('modal.close_unsaved_tab')"
+      @close="confirmingCloseForTabID = null"
+    >
+      <template #body>
+        <div class="text-center">
+          {{ t("confirm.save_unsaved_tab") }}
+        </div>
+      </template>
+      <template #footer>
+        <span class="flex space-x-2">
+          <HoppButtonPrimary
+            v-focus
+            :label="t?.('action.save')"
+            outline
+            @click="onResolveConfirmSaveTab"
+          />
+          <HoppButtonSecondary
+            :label="t?.('action.dont_save')"
+            filled
+            outline
+            @click="onCloseConfirmSaveTab"
+          />
+        </span>
+        <span class="flex space-x-2">
+          <HoppButtonSecondary
+            :label="t?.('action.cancel')"
+            filled
+            outline
+            @click="confirmingCloseForTabID = null"
+          />
+        </span>
+      </template>
+    </HoppSmartModal>
     <CollectionsSaveRequest
       v-if="savingRequest"
       mode="rest"

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -96,14 +96,6 @@
             @click="onCloseConfirmSaveTab"
           />
         </span>
-        <span class="flex space-x-2">
-          <HoppButtonSecondary
-            :label="t?.('action.cancel')"
-            filled
-            outline
-            @click="confirmingCloseForTabID = null"
-          />
-        </span>
       </template>
     </HoppSmartModal>
     <CollectionsSaveRequest


### PR DESCRIPTION
### Description
I noticed that you can't cancel modal window when saving a request. 
<img width="814" alt="Снимок экрана 2024-04-14 в 08 53 29" src="https://github.com/hoppscotch/hoppscotch/assets/1519243/0f75466f-f592-4fbb-a231-2c5e682feee1">

- [ ] Not Completed
- [x] Completed

I suggest adding a third "cancel" button, which will close the window without performing an action.
<img width="672" alt="Снимок экрана 2024-04-14 в 09 08 40" src="https://github.com/hoppscotch/hoppscotch/assets/1519243/15b941fa-9cfb-4623-9a9d-c9ad955f90e9">

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

