### PR TITLE
fix: huge code scroll issue

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -50,7 +50,9 @@
       </div>
     </div>
     <div v-if="bulkMode" class="h-full relative w-full">
-      <div ref="bulkEditor" class="absolute inset-0"></div>
+      <div class="absolute inset-0 overflow-auto">
+        <div ref="bulkEditor"></div>
+      </div>
     </div>
     <div v-else>
       <draggable

--- a/packages/hoppscotch-common/src/components/http/Parameters.vue
+++ b/packages/hoppscotch-common/src/components/http/Parameters.vue
@@ -45,7 +45,9 @@
       </div>
     </div>
     <div v-if="bulkMode" class="h-full relative">
-      <div ref="bulkEditor" class="absolute inset-0"></div>
+      <div class="absolute inset-0 overflow-auto">
+        <div ref="bulkEditor"></div>
+      </div>
     </div>
     <div v-else>
       <draggable

--- a/packages/hoppscotch-common/src/components/http/PreRequestScript.vue
+++ b/packages/hoppscotch-common/src/components/http/PreRequestScript.vue
@@ -31,7 +31,9 @@
     </div>
     <div class="flex flex-1 border-b border-dividerLight">
       <div class="w-2/3 border-r border-dividerLight h-full relative">
-        <div ref="preRequestEditor" class="h-full absolute inset-0"></div>
+        <div class="absolute inset-0 overflow-auto">
+          <div ref="preRequestEditor"></div>
+        </div>
       </div>
       <div
         class="z-[9] sticky top-upperTertiaryStickyFold h-full min-w-[12rem] max-w-1/3 flex-shrink-0 overflow-auto overflow-x-auto bg-primary p-4"

--- a/packages/hoppscotch-common/src/components/http/RawBody.vue
+++ b/packages/hoppscotch-common/src/components/http/RawBody.vue
@@ -60,7 +60,9 @@
       </div>
     </div>
     <div class="h-full relative">
-      <div ref="rawBodyParameters" class="absolute inset-0"></div>
+      <div class="absolute inset-0 overflow-auto">
+        <div ref="rawBodyParameters"></div>
+      </div>
     </div>
   </div>
 </template>

--- a/packages/hoppscotch-common/src/components/http/RequestVariables.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestVariables.vue
@@ -47,7 +47,9 @@
       </div>
     </div>
     <div v-if="bulkMode" class="h-full relative">
-      <div ref="bulkEditor" class="absolute inset-0"></div>
+      <div class="absolute inset-0 overflow-auto">
+        <div ref="bulkEditor"></div>
+      </div>
     </div>
     <div v-else>
       <draggable

--- a/packages/hoppscotch-common/src/components/http/Tests.vue
+++ b/packages/hoppscotch-common/src/components/http/Tests.vue
@@ -31,7 +31,9 @@
     </div>
     <div class="flex flex-1 border-b border-dividerLight">
       <div class="w-2/3 border-r border-dividerLight h-full relative">
-        <div ref="testScriptEditor" class="h-full absolute inset-0"></div>
+        <div class="h-full absolute inset-0 overflow-auto">
+          <div ref="testScriptEditor"></div>
+        </div>
       </div>
       <div
         class="z-[9] sticky top-upperTertiaryStickyFold h-full min-w-[12rem] max-w-1/3 flex-shrink-0 overflow-auto overflow-x-auto bg-primary p-4"

--- a/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
+++ b/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
@@ -45,7 +45,9 @@
       </div>
     </div>
     <div v-if="bulkMode" class="h-full relative">
-      <div ref="bulkEditor" class="absolute inset-0"></div>
+      <div class="absolute inset-0 overflow-auto">
+        <div ref="bulkEditor"></div>
+      </div>
     </div>
     <div v-else>
       <draggable


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4050, #4007

### Description
The codemirror was not functioning correctly on scroll when we have large request bodies, parts of the body was not rendered and it would only render when we click on it. I wrapped the editor with a div, applying absolute and inset on the the referenced div was causing the issue. I've changed in other places where this same issue exists

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
Before vs After
[screen-capture.webm](https://github.com/hoppscotch/hoppscotch/assets/55492635/48509993-0928-4fc4-8fd0-4f4569f6f96e)


