### PR TITLE
fix: persist interceptor state for logged out user

### DIFF
--- a/packages/hoppscotch-common/src/components/app/Interceptor.vue
+++ b/packages/hoppscotch-common/src/components/app/Interceptor.vue
@@ -20,7 +20,7 @@
           :label="unref(interceptor.name(t))"
           :selected="interceptorSelection === interceptor.interceptorID"
           :class="{
-            'px-0 hover:bg-transparent': !isTooltipComponent,
+            '!px-0 hover:bg-transparent': !isTooltipComponent,
           }"
           @change="interceptorSelection = interceptor.interceptorID"
         />

--- a/packages/hoppscotch-common/src/components/app/Interceptor.vue
+++ b/packages/hoppscotch-common/src/components/app/Interceptor.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col space-y-2">
-    <div class="flex flex-col px-4 pt-2">
+    <div v-if="isTooltipComponent" class="flex flex-col px-4 pt-2">
       <h2 class="inline-flex pb-1 font-semibold text-secondaryDark">
         {{ t("settings.interceptor") }}
       </h2>
@@ -19,6 +19,9 @@
           :value="interceptor.interceptorID"
           :label="unref(interceptor.name(t))"
           :selected="interceptorSelection === interceptor.interceptorID"
+          :class="{
+            'px-0 hover:bg-transparent': !isTooltipComponent,
+          }"
           @change="interceptorSelection = interceptor.interceptorID"
         />
 
@@ -38,6 +41,15 @@ import { Ref, unref } from "vue"
 import { InterceptorService } from "~/services/interceptor.service"
 
 const t = useI18n()
+
+withDefaults(
+  defineProps<{
+    isTooltipComponent?: boolean
+  }>(),
+  {
+    isTooltipComponent: true,
+  }
+)
 
 const interceptorService = useService(InterceptorService)
 

--- a/packages/hoppscotch-common/src/components/settings/Extension.vue
+++ b/packages/hoppscotch-common/src/components/settings/Extension.vue
@@ -36,16 +36,6 @@
       />
     </span>
   </div>
-  <div class="space-y-4 py-4">
-    <div class="flex items-center">
-      <HoppSmartToggle
-        :on="extensionEnabled"
-        @change="extensionEnabled = !extensionEnabled"
-      >
-        {{ t("settings.extensions_use_toggle") }}
-      </HoppSmartToggle>
-    </div>
-  </div>
 </template>
 
 <script setup lang="ts">
@@ -55,34 +45,12 @@ import IconCheckCircle from "~icons/lucide/check-circle"
 import { useI18n } from "@composables/i18n"
 import { ExtensionInterceptorService } from "~/platform/std/interceptors/extension"
 import { useService } from "dioc/vue"
-import { computed } from "vue"
-import { InterceptorService } from "~/services/interceptor.service"
-import { platform } from "~/platform"
 
 const t = useI18n()
 
-const interceptorService = useService(InterceptorService)
 const extensionService = useService(ExtensionInterceptorService)
 
 const extensionVersion = extensionService.extensionVersion
 const hasChromeExtInstalled = extensionService.chromeExtensionInstalled
 const hasFirefoxExtInstalled = extensionService.firefoxExtensionInstalled
-
-const extensionEnabled = computed({
-  get() {
-    return (
-      interceptorService.currentInterceptorID.value ===
-      extensionService.interceptorID
-    )
-  },
-  set(active) {
-    if (active) {
-      interceptorService.currentInterceptorID.value =
-        extensionService.interceptorID
-    } else {
-      interceptorService.currentInterceptorID.value =
-        platform.interceptors.default
-    }
-  },
-})
 </script>

--- a/packages/hoppscotch-common/src/components/settings/Proxy.vue
+++ b/packages/hoppscotch-common/src/components/settings/Proxy.vue
@@ -8,16 +8,6 @@
       :label="t('app.proxy_privacy_policy')"
     />.
   </div>
-  <div class="space-y-4 py-4">
-    <div class="flex items-center">
-      <HoppSmartToggle
-        :on="proxyEnabled"
-        @change="proxyEnabled = !proxyEnabled"
-      >
-        {{ t("settings.proxy_use_toggle") }}
-      </HoppSmartToggle>
-    </div>
-  </div>
   <div class="flex items-center space-x-2 py-4">
     <HoppSmartInput
       v-model="PROXY_URL"
@@ -50,7 +40,6 @@ import { computed } from "vue"
 import { useService } from "dioc/vue"
 import { InterceptorService } from "~/services/interceptor.service"
 import { proxyInterceptor } from "~/platform/std/interceptors/proxy"
-import { platform } from "~/platform"
 
 const t = useI18n()
 const toast = useToast()
@@ -59,23 +48,11 @@ const interceptorService = useService(InterceptorService)
 
 const PROXY_URL = useSetting("PROXY_URL")
 
-const proxyEnabled = computed({
-  get() {
-    return (
-      interceptorService.currentInterceptorID.value ===
-      proxyInterceptor.interceptorID
-    )
-  },
-  set(active) {
-    if (active) {
-      interceptorService.currentInterceptorID.value =
-        proxyInterceptor.interceptorID
-    } else {
-      interceptorService.currentInterceptorID.value =
-        platform.interceptors.default
-    }
-  },
-})
+const proxyEnabled = computed(
+  () =>
+    interceptorService.currentInterceptorID.value ===
+    proxyInterceptor.interceptorID
+)
 
 const clearIcon = refAutoReset<typeof IconRotateCCW | typeof IconCheck>(
   IconRotateCCW,

--- a/packages/hoppscotch-common/src/newstore/settings.ts
+++ b/packages/hoppscotch-common/src/newstore/settings.ts
@@ -1,8 +1,6 @@
 import { cloneDeep, defaultsDeep, has } from "lodash-es"
 import { Observable } from "rxjs"
 import { distinctUntilChanged, pluck } from "rxjs/operators"
-import { nextTick } from "vue"
-import { platform } from "~/platform"
 import type { KeysMatching } from "~/types/ts-utils"
 import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
 
@@ -70,61 +68,52 @@ export type SettingsDef = {
   HAS_OPENED_SPOTLIGHT: boolean
 }
 
-export const getDefaultSettings = (): SettingsDef => {
-  const defaultSettings: SettingsDef = {
-    syncCollections: true,
-    syncHistory: true,
-    syncEnvironments: true,
+export const getDefaultSettings = (): SettingsDef => ({
+  syncCollections: true,
+  syncHistory: true,
+  syncEnvironments: true,
 
-    WRAP_LINES: {
-      httpRequestBody: true,
-      httpResponseBody: true,
-      httpHeaders: true,
-      httpParams: true,
-      httpUrlEncoded: true,
-      httpPreRequest: true,
-      httpTest: true,
-      httpRequestVariables: true,
-      graphqlQuery: true,
-      graphqlResponseBody: true,
-      graphqlHeaders: false,
-      graphqlVariables: false,
-      graphqlSchema: true,
-      importCurl: true,
-      codeGen: true,
-      cookie: true,
-    },
+  WRAP_LINES: {
+    httpRequestBody: true,
+    httpResponseBody: true,
+    httpHeaders: true,
+    httpParams: true,
+    httpUrlEncoded: true,
+    httpPreRequest: true,
+    httpTest: true,
+    httpRequestVariables: true,
+    graphqlQuery: true,
+    graphqlResponseBody: true,
+    graphqlHeaders: false,
+    graphqlVariables: false,
+    graphqlSchema: true,
+    importCurl: true,
+    codeGen: true,
+    cookie: true,
+  },
 
-    CURRENT_INTERCEPTOR_ID: "",
+  // Set empty because interceptor module will set the default value
+  CURRENT_INTERCEPTOR_ID: "",
 
-    // TODO: Interceptor related settings should move under the interceptor systems
-    PROXY_URL: "https://proxy.hoppscotch.io/",
-    URL_EXCLUDES: {
-      auth: true,
-      httpUser: true,
-      httpPassword: true,
-      bearerToken: true,
-      oauth2Token: true,
-    },
-    THEME_COLOR: "indigo",
-    BG_COLOR: "system",
-    TELEMETRY_ENABLED: true,
-    EXPAND_NAVIGATION: false,
-    SIDEBAR: true,
-    SIDEBAR_ON_LEFT: false,
-    COLUMN_LAYOUT: true,
+  // TODO: Interceptor related settings should move under the interceptor systems
+  PROXY_URL: "https://proxy.hoppscotch.io/",
+  URL_EXCLUDES: {
+    auth: true,
+    httpUser: true,
+    httpPassword: true,
+    bearerToken: true,
+    oauth2Token: true,
+  },
+  THEME_COLOR: "indigo",
+  BG_COLOR: "system",
+  TELEMETRY_ENABLED: true,
+  EXPAND_NAVIGATION: false,
+  SIDEBAR: true,
+  SIDEBAR_ON_LEFT: false,
+  COLUMN_LAYOUT: true,
 
-    HAS_OPENED_SPOTLIGHT: false,
-  }
-
-  // Wait for platform to initialize before setting CURRENT_INTERCEPTOR_ID
-  nextTick(() => {
-    defaultSettings.CURRENT_INTERCEPTOR_ID =
-      platform?.interceptors.default || "browser"
-  })
-
-  return defaultSettings
-}
+  HAS_OPENED_SPOTLIGHT: false,
+})
 
 type ApplySettingPayload = {
   [K in keyof SettingsDef]: {

--- a/packages/hoppscotch-common/src/newstore/settings.ts
+++ b/packages/hoppscotch-common/src/newstore/settings.ts
@@ -119,10 +119,8 @@ export const getDefaultSettings = (): SettingsDef => {
 
   // Wait for platform to initialize before setting CURRENT_INTERCEPTOR_ID
   nextTick(() => {
-    applySetting(
-      "CURRENT_INTERCEPTOR_ID",
+    defaultSettings.CURRENT_INTERCEPTOR_ID =
       platform?.interceptors.default || "browser"
-    )
   })
 
   return defaultSettings

--- a/packages/hoppscotch-common/src/pages/settings.vue
+++ b/packages/hoppscotch-common/src/pages/settings.vue
@@ -98,13 +98,10 @@
           </p>
         </div>
         <div class="space-y-8 p-8 md:col-span-2">
-          <section class="flex flex-col">
+          <section class="flex flex-col space-y-2">
             <h4 class="font-semibold text-secondaryDark">
               {{ t("settings.interceptor") }}
             </h4>
-            <p class="my-1 text-secondaryLight capitalize">
-              {{ interceptorService.currentInterceptor.value?.interceptorID }}
-            </p>
             <AppInterceptor :is-tooltip-component="false" />
           </section>
           <section v-for="[id, settings] in interceptorsWithSettings" :key="id">

--- a/packages/hoppscotch-common/src/pages/settings.vue
+++ b/packages/hoppscotch-common/src/pages/settings.vue
@@ -98,7 +98,15 @@
           </p>
         </div>
         <div class="space-y-8 p-8 md:col-span-2">
-          <AppInterceptor />
+          <section class="flex flex-col">
+            <h4 class="font-semibold text-secondaryDark">
+              {{ t("settings.interceptor") }}
+            </h4>
+            <p class="my-1 text-secondaryLight capitalize">
+              {{ interceptorService.currentInterceptor.value?.interceptorID }}
+            </p>
+            <AppInterceptor :is-tooltip-component="false" />
+          </section>
           <section v-for="[id, settings] in interceptorsWithSettings" :key="id">
             <h4 class="font-semibold text-secondaryDark">
               {{ settings.entryTitle(t) }}

--- a/packages/hoppscotch-common/src/pages/settings.vue
+++ b/packages/hoppscotch-common/src/pages/settings.vue
@@ -98,6 +98,7 @@
           </p>
         </div>
         <div class="space-y-8 p-8 md:col-span-2">
+          <AppInterceptor />
           <section v-for="[id, settings] in interceptorsWithSettings" :key="id">
             <h4 class="font-semibold text-secondaryDark">
               {{ settings.entryTitle(t) }}


### PR DESCRIPTION
Closes HFE-508 #4059 

### Description
This PR fixes the the bug where a logged out user's interceptor option did not get persisted while refreshing. Also added interceptor option in settings page.


### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

