### PR TITLE
fix: large content scroll bug in codemirror editor

### DIFF
--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -119,10 +119,11 @@
         />
       </div>
     </div>
-    <div class="h-full">
+    <div class="h-full relative overflow-auto">
       <div
         ref="jsonResponse"
         :class="toggleFilter ? 'responseToggleOn' : 'responseToggleOff'"
+        class="absolute inset-0 h-full"
       ></div>
     </div>
     <div

--- a/packages/hoppscotch-common/src/components/lenses/renderers/RawLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/RawLensRenderer.vue
@@ -35,8 +35,8 @@
         />
       </div>
     </div>
-    <div class="h-full">
-      <div ref="rawResponse" class="flex flex-1 flex-col"></div>
+    <div class="h-full relative">
+      <div ref="rawResponse" class="absolute inset-0"></div>
     </div>
   </div>
 </template>

--- a/packages/hoppscotch-common/src/components/lenses/renderers/RawLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/RawLensRenderer.vue
@@ -35,7 +35,7 @@
         />
       </div>
     </div>
-    <div class="h-full relative">
+    <div class="h-full relative overflow-auto">
       <div ref="rawResponse" class="absolute inset-0"></div>
     </div>
   </div>

--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -330,7 +330,10 @@ export function useCodemirror(
       ),
 
       EditorView.domEventHandlers({
-        scroll(event) {
+        scroll(event, view) {
+          // HACK: This is a workaround to fix the issue in CodeMirror where the content doesn't load when the editor is not in view.
+          view.requestMeasure()
+
           if (event.target && options.contextMenuEnabled) {
             // Debounce to make the performance better
             debouncedTextSelection(30)()


### PR DESCRIPTION
Closes #4050, #4007


https://github.com/hoppscotch/hoppscotch/assets/53208152/38d7d4c9-dad1-4c29-ba90-0481f035fe8c



This PR fixes the issue in CodeMirror where content was not loading correctly on scroll when we had large request bodies. Parts of the body were not rendered and would only render when clicked.

[4106](https://github.com/hoppscotch/hoppscotch/pull/4106) fixes the issue, but the CodeMirror component was not filling the parent container. Therefore, a hack fix `view.requestMeasure()` is used. This function re-measures the CodeMirror layout.

### What's changed
Added a function inside the CodeMirror scroll listener that re-measures the CodeMirror layout while scrolling.
Also added CodeMirror scroll for response lenses.


### Notes to reviewers
To check the bug, select the option application/json from the body content-type and paste a large text. Scroll down and you should be able to see the content without clicking the editor.