### PR TITLE
fix: rest and graphql pages not being rendered when french is selected as app language

### DIFF
--- a/packages/hoppscotch-common/locales/fr.json
+++ b/packages/hoppscotch-common/locales/fr.json
@@ -58,24 +58,6 @@
     "new": "Ajouter un nouveau",
     "star": "Ajouter une étoile"
   },
-  "cookies": {
-    "modal": {
-      "new_domain_name": "Nouveau nom de domaine",
-      "set": "Définir un cookie",
-      "cookie_string": "Chaîne de caractères de cookie",
-      "enter_cookie_string": "Saisir la chaîne de caractères du cookie",
-      "cookie_name": "Nom",
-      "cookie_value": "Valeur",
-      "cookie_path": "Chemin d'accès",
-      "cookie_expires": "Expiration",
-      "managed_tab": "Gestion",
-      "raw_tab": "Brut",
-      "interceptor_no_support": "L'intercepteur que vous avez sélectionné ne prend pas en charge les cookies. Sélectionnez un autre intercepteur et réessayez.",
-      "empty_domains": "La liste des domaines est vide",
-      "empty_domain": "Le domaine est vide",
-      "no_cookies_in_domain": "Aucun cookie n'est défini pour ce domaine"
-    }
-  },
   "app": {
     "chat_with_us": "Discuter avec nous",
     "contact_us": "Nous contacter",
@@ -187,7 +169,7 @@
   },
   "confirm": {
     "close_unsaved_tab": "Êtes-vous sûr de vouloir fermer cet onglet ?",
-    "close_unsaved_tabs": "Êtes-vous sûr de vouloir fermer tous les onglets ? {Les onglets non enregistrés seront perdus.",
+    "close_unsaved_tabs": "Êtes-vous sûr de vouloir fermer tous les onglets ? {count} onglets non enregistrés seront perd",
     "exit_team": "Êtes-vous sûr de vouloir quitter cette équipe ?",
     "logout": "Êtes-vous sûr de vouloir vous déconnecter?",
     "remove_collection": "Voulez-vous vraiment supprimer définitivement cette collection ?",
@@ -206,6 +188,24 @@
     "add_parameters": "Ajouter aux paramètres",
     "open_request_in_new_tab": "Ouvrir la demande dans un nouvel onglet",
     "set_environment_variable": "Définir comme variable"
+  },
+  "cookies": {
+    "modal": {
+      "new_domain_name": "Nouveau nom de domaine",
+      "set": "Définir un cookie",
+      "cookie_string": "Chaîne de caractères de cookie",
+      "enter_cookie_string": "Saisir la chaîne de caractères du cookie",
+      "cookie_name": "Nom",
+      "cookie_value": "Valeur",
+      "cookie_path": "Chemin d'accès",
+      "cookie_expires": "Expiration",
+      "managed_tab": "Gestion",
+      "raw_tab": "Brut",
+      "interceptor_no_support": "L'intercepteur que vous avez sélectionné ne prend pas en charge les cookies. Sélectionnez un autre intercepteur et réessayez.",
+      "empty_domains": "La liste des domaines est vide",
+      "empty_domain": "Le domaine est vide",
+      "no_cookies_in_domain": "Aucun cookie n'est défini pour ce domaine"
+    }
   },
   "count": {
     "header": "En-tête {count}",


### PR DESCRIPTION
### Ticket

- Closes HFE-481
- Fixes #4002 

### Description
This PR fixes the issue where selecting French as the app language breaks the REST and GraphQL pages of the app. 


### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed