### PR TITLE
Switching workspace doesn't invalidate context 

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -142,6 +142,11 @@ watch(workspace, (newWorkspace) => {
       })
     }
   } else if (newWorkspace.type === "team") {
+    if (selectedEnvironmentIndex.value.type !== "MY_ENV") {
+      setSelectedEnvironmentIndex({
+        type: "NO_ENV_SELECTED",
+      })
+    }
     updateSelectedTeam(newWorkspace)
   }
 })


### PR DESCRIPTION
As we change workspace we should not conserve the environment that is related to the old workspace. 

Closes #3864

### Description
When switching workspace, we go batck to "NO_ENV_SELECTED" in the local storage

