### PR TITLE
fix: add previous value as optional in test schema env diff

### DIFF
--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -400,7 +400,7 @@ const HoppTestResultSchema = z
                 (x) => "secret" in x && !x.secret
               ).and(
                 z.object({
-                  previousValue: z.string().optional(),
+                  previousValue: z.optional(z.string()),
                 })
               )
             ),
@@ -415,7 +415,7 @@ const HoppTestResultSchema = z
                 (x) => "secret" in x && !x.secret
               ).and(
                 z.object({
-                  previousValue: z.string().optional(),
+                  previousValue: z.optional(z.string()),
                 })
               )
             ),

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -400,7 +400,7 @@ const HoppTestResultSchema = z
                 (x) => "secret" in x && !x.secret
               ).and(
                 z.object({
-                  previousValue: z.string(),
+                  previousValue: z.string().optional(),
                 })
               )
             ),
@@ -415,7 +415,7 @@ const HoppTestResultSchema = z
                 (x) => "secret" in x && !x.secret
               ).and(
                 z.object({
-                  previousValue: z.string(),
+                  previousValue: z.string().optional(),
                 })
               )
             ),


### PR DESCRIPTION
Closes HFE-512

### Description
This PR fixes the issue where the schema validation failed for some restTab where the envDiff missed previousValue so made it a optional field.


### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed


