### PR TITLE
hotix: prevent unwanted variable wrapping during Insomnia import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomnia.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomnia.ts
@@ -48,8 +48,13 @@ const parseInsomniaDoc = (content: string) =>
 const replacePathVarTemplating = (expression: string) =>
   expression.replaceAll(/:([^/]+)/g, "<<$1>>")
 
-const replaceVarTemplating = (expression: string) =>
-  pipe(expression, replacePathVarTemplating, replaceInsomniaTemplating)
+const replaceVarTemplating = (expression: string, pathVar = false) => {
+  return pipe(
+    expression,
+    pathVar ? replacePathVarTemplating : (x) => x,
+    replaceInsomniaTemplating
+  )
+}
 
 const getFoldersIn = (
   folder: InsomniaFolderResource | null,
@@ -208,7 +213,7 @@ const getHoppRequest = (req: InsomniaRequestResource): HoppRESTRequest =>
   makeRESTRequest({
     name: req.name ?? "Untitled Request",
     method: req.method?.toUpperCase() ?? "GET",
-    endpoint: replaceVarTemplating(req.url ?? ""),
+    endpoint: replaceVarTemplating(req.url ?? "", true),
     auth: getHoppReqAuth(req),
     body: getHoppReqBody(req),
     headers: getHoppReqHeaders(req),


### PR DESCRIPTION
### Description
This hotfix addresses an issue where `json` body were being wrapped in unnecessary `<<{json}>>` when importing from Insomnia.

- [ ] Not Completed
- [x] Completed

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed