### PR TITLE
fix: precision lost when json is beautified

### DIFF
--- a/packages/hoppscotch-common/src/components/http/RawBody.vue
+++ b/packages/hoppscotch-common/src/components/http/RawBody.vue
@@ -89,6 +89,7 @@ import { readFileAsText } from "~/helpers/functional/files"
 import xmlFormat from "xml-formatter"
 import { useNestedSetting } from "~/composables/settings"
 import { toggleNestedSetting } from "~/newstore/settings"
+import * as LJSON from "lossless-json"
 
 type PossibleContentTypes = Exclude<
   ValidContentTypes,
@@ -187,8 +188,8 @@ const prettifyRequestBody = () => {
   let prettifyBody = ""
   try {
     if (body.value.contentType.endsWith("json")) {
-      const jsonObj = JSON.parse(rawParamsBody.value as string)
-      prettifyBody = JSON.stringify(jsonObj, null, 2)
+      const jsonObj = LJSON.parse(rawParamsBody.value as string)
+      prettifyBody = LJSON.stringify(jsonObj, undefined, 2) as string
     } else if (body.value.contentType === "application/xml") {
       prettifyBody = prettifyXML(rawParamsBody.value as string)
     }


### PR DESCRIPTION
Closes #4083 #3919 HFE-516

### Description
When JSON is beautified, the precision of long integer values ​​are lost this PR fixes this buy using lossless-json


### Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

