### PR TITLE
HSB-431 fix: email case sensitive in email provider

### DIFF
--- a/packages/hoppscotch-backend/src/admin/admin.service.spec.ts
+++ b/packages/hoppscotch-backend/src/admin/admin.service.spec.ts
@@ -121,6 +121,7 @@ describe('AdminService', () => {
           NOT: {
             inviteeEmail: {
               in: [dbAdminUsers[0].email],
+              mode: 'insensitive',
             },
           },
         },
@@ -229,7 +230,10 @@ describe('AdminService', () => {
 
       expect(mockPrisma.invitedUsers.deleteMany).toHaveBeenCalledWith({
         where: {
-          inviteeEmail: { in: [invitedUsers[0].inviteeEmail] },
+          inviteeEmail: {
+            in: [invitedUsers[0].inviteeEmail],
+            mode: 'insensitive',
+          },
         },
       });
       expect(result).toEqualRight(true);

--- a/packages/hoppscotch-backend/src/admin/admin.service.ts
+++ b/packages/hoppscotch-backend/src/admin/admin.service.ts
@@ -89,12 +89,17 @@ export class AdminService {
     adminEmail: string,
     inviteeEmail: string,
   ) {
-    if (inviteeEmail == adminEmail) return E.left(DUPLICATE_EMAIL);
+    if (inviteeEmail.toLowerCase() == adminEmail.toLowerCase()) {
+      return E.left(DUPLICATE_EMAIL);
+    }
     if (!validateEmail(inviteeEmail)) return E.left(INVALID_EMAIL);
 
     const alreadyInvitedUser = await this.prisma.invitedUsers.findFirst({
       where: {
-        inviteeEmail: inviteeEmail,
+        inviteeEmail: {
+          equals: inviteeEmail,
+          mode: 'insensitive',
+        },
       },
     });
     if (alreadyInvitedUser != null) return E.left(USER_ALREADY_INVITED);
@@ -159,7 +164,7 @@ export class AdminService {
     try {
       await this.prisma.invitedUsers.deleteMany({
         where: {
-          inviteeEmail: { in: inviteeEmails },
+          inviteeEmail: { in: inviteeEmails, mode: 'insensitive' },
         },
       });
       return E.right(true);
@@ -189,6 +194,7 @@ export class AdminService {
         NOT: {
           inviteeEmail: {
             in: userEmailObjs.map((user) => user.email),
+            mode: 'insensitive',
           },
         },
       },

--- a/packages/hoppscotch-backend/src/shortcode/shortcode.service.ts
+++ b/packages/hoppscotch-backend/src/shortcode/shortcode.service.ts
@@ -299,7 +299,10 @@ export class ShortcodeService implements UserDataHandler, OnModuleInit {
       where: userEmail
         ? {
             User: {
-              email: userEmail,
+              email: {
+                equals: userEmail,
+                mode: 'insensitive',
+              },
             },
           }
         : undefined,

--- a/packages/hoppscotch-backend/src/team-invitation/team-invitation.service.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invitation.service.ts
@@ -75,12 +75,13 @@ export class TeamInvitationService {
     if (!isEmailValid) return E.left(INVALID_EMAIL);
 
     try {
-      const teamInvite = await this.prisma.teamInvitation.findUniqueOrThrow({
+      const teamInvite = await this.prisma.teamInvitation.findFirstOrThrow({
         where: {
-          teamID_inviteeEmail: {
-            inviteeEmail: inviteeEmail,
-            teamID: teamID,
+          inviteeEmail: {
+            equals: inviteeEmail,
+            mode: 'insensitive',
           },
+          teamID,
         },
       });
 

--- a/packages/hoppscotch-backend/src/user/user.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user/user.service.spec.ts
@@ -149,7 +149,7 @@ beforeEach(() => {
 describe('UserService', () => {
   describe('findUserByEmail', () => {
     test('should successfully return a valid user given a valid email', async () => {
-      mockPrisma.user.findUniqueOrThrow.mockResolvedValueOnce(user);
+      mockPrisma.user.findFirst.mockResolvedValueOnce(user);
 
       const result = await userService.findUserByEmail(
         'dwight@dundermifflin.com',

--- a/packages/hoppscotch-backend/src/user/user.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user/user.service.spec.ts
@@ -158,7 +158,7 @@ describe('UserService', () => {
     });
 
     test('should return a null user given a invalid email', async () => {
-      mockPrisma.user.findUniqueOrThrow.mockRejectedValueOnce('NotFoundError');
+      mockPrisma.user.findFirst.mockResolvedValueOnce(null);
 
       const result = await userService.findUserByEmail('jim@dundermifflin.com');
       expect(result).resolves.toBeNone;

--- a/packages/hoppscotch-backend/src/user/user.service.ts
+++ b/packages/hoppscotch-backend/src/user/user.service.ts
@@ -62,16 +62,16 @@ export class UserService {
    * @returns Option of found User
    */
   async findUserByEmail(email: string): Promise<O.None | O.Some<AuthUser>> {
-    try {
-      const user = await this.prisma.user.findUniqueOrThrow({
-        where: {
-          email: email,
+    const user = await this.prisma.user.findFirst({
+      where: {
+        email: {
+          equals: email,
+          mode: 'insensitive',
         },
-      });
-      return O.some(user);
-    } catch (error) {
-      return O.none;
-    }
+      },
+    });
+    if (!user) return O.none;
+    return O.some(user);
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HSB-431
Closes #4027 

### Description
<!-- Add a brief description of the pull request -->

This pull request addresses a problem where user emails are treated as case-sensitive during signup. This means that signing up with `user@gmail.com` and `USER@gmail.com` would create two separate user entries in the database.

#### Solution
This PR implements logic to convert all email addresses to lowercase before saving them in the database. This ensures that regardless of the case used during signup, only one user entry will be created for the same email address.


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
Nil