### PR TITLE
fix: ctrl+enter inserting newline in code

### DIFF
--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -371,7 +371,7 @@ export function useCodemirror(
       Prec.highest(
         keymap.of([
           {
-            key: "Ctrl-Enter",
+            key: "Cmd-Enter" /* macOS */ || "Ctrl-Enter" /* Windows */,
             preventDefault: true,
             run: () => true,
           },

--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -11,6 +11,7 @@ import {
   EditorState,
   Compartment,
   EditorSelection,
+  Prec,
 } from "@codemirror/state"
 import {
   Language,
@@ -367,6 +368,15 @@ export function useCodemirror(
           run: indentLess,
         },
       ]),
+      Prec.highest(
+        keymap.of([
+          {
+            key: "Ctrl-Enter",
+            preventDefault: true,
+            run: () => true,
+          },
+        ])
+      ),
       tooltips({
         parent: document.body,
         position: "absolute",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4029, #3788

### Description
Ctrl+Enter is a keybind for running requests. But using that from codemirror can create a new line along with running the request, so I've overridden the default behaviour of codemirror. Precedence highest is used to override the default ones

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
[screen-capture (1) (1).webm](https://github.com/hoppscotch/hoppscotch/assets/55492635/f391eedc-0fde-4609-8ddc-1d62cabb64da)

