### PR TITLE
refactor: Set default interceptor to "proxy"

### DIFF
--- a/packages/hoppscotch-common/src/newstore/settings.ts
+++ b/packages/hoppscotch-common/src/newstore/settings.ts
@@ -119,8 +119,10 @@ export const getDefaultSettings = (): SettingsDef => {
 
   // Wait for platform to initialize before setting CURRENT_INTERCEPTOR_ID
   nextTick(() => {
-    defaultSettings.CURRENT_INTERCEPTOR_ID =
-      platform.interceptors.default || "browser"
+    applySetting(
+      "CURRENT_INTERCEPTOR_ID",
+      platform?.interceptors.default || "browser"
+    )
   })
 
   return defaultSettings as SettingsDef

--- a/packages/hoppscotch-common/src/newstore/settings.ts
+++ b/packages/hoppscotch-common/src/newstore/settings.ts
@@ -71,7 +71,7 @@ export type SettingsDef = {
 }
 
 export const getDefaultSettings = (): SettingsDef => {
-  const defaultSettings: Partial<SettingsDef> = {
+  const defaultSettings: SettingsDef = {
     syncCollections: true,
     syncHistory: true,
     syncEnvironments: true,
@@ -125,7 +125,7 @@ export const getDefaultSettings = (): SettingsDef => {
     )
   })
 
-  return defaultSettings as SettingsDef
+  return defaultSettings
 }
 
 type ApplySettingPayload = {

--- a/packages/hoppscotch-common/src/newstore/settings.ts
+++ b/packages/hoppscotch-common/src/newstore/settings.ts
@@ -1,9 +1,10 @@
-import { pluck, distinctUntilChanged } from "rxjs/operators"
 import { cloneDeep, defaultsDeep, has } from "lodash-es"
 import { Observable } from "rxjs"
-
-import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
+import { distinctUntilChanged, pluck } from "rxjs/operators"
+import { nextTick } from "vue"
+import { platform } from "~/platform"
 import type { KeysMatching } from "~/types/ts-utils"
+import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
 
 export const HoppBgColors = ["system", "light", "dark", "black"] as const
 
@@ -69,51 +70,61 @@ export type SettingsDef = {
   HAS_OPENED_SPOTLIGHT: boolean
 }
 
-export const getDefaultSettings = (): SettingsDef => ({
-  syncCollections: true,
-  syncHistory: true,
-  syncEnvironments: true,
+export const getDefaultSettings = (): SettingsDef => {
+  const defaultSettings: Partial<SettingsDef> = {
+    syncCollections: true,
+    syncHistory: true,
+    syncEnvironments: true,
 
-  WRAP_LINES: {
-    httpRequestBody: true,
-    httpResponseBody: true,
-    httpHeaders: true,
-    httpParams: true,
-    httpUrlEncoded: true,
-    httpPreRequest: true,
-    httpTest: true,
-    httpRequestVariables: true,
-    graphqlQuery: true,
-    graphqlResponseBody: true,
-    graphqlHeaders: false,
-    graphqlVariables: false,
-    graphqlSchema: true,
-    importCurl: true,
-    codeGen: true,
-    cookie: true,
-  },
+    WRAP_LINES: {
+      httpRequestBody: true,
+      httpResponseBody: true,
+      httpHeaders: true,
+      httpParams: true,
+      httpUrlEncoded: true,
+      httpPreRequest: true,
+      httpTest: true,
+      httpRequestVariables: true,
+      graphqlQuery: true,
+      graphqlResponseBody: true,
+      graphqlHeaders: false,
+      graphqlVariables: false,
+      graphqlSchema: true,
+      importCurl: true,
+      codeGen: true,
+      cookie: true,
+    },
 
-  CURRENT_INTERCEPTOR_ID: "browser", // TODO: Allow the platform definition to take this place
+    CURRENT_INTERCEPTOR_ID: "",
 
-  // TODO: Interceptor related settings should move under the interceptor systems
-  PROXY_URL: "https://proxy.hoppscotch.io/",
-  URL_EXCLUDES: {
-    auth: true,
-    httpUser: true,
-    httpPassword: true,
-    bearerToken: true,
-    oauth2Token: true,
-  },
-  THEME_COLOR: "indigo",
-  BG_COLOR: "system",
-  TELEMETRY_ENABLED: true,
-  EXPAND_NAVIGATION: false,
-  SIDEBAR: true,
-  SIDEBAR_ON_LEFT: false,
-  COLUMN_LAYOUT: true,
+    // TODO: Interceptor related settings should move under the interceptor systems
+    PROXY_URL: "https://proxy.hoppscotch.io/",
+    URL_EXCLUDES: {
+      auth: true,
+      httpUser: true,
+      httpPassword: true,
+      bearerToken: true,
+      oauth2Token: true,
+    },
+    THEME_COLOR: "indigo",
+    BG_COLOR: "system",
+    TELEMETRY_ENABLED: true,
+    EXPAND_NAVIGATION: false,
+    SIDEBAR: true,
+    SIDEBAR_ON_LEFT: false,
+    COLUMN_LAYOUT: true,
 
-  HAS_OPENED_SPOTLIGHT: false,
-})
+    HAS_OPENED_SPOTLIGHT: false,
+  }
+
+  // Wait for platform to initialize before setting CURRENT_INTERCEPTOR_ID
+  nextTick(() => {
+    defaultSettings.CURRENT_INTERCEPTOR_ID =
+      platform.interceptors.default || "browser"
+  })
+
+  return defaultSettings as SettingsDef
+}
 
 type ApplySettingPayload = {
   [K in keyof SettingsDef]: {

--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -26,7 +26,7 @@ createHoppApp("#app", {
     history: historyDef,
   },
   interceptors: {
-    default: "browser",
+    default: "proxy",
     interceptors: [
       { type: "standalone", interceptor: browserInterceptor },
       { type: "standalone", interceptor: proxyInterceptor },


### PR DESCRIPTION
Closes HFE-496

### Description
This PR set's the default interceptor to "proxy" instead of "browser".

### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

