### PR TITLE
chore: cleanup i18n translations

### DIFF
--- a/packages/hoppscotch-common/locales/af.json
+++ b/packages/hoppscotch-common/locales/af.json
@@ -24,8 +24,10 @@
     "go_back": "Gaan terug",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Etiket",
     "learn_more": "Leer meer",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Meer",
     "new": "Nuut",
@@ -43,6 +45,7 @@
     "search": "Soek",
     "send": "Stuur",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Begin",
     "starting": "Starting",
     "stop": "Stop",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Tik 'n opdrag of soek ...",
     "we_use_cookies": "Ons gebruik koekies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Wat's nuut?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Rekening bestaan met verskillende geloofsbriewe - Meld aan om beide rekeninge te koppel",
     "all_sign_in_options": "Alle aanmeldopsies",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Gaan voort met e -pos",
     "continue_with_github": "Gaan voort met GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Gaan voort met Google",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "E -pos",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Wagwoord",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Teken",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Wysig versameling",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Gee 'n geldige naam vir die versameling",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Kies 'n versameling",
     "select_location": "Kies ligging",
+    "details": "Details",
     "select_team": "Kies 'n span",
     "team_collections": "Spanversamelings"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Weet u seker dat u van Telemetry wil afskakel?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Is u seker dat u hierdie werkruimte wil sinkroniseer?"
+    "sync": "Is u seker dat u hierdie werkruimte wil sinkroniseer?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "There are no pending invites for this team",
     "profile": "Login to view your profile",
     "protocols": "Protokolle is leeg",
+    "request_variables": "This request does not have any request variables",
     "schema": "Koppel aan 'n GraphQL -eindpunt",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Spannaam leeg",
     "teams": "Spanne is leeg",
     "tests": "Daar is geen toetse vir hierdie versoek nie",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Kies omgewing",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Veranderlike lys"
+    "variables": "Variables",
+    "variable_list": "Veranderlike lys",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Leë versoeknaam",
     "f12_details": "(F12 vir meer inligting)",
     "gql_prettify_invalid_query": "Kon nie 'n ongeldige navraag mooi maak nie, los sintaksisfoute op en probeer weer",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Kon nie 'n ongeldige liggaam mooi maak nie, los json -sintaksisfoute op en probeer weer",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Kon nie voorafversoekskrip uitvoer nie",
     "something_went_wrong": "Iets het verkeerd geloop",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Uitvoer as JSON",
     "create_secret_gist": "Skep geheime Gist",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gis geskep",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Teken in met GitHub om 'n geheime idee te skep",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Gis geskep"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutasies",
     "schema": "Skema",
     "subscriptions": "Inskrywings",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Invoer"
+    "title": "Invoer",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Rou versoeksliggaam",
     "rename": "Rename Request",
     "renamed": "Versoek hernoem",
+    "request_variables": "Request variables",
     "run": "Hardloop",
     "save": "Stoor",
     "save_as": "Stoor as",
@@ -557,6 +613,7 @@
     "title": "Versoek",
     "type": "Soort versoek",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Veranderlikes",
     "view_my_links": "View my links",
     "copy_link": "Kopieer skakel"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Stel vrae en kry antwoorde",
     "github": "Follow us on Github",
     "shortcuts": "Blaai vinniger deur die app",
-    "team": "Kontak die span",
     "title": "Ondersteuning",
-    "twitter": "volg ons op Twitter"
+    "twitter": "volg ons op Twitter",
+    "team": "Kontak die span"
   },
   "tab": {
     "authorization": "Magtiging",
@@ -889,6 +953,9 @@
     "query": "Navraag",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Toetse",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite people to this workspace",
     "invited_to_team": "{owner} invited you to join {team}",
     "join": "Invitation accepted",
-    "join_beta": "Sluit aan by die beta -program om toegang tot spanne te kry.",
     "join_team": "Join {team}",
     "joined_team": "You have joined {team}",
     "joined_team_description": "You are now a member of this team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Spanne",
     "we_sent_invite_link": "We sent an invite link to all invitees!",
-    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Sluit aan by die beta -program om toegang tot spanne te kry."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/ar.json
+++ b/packages/hoppscotch-common/locales/ar.json
@@ -24,8 +24,10 @@
     "go_back": "عد",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "ملصق",
     "learn_more": "اقرأ أكثر",
+    "download_here": "Download here",
     "less": "اقل",
     "more": "أكثر",
     "new": "جديد",
@@ -43,6 +45,7 @@
     "search": "بحث",
     "send": "ارسل",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "ابدأ",
     "starting": "Starting",
     "stop": "قف",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "اكتب أمرًا أو ابحث ...",
     "we_use_cookies": "نحن نستخدم ملفات تعريف الارتباط",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "ما هو الجديد؟",
+    "see_whats_new": "See what’s new",
     "wiki": "ويكي"
   },
   "auth": {
     "account_exists": "الحساب موجود ببيانات اعتماد مختلفة - تسجيل الدخول لربط كلا الحسابين",
     "all_sign_in_options": "كل خيارات تسجيل الدخول",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "تواصل مع البريد الإلكتروني",
     "continue_with_github": "تواصل مع جيثب",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "تواصل مع جوجل",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "بريد إلكتروني",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "كلمة المرور",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "رمز",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "تحرير المجموعة",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "الرجاء تقديم اسم صالح للمجموعة",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "حدد مجموعة",
     "select_location": "اختر موقعا",
+    "details": "Details",
     "select_team": "اختر فريقًا",
     "team_collections": "مجموعات الفريق"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "هل أنت متأكد أنك تريد الانسحاب من القياس عن بعد؟",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "هل أنت متأكد أنك تريد مزامنة مساحة العمل هذه؟"
+    "sync": "هل أنت متأكد أنك تريد مزامنة مساحة العمل هذه؟",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "لاتوجد اي دعوات معلقة لهذا الفريق",
     "profile": "سجل الدخول لرؤية فريقك",
     "protocols": "البروتوكولات فارغة",
+    "request_variables": "This request does not have any request variables",
     "schema": "اتصل بنقطة نهاية GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "اسم الفريق فارغ",
     "teams": "الفرق فارغة",
     "tests": "لا توجد اختبارات لهذا الطلب",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "حدد البيئة",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "تحديث بيئة العمل",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "قائمة متغيرة"
+    "variables": "Variables",
+    "variable_list": "قائمة متغيرة",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "اسم الطلب فارغ",
     "f12_details": "(للحصول على تفاصيل F12)",
     "gql_prettify_invalid_query": "تعذر تحسين استعلام غير صالح وحل أخطاء بنية الاستعلام وحاول مرة أخرى",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "تعذر تجميل جسم غير صالح وحل أخطاء بناء جملة json وحاول مرة أخرى",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "تعذر تنفيذ نص الطلب المسبق",
     "something_went_wrong": "هناك خطأ ما",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "تصدير بتنسيق JSON",
     "create_secret_gist": "إنشاء جوهر سري",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "خلقت الجست",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "تسجيل الدخول باستخدام GitHub لإنشاء جوهر سري",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "خلقت الجست"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "الطفرات",
     "schema": "مخطط",
     "subscriptions": "الاشتراكات",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "استيراد مجموعة من ملفHoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "يستورد"
+    "title": "يستورد",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "نص طلب خام",
     "rename": "Rename Request",
     "renamed": "تمت إعادة تسمية الطلب",
+    "request_variables": "Request variables",
     "run": "يركض",
     "save": "يحفظ",
     "save_as": "حفظ باسم",
@@ -557,6 +613,7 @@
     "title": "طلب",
     "type": "نوع الطلب",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "المتغيرات",
     "view_my_links": "View my links",
     "copy_link": "نسخ الوصلة"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "اسأل سؤالا وتلقى جوابا",
     "github": "Follow us on Github",
     "shortcuts": "تصفح التطبيق بشكل أسرع",
-    "team": "تواصل مع الفريق",
     "title": "يدعم",
-    "twitter": "تابعنا على تويتر"
+    "twitter": "تابعنا على تويتر",
+    "team": "تواصل مع الفريق"
   },
   "tab": {
     "authorization": "تفويض",
@@ -889,6 +953,9 @@
     "query": "استفسار",
     "schema": "مخطط",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "مقبس",
     "sse": "SSE",
     "tests": "الاختبارات",
@@ -917,7 +984,6 @@
     "invite_tooltip": "ادعو الناس الى العمل",
     "invited_to_team": "{owner} قادم بدعوتك للإنضمام الى {team}",
     "join": "تم قبول الدعوة",
-    "join_beta": "انضم إلى برنامج بيتا للوصول إلى الفرق.",
     "join_team": "انصم الى فريق {team}",
     "joined_team": "لقد انضممت الى فريق {team}",
     "joined_team_description": "انت الآن عضو في الفريق",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "فرق",
     "we_sent_invite_link": "لقد أرسلنا رابط دعوة لجميع المدعوين!",
-    "we_sent_invite_link_description": "اطلب من جميع المدعوين التحقق من صندوق الوارد الخاص بهم. انقر على الرابط للانضمام إلى الفريق."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "اطلب من جميع المدعوين التحقق من صندوق الوارد الخاص بهم. انقر على الرابط للانضمام إلى الفريق.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "انضم إلى برنامج بيتا للوصول إلى الفرق."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/ca.json
+++ b/packages/hoppscotch-common/locales/ca.json
@@ -24,8 +24,10 @@
     "go_back": "Tornar",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Etiquetar",
     "learn_more": "Aprèn més",
+    "download_here": "Download here",
     "less": "Menys",
     "more": "Més",
     "new": "Novetat",
@@ -43,6 +45,7 @@
     "search": "Cercar",
     "send": "Enviar",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Començar",
     "starting": "Starting",
     "stop": "Aturar",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Escriviu una comanda o cerqueu...",
     "we_use_cookies": "Utilitzem cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Què hi ha de nou?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "El compte existeix amb credencials diferents - Inicieu sessió per enllaçar els dos comptes",
     "all_sign_in_options": "Totes les opcions d'inici de sessió",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Continuar amb el correu electrònic",
     "continue_with_github": "Continuar amb GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Continuar amb Google",
     "continue_with_microsoft": "Continuar amb Microsoft",
     "email": "Correu electrònic",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Passar per",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Contrasenya",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Token",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Editar la col·lecció",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Proporcioneu un nom vàlid per a la col·lecció",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Seleccionar una col·lecció",
     "select_location": "Seleccionar la ubicació",
+    "details": "Details",
     "select_team": "Seleccionar un equip",
     "team_collections": "Col·leccions per equips"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Està segur que vol desactivar Telemetry?",
     "request_change": "Està segur que vol descartar la sol·licitud actual, els canvis no desats es perdran.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Està segur que vol sincronitzar aquest espai de treball?"
+    "sync": "Està segur que vol sincronitzar aquest espai de treball?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "No hi ha invitacions pendents per a aquest equip",
     "profile": "Inicia sessió per veure el vostre perfil",
     "protocols": "Els protocols estan buits",
+    "request_variables": "This request does not have any request variables",
     "schema": "Connecta't a un endpoint GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "El nom de l'equip és buit",
     "teams": "Els equips estan buits",
     "tests": "No hi ha proves per a aquesta sol·licitud",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Els shortcodes estan buits"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Seleccioneu un entorn",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Entorn actualitzat",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Llista de variables"
+    "variables": "Variables",
+    "variable_list": "Llista de variables",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Nom de la sol·licitud buida",
     "f12_details": "(F12 per obtenir més informació)",
     "gql_prettify_invalid_query": "No s'ha pogut definir una consulta no vàlida, resoldre els errors de sintaxi de la consulta i tornar-ho a provar",
@@ -296,6 +336,7 @@
     "incorrect_email": "Correu electrònic incorrecte",
     "invalid_link": "Enllaç invalid",
     "invalid_link_description": "L'enllaç en que heu fet clic no és vàlid o ha caducat.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "JSON no vàlid",
     "json_prettify_invalid_body": "No s'ha pogut personalitzar un cos no vàlid, resol els errors de sintaxi json i tornar-ho a provar",
     "network_error": "Sembla que hi ha un error de xarxa. Si us plau torna-ho a provar.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "No s'ha pogut executar l'script de sol·licitud prèvia",
     "something_went_wrong": "Alguna cosa ha anat malament",
-    "test_script_fail": "No s'ha pogut executar l'script posterior a la sol·licitud"
+    "test_script_fail": "No s'ha pogut executar l'script posterior a la sol·licitud",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Exporta com a JSON",
     "create_secret_gist": "Crear un Gist secret",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist creat",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Inicieu la sessió amb GitHub per crear un Gisst secret",
-    "title": "Exportar"
+    "title": "Exportar",
+    "success": "Successfully exported",
+    "gist_created": "Gist creat"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutacions",
     "schema": "Esquema",
     "subscriptions": "Subscripcions",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Importar col·leccions des d'un fitxer JSON de col·leccions Hoppscotch",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Importació"
+    "title": "Importació",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Cos de sol·licitud sense processar",
     "rename": "Rename Request",
     "renamed": "S'ha canviat el nom de la sol·licitud",
+    "request_variables": "Request variables",
     "run": "Executar",
     "save": "Guardar",
     "save_as": "Guardar com",
@@ -557,6 +613,7 @@
     "title": "Sol·licitud",
     "type": "Tipus de sol·licitud",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variables",
     "view_my_links": "Visualitzar els meus enllaços",
     "copy_link": "Copia l'enllaç"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Feu preguntes i obteniu respostes",
     "github": "Segueix-nos a Github",
     "shortcuts": "Navega per l'aplicació més ràpidament",
-    "team": "Poseu-vos en contacte amb l'equip",
     "title": "Suport",
-    "twitter": "Segueix-nos a Twitter"
+    "twitter": "Segueix-nos a Twitter",
+    "team": "Poseu-vos en contacte amb l'equip"
   },
   "tab": {
     "authorization": "Autorització",
@@ -889,6 +953,9 @@
     "query": "Consulta",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Proves",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invitar persones a aquest espai de treball",
     "invited_to_team": "{owner} t'ha invitat a unir-te a {team}",
     "join": "S'ha acceptat la invitació",
-    "join_beta": "Uneix-te al programa beta per accedir als equips.",
     "join_team": "Uneix-te a {team}",
     "joined_team": "T'has unit a {team}",
     "joined_team_description": "Ara ets membre d'aquest equip",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Equips",
     "we_sent_invite_link": "Hem enviat un enllaç d'invitació a tots els convidats!",
-    "we_sent_invite_link_description": "Demaneu a tots els convidats que comprovin la seva safata d'entrada. Feu clic a l'enllaç per unir-vos a l'equip."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Demaneu a tots els convidats que comprovin la seva safata d'entrada. Feu clic a l'enllaç per unir-vos a l'equip.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Uneix-te al programa beta per accedir als equips."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Accions",

--- a/packages/hoppscotch-common/locales/cn.json
+++ b/packages/hoppscotch-common/locales/cn.json
@@ -24,8 +24,10 @@
     "go_back": "返回",
     "go_forward": "前进",
     "group_by": "分组方式",
+    "hide_secret": "Hide secret",
     "label": "标签",
     "learn_more": "了解更多",
+    "download_here": "Download here",
     "less": "更少",
     "more": "更多",
     "new": "新增",
@@ -43,6 +45,7 @@
     "search": "搜索",
     "send": "发送",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "开始",
     "starting": "正在开始",
     "stop": "停止",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "输入命令或搜索内容……",
     "we_use_cookies": "我们使用 cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "新增内容",
+    "see_whats_new": "See what’s new",
     "wiki": "帮助"
   },
   "auth": {
     "account_exists": "当前帐号已存在 - 登录以链接两个帐号",
     "all_sign_in_options": "所有登录选项",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "使用电子邮箱登录",
     "continue_with_github": "使用 GitHub 登录",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "使用 Google 登录",
     "continue_with_microsoft": "使用 Microsoft 登录",
     "email": "电子邮箱地址",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "传递方式",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "密码",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "令牌",
@@ -149,6 +177,7 @@
     "different_parent": "不能用不同的父类来重新排序集合",
     "edit": "编辑集合",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "请提供有效的集合名称",
     "invalid_root_move": "该集合已经在根级了",
     "moved": "移动完成",
@@ -165,6 +194,7 @@
     "save_to_collection": "保存至集合",
     "select": "选择一个集合",
     "select_location": "选择位置",
+    "details": "Details",
     "select_team": "选择一个团队",
     "team_collections": "团队集合"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "你确定要退出遥测服务吗？",
     "request_change": "你确定你要放弃当前的请求，未保存的修改将被丢失。",
     "save_unsaved_tab": "你想保存在此标签页中所作的修改吗？",
-    "sync": "您确定要同步该工作区吗？"
+    "sync": "您确定要同步该工作区吗？",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "添加至参数",
@@ -237,13 +268,16 @@
     "pending_invites": "此团队无待办邀请",
     "profile": "登录以查看你的个人资料",
     "protocols": "协议为空",
+    "request_variables": "This request does not have any request variables",
     "schema": "连接至 GraphQL 端点",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "订阅为空",
     "team_name": "团队名称为空",
     "teams": "团队为空",
     "tests": "没有针对该请求的测试",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "短链接为空"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "快速浏览环境",
     "replace_with_variable": "替换为变量",
     "scope": "范围",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "选择环境",
     "set": "设置环境",
     "set_as_environment": "设置为环境",
@@ -278,7 +314,10 @@
     "updated": "环境已更新",
     "value": "值",
     "variable": "变量",
-    "variable_list": "变量列表"
+    "variables": "Variables",
+    "variable_list": "变量列表",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "危险区域",
     "delete_account": "您的帐号目前为这些团队的拥有者：",
     "delete_account_description": "您在删除帐号前必须先将您自己从团队中移除、转移拥有权，或是删除团队。",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "空请求名称",
     "f12_details": "（F12 详情）",
     "gql_prettify_invalid_query": "无法美化无效的查询，处理查询语法错误并重试",
@@ -308,9 +348,14 @@
     "page_not_found": "找不到此頁面",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "代理错误",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "无法执行预请求脚本",
     "something_went_wrong": "发生了一些错误",
-    "test_script_fail": "无法执行请求脚本"
+    "test_script_fail": "无法执行请求脚本",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "导出为 JSON",
@@ -343,7 +388,8 @@
     "mutations": "变更",
     "schema": "模式",
     "subscriptions": "订阅",
-    "switch_connection": "切换连接"
+    "switch_connection": "切换连接",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -409,12 +455,17 @@
     "json_description": "从 Hoppscotch 的集合文件导入（JSON）",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "导入"
+    "title": "导入",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "查可能的错误",
     "environment": {
       "add_environment": "添加到环境",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "环境变量“{environment}”未找到。"
     },
     "header": {
@@ -550,6 +601,7 @@
     "raw_body": "原始请求体",
     "rename": "重命名请求",
     "renamed": "请求重命名",
+    "request_variables": "Request variables",
     "run": "运行",
     "save": "保存",
     "save_as": "另存为",
@@ -561,6 +613,7 @@
     "title": "请求",
     "type": "请求类型",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "变量",
     "view_my_links": "查看我的链接",
     "copy_link": "复制链接"
@@ -815,6 +868,13 @@
       "new": "创建新团队",
       "switch_to_personal": "切换到您的个人工作空间",
       "title": "团队"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -871,9 +931,9 @@
     "forum": "答疑解惑",
     "github": "在 Github 关注我们",
     "shortcuts": "更快浏览应用",
-    "team": "与团队保持联系",
     "title": "支持",
-    "twitter": "在 Twitter 关注我们"
+    "twitter": "在 Twitter 关注我们",
+    "team": "与团队保持联系"
   },
   "tab": {
     "authorization": "授权",
@@ -893,6 +953,9 @@
     "query": "查询",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "测试",
@@ -921,7 +984,6 @@
     "invite_tooltip": "邀请成员加入此工作区",
     "invited_to_team": "{owner} 邀请你加入 {team}",
     "join": "邀请已被接受",
-    "join_beta": "加入 Beta 计划以访问团队。",
     "join_team": "加入 {team}",
     "joined_team": "你已加入 {team}",
     "joined_team_description": "你现在是此团队的成员了",
@@ -954,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "团队",
     "we_sent_invite_link": "我们向所有受邀者发送了邀请链接！",
-    "we_sent_invite_link_description": "请所有受邀者检查他们的收件箱，点击链接以加入团队。"
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "请所有受邀者检查他们的收件箱，点击链接以加入团队。",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "加入 Beta 计划以访问团队。"
   },
   "team_environment": {
     "deleted": "已刪除环境",
@@ -981,8 +1048,49 @@
   "workspace": {
     "change": "切换工作空间",
     "personal": "我的工作空间",
+    "other_workspaces": "My Workspaces",
     "team": "团队工作空间",
     "title": "工作空间"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "操作",

--- a/packages/hoppscotch-common/locales/cs.json
+++ b/packages/hoppscotch-common/locales/cs.json
@@ -24,8 +24,10 @@
     "go_back": "Vrať se",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Označení",
     "learn_more": "Další informace",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Více",
     "new": "Nový",
@@ -43,6 +45,7 @@
     "search": "Vyhledávání",
     "send": "Poslat",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Start",
     "starting": "Starting",
     "stop": "Stop",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Zadejte příkaz nebo hledejte…",
     "we_use_cookies": "Používáme cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Co je nového?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Účet existuje s různými pověřeními - Přihlaste se a propojte oba účty",
     "all_sign_in_options": "Všechny možnosti přihlášení",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Pokračujte e -mailem",
     "continue_with_github": "Pokračujte na GitHubu",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Pokračovat s Google",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "E-mailem",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Heslo",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Žeton",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Upravit sbírku",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Uveďte prosím platný název kolekce",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Vyberte sbírku",
     "select_location": "Vyberte umístění",
+    "details": "Details",
     "select_team": "Vyberte tým",
     "team_collections": "Týmové sbírky"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Opravdu se chcete odhlásit z telemetrie?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Opravdu chcete synchronizovat tento pracovní prostor?"
+    "sync": "Opravdu chcete synchronizovat tento pracovní prostor?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "There are no pending invites for this team",
     "profile": "Login to view your profile",
     "protocols": "Protokoly jsou prázdné",
+    "request_variables": "This request does not have any request variables",
     "schema": "Připojte se ke koncovému bodu GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Název týmu prázdný",
     "teams": "Týmy jsou prázdné",
     "tests": "Pro tento požadavek neexistují žádné testy",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Vyberte prostředí",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Seznam proměnných"
+    "variables": "Variables",
+    "variable_list": "Seznam proměnných",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Název prázdného požadavku",
     "f12_details": "(F12 pro podrobnosti)",
     "gql_prettify_invalid_query": "Neplatný dotaz nelze předběžně upravit, vyřešit chyby syntaxe dotazu a zkusit to znovu",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Nelze předtifikovat neplatné tělo, vyřešit chyby syntaxe json a zkusit to znovu",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Skript předběžného požadavku nelze spustit",
     "something_went_wrong": "Něco se pokazilo",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Exportovat jako JSON",
     "create_secret_gist": "Vytvořte tajnou podstatu",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Podstata vytvořena",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Přihlaste se pomocí GitHub a vytvořte tajný seznam",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Podstata vytvořena"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutace",
     "schema": "Schéma",
     "subscriptions": "Předplatné",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Import"
+    "title": "Import",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Raw Request Body",
     "rename": "Rename Request",
     "renamed": "Žádost přejmenována",
+    "request_variables": "Request variables",
     "run": "Běh",
     "save": "Uložit",
     "save_as": "Uložit jako",
@@ -557,6 +613,7 @@
     "title": "Žádost",
     "type": "Typ požadavku",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Proměnné",
     "view_my_links": "View my links",
     "copy_link": "Kopírovat odkaz"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Ptejte se a získejte odpovědi",
     "github": "Follow us on Github",
     "shortcuts": "Procházejte aplikaci rychleji",
-    "team": "Spojte se s týmem",
     "title": "Podpěra, podpora",
-    "twitter": "Sleduj nás na Twitteru"
+    "twitter": "Sleduj nás na Twitteru",
+    "team": "Spojte se s týmem"
   },
   "tab": {
     "authorization": "Povolení",
@@ -889,6 +953,9 @@
     "query": "Dotaz",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Testy",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite people to this workspace",
     "invited_to_team": "{owner} invited you to join {team}",
     "join": "Invitation accepted",
-    "join_beta": "Připojte se k beta programu a získejte přístup k týmům.",
     "join_team": "Join {team}",
     "joined_team": "You have joined {team}",
     "joined_team_description": "You are now a member of this team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Týmy",
     "we_sent_invite_link": "We sent an invite link to all invitees!",
-    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Připojte se k beta programu a získejte přístup k týmům."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/da.json
+++ b/packages/hoppscotch-common/locales/da.json
@@ -24,8 +24,10 @@
     "go_back": "Gå tilbage",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Etiket",
     "learn_more": "Lær mere",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Mere",
     "new": "Ny",
@@ -43,6 +45,7 @@
     "search": "Søg",
     "send": "Sende",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Start",
     "starting": "Starting",
     "stop": "Hold op",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Skriv en kommando eller søg ...",
     "we_use_cookies": "Vi bruger cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Hvad er nyt?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Kontoen findes med forskellige legitimationsoplysninger - Log ind for at linke begge konti",
     "all_sign_in_options": "Alle muligheder for login",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Fortsæt med e -mail",
     "continue_with_github": "Fortsæt med GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Fortsæt med Google",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "E -mail",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Adgangskode",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Polet",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Rediger samling",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Angiv et gyldigt navn til samlingen",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Vælg en samling",
     "select_location": "Vælg placering",
+    "details": "Details",
     "select_team": "Vælg et hold",
     "team_collections": "Teamsamlinger"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Er du sikker på, at du vil fravælge telemetri?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Er du sikker på, at du vil synkronisere dette arbejdsområde?"
+    "sync": "Er du sikker på, at du vil synkronisere dette arbejdsområde?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "There are no pending invites for this team",
     "profile": "Login to view your profile",
     "protocols": "Protokoller er tomme",
+    "request_variables": "This request does not have any request variables",
     "schema": "Opret forbindelse til et GraphQL -slutpunkt",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Teamnavn er tomt",
     "teams": "Hold er tomme",
     "tests": "Der er ingen test for denne anmodning",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Vælg miljø",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Variabel liste"
+    "variables": "Variables",
+    "variable_list": "Variabel liste",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Tom anmodningsnavn",
     "f12_details": "(F12 for detaljer)",
     "gql_prettify_invalid_query": "Kunne ikke prætificere en ugyldig forespørgsel, løse forespørgselssyntaksfejl og prøve igen",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Kunne ikke pryde et ugyldigt brødtekst, løse json -syntaksfejl og prøve igen",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Kunne ikke udføre pre-request script",
     "something_went_wrong": "Noget gik galt",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Eksporter som JSON",
     "create_secret_gist": "Opret hemmelig Gist",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist skabt",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Log ind med GitHub for at skabe hemmelig kerne",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Gist skabt"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutationer",
     "schema": "Skema",
     "subscriptions": "Abonnementer",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Importere"
+    "title": "Importere",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Raw Request Body",
     "rename": "Rename Request",
     "renamed": "Anmodning omdøbt",
+    "request_variables": "Request variables",
     "run": "Løb",
     "save": "Gemme",
     "save_as": "Gem som",
@@ -557,6 +613,7 @@
     "title": "Anmodning",
     "type": "Anmodningstype",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variabler",
     "view_my_links": "View my links",
     "copy_link": "Kopier link"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Stil spørgsmål og få svar",
     "github": "Follow us on Github",
     "shortcuts": "Gennemse appen hurtigere",
-    "team": "Kom i kontakt med teamet",
     "title": "Support",
-    "twitter": "Følg os på Twitter"
+    "twitter": "Følg os på Twitter",
+    "team": "Kom i kontakt med teamet"
   },
   "tab": {
     "authorization": "Bemyndigelse",
@@ -889,6 +953,9 @@
     "query": "Forespørgsel",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Test",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite people to this workspace",
     "invited_to_team": "{owner} invited you to join {team}",
     "join": "Invitation accepted",
-    "join_beta": "Deltag i betaprogrammet for at få adgang til teams.",
     "join_team": "Join {team}",
     "joined_team": "You have joined {team}",
     "joined_team_description": "You are now a member of this team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Hold",
     "we_sent_invite_link": "We sent an invite link to all invitees!",
-    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Deltag i betaprogrammet for at få adgang til teams."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/de.json
+++ b/packages/hoppscotch-common/locales/de.json
@@ -24,8 +24,10 @@
     "go_back": "Zurück",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Etikett",
     "learn_more": "Mehr erfahren",
+    "download_here": "Download here",
     "less": "Weniger",
     "more": "Mehr",
     "new": "Neu",
@@ -43,6 +45,7 @@
     "search": "Suchen",
     "send": "Senden",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Start",
     "starting": "Starting",
     "stop": "Stopp",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Gib einen Befehl ein oder suche…",
     "we_use_cookies": "Wir verwenden Cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Was gibt's Neues?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Konto existiert mit unterschiedlichen Zugangsdaten - Melde Dich an, um beide Konten zu verknüpfen",
     "all_sign_in_options": "Alle Anmeldeoptionen",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Mit E-Mail anmelden",
     "continue_with_github": "Mit GitHub anmelden",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Mit Google anmelden",
     "continue_with_microsoft": "Mit Microsoft anmelden",
     "email": "E-Mail-Adresse",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Übertragungsart",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Passwort",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Token",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Sammlung bearbeiten",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Bitte gib einen gültigen Namen für die Sammlung an",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Wähle eine Sammlung",
     "select_location": "Ort auswählen",
+    "details": "Details",
     "select_team": "Wähle ein Team",
     "team_collections": "Teamsammlungen"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Möchtest Du die Telemetrie wirklich deaktivieren?",
     "request_change": "Möchtest Du diese Anfrage verwerfen? Ungespeicherte Änderungen gehen verloren.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Möchtest Du diesen Arbeitsbereich wirklich synchronisieren?"
+    "sync": "Möchtest Du diesen Arbeitsbereich wirklich synchronisieren?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "Es gibt keine offenen Einladungen für dieses Team",
     "profile": "Einloggen um das Profil anzusehen",
     "protocols": "Protokolle sind leer",
+    "request_variables": "This request does not have any request variables",
     "schema": "Verbinden mit einem GraphQL-Endpunkt",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Teamname leer",
     "teams": "Teams sind leer",
     "tests": "Es gibt keine Tests für diese Anfrage",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Umgebung auswählen",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Umgebung aktualisiert",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Variablenliste"
+    "variables": "Variables",
+    "variable_list": "Variablenliste",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Leerer Anfragename",
     "f12_details": "(F12 für Details)",
     "gql_prettify_invalid_query": "Eine ungültige Abfrage konnte nicht verschönert werden. Fehler in der Abfragesyntax beheben und erneut versuchen",
@@ -296,6 +336,7 @@
     "incorrect_email": "Falsche E-Mail Adresse",
     "invalid_link": "Falscher Link",
     "invalid_link_description": "Der verwendete Link ist entweder ungültig oder abgelaufen.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Ein ungültiger Text konnte nicht verschönert werden, JSON-Syntaxfehler beheben und erneut versuchen",
     "network_error": "Netzwerkfehler. Bitte versuche es erneut.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Pre-Request-Skripte konnte nicht ausgeführt werden",
     "something_went_wrong": "Etwas ist schief gelaufen",
-    "test_script_fail": "Testskripts konnten nicht ausgeführt werden"
+    "test_script_fail": "Testskripts konnten nicht ausgeführt werden",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Als JSON exportieren",
     "create_secret_gist": "Geheimen Github Gist erstellen",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist erstellt",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Melde Dich bei GitHub an, um einen geheimen Gist zu erstellen",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Gist erstellt"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutationen",
     "schema": "Schema",
     "subscriptions": "Abonnements",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Hoppscotch Sammlungsdatei (JSON) importieren",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Importieren"
+    "title": "Importieren",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Roher Anfragetext",
     "rename": "Rename Request",
     "renamed": "Anfrage umbenannt",
+    "request_variables": "Request variables",
     "run": "Ausführen",
     "save": "Speichern",
     "save_as": "Speichern als",
@@ -557,6 +613,7 @@
     "title": "Anfrage",
     "type": "Anfragetyp",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variablen",
     "view_my_links": "View my links",
     "copy_link": "Link kopieren"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Stelle Fragen und erhalte Antworten",
     "github": "Folge uns auf Github",
     "shortcuts": "Hoppscotch schneller bedienen",
-    "team": "Nehme Kontakt mit dem Team auf",
     "title": "Hilfe",
-    "twitter": "Folge uns auf Twitter"
+    "twitter": "Folge uns auf Twitter",
+    "team": "Nehme Kontakt mit dem Team auf"
   },
   "tab": {
     "authorization": "Autorisierung",
@@ -889,6 +953,9 @@
     "query": "Anfrage",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Tests",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Personen zum Arbeitsbereich einladen",
     "invited_to_team": "{owner} hat dich zu {team} eingeladen",
     "join": "Einladung angenommen",
-    "join_beta": "Nimm am Beta-Programm teil, um auf Teams zuzugreifen.",
     "join_team": "{team} beitreten",
     "joined_team": "Du bist {team} beigetreten",
     "joined_team_description": "Du bist nun ein Mitglied des Teams",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Team",
     "we_sent_invite_link": "Einladungen wurden an alle E-Mails verschickt!",
-    "we_sent_invite_link_description": "Bitte alle eingeladenen Personen, ihren Posteingang zu überprüfen. Klicke auf den Link, um dem Team beizutreten."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Bitte alle eingeladenen Personen, ihren Posteingang zu überprüfen. Klicke auf den Link, um dem Team beizutreten.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Nimm am Beta-Programm teil, um auf Teams zuzugreifen."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/el.json
+++ b/packages/hoppscotch-common/locales/el.json
@@ -24,8 +24,10 @@
     "go_back": "Πήγαινε πίσω",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Επιγραφή",
     "learn_more": "Μάθε περισσότερα",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Περισσότερο",
     "new": "Νέος",
@@ -43,6 +45,7 @@
     "search": "Αναζήτηση",
     "send": "Στείλετε",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Αρχή",
     "starting": "Starting",
     "stop": "Να σταματήσει",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Πληκτρολογήστε μια εντολή ή αναζήτηση…",
     "we_use_cookies": "Χρησιμοποιούμε cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Τι νέα?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Ο λογαριασμός υπάρχει με διαφορετικά διαπιστευτήρια - Συνδεθείτε για να συνδέσετε και τους δύο λογαριασμούς",
     "all_sign_in_options": "Όλες οι επιλογές σύνδεσης",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Συνεχίστε με το Email",
     "continue_with_github": "Συνεχίστε με το GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Συνεχίστε με την Google",
     "continue_with_microsoft": "Συνεχίστε με την Microsoft",
     "email": "ΗΛΕΚΤΡΟΝΙΚΗ ΔΙΕΥΘΥΝΣΗ",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Κωδικός πρόσβασης",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Ενδειξη",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Επεξεργασία Συλλογής",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Καταχωρίστε ένα έγκυρο όνομα για τη συλλογή",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Επιλέξτε μια Συλλογή",
     "select_location": "Επιλέξτε τοποθεσία",
+    "details": "Details",
     "select_team": "Επιλέξτε μια ομάδα",
     "team_collections": "Συλλογές ομάδων"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Είστε βέβαιοι ότι θέλετε να εξαιρεθείτε από την τηλεμετρία;",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Είστε βέβαιοι ότι θέλετε να συγχρονίσετε αυτόν τον χώρο εργασίας;"
+    "sync": "Είστε βέβαιοι ότι θέλετε να συγχρονίσετε αυτόν τον χώρο εργασίας;",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "Δεν υπάρχουν εκκρεμείς προσκλήσεις για αυτή την ομάδα",
     "profile": "Συνδεθείτε για προβολή του προφίλ σας",
     "protocols": "Τα πρωτόκολλα είναι κενά",
+    "request_variables": "This request does not have any request variables",
     "schema": "Συνδεθείτε σε ένα τελικό σημείο GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Το όνομα της ομάδας είναι κενό",
     "teams": "Οι ομάδες είναι άδειες",
     "tests": "Δεν υπάρχουν δοκιμές για αυτό το αίτημα",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Τα Shortcodes είναι κενά"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Επιλέξτε περιβάλλον",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Αναβάθμιση Περιβάλλοντος",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Λίστα μεταβλητών"
+    "variables": "Variables",
+    "variable_list": "Λίστα μεταβλητών",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Όνομα κενού αιτήματος",
     "f12_details": "(F12 για λεπτομέρειες)",
     "gql_prettify_invalid_query": "Δεν ήταν δυνατή η προεπιλογή ενός μη έγκυρου ερωτήματος, η επίλυση σφαλμάτων σύνταξης ερωτήματος και η δοκιμή ξανά",
@@ -296,6 +336,7 @@
     "incorrect_email": "Λάθος email",
     "invalid_link": "Μή έγκυρο link",
     "invalid_link_description": "Ο σύνδεσμος που επιλέξατε έχει λήξει ή δεν είναι έγκυρος.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Μη έγκυρο JSON",
     "json_prettify_invalid_body": "Δεν ήταν δυνατή η ομορφιά ενός μη έγκυρου σώματος, η επίλυση σφαλμάτων σύνταξης json και η προσπάθεια ξανά",
     "network_error": "Από ότι φαίνεται υπάρχει ένα σφάλμα δικτύου. Παρακαλούμε προσπαθήστε ξανά.",
@@ -307,17 +348,25 @@
     "page_not_found": "Αυτή η σελίδα δεν βρέθηκε",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Δεν ήταν δυνατή η εκτέλεση του σεναρίου πριν από το αίτημα",
     "something_went_wrong": "Κάτι πήγε στραβά",
-    "test_script_fail": "Δεν μπορεσε να εκτελεστεί το post-request script"
+    "test_script_fail": "Δεν μπορεσε να εκτελεστεί το post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Εξαγωγή ως JSON",
     "create_secret_gist": "Δημιουργήστε μυστική ουσία",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Η ουσία δημιουργήθηκε",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Συνδεθείτε με το GitHub για να δημιουργήσετε μυστική ουσία",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Η ουσία δημιουργήθηκε"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Μεταλλάξεις",
     "schema": "Σχήμα",
     "subscriptions": "Συνδρομές",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Εισαγωγή συλλογών αρχείο JSON Hoppscotch Collections",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Εισαγωγή"
+    "title": "Εισαγωγή",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Σώμα Ακατέργαστου Αιτήματος",
     "rename": "Rename Request",
     "renamed": "Το αίτημα μετονομάστηκε",
+    "request_variables": "Request variables",
     "run": "Τρέξιμο",
     "save": "Σώσει",
     "save_as": "Αποθήκευση ως",
@@ -557,6 +613,7 @@
     "title": "Αίτηση",
     "type": "Τύπος αιτήματος",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Μεταβλητές",
     "view_my_links": "Προβολή των links μου",
     "copy_link": "Αντιγραφή συνδέσμου"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Κάντε ερωτήσεις και λάβετε απαντήσεις",
     "github": "Follow us on Github",
     "shortcuts": "Περιηγηθείτε πιο γρήγορα στην εφαρμογή",
-    "team": "Επικοινωνήστε με την ομάδα",
     "title": "Υποστήριξη",
-    "twitter": "Ακολουθήστε μας στο Twitter"
+    "twitter": "Ακολουθήστε μας στο Twitter",
+    "team": "Επικοινωνήστε με την ομάδα"
   },
   "tab": {
     "authorization": "Εξουσιοδότηση",
@@ -889,6 +953,9 @@
     "query": "Ερώτηση",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Υποδοχή.IO",
     "sse": "SSE",
     "tests": "Δοκιμές",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Πρόσκληση χρηστών σε αυτό το workspace",
     "invited_to_team": "{owner} σου έκανε πρόσκληση για να μπεις στην {team}",
     "join": "Πρόσκληση Αποδεκτή",
-    "join_beta": "Εγγραφείτε στο πρόγραμμα beta για πρόσβαση σε ομάδες.",
     "join_team": "Γίνε Μέλος {team}",
     "joined_team": "Μπήκες στην ομάδα: {team}",
     "joined_team_description": "Είστε πλέον μέλος αυτής της ομάδας",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Της ομάδας",
     "we_sent_invite_link": "Στείλαμε έναν σύνδεσμο πρόσκλησης σε όλους!",
-    "we_sent_invite_link_description": "Ζητήστε από όλους όσους στείλατε πρόσκληση να ελέγξουν τα email τους. Click στον σύνδεσμο για εισαγωγή στην ομάδα."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ζητήστε από όλους όσους στείλατε πρόσκληση να ελέγξουν τα email τους. Click στον σύνδεσμο για εισαγωγή στην ομάδα.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Εγγραφείτε στο πρόγραμμα beta για πρόσβαση σε ομάδες."
   },
   "team_environment": {
     "deleted": "Το περιβάλλον διαγράφηκε",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Δράσεις",

--- a/packages/hoppscotch-common/locales/es.json
+++ b/packages/hoppscotch-common/locales/es.json
@@ -24,8 +24,10 @@
     "go_back": "Volver",
     "go_forward": "Adelante",
     "group_by": "Agrupar por",
+    "hide_secret": "Hide secret",
     "label": "Etiqueta",
     "learn_more": "Aprender más",
+    "download_here": "Download here",
     "less": "Menos",
     "more": "Más",
     "new": "Nuevo",
@@ -43,6 +45,7 @@
     "search": "Buscar",
     "send": "Enviar",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Comenzar",
     "starting": "Iniciando",
     "stop": "Detener",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Escribe un comando o buscar algo…",
     "we_use_cookies": "Usamos cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "¿Qué hay de nuevo?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "La cuenta existe con una credencial diferente - Inicia sesión para vincular ambas cuentas",
     "all_sign_in_options": "Todas las opciones de inicio de sesión",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Continuar con correo electrónico",
     "continue_with_github": "Continuar con GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Continuar con Google",
     "continue_with_microsoft": "Continuar con Microsoft",
     "email": "Correo electrónico",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No se ha definido ningún punto final de token",
       "something_went_wrong_on_oauth_redirect": "Algo ha ido mal durante la redirección OAuth",
       "something_went_wrong_on_token_generation": "Algo salió mal en la generación del token",
-      "token_generation_oidc_discovery_failed": "Fallo en la generación del token: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Fallo en la generación del token: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pasar por",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Contraseña",
     "save_to_inherit": "Por favor, guarda esta solicitud en cualquier colección para heredar la autorización",
     "token": "Token",
@@ -149,6 +177,7 @@
     "different_parent": "No se puede reordenar la colección con un padre diferente",
     "edit": "Editar colección",
     "import_or_create": "Importar o crear una colección",
+    "import_collection": "Import Collection",
     "invalid_name": "Proporciona un nombre válido para la colección.",
     "invalid_root_move": "La colección ya está en la raíz",
     "moved": "Movido con éxito",
@@ -165,6 +194,7 @@
     "save_to_collection": "Guardar en la colección",
     "select": "Seleccionar colección",
     "select_location": "Seleccionar ubicación",
+    "details": "Details",
     "select_team": "Seleccionar equipo",
     "team_collections": "Colecciones de equipos"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "¿Estás seguro de que deseas darse de baja de la telemetría?",
     "request_change": "¿Estás seguro de que deseas descartar la solicitud actual, los cambios no guardados se perderán.",
     "save_unsaved_tab": "¿Deseas guardar los cambios realizados en esta pestaña?",
-    "sync": "¿Estás seguro de que deseas sincronizar este espacio de trabajo?"
+    "sync": "¿Estás seguro de que deseas sincronizar este espacio de trabajo?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Añadir a parámetros",
@@ -237,13 +268,16 @@
     "pending_invites": "No hay invitaciones pendientes para este equipo",
     "profile": "Iniciar sesión para ver tu perfil",
     "protocols": "No hay protocolos",
+    "request_variables": "This request does not have any request variables",
     "schema": "Conectarse a un punto final de GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "No hay solicitudes compartidas",
     "shared_requests_logout": "Iniciar sesión para ver sus solicitudes compartidas o crear una nueva",
     "subscription": "No hay suscripciones",
     "team_name": "Nombre del equipo vacío",
     "teams": "No hay equipos",
     "tests": "No hay pruebas para esta solicitud",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Aún no se han creado Shortcodes"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Vistazo rápido al entorno",
     "replace_with_variable": "Sustituir por variable",
     "scope": "Ámbito",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Seleccionar entorno",
     "set": "Establecer entorno",
     "set_as_environment": "Establecer como entorno",
@@ -278,7 +314,10 @@
     "updated": "Entorno actualizado",
     "value": "Valor",
     "variable": "Variable",
-    "variable_list": "Lista de variables"
+    "variables": "Variables",
+    "variable_list": "Lista de variables",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "No se han podido cargar los proveedores de autenticación",
@@ -289,6 +328,7 @@
     "danger_zone": "Zona de peligro",
     "delete_account": "Tu cuenta es actualmente propietaria en estos equipos:",
     "delete_account_description": "Para poder eliminar tu cuenta, debes darte de baja, transferir la propiedad o eliminar estos equipos.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Nombre de solicitud vacío",
     "f12_details": "(F12 para más detalles)",
     "gql_prettify_invalid_query": "No se puede aplicar embellecedor a una consulta no válida, resuelve los errores de sintaxis de la consulta y vuelve a intentarlo",
@@ -296,6 +336,7 @@
     "incorrect_email": "Correo electrónico incorrecto",
     "invalid_link": "Enlace no válido",
     "invalid_link_description": "El enlace que has pulsado no es válido o ha caducado.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "JSON no válido",
     "json_prettify_invalid_body": "No se puede aplicar embellecedor a un cuerpo inválido, resuelve errores de sintaxis json y vuelve a intentarlo",
     "network_error": "Parece que hay un error de red. Por favor, inténtalo de nuevo.",
@@ -307,17 +348,25 @@
     "page_not_found": "No se ha podido encontrar esta página",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Error de proxy",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "No se pudo ejecutar el script de solicitud previa",
     "something_went_wrong": "Algo salió mal",
-    "test_script_fail": "No se ha podido ejecutar la secuencia de comandos posterior a la solicitud"
+    "test_script_fail": "No se ha podido ejecutar la secuencia de comandos posterior a la solicitud",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Exportar como JSON",
     "create_secret_gist": "Crear un Gist secreto",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Algo ha ido mal al exportar",
-    "gist_created": "Gist creado",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Iniciar sesión con GitHub para crear un Gist secreto",
-    "title": "Exportar"
+    "title": "Exportar",
+    "success": "Successfully exported",
+    "gist_created": "Gist creado"
   },
   "filter": {
     "all": "Todos",
@@ -339,7 +388,8 @@
     "mutations": "Mutaciones",
     "schema": "Esquema",
     "subscriptions": "Suscripciones",
-    "switch_connection": "Cambiar conexión"
+    "switch_connection": "Cambiar conexión",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "Colecciones de GraphQL"
@@ -405,12 +455,17 @@
     "json_description": "Importar colecciones desde un archivo JSON de colecciones de Hoppscotch",
     "postman_environment": "Entorno de Postman",
     "postman_environment_description": "Importar entorno de Postman desde un archivo JSON",
-    "title": "Importar"
+    "title": "Importar",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspeccionar posibles errores",
     "environment": {
       "add_environment": "Añadir al Entorno",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "No se ha encontrado la variable de entorno \"{environment}\"."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "cuerpo sin procesar",
     "rename": "Renombrar solicitud",
     "renamed": "Solicitud renombrada",
+    "request_variables": "Request variables",
     "run": "Ejecutar",
     "save": "Guardar",
     "save_as": "Guardar como",
@@ -557,6 +613,7 @@
     "title": "Solicitud",
     "type": "Tipo de solicitud",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variables",
     "view_my_links": "Ver mis enlaces",
     "copy_link": "Copiar enlace"
@@ -811,6 +868,13 @@
       "new": "Crear un nuevo equipo",
       "switch_to_personal": "Cambia a tu espacio de trabajo personal",
       "title": "Equipos"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Haz preguntas y obtén respuestas",
     "github": "Síguenos en Github",
     "shortcuts": "Navega por la aplicación más rápido",
-    "team": "Ponte en contacto con el equipo",
     "title": "Ayuda",
-    "twitter": "Síguenos en Twitter"
+    "twitter": "Síguenos en Twitter",
+    "team": "Ponte en contacto con el equipo"
   },
   "tab": {
     "authorization": "Autorización",
@@ -889,6 +953,9 @@
     "query": "Consulta",
     "schema": "Esquema",
     "shared_requests": "Solicitudes compartidas",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Pruebas",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite a personas a este espacio de trabajo",
     "invited_to_team": "{owner} te ha invitado al equipo {team}",
     "join": "Invitación aceptada",
-    "join_beta": "Únete al programa beta para acceder a los equipos.",
     "join_team": "Entrar a {team}",
     "joined_team": "Haz entrado a {team}",
     "joined_team_description": "Ahora eres miembro de este equipo",
@@ -950,7 +1016,12 @@
     "success_invites": "Invitaciones con éxito",
     "title": "Equipos",
     "we_sent_invite_link": "¡Hemos enviado un enlace de invitación a todos los invitados!",
-    "we_sent_invite_link_description": "Pide a todos los invitados que revisen su bandeja de entrada. Tienen que hacer clic en el enlace para unirse al equipo."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Pide a todos los invitados que revisen su bandeja de entrada. Tienen que hacer clic en el enlace para unirse al equipo.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Únete al programa beta para acceder a los equipos."
   },
   "team_environment": {
     "deleted": "Entorno eliminado",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Cambiar el espacio de trabajo",
     "personal": "Mi espacio de trabajo",
+    "other_workspaces": "My Workspaces",
     "team": "Espacio de trabajo en equipo",
     "title": "Espacios de trabajo"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Acciones",

--- a/packages/hoppscotch-common/locales/fi.json
+++ b/packages/hoppscotch-common/locales/fi.json
@@ -24,8 +24,10 @@
     "go_back": "Mene takaisin",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Etiketti",
     "learn_more": "Lue lisää",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Lisää",
     "new": "Uusi",
@@ -43,6 +45,7 @@
     "search": "Hae",
     "send": "Lähettää",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "alkaa",
     "starting": "Starting",
     "stop": "Lopettaa",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Kirjoita komento tai hae…",
     "we_use_cookies": "Käytämme evästeitä",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Mikä on uutta?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Tili on eri kirjautumistiedoilla - Kirjaudu linkittääksesi molemmat tilit",
     "all_sign_in_options": "Kaikki kirjautumisvaihtoehdot",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Jatka sähköpostilla",
     "continue_with_github": "Jatka GitHubilla",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Jatka Googlella",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "Sähköposti",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Salasana",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Token",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Muokkaa kokoelmaa",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Anna kokoelmalle kelvollinen nimi",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Valitse kokoelma",
     "select_location": "Valitse sijainti",
+    "details": "Details",
     "select_team": "Valitse joukkue",
     "team_collections": "Joukkuekokoelmat"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Haluatko varmasti poistaa telemetrian käytöstä?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Haluatko varmasti synkronoida tämän työtilan?"
+    "sync": "Haluatko varmasti synkronoida tämän työtilan?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "There are no pending invites for this team",
     "profile": "Login to view your profile",
     "protocols": "Protokollat ovat tyhjiä",
+    "request_variables": "This request does not have any request variables",
     "schema": "Muodosta yhteys GraphQL -päätepisteeseen",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Joukkueen nimi tyhjä",
     "teams": "Joukkueet ovat tyhjiä",
     "tests": "Tätä pyyntöä ei ole testattu",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Valitse ympäristö",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Muuttujien luettelo"
+    "variables": "Variables",
+    "variable_list": "Muuttujien luettelo",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Tyhjä pyynnön nimi",
     "f12_details": "(F12 lisätietoja)",
     "gql_prettify_invalid_query": "Virheellistä kyselyä ei voitu määrittää, ratkaista kyselyn syntaksivirheet ja yrittää uudelleen",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Virheellistä runkoa ei voitu määrittää, ratkaista json -syntaksivirheitä ja yrittää uudelleen",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Ennakkopyyntöskriptiä ei voitu suorittaa",
     "something_went_wrong": "Jotain meni pieleen",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Vie JSON -muodossa",
     "create_secret_gist": "Luo salainen ydin",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist luotu",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Kirjaudu sisään GitHubilla luodaksesi salaisen sisällön",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Gist luotu"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutaatiot",
     "schema": "Kaavio",
     "subscriptions": "Tilaukset",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Tuonti"
+    "title": "Tuonti",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Raaka pyynnön runko",
     "rename": "Rename Request",
     "renamed": "Pyyntö nimettiin uudelleen",
+    "request_variables": "Request variables",
     "run": "Juosta",
     "save": "Tallentaa",
     "save_as": "Tallenna nimellä",
@@ -557,6 +613,7 @@
     "title": "Pyyntö",
     "type": "Pyynnön tyyppi",
     "url": "URL -osoite",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Muuttujat",
     "view_my_links": "View my links",
     "copy_link": "Kopioi linkki"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Esitä kysymyksiä ja saat vastauksia",
     "github": "Follow us on Github",
     "shortcuts": "Selaa sovellusta nopeammin",
-    "team": "Ota yhteyttä tiimiin",
     "title": "Tuki",
-    "twitter": "Seuraa meitä Twitterissä"
+    "twitter": "Seuraa meitä Twitterissä",
+    "team": "Ota yhteyttä tiimiin"
   },
   "tab": {
     "authorization": "Valtuutus",
@@ -889,6 +953,9 @@
     "query": "Kysely",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Pistorasia.IO",
     "sse": "SSE",
     "tests": "Testit",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite people to this workspace",
     "invited_to_team": "{owner} invited you to join {team}",
     "join": "Invitation accepted",
-    "join_beta": "Liity beta -ohjelmaan päästäksesi tiimeihin.",
     "join_team": "Join {team}",
     "joined_team": "You have joined {team}",
     "joined_team_description": "You are now a member of this team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Joukkueet",
     "we_sent_invite_link": "We sent an invite link to all invitees!",
-    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Liity beta -ohjelmaan päästäksesi tiimeihin."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/fr.json
+++ b/packages/hoppscotch-common/locales/fr.json
@@ -24,8 +24,10 @@
     "go_back": "Retour",
     "go_forward": "Avancer",
     "group_by": "Grouper par",
+    "hide_secret": "Hide secret",
     "label": "Étiqueter",
     "learn_more": "En savoir plus",
+    "download_here": "Download here",
     "less": "Moins",
     "more": "Suite",
     "new": "Nouveau",
@@ -43,6 +45,7 @@
     "search": "Chercher",
     "send": "Envoyer",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Démarrer",
     "starting": "Démarrage",
     "stop": "Arrêter",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Tapez une commande ou recherchez…",
     "we_use_cookies": "Nous utilisons des cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Quoi de neuf ?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Le compte existe avec des informations d'identification différentes - Connectez-vous pour lier les deux comptes",
     "all_sign_in_options": "Toutes les options de connexion",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Continuer par e-mail",
     "continue_with_github": "Continuer avec GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Continuer avec Google",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "E-mail",
@@ -123,31 +130,54 @@
     "include_in_url": "Inclure dans l'URL",
     "inherited_from": "Inherited from {auth} from Parent Collection {collection} ",
     "learn": "Apprendre comment",
+    "oauth": {
+      "redirect_auth_server_returned_error": "Le serveur d'authentification a renvoyé un état d'erreur",
+      "redirect_auth_token_request_failed": "La demande d'obtention du jeton d'authentification a échoué",
+      "redirect_auth_token_request_invalid_response": "Réponse invalide du point de terminaison Token lors de la demande d'un jeton d'authentification",
+      "redirect_invalid_state": "Valeur d'état non valide présente dans la redirection",
+      "redirect_no_auth_code": "Pas de code d'autorisation dans la redirection",
+      "redirect_no_client_id": "Pas d'ID client défini",
+      "redirect_no_client_secret": "Pas de secret client défini",
+      "redirect_no_code_verifier": "Pas de vérificateur de code défini",
+      "redirect_no_token_endpoint": "Aucun point de terminaison de jeton n'est défini",
+      "something_went_wrong_on_oauth_redirect": "Quelque chose s'est mal passé lors de la redirection OAuth",
+      "something_went_wrong_on_token_generation": "Un problème s'est produit lors de la génération des jetons",
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
+    },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Mot de passe",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Jeton",
     "type": "Type d'autorisation",
-    "username": "Nom d'utilisateur",
-    "oauth": {
-      "something_went_wrong_on_token_generation": "Un problème s'est produit lors de la génération des jetons",
-      "redirect_auth_server_returned_error": "Le serveur d'authentification a renvoyé un état d'erreur",
-      "redirect_no_auth_code": "Pas de code d'autorisation dans la redirection",
-      "redirect_invalid_state": "Valeur d'état non valide présente dans la redirection",
-      "redirect_no_token_endpoint": "Aucun point de terminaison de jeton n'est défini",
-      "redirect_no_client_id": "Pas d'ID client défini",
-      "redirect_no_client_secret": "Pas de secret client défini",
-      "redirect_no_code_verifier": "Pas de vérificateur de code défini",
-      "redirect_auth_token_request_failed": "La demande d'obtention du jeton d'authentification a échoué",
-      "redirect_auth_token_request_invalid_response": "Réponse invalide du point de terminaison Token lors de la demande d'un jeton d'authentification",
-      "something_went_wrong_on_oauth_redirect": "Quelque chose s'est mal passé lors de la redirection OAuth"
-    }
+    "username": "Nom d'utilisateur"
   },
   "collection": {
     "created": "Collection créée",
     "different_parent": "Impossible de réorganiser une collection dont le parent est différent",
     "edit": "Modifier la collection",
     "import_or_create": "Importer ou créer une collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Veuillez fournir un nom valide pour la collection",
     "invalid_root_move": "Collection déjà présente dans la racine",
     "moved": "Déplacement réussi",
@@ -164,6 +194,7 @@
     "save_to_collection": "Enregistrer dans la collection",
     "select": "Sélectionnez une collection",
     "select_location": "Sélectionnez l'emplacement",
+    "details": "Details",
     "select_team": "Sélectionnez une équipe",
     "team_collections": "Collections de l'équipe"
   },
@@ -182,7 +213,8 @@
     "remove_telemetry": "Êtes-vous sûr de vouloir désactiver la télémétrie ?",
     "request_change": "Êtes-vous sûr de vouloir rejeter la demande en cours ? Les modifications non enregistrées seront perdues.",
     "save_unsaved_tab": "Souhaitez-vous enregistrer les modifications apportées dans cet onglet ?",
-    "sync": "Voulez-vous vraiment synchroniser cet espace de travail ?"
+    "sync": "Voulez-vous vraiment synchroniser cet espace de travail ?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Ajouter aux paramètres",
@@ -191,20 +223,20 @@
   },
   "cookies": {
     "modal": {
-      "new_domain_name": "Nouveau nom de domaine",
-      "set": "Définir un cookie",
-      "cookie_string": "Chaîne de caractères de cookie",
-      "enter_cookie_string": "Saisir la chaîne de caractères du cookie",
-      "cookie_name": "Nom",
-      "cookie_value": "Valeur",
-      "cookie_path": "Chemin d'accès",
       "cookie_expires": "Expiration",
-      "managed_tab": "Gestion",
-      "raw_tab": "Brut",
-      "interceptor_no_support": "L'intercepteur que vous avez sélectionné ne prend pas en charge les cookies. Sélectionnez un autre intercepteur et réessayez.",
-      "empty_domains": "La liste des domaines est vide",
+      "cookie_name": "Nom",
+      "cookie_path": "Chemin d'accès",
+      "cookie_string": "Chaîne de caractères de cookie",
+      "cookie_value": "Valeur",
       "empty_domain": "Le domaine est vide",
-      "no_cookies_in_domain": "Aucun cookie n'est défini pour ce domaine"
+      "empty_domains": "La liste des domaines est vide",
+      "enter_cookie_string": "Saisir la chaîne de caractères du cookie",
+      "interceptor_no_support": "L'intercepteur que vous avez sélectionné ne prend pas en charge les cookies. Sélectionnez un autre intercepteur et réessayez.",
+      "managed_tab": "Gestion",
+      "new_domain_name": "Nouveau nom de domaine",
+      "no_cookies_in_domain": "Aucun cookie n'est défini pour ce domaine",
+      "raw_tab": "Brut",
+      "set": "Définir un cookie"
     }
   },
   "count": {
@@ -236,13 +268,16 @@
     "pending_invites": "Il n'y a pas d'invitation en cours pour cette équipe",
     "profile": "Connectez-vous pour voir votre profil",
     "protocols": "Les protocoles sont vides",
+    "request_variables": "This request does not have any request variables",
     "schema": "Se connecter à un point de terminaison GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Il n'y a pas de requêtes partagées",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Nom de l'équipe vide",
     "teams": "Les équipes sont vides",
     "tests": "Il n'y a pas de tests pour cette requête",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Les shortcodes sont vides"
   },
   "environment": {
@@ -269,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Sélectionnez l'environnement",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -277,7 +314,10 @@
     "updated": "Mise à jour de l'environnement",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Liste des variables"
+    "variables": "Variables",
+    "variable_list": "Liste des variables",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -288,6 +328,7 @@
     "danger_zone": "Zone de danger",
     "delete_account": "Votre compte est actuellement propriétaire de ces équipes :",
     "delete_account_description": "Vous devez vous retirer, transférer la propriété ou supprimer ces équipes avant de pouvoir supprimer votre compte.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Nom de la requête vide",
     "f12_details": "(F12 pour les détails)",
     "gql_prettify_invalid_query": "Impossible de formater une requête non valide, résolvez les erreurs de syntaxe de la requête et réessayer",
@@ -295,6 +336,7 @@
     "incorrect_email": "Email incorrect",
     "invalid_link": "Lien invalide",
     "invalid_link_description": "Le lien sur lequel vous avez cliqué n'est pas valide ou a expiré.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "JSON non valide",
     "json_prettify_invalid_body": "Impossible de formater un corps non valide, résolvez les erreurs de syntaxe json et réessayez",
     "network_error": "Il semble y avoir une erreur de réseau. Veuillez réessayer.",
@@ -306,17 +348,25 @@
     "page_not_found": "Cette page n'a pas pu être trouvée",
     "please_install_extension": "Veuillez installer l'extension et ajouter l'origine à l'extension.",
     "proxy_error": "Erreur de proxy",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Impossible d'exécuter le script de pré-requête",
     "something_went_wrong": "Quelque chose s'est mal passé",
-    "test_script_fail": "Impossible d'exécuter le script post-requête"
+    "test_script_fail": "Impossible d'exécuter le script post-requête",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Exporter au format JSON",
     "create_secret_gist": "Créer un Gist secret",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist créé",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Connectez-vous avec GitHub pour créer un Gist secret",
-    "title": "Exportation"
+    "title": "Exportation",
+    "success": "Successfully exported",
+    "gist_created": "Gist créé"
   },
   "filter": {
     "all": "Tout",
@@ -338,7 +388,8 @@
     "mutations": "Mutations",
     "schema": "Schéma",
     "subscriptions": "Abonnements",
-    "switch_connection": "Changer de connexion"
+    "switch_connection": "Changer de connexion",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -404,12 +455,17 @@
     "json_description": "Importer des collections depuis un fichier JSON Hoppscotch",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Importer"
+    "title": "Importer",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspecter les erreurs possibles",
     "environment": {
       "add_environment": "Ajouter à l'environnement",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "La variable d'environnement “{environment}“ n'a pas été trouvée."
     },
     "header": {
@@ -525,8 +581,8 @@
     "enter_curl": "Entrer cURL",
     "generate_code": "Générer le code",
     "generated_code": "Code généré",
-    "go_to_body_tab": "Go to Body tab",
     "go_to_authorization_tab": "Aller à l'autorisation",
+    "go_to_body_tab": "Go to Body tab",
     "header_list": "Liste des en-têtes",
     "invalid_name": "Veuillez fournir un nom pour la requête",
     "method": "Méthode",
@@ -545,6 +601,7 @@
     "raw_body": "Corps de requête brut",
     "rename": "Demande de renommage",
     "renamed": "Requête renommée",
+    "request_variables": "Request variables",
     "run": "Lancer",
     "save": "Sauvegarder",
     "save_as": "Enregistrer sous",
@@ -556,6 +613,7 @@
     "title": "Requête",
     "type": "Type de requête",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variables",
     "view_my_links": "Voir mes liens",
     "copy_link": "Copier le lien"
@@ -810,6 +868,13 @@
       "new": "Créer une nouvelle équipe",
       "switch_to_personal": "Passez à votre espace de travail personnel",
       "title": "Les équipes"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -835,8 +900,8 @@
     "disconnected": "Déconnecté",
     "disconnected_from": "Déconnecté de {name}",
     "docs_generated": "Documentation générée",
-    "download_started": "Téléchargement commencé",
     "download_failed": "Téléchargement échoué",
+    "download_started": "Téléchargement commencé",
     "enabled": "Active",
     "file_imported": "Fichier importé",
     "finished_in": "Terminé en {duration} ms",
@@ -866,9 +931,9 @@
     "forum": "Posez des questions et obtenez des réponses",
     "github": "Follow us on Github",
     "shortcuts": "Parcourir l'application plus rapidement",
-    "team": "Entrez en contact avec l'équipe",
     "title": "Support",
-    "twitter": "Suivez-nous sur Twitter"
+    "twitter": "Suivez-nous sur Twitter",
+    "team": "Entrez en contact avec l'équipe"
   },
   "tab": {
     "authorization": "Autorisation",
@@ -888,6 +953,9 @@
     "query": "Requête",
     "schema": "Schema",
     "shared_requests": "Requêtes partagées",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "ESS",
     "tests": "Tests",
@@ -904,6 +972,7 @@
     "email_do_not_match": "L'email ne correspond pas aux détails de votre compte. Contactez le propriétaire de votre équipe.",
     "exit": "Quitter l'équipe",
     "exit_disabled": "Seul le propriétaire ne peut pas quitter l'équipe",
+    "failed_invites": "Échec des invitations",
     "invalid_coll_id": "Invalid collection ID",
     "invalid_email_format": "Le format de l'e-mail n'est pas valide",
     "invalid_id": "L'email ne correspond pas aux détails de votre compte. Contactez le propriétaire de votre équipe.",
@@ -915,7 +984,6 @@
     "invite_tooltip": "Invitez des personnes à cet espace de travail",
     "invited_to_team": "{owner} vous invite à rejoindre {team}",
     "join": "Invitation accepté",
-    "join_beta": "Rejoignez le programme bêta pour accéder aux équipes.",
     "join_team": "Rejoindre {team}",
     "joined_team": "Vous avez rejoint {team}",
     "joined_team_description": "Vous êtes maintenant membre de cette équipe",
@@ -940,16 +1008,20 @@
     "not_found": "Équipe non trouvée. Contactez le propriétaire de votre équipe.",
     "not_valid_viewer": "Vous n'êtes pas un visionneur valide. Contactez le propriétaire de votre équipe.",
     "parent_coll_move": "Impossible de déplacer une collection vers une collection enfant",
-    "success_invites": "Les invitations réussites",
     "pending_invites": "Invitations en attente",
-    "failed_invites": "Échec des invitations",
     "permissions": "Autorisations",
     "same_target_destination": "Même destinataire et même cible",
     "saved": "Équipe enregistrée",
     "select_a_team": "Choisir une équipe",
+    "success_invites": "Les invitations réussites",
     "title": "Équipes",
     "we_sent_invite_link": "Nous avons envoyé un lien d'invitation à tous les invités !",
-    "we_sent_invite_link_description": "Demandez à tous les invités de vérifier leur boîte de réception. Cliquez sur le lien pour rejoindre l'équipe."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Demandez à tous les invités de vérifier leur boîte de réception. Cliquez sur le lien pour rejoindre l'équipe.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Rejoignez le programme bêta pour accéder aux équipes."
   },
   "team_environment": {
     "deleted": "Environment supprimé",
@@ -976,8 +1048,49 @@
   "workspace": {
     "change": "Changer d'espace de travail",
     "personal": "Mon espace de travail",
+    "other_workspaces": "My Workspaces",
     "team": "Espace de travail de l'équipe",
     "title": "Espaces de travail"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/he.json
+++ b/packages/hoppscotch-common/locales/he.json
@@ -24,8 +24,10 @@
     "go_back": "תחזור",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "תווית",
     "learn_more": "למד עוד",
+    "download_here": "Download here",
     "less": "Less",
     "more": "יותר",
     "new": "חָדָשׁ",
@@ -43,6 +45,7 @@
     "search": "לחפש",
     "send": "לִשְׁלוֹחַ",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "הַתחָלָה",
     "starting": "Starting",
     "stop": "תפסיק",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "הקלד פקודה או חפש ...",
     "we_use_cookies": "אנו משתמשים בעוגיות",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "מה חדש?",
+    "see_whats_new": "See what’s new",
     "wiki": "ויקי"
   },
   "auth": {
     "account_exists": "החשבון קיים עם אישורים שונים - התחבר לקישור שני החשבונות",
     "all_sign_in_options": "כל אפשרויות הכניסה",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "המשך עם מייל",
     "continue_with_github": "המשך עם GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "המשך עם גוגל",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "אימייל",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "סיסמה",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "אֲסִימוֹן",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "ערוך אוסף",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "אנא ספק שם תקף לאוסף",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "בחר אוסף",
     "select_location": "תבחר מיקום",
+    "details": "Details",
     "select_team": "בחר צוות",
     "team_collections": "אוספי צוות"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "האם אתה בטוח שברצונך לבטל את הסכמתך לטלמטריה?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "האם אתה בטוח שברצונך לסנכרן את סביבת העבודה הזו?"
+    "sync": "האם אתה בטוח שברצונך לסנכרן את סביבת העבודה הזו?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "There are no pending invites for this team",
     "profile": "Login to view your profile",
     "protocols": "הפרוטוקולים ריקים",
+    "request_variables": "This request does not have any request variables",
     "schema": "התחבר לנקודת קצה של GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "שם הקבוצה ריק",
     "teams": "הקבוצות ריקות",
     "tests": "אין בדיקות לבקשה זו",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "בחר סביבה",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "רשימת משתנים"
+    "variables": "Variables",
+    "variable_list": "רשימת משתנים",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "שם הבקשה ריק",
     "f12_details": "(F12 לפרטים)",
     "gql_prettify_invalid_query": "לא ניתן היה לייפות שאילתה לא חוקית, לפתור שגיאות תחביר שאילתות ולנסות שוב",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "לא ניתן היה לייפות גוף לא חוקי, לפתור שגיאות תחביר של json ולנסות שוב",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "לא ניתן להפעיל סקריפט של בקשה מראש",
     "something_went_wrong": "משהו השתבש",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "ייצא כ- JSON",
     "create_secret_gist": "צור גיסט סודי",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "גיסט נוצר",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "התחבר עם GitHub כדי ליצור תמצית סודית",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "גיסט נוצר"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "מוטציות",
     "schema": "סכֵימָה",
     "subscriptions": "מנויים",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "יְבוּא"
+    "title": "יְבוּא",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "גוף בקשה גולמית",
     "rename": "Rename Request",
     "renamed": "שם הבקשה שונה",
+    "request_variables": "Request variables",
     "run": "לָרוּץ",
     "save": "להציל",
     "save_as": "שמור כ",
@@ -557,6 +613,7 @@
     "title": "בַּקָשָׁה",
     "type": "סוג בקשה",
     "url": "כתובת URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "משתנים",
     "view_my_links": "View my links",
     "copy_link": "העתק קישור"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "שאל שאלות וקבל תשובות",
     "github": "Follow us on Github",
     "shortcuts": "עיון באפליקציה מהר יותר",
-    "team": "צרו קשר עם הצוות",
     "title": "תמיכה",
-    "twitter": "עקבו אחרינו בטוויטר"
+    "twitter": "עקבו אחרינו בטוויטר",
+    "team": "צרו קשר עם הצוות"
   },
   "tab": {
     "authorization": "הרשאה",
@@ -889,6 +953,9 @@
     "query": "שאילתא",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "בדיקות",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite people to this workspace",
     "invited_to_team": "{owner} invited you to join {team}",
     "join": "Invitation accepted",
-    "join_beta": "הצטרף לתוכנית הביטא לגישה לצוותים.",
     "join_team": "Join {team}",
     "joined_team": "You have joined {team}",
     "joined_team_description": "You are now a member of this team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "צוותים",
     "we_sent_invite_link": "We sent an invite link to all invitees!",
-    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "הצטרף לתוכנית הביטא לגישה לצוותים."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/hu.json
+++ b/packages/hoppscotch-common/locales/hu.json
@@ -24,8 +24,10 @@
     "go_back": "Vissza",
     "go_forward": "Előre",
     "group_by": "Csoportosítás",
+    "hide_secret": "Hide secret",
     "label": "Címke",
     "learn_more": "Tudjon meg többet",
+    "download_here": "Download here",
     "less": "Kevesebb",
     "more": "Több",
     "new": "Új",
@@ -43,6 +45,7 @@
     "search": "Keresés",
     "send": "Küldés",
     "share": "Megosztás",
+    "show_secret": "Show secret",
     "start": "Indítás",
     "starting": "Indítás",
     "stop": "Leállítás",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Írjon be parancsot vagy keresést…",
     "we_use_cookies": "Sütiket használunk",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Mik az újdonságok?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "A fiók különböző hitelesítési adatokkal létezik – jelentkezzen be a két fiók összekapcsolásához",
     "all_sign_in_options": "Összes bejelentkezési lehetőség",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Folytatás e-mail-címmel",
     "continue_with_github": "Folytatás GitHub használatával",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Folytatás Google használatával",
     "continue_with_microsoft": "Folytatás Microsoft használatával",
     "email": "E-mail",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "Nincs \"Token Endpoint\"",
       "something_went_wrong_on_oauth_redirect": "Valami rosszul sikerült az OAuth átirányításakor",
       "something_went_wrong_on_token_generation": "Valami rosszul sikerült a token generálásakor",
-      "token_generation_oidc_discovery_failed": "Hiba a token generálásakor: OpenID Connect Discovery hiba"
+      "token_generation_oidc_discovery_failed": "Hiba a token generálásakor: OpenID Connect Discovery hiba",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Átadta",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Jelszó",
     "save_to_inherit": "Kérjük, mentse el ezt kérést bármelyik gyűjteménybe, hogy az azonosítás örökölhető lehessen",
     "token": "Token",
@@ -149,6 +177,7 @@
     "different_parent": "Nem lehet átrendezni a különböző szülővel rendelkező gyűjteményt",
     "edit": "Gyűjtemény szerkesztése",
     "import_or_create": "Gyűjtemény importálása vagy létrehozása",
+    "import_collection": "Import Collection",
     "invalid_name": "Adjon nevet a gyűjteménynek",
     "invalid_root_move": "A gyűjtemény már a gyökérben van",
     "moved": "Sikeresen áthelyezve",
@@ -165,6 +194,7 @@
     "save_to_collection": "Mentés egy gyűjteménybe",
     "select": "Gyűjtemény kiválasztása",
     "select_location": "Hely kiválasztása",
+    "details": "Details",
     "select_team": "Csapat kiválasztása",
     "team_collections": "Csapat gyűjteményei"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Biztosan ki szeretné kapcsolni a telemetriát?",
     "request_change": "Biztosan el szeretné vetni a jelenlegi kérést? Minden mentetlen változtatás el fog veszni.",
     "save_unsaved_tab": "Szeretné menteni az ezen a lapon elvégzett változtatásokat?",
-    "sync": "Szeretné visszaállítani a munkaterületét a felhőből? Ez el fogja vetni a helyi folyamatát."
+    "sync": "Szeretné visszaállítani a munkaterületét a felhőből? Ez el fogja vetni a helyi folyamatát.",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Paraméterek hozzáadása",
@@ -237,13 +268,16 @@
     "pending_invites": "Nincsenek függőben lévő meghívások ennél a csapatnál",
     "profile": "Jelentkezzen be a profilja megtekintéséhez",
     "protocols": "A protokollok üresek",
+    "request_variables": "This request does not have any request variables",
     "schema": "Kapcsolódjon egy GraphQL-végponthoz a séma megtekintéséhez",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "A feliratkozások üresek",
     "team_name": "A csapat neve üres",
     "teams": "Ön nem tartozik semmilyen csapathoz",
     "tests": "Nincsenek tesztek ehhez a kéréshez",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "A rövid kódok üresek"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Környezet gyors megnézése",
     "replace_with_variable": "Cserélje le egy változóra",
     "scope": "Hatókör",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Környezet kiválasztása",
     "set": "Környezet beállítása",
     "set_as_environment": "Környezetként való beállítás",
@@ -278,7 +314,10 @@
     "updated": "Környezet frissítve",
     "value": "Érték",
     "variable": "Változó",
-    "variable_list": "Változólista"
+    "variables": "Variables",
+    "variable_list": "Változólista",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Nem sikerült betölteni az azonosító szolgáltatókat",
@@ -289,6 +328,7 @@
     "danger_zone": "Veszélyes zóna",
     "delete_account": "Az Ön fiókja jelenleg tulajdonos ezekben a csapatokban:",
     "delete_account_description": "El kell távolítani magát, át kell adnia a tulajdonjogot vagy törölnie kell ezeket a csapatokat, mielőtt törölhetné a fiókját.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Üres kérésnév",
     "f12_details": "(F12 a részletekért)",
     "gql_prettify_invalid_query": "Nem sikerült csinosítani egy érvénytelen lekérdezést, oldja meg a lekérdezés szintaktikai hibáit, és próbálja újra",
@@ -296,6 +336,7 @@
     "incorrect_email": "Hibás e-mail",
     "invalid_link": "Érvénytelen hivatkozás",
     "invalid_link_description": "A kattintott hivatkozás érvénytelen vagy lejárt.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Érvénytelen JSON",
     "json_prettify_invalid_body": "Nem sikerült csinosítani egy érvénytelen törzset, oldja meg a JSON szintaktikai hibáit, és próbálja újra",
     "network_error": "Úgy tűnik, hogy hálózati hiba van. Próbálja újra.",
@@ -307,17 +348,25 @@
     "page_not_found": "Ez az oldal nem található",
     "please_install_extension": "Kérjük telepítse a bővítményt és adja hozzá a forráshoz.",
     "proxy_error": "Proxy hiba",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Nem sikerült végrehajtani a kérés előtti parancsfájlt",
     "something_went_wrong": "Valami elromlott",
-    "test_script_fail": "Nem sikerült végrehajtani a kérés utáni parancsfájlt"
+    "test_script_fail": "Nem sikerült végrehajtani a kérés utáni parancsfájlt",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Exportálás JSON formátumban",
     "create_secret_gist": "Titkos Gist létrehozása",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Valami hiba történt az exportálás közben",
-    "gist_created": "Gist létrehozva",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Jelentkezzen be GitHub használatával a titkos Gist létrehozásához",
-    "title": "Exportálás"
+    "title": "Exportálás",
+    "success": "Successfully exported",
+    "gist_created": "Gist létrehozva"
   },
   "filter": {
     "all": "Összes",
@@ -339,7 +388,8 @@
     "mutations": "Mutációk",
     "schema": "Séma",
     "subscriptions": "Feliratkozások",
-    "switch_connection": "Kapcsolat váltása"
+    "switch_connection": "Kapcsolat váltása",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL gyűjtemény"
@@ -405,12 +455,17 @@
     "json_description": "Gyűjtemények importálása Hoppscotch-gyűjtemények JSON-fájlból",
     "postman_environment": "Postman környezet",
     "postman_environment_description": "Postman környezet importálása  JSON fájlból",
-    "title": "Importálás"
+    "title": "Importálás",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Lehetséges hibák ellenőrzése",
     "environment": {
       "add_environment": "Hozzáadás a környezethez",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "\"{environment}\" környezet nem található."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Nyers kéréstörzs",
     "rename": "Rename Request",
     "renamed": "Kérés átnevezve",
+    "request_variables": "Request variables",
     "run": "Futtatás",
     "save": "Mentés",
     "save_as": "Mentés másként",
@@ -557,6 +613,7 @@
     "title": "Kérés",
     "type": "Kérés típusa",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Változók",
     "view_my_links": "Saját hivatkozások megtekintése",
     "copy_link": "Hivatkozás másolása"
@@ -811,6 +868,13 @@
       "new": "Új csapat létrehozása",
       "switch_to_personal": "Váltás a személyes munkaterületére",
       "title": "Csapatok"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Tegyen fel kérdéseket és kapjon válaszokat",
     "github": "Kövessen minket GitHubon",
     "shortcuts": "Az alkalmazás gyorsabb böngészése",
-    "team": "Vegye fel a kapcsolatot a csapattal",
     "title": "Támogatás",
-    "twitter": "Kövessen minket Twitteren"
+    "twitter": "Kövessen minket Twitteren",
+    "team": "Vegye fel a kapcsolatot a csapattal"
   },
   "tab": {
     "authorization": "Azonosítás",
@@ -889,6 +953,9 @@
     "query": "Lekérdezés",
     "schema": "Séma",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Tesztek",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Emberek meghívása erre a munkaterületre",
     "invited_to_team": "{owner} meghívta Önt, hogy csatlakozzon ehhez a csapathoz: {team}",
     "join": "Meghívás elfogadva",
-    "join_beta": "Csatlakozzon a béta programhoz, hogy hozzáférjen a csapatokhoz.",
     "join_team": "Csatlakozás ehhez: {team}",
     "joined_team": "Ön csatlakozott ehhez a csapathoz: {team}",
     "joined_team_description": "Ön mostantól ennek a csapatnak a tagja",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Csapatok",
     "we_sent_invite_link": "Elküldtünk egy meghívási hivatkozást az összes meghívottnak.",
-    "we_sent_invite_link_description": "Kérje meg az összes meghívottat, hogy nézzék meg a beérkező leveleiket. Kattintsanak a hivatkozásra a csapathoz való csatlakozáshoz."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Kérje meg az összes meghívottat, hogy nézzék meg a beérkező leveleiket. Kattintsanak a hivatkozásra a csapathoz való csatlakozáshoz.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Csatlakozzon a béta programhoz, hogy hozzáférjen a csapatokhoz."
   },
   "team_environment": {
     "deleted": "Környezet törölve",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Munkaterület váltása",
     "personal": "Saját munkaterület",
+    "other_workspaces": "My Workspaces",
     "team": "Csapat-munkaterület",
     "title": "Munkaterületek"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Műveletek",

--- a/packages/hoppscotch-common/locales/id.json
+++ b/packages/hoppscotch-common/locales/id.json
@@ -24,8 +24,10 @@
     "go_back": "Kembali",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Label",
     "learn_more": "Pelajari lebih lanjut",
+    "download_here": "Download here",
     "less": "Lebih sedikit",
     "more": "Lebih banyak",
     "new": "Baru",
@@ -43,6 +45,7 @@
     "search": "Cari",
     "send": "Kirim",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Mulai",
     "starting": "Memulai",
     "stop": "Berhenti",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Ketik perintah atau cari…",
     "we_use_cookies": "Kami menggunakan cookie",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Apa yang baru?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Akun ada dengan kredensial berbeda - Masuk untuk menautkan kedua akun",
     "all_sign_in_options": "Semua opsi masuk",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Lanjutkan dengan Surel",
     "continue_with_github": "Lanjutkan dengan GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Lanjutkan dengan Google",
     "continue_with_microsoft": "Lanjutkan dengan Microsoft",
     "email": "Surel",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Lewat",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Kata Sandi",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Token",
@@ -149,6 +177,7 @@
     "different_parent": "Tidak dapat mengubah urutan koleksi dengan induk yang berbeda",
     "edit": "Mengubah Koleksi",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Berikan nama untuk Koleksi",
     "invalid_root_move": "Koleksi sudah berada di akar direktori",
     "moved": "Berhasil Dipindahkan",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Pilih Koleksi",
     "select_location": "Pilih lokasi",
+    "details": "Details",
     "select_team": "Pilih tim",
     "team_collections": "Koleksi Tim"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Apakah Anda yakin ingin menyisih dari Telemetri?",
     "request_change": "Apakah Anda yakin ingin membuang permintaan saat ini, perubahan yang belum disimpan akan hilang.",
     "save_unsaved_tab": "Apakah Anda ingin menyimpan perubahan yang dibuat di tab ini?",
-    "sync": "Apakah Anda ingin memulihkan ruang kerja Anda dari cloud? Ini akan membuang kemajuan lokal Anda."
+    "sync": "Apakah Anda ingin memulihkan ruang kerja Anda dari cloud? Ini akan membuang kemajuan lokal Anda.",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "Tidak ada undangan yang tertunda untuk tim ini",
     "profile": "Masuk untuk melihat profil Anda",
     "protocols": "Protokol kosong",
+    "request_variables": "This request does not have any request variables",
     "schema": "Hubungkan ke endpoint GraphQL untuk melihat skema",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Langganan kosong",
     "team_name": "Nama team kosong",
     "teams": "Kamu bukan di team manapun",
     "tests": "Tidak ada tes untuk permintaan ini",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes kosong"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Pilih environment",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment diperbarui",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Daftar Variable"
+    "variables": "Variables",
+    "variable_list": "Daftar Variable",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Akun Anda saat ini merupakan pemilik dalam tim-tim ini:",
     "delete_account_description": "Anda harus menghapus diri Anda dari tim-tim ini, mentransfer kepemilikan, atau menghapus tim-tim ini sebelum Anda dapat menghapus akun Anda.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Nama Permintaan Kosong",
     "f12_details": "(F12 untuk detailnya)",
     "gql_prettify_invalid_query": "Tidak dapat prettify kueri yang tidak valid, menyelesaikan kesalahan sintaksis kueri, dan coba lagi",
@@ -296,6 +336,7 @@
     "incorrect_email": "Surel Salah",
     "invalid_link": "Tautan tidak valid",
     "invalid_link_description": "Tautan yang Anda klik tidak valid atau kedaluwarsa.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "JSON tidak valid",
     "json_prettify_invalid_body": "Tidak dapat prettify body yang tidak valid, selesaikan kesalahan sintaks json dan coba lagi",
     "network_error": "Sepertinya ada kesalahan jaringan. Silakan coba lagi.",
@@ -307,17 +348,25 @@
     "page_not_found": "Halaman ini tidak dapat ditemukan",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Tidak dapat menjalankan pre-request script",
     "something_went_wrong": "Ada yang salah",
-    "test_script_fail": "Tidak dapat mengeksekusi post-request script"
+    "test_script_fail": "Tidak dapat mengeksekusi post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Export sebagai JSON",
     "create_secret_gist": "Buat secret Gist",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist dibuat",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Masuk dengan GitHub untuk membuat secret gist",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Gist dibuat"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutations",
     "schema": "Schema",
     "subscriptions": "Subscriptions",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Impor Koleksi dari berkas JSON Koleksi Hoppscotch",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Impor"
+    "title": "Impor",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Raw Request Body",
     "rename": "Rename Request",
     "renamed": "Request berganti nama",
+    "request_variables": "Request variables",
     "run": "Jalankan",
     "save": "Menyimpan",
     "save_as": "Simpan sebagai",
@@ -557,6 +613,7 @@
     "title": "Request",
     "type": "Tipe Request",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variables",
     "view_my_links": "Lihat tautan saya",
     "copy_link": "Salin tautan"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Ajukan pertanyaan dan dapatkan jawaban",
     "github": "Ikuti kami di GitHub",
     "shortcuts": "Jelajahi aplikasi lebih cepat",
-    "team": "Hubungi tim",
     "title": "Mendukung",
-    "twitter": "Ikuti kami di Twitter"
+    "twitter": "Ikuti kami di Twitter",
+    "team": "Hubungi tim"
   },
   "tab": {
     "authorization": "Authorization",
@@ -889,6 +953,9 @@
     "query": "Query",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Tests",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Undang orang ke ruang kerja ini",
     "invited_to_team": "{owner} mengundang Anda untuk bergabung {team}",
     "join": "Undangan diterima",
-    "join_beta": "Bergabunglah dengan program beta untuk mengakses tim.",
     "join_team": "Bergabung {team}",
     "joined_team": "Anda telah bergabung {team}",
     "joined_team_description": "Anda sekarang adalah anggota tim ini",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "tim",
     "we_sent_invite_link": "Kami mengirim tautan undangan ke semua undangan!",
-    "we_sent_invite_link_description": "Minta semua undangan untuk memeriksa kotak masuk mereka. Klik tautan untuk bergabung dengan tim."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Minta semua undangan untuk memeriksa kotak masuk mereka. Klik tautan untuk bergabung dengan tim.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Bergabunglah dengan program beta untuk mengakses tim."
   },
   "team_environment": {
     "deleted": "Environment dihapus",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Beralih workspace",
     "personal": "Workspace Saya",
+    "other_workspaces": "My Workspaces",
     "team": "Workspace Tim",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Tindakan",

--- a/packages/hoppscotch-common/locales/it.json
+++ b/packages/hoppscotch-common/locales/it.json
@@ -24,8 +24,10 @@
     "go_back": "Torna indietro",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Etichetta",
     "learn_more": "Per saperne di più",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Di più",
     "new": "Nuovo",
@@ -43,6 +45,7 @@
     "search": "Cerca",
     "send": "Invia",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Avvia",
     "starting": "Starting",
     "stop": "Interrompi",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Digita un comando o cerca...",
     "we_use_cookies": "Utilizziamo i cookie",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Cosa c'è di nuovo?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "L'account esiste con credenziali diverse - Accedi per collegare entrambi gli account",
     "all_sign_in_options": "Tutte le opzioni di accesso",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Continua con e-mail",
     "continue_with_github": "Continua con GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Continua con Google",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "E-mail",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Password",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Token",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Modifica raccolta",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Si prega di fornire un nome valido per la raccolta",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Seleziona una raccolta",
     "select_location": "Seleziona la posizione",
+    "details": "Details",
     "select_team": "Seleziona un team",
     "team_collections": "Raccolte di team"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Sei sicuro di voler disattivare la telemetria?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Vuoi ripristinare il tuo spazio di lavoro con quello del cloud? Questo annullerà le tue modifiche fatte in locale."
+    "sync": "Vuoi ripristinare il tuo spazio di lavoro con quello del cloud? Questo annullerà le tue modifiche fatte in locale.",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "Non ci sono inviti pendenti per questo team",
     "profile": "Accedi per mostrare il tuo profilo",
     "protocols": "I protocolli sono vuoti",
+    "request_variables": "This request does not have any request variables",
     "schema": "Connettiti a un endpoint GraphQL per mostrare lo schema",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Il nome del team è vuoto",
     "teams": "I team sono vuoti",
     "tests": "Non ci sono test per questa richiesta",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Seleziona ambiente",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Elenco variabili"
+    "variables": "Variables",
+    "variable_list": "Elenco variabili",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Nome richiesta vuoto",
     "f12_details": "(F12 per i dettagli)",
     "gql_prettify_invalid_query": "Impossibile abbellire una query non valida, risolvere gli errori di sintassi della query e riprovare",
@@ -296,6 +336,7 @@
     "incorrect_email": "Indirizzo email errato",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Impossibile abbellire un corpo non valido, risolvere gli errori di sintassi JSON e riprovare",
     "network_error": "Sembra ci sia un problema di rete. Per favore prova di nuovo.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Impossibile eseguire lo script di pre-richiesta",
     "something_went_wrong": "Qualcosa è andato storto",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Esporta come JSON",
     "create_secret_gist": "Crea un Gist segreto",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist creato",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Accedi con GitHub per creare un Gist segreto",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Gist creato"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutazioni",
     "schema": "Schema",
     "subscriptions": "Sottoscrizioni",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Importa"
+    "title": "Importa",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Corpo della richiesta non formattato",
     "rename": "Rename Request",
     "renamed": "Richiesta rinominata",
+    "request_variables": "Request variables",
     "run": "Esegui",
     "save": "Salva",
     "save_as": "Salva come",
@@ -557,6 +613,7 @@
     "title": "Richiesta",
     "type": "Tipo di richiesta",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variabili",
     "view_my_links": "View my links",
     "copy_link": "Copia collegamento"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Fai domande e ottieni risposte",
     "github": "Follow us on Github",
     "shortcuts": "Naviga nella app più velocemente",
-    "team": "Mettiti in contatto con il team",
     "title": "Supporto",
-    "twitter": "Seguici su Twitter"
+    "twitter": "Seguici su Twitter",
+    "team": "Mettiti in contatto con il team"
   },
   "tab": {
     "authorization": "Autorizzazione",
@@ -889,6 +953,9 @@
     "query": "Query",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Test",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invita persone in questo spazio di lavoro",
     "invited_to_team": "{owner} ti ha invitato ad unirti al team {team}",
     "join": "Invito accettato",
-    "join_beta": "Partecipa al programma beta per accedere ai team.",
     "join_team": "Unisciti al team {team}",
     "joined_team": "Sei parte del team {team}",
     "joined_team_description": "Ora sei un membro di questo team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Team",
     "we_sent_invite_link": "Abbiamo inviato un link di invito a tutti gli invitati!",
-    "we_sent_invite_link_description": "Chiedi a tutti gli invitati di controllare la loro casella email. Cliccando sul link possono entrare nel team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Chiedi a tutti gli invitati di controllare la loro casella email. Cliccando sul link possono entrare nel team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Partecipa al programma beta per accedere ai team."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/ja.json
+++ b/packages/hoppscotch-common/locales/ja.json
@@ -24,8 +24,10 @@
     "go_back": "戻る",
     "go_forward": "Go forward",
     "group_by": "グループ化",
+    "hide_secret": "Hide secret",
     "label": "ラベル",
     "learn_more": "もっと詳しく",
+    "download_here": "Download here",
     "less": "表示を減らす",
     "more": "もっと見る",
     "new": "新規",
@@ -43,6 +45,7 @@
     "search": "検索",
     "send": "送信",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "はじめる",
     "starting": "開始中",
     "stop": "止める",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "コマンドもしくは検索ワードを入力…",
     "we_use_cookies": "Cookieを使用しています",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "新着情報",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "アカウントがそれぞれの認証情報で存在しています - ログインして両方のアカウントを連携する",
     "all_sign_in_options": "すべてのサインインオプション",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "メールアドレスで続行",
     "continue_with_github": "GitHubアカウントで続行",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Googleアカウントで続行",
     "continue_with_microsoft": "Microsoftアカウントで続行",
     "email": "メールアドレス",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "認証元: ",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "パスワード",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "トークン",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "コレクションの編集",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "コレクション名を入力してください",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "コレクションを選択",
     "select_location": "場所を選択",
+    "details": "Details",
     "select_team": "チームを選択",
     "team_collections": "チームコレクション"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "テレメトリをオプトアウトしてもよろしいですか？",
     "request_change": "現在のリクエストを削除してもよろしいですか？保存されていない変更は削除されます。",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "クラウドからワークスペースを復元しますか？この場合、ローカルの進行状況は破棄されます。"
+    "sync": "クラウドからワークスペースを復元しますか？この場合、ローカルの進行状況は破棄されます。",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "このチームに保留中の招待はありません",
     "profile": "ログインしてプロフィールを見る",
     "protocols": "プロトコルがありません",
+    "request_variables": "This request does not have any request variables",
     "schema": "GraphQLエンドポイントに接続する",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "サブスクリプションはありません",
     "team_name": "チーム名がありません",
     "teams": "チームに参加していません",
     "tests": "このリクエストのテストはありません",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "ショートコードはありません"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "環境変数を選択",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "環境変数を更新しました",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "環境変数リスト"
+    "variables": "Variables",
+    "variable_list": "環境変数リスト",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "危険",
     "delete_account": "あなたのアカウントは以下のチームのオーナーとなっています:",
     "delete_account_description": "アカウントを削除する前にチームを離脱するか、オーナーを委任するか、チームを削除してください。",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "リクエスト名がありません",
     "f12_details": "（詳細はF12キーを押してください）",
     "gql_prettify_invalid_query": "クエリを整形できませんでした。クエリの構文エラーを解決して再試行してください。",
@@ -296,6 +336,7 @@
     "incorrect_email": "メールアドレスが間違っています",
     "invalid_link": "リンクが無効です",
     "invalid_link_description": "クリックしたリンクは無効か期限切れです。",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "JSONが無効です",
     "json_prettify_invalid_body": "ボディを整形できませんでした。JSONの構文エラーを解決して再試行してください。",
     "network_error": "ネットワークエラーが発生したようです。もう一度お試しください。",
@@ -307,17 +348,25 @@
     "page_not_found": "このページは見つかりませんでした",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "リクエスト前のスクリプトを実行できませんでした",
     "something_went_wrong": "不明なエラーです",
-    "test_script_fail": "リクエスト後のスクリプトを実行できませんでした"
+    "test_script_fail": "リクエスト後のスクリプトを実行できませんでした",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "JSONとしてエクスポート",
     "create_secret_gist": "Secret Gistを作成",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gistが作成されました",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "GitHubにログインしてSecret Gistを作成",
-    "title": "エクスポート"
+    "title": "エクスポート",
+    "success": "Successfully exported",
+    "gist_created": "Gistが作成されました"
   },
   "filter": {
     "all": "全て",
@@ -339,7 +388,8 @@
     "mutations": "ミューテーション",
     "schema": "スキーマ",
     "subscriptions": "サブスクリプション",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Hoppscotchのコレクション (JSONファイル) からインポート",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "インポート"
+    "title": "インポート",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "生のリクエストボディ",
     "rename": "Rename Request",
     "renamed": "リクエストの名前を変更",
+    "request_variables": "Request variables",
     "run": "実行",
     "save": "保存",
     "save_as": "名前を付けて保存",
@@ -557,6 +613,7 @@
     "title": "リクエスト",
     "type": "リクエストの種類",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "変数",
     "view_my_links": "自分のリンクを見る",
     "copy_link": "リンクをコピー"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "質問をして答えを得る",
     "github": "GitHubでフォローする",
     "shortcuts": "アプリをより効率よく使いこなす",
-    "team": "チームと連絡を取る",
     "title": "サポート",
-    "twitter": "私たちのTwitterをフォローする"
+    "twitter": "私たちのTwitterをフォローする",
+    "team": "チームと連絡を取る"
   },
   "tab": {
     "authorization": "認証",
@@ -889,6 +953,9 @@
     "query": "クエリ",
     "schema": "スキーマ",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "テスト",
@@ -917,7 +984,6 @@
     "invite_tooltip": "このワークスペースに招待",
     "invited_to_team": "{owner}が{team}にあなたを招待しました",
     "join": "招待を了承しました",
-    "join_beta": "ベータプログラムに参加して、チームにアクセスする。",
     "join_team": "{team}に参加",
     "joined_team": "あなたは{team}に参加しました",
     "joined_team_description": "あなたはこのチームのメンバーです",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "チーム",
     "we_sent_invite_link": "招待者の皆様に、招待リンクを送信しました！",
-    "we_sent_invite_link_description": "招待者全員に受信トレイを確認するよう依頼します。リンクをクリックすると、チームに参加できます。"
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "招待者全員に受信トレイを確認するよう依頼します。リンクをクリックすると、チームに参加できます。",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "ベータプログラムに参加して、チームにアクセスする。"
   },
   "team_environment": {
     "deleted": "環境変数を削除しました",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "アクション",

--- a/packages/hoppscotch-common/locales/ko.json
+++ b/packages/hoppscotch-common/locales/ko.json
@@ -24,8 +24,10 @@
     "go_back": "돌아가기",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "이름",
     "learn_more": "더 알아보기",
+    "download_here": "Download here",
     "less": "접기",
     "more": "더보기",
     "new": "추가",
@@ -43,6 +45,7 @@
     "search": "검색",
     "send": "보내기",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "시작",
     "starting": "Starting",
     "stop": "정지",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "명령을 입력하거나 검색...",
     "we_use_cookies": "우리는 쿠키를 사용중입니다.",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "새로 바뀐 점",
+    "see_whats_new": "See what’s new",
     "wiki": "위키"
   },
   "auth": {
     "account_exists": "계정이 다른 자격 증명으로 존재합니다. 두 계정을 연결하려면 로그인하세요.",
     "all_sign_in_options": "모든 로그인 옵션",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "이메일로 계속하기",
     "continue_with_github": "GitHub로 계속하기",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Google로 계속하기",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "이메일",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "전달 방식",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "비밀번호",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "토큰",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "모음집 편집",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "모음집 이름을 바르게 입력하세요.",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "모음집 선택",
     "select_location": "위치 선택",
+    "details": "Details",
     "select_team": "팀 선택",
     "team_collections": "팀 모음집"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "진단 데이터를 보내지 않겠습니까?",
     "request_change": "현재 요청을 취소하시겠습니까? 저장되지 않은 변경사항은 삭제됩니다.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "이 작업 공간을 동기화하겠습니까?"
+    "sync": "이 작업 공간을 동기화하겠습니까?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "이 팀에는 대기 중인 초대가 없습니다.",
     "profile": "로그인하여 프로필을 확인합니다.",
     "protocols": "프로토콜이 비어 있습니다.",
+    "request_variables": "This request does not have any request variables",
     "schema": "스키마를 보려면 GraphQL 엔드포인트에 연결하세요.",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "팀 이름이 비어 있습니다.",
     "teams": "아무 팀에도 속하지 않았습니다.",
     "tests": "이 요청에 대한 테스트가 없습니다.",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "환경 선택",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "환경 수정됨",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "변수 목록"
+    "variables": "Variables",
+    "variable_list": "변수 목록",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "빈 요청 이름",
     "f12_details": "(자세한 내용은 F12)",
     "gql_prettify_invalid_query": "잘못된 쿼리를 구문 강조할 수 없습니다. 쿼리 구문 오류를 해결하고 다시 시도하세요.",
@@ -296,6 +336,7 @@
     "incorrect_email": "잘못된 이메일 형식",
     "invalid_link": "잘못된 링크",
     "invalid_link_description": "잘못된 링크이거나 만료된 링크입니다.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "잘못된 본문을 구문 강조할 수 없습니다. json 구문 오류를 해결하고 다시 시도하세요.",
     "network_error": "네트워크 에러인 것 같습니다. 다시 시도하세요.",
@@ -307,17 +348,25 @@
     "page_not_found": "해당 페이지를 찾을 수 없습니다.",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "사전 요청 스크립트를 실행할 수 없습니다.",
     "something_went_wrong": "문제가 발생했습니다.",
-    "test_script_fail": "테스트 스크립트를 실행할 수 없습니다."
+    "test_script_fail": "테스트 스크립트를 실행할 수 없습니다.",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "JSON으로 내보내기",
     "create_secret_gist": "Secret Gist 만들기",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist가 생성됨",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "GitHub에 로그인하여 secret gist 만들기",
-    "title": "내보내기"
+    "title": "내보내기",
+    "success": "Successfully exported",
+    "gist_created": "Gist가 생성됨"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "뮤테이션",
     "schema": "스키마",
     "subscriptions": "섭스크립션",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "호프스카치 모음집 JSON 파일을 가져옵니다.",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "가져오기"
+    "title": "가져오기",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "원시 요청 본문",
     "rename": "Rename Request",
     "renamed": "요청 이름이 변경됨",
+    "request_variables": "Request variables",
     "run": "실행",
     "save": "저장",
     "save_as": "다른 이름으로 저장",
@@ -557,6 +613,7 @@
     "title": "제목",
     "type": "요청 유형",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "변수",
     "view_my_links": "내 링크 보기",
     "copy_link": "링크 복사"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "질문하고 답변 받기",
     "github": "Follow us on Github",
     "shortcuts": "더 빠르게 앱 탐색",
-    "team": "팀에 연락하기",
     "title": "지원",
-    "twitter": "트위터에서 팔로우"
+    "twitter": "트위터에서 팔로우",
+    "team": "팀에 연락하기"
   },
   "tab": {
     "authorization": "인증",
@@ -889,6 +953,9 @@
     "query": "쿼리",
     "schema": "스키마",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "테스트",
@@ -917,7 +984,6 @@
     "invite_tooltip": "사람들을 이 작업 공간에 초대하기",
     "invited_to_team": "{owner}가 당신을 {team} 팀에 초대했습니다.",
     "join": "Invitation accepted",
-    "join_beta": "베타 프로그램에 참여하여 팀에 액세스하세요.",
     "join_team": "{team}에 합류",
     "joined_team": "{team}에 합류했습니다.",
     "joined_team_description": "이 팀의 구성원이 되었습니다.",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "팀",
     "we_sent_invite_link": "모든 초대 대상에게 초대 링크를 보냈습니다.",
-    "we_sent_invite_link_description": "초대 대상들이 이메일을 확인하도록 권하세요. 이메일 속 링크를 클릭하면 팀에 합류할 수 있습니다."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "초대 대상들이 이메일을 확인하도록 권하세요. 이메일 속 링크를 클릭하면 팀에 합류할 수 있습니다.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "베타 프로그램에 참여하여 팀에 액세스하세요."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/nl.json
+++ b/packages/hoppscotch-common/locales/nl.json
@@ -24,8 +24,10 @@
     "go_back": "Ga terug",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Label",
     "learn_more": "Leer meer",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Meer",
     "new": "Nieuw",
@@ -43,6 +45,7 @@
     "search": "Zoeken",
     "send": "Versturen",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Begin",
     "starting": "Starting",
     "stop": "Stop",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Typ een opdracht of zoek...",
     "we_use_cookies": "Wij gebruiken cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Wat is er nieuw?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Account bestaat met verschillende inloggegevens. Log in om beide accounts te koppelen",
     "all_sign_in_options": "Alle aanmeldmogelijkheden",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Ga verder met e-mail",
     "continue_with_github": "Ga verder met GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Ga verder met Google",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "E-mail",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Wachtwoord",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "token",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Verzameling bewerken",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Geef een geldige naam op voor de collectie",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Selecteer een collectie",
     "select_location": "Selecteer een locatie",
+    "details": "Details",
     "select_team": "Selecteer een team",
     "team_collections": "Teamcollecties"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Weet u zeker dat u zich wilt afmelden voor telemetrie?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Weet u zeker dat u deze werkruimte wilt synchroniseren?"
+    "sync": "Weet u zeker dat u deze werkruimte wilt synchroniseren?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "There are no pending invites for this team",
     "profile": "Login to view your profile",
     "protocols": "Protocollen zijn leeg",
+    "request_variables": "This request does not have any request variables",
     "schema": "Verbinding maken met een GraphQL-eindpunt",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Teamnaam leeg",
     "teams": "Teams zijn leeg",
     "tests": "Er zijn geen tests voor dit verzoek",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Selecteer omgeving",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Variabele lijst"
+    "variables": "Variables",
+    "variable_list": "Variabele lijst",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Lege aanvraagnaam",
     "f12_details": "(F12 voor details)",
     "gql_prettify_invalid_query": "Kon een ongeldige zoekopdracht niet mooier maken, syntaxisfouten in de query oplossen en opnieuw proberen",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Kon een ongeldige hoofdtekst niet mooier maken, json-syntaxisfouten oplossen en opnieuw proberen",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Kon pre-aanvraagscript niet uitvoeren",
     "something_went_wrong": "Er is iets fout gegaan",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Exporteren als JSON",
     "create_secret_gist": "Maak geheime kern",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Kern gemaakt",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Log in met GitHub om een geheime kern te maken",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Kern gemaakt"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutaties",
     "schema": "Schema",
     "subscriptions": "Abonnementen",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Importeren"
+    "title": "Importeren",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Ruwe body",
     "rename": "Rename Request",
     "renamed": "Verzoek hernoemd",
+    "request_variables": "Request variables",
     "run": "Uitvoeren",
     "save": "Opslaan",
     "save_as": "Opslaan als",
@@ -557,6 +613,7 @@
     "title": "Verzoek",
     "type": "Aanvraag type",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variabelen",
     "view_my_links": "View my links",
     "copy_link": "Kopieer link"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Stel vragen en krijg antwoorden",
     "github": "Follow us on Github",
     "shortcuts": "Sneller door de app bladeren",
-    "team": "Neem contact op met het team",
     "title": "Steun",
-    "twitter": "Volg ons op Twitter"
+    "twitter": "Volg ons op Twitter",
+    "team": "Neem contact op met het team"
   },
   "tab": {
     "authorization": "Autorisatie",
@@ -889,6 +953,9 @@
     "query": "Query",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Testen",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite people to this workspace",
     "invited_to_team": "{owner} invited you to join {team}",
     "join": "Invitation accepted",
-    "join_beta": "Doe mee aan het bètaprogramma om toegang te krijgen tot teams.",
     "join_team": "Join {team}",
     "joined_team": "You have joined {team}",
     "joined_team_description": "You are now a member of this team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "teams",
     "we_sent_invite_link": "We sent an invite link to all invitees!",
-    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Doe mee aan het bètaprogramma om toegang te krijgen tot teams."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/no.json
+++ b/packages/hoppscotch-common/locales/no.json
@@ -24,8 +24,10 @@
     "go_back": "Gå tilbake",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Merkelapp",
     "learn_more": "Lær mer",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Mer",
     "new": "Ny",
@@ -43,6 +45,7 @@
     "search": "Søk",
     "send": "Sende",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Start",
     "starting": "Starting",
     "stop": "Stoppe",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Skriv inn en kommando eller søk ...",
     "we_use_cookies": "Vi bruker informasjonskapsler",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Hva er nytt?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Kontoen eksisterer med annen legitimasjon - Logg på for å koble begge kontoene",
     "all_sign_in_options": "Alle påloggingsalternativer",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Fortsett med e-post",
     "continue_with_github": "Fortsett med GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Fortsett med Google",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "E-post",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Passord",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Nøkkel",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Rediger samling",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Oppgi et gyldig navn på samlingen",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Velg en samling",
     "select_location": "Velg plassering",
+    "details": "Details",
     "select_team": "Velg et lag",
     "team_collections": "Lagsamlinger"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Er du sikker på at du vil velge bort telemetri?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Er du sikker på at du vil synkronisere dette arbeidsområdet?"
+    "sync": "Er du sikker på at du vil synkronisere dette arbeidsområdet?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "There are no pending invites for this team",
     "profile": "Login to view your profile",
     "protocols": "Protokoller er tomme",
+    "request_variables": "This request does not have any request variables",
     "schema": "Koble til et GraphQL-endepunkt",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Lagnavnet er tomt",
     "teams": "Lagene er tomme",
     "tests": "Det er ingen tester for denne forespørselen",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Velg miljø",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Variabel liste"
+    "variables": "Variables",
+    "variable_list": "Variabel liste",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Tom forespørselsnavn",
     "f12_details": "(F12 for detaljer)",
     "gql_prettify_invalid_query": "Kunne ikke forskjønne en ugyldig spørring, løse spørringssyntaksfeil og prøve igjen",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Kunne ikke forskjønne et ugyldig brødtekst, løse json -syntaksfeil og prøve igjen",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Kunne ikke kjøre forhåndsforespørselsskript",
     "something_went_wrong": "Noe gikk galt",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Eksporter som JSON",
     "create_secret_gist": "Lag hemmelig Gist",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist opprettet",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Logg på med GitHub for å lage en hemmelig oppgave",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Gist opprettet"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutasjoner",
     "schema": "Skjema",
     "subscriptions": "Abonnementer",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Import"
+    "title": "Import",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Raw Request Body",
     "rename": "Rename Request",
     "renamed": "Forespørsel omdøpt",
+    "request_variables": "Request variables",
     "run": "Løpe",
     "save": "Lagre",
     "save_as": "Lagre som",
@@ -557,6 +613,7 @@
     "title": "Be om",
     "type": "Type forespørsel",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variabler",
     "view_my_links": "View my links",
     "copy_link": "Kopier link"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Still spørsmål og få svar",
     "github": "Follow us on Github",
     "shortcuts": "Bla gjennom appen raskere",
-    "team": "Ta kontakt med teamet",
     "title": "Brukerstøtte",
-    "twitter": "Følg oss på Twitter"
+    "twitter": "Følg oss på Twitter",
+    "team": "Ta kontakt med teamet"
   },
   "tab": {
     "authorization": "Autorisasjon",
@@ -889,6 +953,9 @@
     "query": "Spørsmål",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Tester",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite people to this workspace",
     "invited_to_team": "{owner} invited you to join {team}",
     "join": "Invitation accepted",
-    "join_beta": "Bli med i betaprogrammet for å få tilgang til lag.",
     "join_team": "Join {team}",
     "joined_team": "You have joined {team}",
     "joined_team_description": "You are now a member of this team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Lag",
     "we_sent_invite_link": "We sent an invite link to all invitees!",
-    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Bli med i betaprogrammet for å få tilgang til lag."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/pl.json
+++ b/packages/hoppscotch-common/locales/pl.json
@@ -24,8 +24,10 @@
     "go_back": "Wróć",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Etykieta",
     "learn_more": "Dowiedz się więcej",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Więcej",
     "new": "Nowa",
@@ -43,6 +45,7 @@
     "search": "Szukaj",
     "send": "Wyślij",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Rozpocznij",
     "starting": "Starting",
     "stop": "Zatrzymaj",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Wpisz polecenie lub wyszukaj…",
     "we_use_cookies": "Używamy plików cookie",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Co nowego?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Konto istnieje z różnymi danymi uwierzytelniającymi - Zaloguj się, aby połączyć oba konta",
     "all_sign_in_options": "Wszystkie opcje logowania",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Kontynuuj z e-mailem",
     "continue_with_github": "Kontynuuj z GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Kontynuuj z Google",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "E-mail",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Hasło",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Token",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Edytuj kolekcję",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Podaj prawidłową nazwę kolekcji",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Wybierz kolekcję",
     "select_location": "Wybierz lokalizację",
+    "details": "Details",
     "select_team": "Wybierz zespół",
     "team_collections": "Kolekcje zespołowe"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Czy na pewno chcesz zrezygnować z telemetrii?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Czy na pewno chcesz zsynchronizować ten obszar roboczy?"
+    "sync": "Czy na pewno chcesz zsynchronizować ten obszar roboczy?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "There are no pending invites for this team",
     "profile": "Login to view your profile",
     "protocols": "Protokoły są puste",
+    "request_variables": "This request does not have any request variables",
     "schema": "Połącz się z punktem końcowym GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Nazwa zespołu jest pusta",
     "teams": "Zespoły są puste",
     "tests": "Nie ma testów dla tego żądania",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Wybierz środowisko",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Lista zmiennych"
+    "variables": "Variables",
+    "variable_list": "Lista zmiennych",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Pusta nazwa żądania",
     "f12_details": "(F12 po szczegóły)",
     "gql_prettify_invalid_query": "Nie można poprawić czytelności nieprawidłowego zapytania, napraw błędy składni zapytania i spróbuj ponownie",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Nie można poprawić czytelności nieprawidłowej treści, napraw błędy składni json i spróbuj ponownie",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Nie można wykonać skryptu żądania wstępnego",
     "something_went_wrong": "Coś poszło nie tak",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Eksportuj jako JSON",
     "create_secret_gist": "Utwórz tajny Gist",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Utworzono Gist",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Zaloguj się za pomocą GitHub, aby utworzyć tajny Gist",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Utworzono Gist"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutacje",
     "schema": "Schemat",
     "subscriptions": "Subskrypcje",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Import"
+    "title": "Import",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Surowa treść żądania",
     "rename": "Rename Request",
     "renamed": "Zmieniono nazwę żądania",
+    "request_variables": "Request variables",
     "run": "Uruchom",
     "save": "Zapisz",
     "save_as": "Zapisz jako",
@@ -557,6 +613,7 @@
     "title": "Żądanie",
     "type": "Typ żądania",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Zmienne",
     "view_my_links": "View my links",
     "copy_link": "Skopiuj link"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Zadawaj pytania i otrzymuj odpowiedzi",
     "github": "Follow us on Github",
     "shortcuts": "Przeglądaj aplikację szybciej",
-    "team": "Skontaktuj się z zespołem",
     "title": "Wsparcie",
-    "twitter": "Śledź nas na Twitterze"
+    "twitter": "Śledź nas na Twitterze",
+    "team": "Skontaktuj się z zespołem"
   },
   "tab": {
     "authorization": "Autoryzacja",
@@ -889,6 +953,9 @@
     "query": "Zapytanie",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Testy",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite people to this workspace",
     "invited_to_team": "{owner} invited you to join {team}",
     "join": "Invitation accepted",
-    "join_beta": "Dołącz do programu beta, aby uzyskać dostęp do zespołów.",
     "join_team": "Join {team}",
     "joined_team": "You have joined {team}",
     "joined_team_description": "You are now a member of this team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Zespoły",
     "we_sent_invite_link": "We sent an invite link to all invitees!",
-    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Dołącz do programu beta, aby uzyskać dostęp do zespołów."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/pt-br.json
+++ b/packages/hoppscotch-common/locales/pt-br.json
@@ -24,8 +24,10 @@
     "go_back": "Voltar",
     "go_forward": "Avançar",
     "group_by": "Agrupar por",
+    "hide_secret": "Hide secret",
     "label": "Etiqueta",
     "learn_more": "Saber mais",
+    "download_here": "Download here",
     "less": "Menos",
     "more": "Mais",
     "new": "Novo",
@@ -43,6 +45,7 @@
     "search": "Buscar",
     "send": "Enviar",
     "share": "Compartilhar",
+    "show_secret": "Show secret",
     "start": "Começar",
     "starting": "Iniciando",
     "stop": "Parar",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Digite um comando ou pesquise...",
     "we_use_cookies": "Usamos cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "O que há de novo?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "A conta existe com credenciais diferentes - Faça login para vincular as duas contas",
     "all_sign_in_options": "Todas as opções de login",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Continuar com Email",
     "continue_with_github": "Continuar com GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Continuar com o Google",
     "continue_with_microsoft": "Continuar com Microsoft",
     "email": "E-mail",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "Nenhum endpoint de token definido",
       "something_went_wrong_on_oauth_redirect": "Algo deu errado no redirecionamento OAuth",
       "something_went_wrong_on_token_generation": "Algo deu errado na geração do token",
-      "token_generation_oidc_discovery_failed": "Falha na geração do token: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Falha na geração do token: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Passar por",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Senha",
     "save_to_inherit": "Por favor, salve essa requisição em alguma coleção para herdar a autorização",
     "token": "Símbolo",
@@ -149,6 +177,7 @@
     "different_parent": "Não é possível reordenar coleções com Coleções Pai diferentes",
     "edit": "Editar coleção",
     "import_or_create": "Importar ou criar uma coleção",
+    "import_collection": "Import Collection",
     "invalid_name": "Forneça um nome válido para a coleção",
     "invalid_root_move": "A coleção já está na raiz",
     "moved": "Movido com sucesso",
@@ -165,6 +194,7 @@
     "save_to_collection": "Salvar na Coleção",
     "select": "Selecione uma coleção",
     "select_location": "Selecione a localização",
+    "details": "Details",
     "select_team": "Selecione uma equipe",
     "team_collections": "Coleções da equipe"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Tem certeza de que deseja cancelar a telemetria?",
     "request_change": "Tem certeza que deseja descartar a requisição atual? Alterações não salvas serão perdidas.",
     "save_unsaved_tab": "Deseja salvar as atualizações feitas nesta aba?",
-    "sync": "Tem certeza de que deseja sincronizar este espaço de trabalho?"
+    "sync": "Tem certeza de que deseja sincronizar este espaço de trabalho?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Adicionar aos parâmetros",
@@ -237,13 +268,16 @@
     "pending_invites": "Não há convites pendentes para esta equipe",
     "profile": "Entre para visualizar seu perfil",
     "protocols": "Os protocolos estão vazios",
+    "request_variables": "This request does not have any request variables",
     "schema": "Conecte-se a um endpoint GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Lista de requisições compartilhadas vazia",
     "shared_requests_logout": "Faça Login para visualizar suas requisições compartilhadas ou crie uma nova",
     "subscription": "Lista de inscrições vazia",
     "team_name": "Nome da equipe vazio",
     "teams": "Equipes estão vazias",
     "tests": "Não há testes para esta requisição",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Visualização rápida do ambiente",
     "replace_with_variable": "Substituir por variável",
     "scope": "Escopo",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Selecione o ambiente",
     "set": "Definir ambiente",
     "set_as_environment": "Definir como ambiente",
@@ -278,7 +314,10 @@
     "updated": "Atualizacao de ambientes",
     "value": "Valor",
     "variable": "Variável",
-    "variable_list": "Lista de Variáveis"
+    "variables": "Variables",
+    "variable_list": "Lista de Variáveis",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Não foi possível carregar os provedores de autenticação",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Atualmente sua conta é proprietária nesses times:",
     "delete_account_description": "Você precisa sair, transferir para outro proprietário ou remover essas equipes antes de excluir sua conta.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Nome de requisição vazio",
     "f12_details": "(F12 para detalhes)",
     "gql_prettify_invalid_query": "Não foi possível justificar uma requisição inválida, resolva os erros de sintaxe da requisição e tente novamente",
@@ -296,6 +336,7 @@
     "incorrect_email": "Email incorreto",
     "invalid_link": "Link inválido",
     "invalid_link_description": "O link que você clicou é inválido ou já expirou.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Não foi possível embelezar um corpo inválido, resolver erros de sintaxe json e tentar novamente",
     "network_error": "Parece que houve um problema de rede. Por favor, tente novamente.",
@@ -307,17 +348,25 @@
     "page_not_found": "Esta página não foi encontrada",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Erro de Proxy",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Não foi possível executar o script pré-requisição",
     "something_went_wrong": "Algo deu errado",
-    "test_script_fail": "Não foi possível executar o script pós-requisição"
+    "test_script_fail": "Não foi possível executar o script pós-requisição",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Exportar como JSON",
     "create_secret_gist": "Crie um gist secreto",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Algo deu errado ao exportar",
-    "gist_created": "Gist criado",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Faça login com GitHub para criar um gist secreta",
-    "title": "Exportar"
+    "title": "Exportar",
+    "success": "Successfully exported",
+    "gist_created": "Gist criado"
   },
   "filter": {
     "all": "Todos",
@@ -339,7 +388,8 @@
     "mutations": "Mutações",
     "schema": "Esquema",
     "subscriptions": "Assinaturas",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "Coleções GraphQL"
@@ -405,12 +455,17 @@
     "json_description": "Importa coleções de um arquivo JSON de Coleções Hoppscotch",
     "postman_environment": "Ambiente Postman",
     "postman_environment_description": "Importar Ambiente Postman de arquivo JSON/YAML",
-    "title": "Importar"
+    "title": "Importar",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspecionar possíveis erros",
     "environment": {
       "add_environment": "Adicionar ao Ambiente",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Variável de ambiente “{environment}” não encontrada."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Corpo de Requisição Bruta",
     "rename": "Renomear Requisição",
     "renamed": "Requisição renomeada",
+    "request_variables": "Request variables",
     "run": "Executar",
     "save": "Salvar",
     "save_as": "Salvar como",
@@ -557,6 +613,7 @@
     "title": "Solicitar",
     "type": "Tipo de requisição",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variáveis",
     "view_my_links": "View my links",
     "copy_link": "Link de cópia"
@@ -811,6 +868,13 @@
       "new": "Criar nova equipe",
       "switch_to_personal": "Alternar para seu Workspace pessoal",
       "title": "Equipes"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Faça perguntas e obtenha respostas",
     "github": "Siga-nos no Github",
     "shortcuts": "Navegue pelo aplicativo mais rápido",
-    "team": "Entre em contato com a equipe",
     "title": "Apoio, suporte",
-    "twitter": "Siga-nos no Twitter"
+    "twitter": "Siga-nos no Twitter",
+    "team": "Entre em contato com a equipe"
   },
   "tab": {
     "authorization": "Autorização",
@@ -889,6 +953,9 @@
     "query": "Consulta",
     "schema": "Schema",
     "shared_requests": "Requisições compartilhadas",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Testes",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Convidar pessoas para esse workspace",
     "invited_to_team": "{owner} te convidou para se juntar ao {team}",
     "join": "Convite aceito",
-    "join_beta": "Junte-se ao programa beta para acessar as equipes.",
     "join_team": "Junte-se ao {team}",
     "joined_team": "Você se juntou ao {team}",
     "joined_team_description": "Você agora é um membro deste time",
@@ -950,7 +1016,12 @@
     "success_invites": "Convites com sucesso",
     "title": "Equipes",
     "we_sent_invite_link": "Link de convite enviado para todos os convidados!",
-    "we_sent_invite_link_description": "Peça a todos os convidados que verifiquem sua caixa de entrada. Clique no link para se juntar à equipe."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Peça a todos os convidados que verifiquem sua caixa de entrada. Clique no link para se juntar à equipe.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Junte-se ao programa beta para acessar as equipes."
   },
   "team_environment": {
     "deleted": "Ambiente Excluído",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Alterar Workspace",
     "personal": "Meu Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Workspace da Equipe",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Ações",

--- a/packages/hoppscotch-common/locales/pt.json
+++ b/packages/hoppscotch-common/locales/pt.json
@@ -24,8 +24,10 @@
     "go_back": "Volte",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Etiqueta",
     "learn_more": "Saber mais",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Mais",
     "new": "Novo",
@@ -43,6 +45,7 @@
     "search": "Procurar",
     "send": "Mandar",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Começar",
     "starting": "Starting",
     "stop": "Pare",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Digite um comando ou pesquise ...",
     "we_use_cookies": "Usamos cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "O que há de novo?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "A conta existe com credenciais diferentes - Faça login para vincular as duas contas",
     "all_sign_in_options": "Todas as opções de login",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Continue com Email",
     "continue_with_github": "Continue com GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Continue com o Google",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "E-mail",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Senha",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Símbolo",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Editar coleção",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Forneça um nome válido para a coleção",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Selecione uma coleção",
     "select_location": "Selecione a localização",
+    "details": "Details",
     "select_team": "Selecione uma equipe",
     "team_collections": "Coleções da equipe"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Tem certeza de que deseja cancelar a telemetria?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Tem certeza de que deseja sincronizar este espaço de trabalho?"
+    "sync": "Tem certeza de que deseja sincronizar este espaço de trabalho?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "There are no pending invites for this team",
     "profile": "Login to view your profile",
     "protocols": "Os protocolos estão vazios",
+    "request_variables": "This request does not have any request variables",
     "schema": "Conecte-se a um endpoint GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Nome do time vazio",
     "teams": "Times estão vazios",
     "tests": "Não há testes para esta solicitação",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Selecione o ambiente",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Lista de Variáveis"
+    "variables": "Variables",
+    "variable_list": "Lista de Variáveis",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Nome do pedido vazio",
     "f12_details": "(F12 para detalhes)",
     "gql_prettify_invalid_query": "Não foi possível justificar uma consulta inválida, resolva os erros de sintaxe da consulta e tente novamente",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Não foi possível embelezar um corpo inválido, resolver erros de sintaxe json e tentar novamente",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Não foi possível executar o script de pré-solicitação",
     "something_went_wrong": "Algo deu errado",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Exportar como JSON",
     "create_secret_gist": "Crie uma essência secreta",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist criado",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Faça login com GitHub para criar uma essência secreta",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Gist criado"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutações",
     "schema": "Esquema",
     "subscriptions": "Assinaturas",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Importar"
+    "title": "Importar",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Corpo de Solicitação Bruta",
     "rename": "Rename Request",
     "renamed": "Pedido renomeado",
+    "request_variables": "Request variables",
     "run": "Corre",
     "save": "Salvar",
     "save_as": "Salvar como",
@@ -557,6 +613,7 @@
     "title": "Solicitar",
     "type": "Tipo de solicitação",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variáveis",
     "view_my_links": "View my links",
     "copy_link": "Link de cópia"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Faça perguntas e obtenha respostas",
     "github": "Follow us on Github",
     "shortcuts": "Navegue pelo aplicativo mais rápido",
-    "team": "Entre em contato com a equipe",
     "title": "Apoio, suporte",
-    "twitter": "Siga-nos no Twitter"
+    "twitter": "Siga-nos no Twitter",
+    "team": "Entre em contato com a equipe"
   },
   "tab": {
     "authorization": "Autorização",
@@ -889,6 +953,9 @@
     "query": "Consulta",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Testes",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite people to this workspace",
     "invited_to_team": "{owner} invited you to join {team}",
     "join": "Invitation accepted",
-    "join_beta": "Junte-se ao programa beta para acessar as equipes.",
     "join_team": "Join {team}",
     "joined_team": "You have joined {team}",
     "joined_team_description": "You are now a member of this team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Times",
     "we_sent_invite_link": "We sent an invite link to all invitees!",
-    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Junte-se ao programa beta para acessar as equipes."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/ro.json
+++ b/packages/hoppscotch-common/locales/ro.json
@@ -24,8 +24,10 @@
     "go_back": "Înapoi",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Etichetă",
     "learn_more": "Află mai multe",
+    "download_here": "Download here",
     "less": "Mai puțin",
     "more": "Mai mult",
     "new": "Nou",
@@ -43,6 +45,7 @@
     "search": "Căutare",
     "send": "Trimite",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Start",
     "starting": "Starting",
     "stop": "Stop",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Tastați o comandă sau căutați ...",
     "we_use_cookies": "Folosim cookie-uri",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Ce mai e nou?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Contul există cu credențiale diferite - Conectați-vă pentru a conecta ambele conturi",
     "all_sign_in_options": "Toate opțiunile de conectare",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Continuați cu e-mailul",
     "continue_with_github": "Continuați cu GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Continuați cu Google",
     "continue_with_microsoft": "Continuați cu Microsoft",
     "email": "E-mail",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Transimteți cheia",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Parolă",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Token",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Editați colecția",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Vă rugăm să furnizați un nume valid pentru colecție",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Selectați o colecție",
     "select_location": "Selectați locația",
+    "details": "Details",
     "select_team": "Selectați o echipă",
     "team_collections": "Colecții de echipă"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Sigur doriți să renunțați la telemetrie?",
     "request_change": "Sigur doriți să renunțați la cererea curentă? Modificările nesalvate se vor pierde.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Sigur doriți să sincronizați acest spațiu de lucru?"
+    "sync": "Sigur doriți să sincronizați acest spațiu de lucru?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "Nu sunt invitații în așteptare pentru această echipă",
     "profile": "Autentificați-vă pentru a putea vizualiza profilul",
     "protocols": "Protocoalele sunt goale",
+    "request_variables": "This request does not have any request variables",
     "schema": "Conectați-vă la un Endpoint GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Numele echipei este gol",
     "teams": "Echipele sunt goale",
     "tests": "Nu există teste pentru această solicitare",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Codurile scurte sunt goale"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Selectați mediul",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Mediu actualizat",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Lista variabilelor"
+    "variables": "Variables",
+    "variable_list": "Lista variabilelor",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Nume cerere goală",
     "f12_details": "(F12 pentru detalii)",
     "gql_prettify_invalid_query": "Nu am putut formata o interogare nevalidă, rezolvați erorile de sintaxă ale interogării și încercați din nou",
@@ -296,6 +336,7 @@
     "incorrect_email": "Email incorect",
     "invalid_link": "Link invalid",
     "invalid_link_description": "Link-ul este invalid sau a expirat.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "JSON invalid",
     "json_prettify_invalid_body": "Nu s-a putut formata un corp invalid, rezolvați erorile de sintaxă JSON și încercați din nou",
     "network_error": "Probleme cu conexiunea. Încercați din nou.",
@@ -307,17 +348,25 @@
     "page_not_found": "Pagina nu a putut fi găsită",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Nu s-a putut executa scriptul",
     "something_went_wrong": "Ceva nu a mers bine",
-    "test_script_fail": "Nu s-a putut executa scriptul"
+    "test_script_fail": "Nu s-a putut executa scriptul",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Exportați ca JSON",
     "create_secret_gist": "Creați Gist secret",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist creat",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Conectați-vă cu GitHub pentru a crea un Gist secret",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Gist creat"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutații",
     "schema": "Schemă",
     "subscriptions": "Abonamente",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Importați colecții dintr-un fisier de collectii JSON Hoppscotch",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Import"
+    "title": "Import",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Corpul cererii",
     "rename": "Rename Request",
     "renamed": "Cerere redenumită",
+    "request_variables": "Request variables",
     "run": "Execută",
     "save": "Salvează",
     "save_as": "Salvează ca",
@@ -557,6 +613,7 @@
     "title": "Cerere",
     "type": "Tip de cerere",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variabile",
     "view_my_links": "Vizualizare link-uri",
     "copy_link": "Copiază legătură"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Puneți întrebări și primiți răspunsuri",
     "github": "Urmarește-ne pe Github",
     "shortcuts": "Utilizați aplicația mai rapid",
-    "team": "Luați legătura cu echipa",
     "title": "Suport",
-    "twitter": "Urmăriți-ne pe Twitter"
+    "twitter": "Urmăriți-ne pe Twitter",
+    "team": "Luați legătura cu echipa"
   },
   "tab": {
     "authorization": "Autorizare",
@@ -889,6 +953,9 @@
     "query": "Interogare",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Teste",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invită oameni la acest workspace",
     "invited_to_team": "{owner} te-a invitat să te alături echipei {team}",
     "join": "Invitație acceptată",
-    "join_beta": "Alăturați-vă programului beta pentru a accesa echipe.",
     "join_team": "Alăturați-vă {team}",
     "joined_team": "V-ați alăturat echipei {team}",
     "joined_team_description": "Sunteți acum membru al acestei echipe",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Echipe",
     "we_sent_invite_link": "Am trimis un link de invitație către toți invitații!",
-    "we_sent_invite_link_description": "Rugați toate persoanele invitate să iși verifice căsuța. Click pe link pentru a se alătura echipei."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Rugați toate persoanele invitate să iși verifice căsuța. Click pe link pentru a se alătura echipei.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Alăturați-vă programului beta pentru a accesa echipe."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Acțiuni",

--- a/packages/hoppscotch-common/locales/ru.json
+++ b/packages/hoppscotch-common/locales/ru.json
@@ -17,7 +17,6 @@
     "dismiss": "Скрыть",
     "dont_save": "Не сохранять",
     "download_file": "Скачать файл",
-    "download_here": "Download here",
     "drag_to_reorder": "Перетягивайте для сортировки",
     "duplicate": "Дублировать",
     "edit": "Редактировать",
@@ -28,6 +27,7 @@
     "hide_secret": "Hide secret",
     "label": "Название",
     "learn_more": "Узнать больше",
+    "download_here": "Download here",
     "less": "Меньше",
     "more": "Больше",
     "new": "Создать новый",
@@ -98,7 +98,9 @@
     "twitter": "Twitter",
     "type_a_command_search": "Введите команду или выполните поиск…",
     "we_use_cookies": "Мы используем куки",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Что нового?",
+    "see_whats_new": "See what’s new",
     "wiki": "Узнать больше"
   },
   "auth": {
@@ -161,9 +163,9 @@
       "label_auth_code": "Authorization Code",
       "label_client_credentials": "Client Credentials"
     },
-    "pass_by_headers_label": "Headers",
-    "pass_by_query_params_label": "Query Parameters",
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Пароль",
     "save_to_inherit": "Чтобы унаследовать аутентификации, нужно сохранить запрос в коллекции",
     "token": "Токен",
@@ -191,7 +193,8 @@
     "save_as": "Сохранить как",
     "save_to_collection": "Сохранить в коллекцию",
     "select": "Выбрать коллекцию",
-    "select_location": "Выберите местоположение"
+    "select_location": "Выберите местоположение",
+    "details": "Details"
   },
   "confirm": {
     "close_unsaved_tab": "Вы уверены, что хотите закрыть эту вкладку?",
@@ -208,7 +211,8 @@
     "remove_telemetry": "Вы действительно хотите отказаться от телеметрии?",
     "request_change": "Вы уверены, что хотите сбросить текущий запрос, все не сохранённые данные будт утеряны?",
     "save_unsaved_tab": "Вы хотите сохранить изменения в этой вкладке?",
-    "sync": "Вы уверены, что хотите синхронизировать это рабочее пространство?"
+    "sync": "Вы уверены, что хотите синхронизировать это рабочее пространство?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Добавить в список параметров",
@@ -263,14 +267,15 @@
     "profile": "Войдите, чтобы просмотреть свой профиль",
     "protocols": "Протоколы пустые",
     "request_variables": "Этот запрос не содержит никаких переменных",
-    "secret_environments": "Секреты хранятся только на этом устройстве и не синхронизируются с сервером",
     "schema": "Подключиться к конечной точке GraphQL",
+    "secret_environments": "Секреты хранятся только на этом устройстве и не синхронизируются с сервером",
     "shared_requests": "Вы еще не делились запросами с другими",
     "shared_requests_logout": "Нужно войти, чтобы делиться запросами и управлять ими",
     "subscription": "Нет подписок",
     "team_name": "Название команды пусто",
     "teams": "Команды пустые",
-    "tests": "Для этого запроса нет тестов"
+    "tests": "Для этого запроса нет тестов",
+    "access_tokens": "Access tokens are empty"
   },
   "environment": {
     "add_to_global": "Добавить в глобальное окружение",
@@ -307,7 +312,9 @@
     "value": "Значение",
     "variable": "Переменная",
     "variables": "Переменные",
-    "variable_list": "Список переменных"
+    "variable_list": "Список переменных",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -338,11 +345,14 @@
     "page_not_found": "Эта страница не найдена",
     "please_install_extension": "Ничего страшного. Просто нужно установить специальное расширение в браузере.",
     "proxy_error": "Proxy error",
-    "reading_files": "Произошла ошибка при чтении файла или нескольких файлов",
     "same_profile_name": "Задано имя пользователя такое же как и было",
     "script_fail": "Не удалось выполнить сценарий предварительного запроса",
     "something_went_wrong": "Что-то пошло не так",
-    "test_script_fail": "Не удалось выполнить тестирование запроса"
+    "test_script_fail": "Не удалось выполнить тестирование запроса",
+    "reading_files": "Произошла ошибка при чтении файла или нескольких файлов",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Экспорт как JSON",
@@ -374,7 +384,8 @@
     "mutations": "Мутации",
     "schema": "Схема",
     "subscriptions": "Подписки",
-    "switch_connection": "Изменить соединение"
+    "switch_connection": "Изменить соединение",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "Коллекции GraphQL"
@@ -414,8 +425,6 @@
     "environments_from_gist": "Импортировать из Gist",
     "environments_from_gist_description": "Импортировать переменные окружения Hoppscotch из Gist",
     "failed": "Ошибка импорта",
-    "file_size_limit_exceeded_warning_multiple_files": "Выбранные файлы превышают рекомендованный лимит в 10MB. Были импортированы только первые {files}",
-    "file_size_limit_exceeded_warning_single_file": "Размер выбранного в данный момент файла превышает рекомендуемый лимит в 10 МБ. Пожалуйста, выберите другой файл.",
     "from_file": "Импортировать из одного или нескольких файлов",
     "from_gist": "Импорт из Gist",
     "from_gist_description": "Импортировать через Gist URL",
@@ -442,8 +451,10 @@
     "json_description": "Импортировать из коллекции Hoppscotch",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "success": "Успешно импортировано",
-    "title": "Импортировать"
+    "title": "Импортировать",
+    "file_size_limit_exceeded_warning_multiple_files": "Выбранные файлы превышают рекомендованный лимит в 10MB. Были импортированы только первые {files}",
+    "file_size_limit_exceeded_warning_single_file": "Размер выбранного в данный момент файла превышает рекомендуемый лимит в 10 МБ. Пожалуйста, выберите другой файл.",
+    "success": "Успешно импортировано"
   },
   "inspections": {
     "description": "Показать возможные ошибки",
@@ -598,6 +609,7 @@
     "title": "Запрос",
     "type": "Тип запроса",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Переменные",
     "view_my_links": "Посмотреть мои ссылки"
   },
@@ -765,11 +777,6 @@
     "more": "Показать больше",
     "sidebar": "Показать боковую панель"
   },
-  "site_protection": {
-    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status",
-    "login_to_continue": "Login to continue",
-    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance."
-  },
   "socketio": {
     "communication": "Коммуникация",
     "connection_not_authorized": "Это SocketIO соединение не использует какую-либо авторизацию.",
@@ -806,13 +813,6 @@
     "miscellaneous": {
       "invite": "Пригласить друзей в Hoppscotch",
       "title": "Другое"
-    },
-    "phrases": {
-      "create_environment": "Создать окружение",
-      "create_workspace": "Создать пространство",
-      "import_collections": "Импортировать коллекцию",
-      "share_request": "Поделиться запросом",
-      "try": "Попробовать"
     },
     "request": {
       "save_as_new": "Сохранить как новый запрос",
@@ -862,6 +862,13 @@
       "new": "Создать новую команду",
       "switch_to_personal": "Переключить на персональное пространство",
       "title": "Команды"
+    },
+    "phrases": {
+      "try": "Попробовать",
+      "import_collections": "Импортировать коллекцию",
+      "create_environment": "Создать окружение",
+      "create_workspace": "Создать пространство",
+      "share_request": "Поделиться запросом"
     }
   },
   "sse": {
@@ -939,6 +946,8 @@
     "query": "Запрос",
     "schema": "Схема",
     "shared_requests": "Запросы в общем доступе",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
     "share_tab_request": "Поделиться запросом",
     "socketio": "Socket.IO",
     "sse": "SSE",
@@ -996,12 +1005,15 @@
     "permissions": "Разрешения",
     "same_target_destination": "Таже цель и конечная точка",
     "saved": "Команда сохранена",
-    "search_title": "Team Requests",
     "select_a_team": "Выбрать команду",
     "success_invites": "Принятые приглашения",
     "title": "Команды",
     "we_sent_invite_link": "Мы отправили все приглашения!",
-    "we_sent_invite_link_description": "Попросите тех, кого Вы пригласили, проверить их почтовые ящики. Им нужно перейди по ссылке, чтобы подтвердить вступление в эту команду."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Попросите тех, кого Вы пригласили, проверить их почтовые ящики. Им нужно перейди по ссылке, чтобы подтвердить вступление в эту команду.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests"
   },
   "team_environment": {
     "deleted": "Окружение удалено",
@@ -1031,5 +1043,45 @@
     "other_workspaces": "Пространства",
     "team": "Пространство команды",
     "title": "Рабочие пространства"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   }
 }

--- a/packages/hoppscotch-common/locales/sr.json
+++ b/packages/hoppscotch-common/locales/sr.json
@@ -24,8 +24,10 @@
     "go_back": "Вратити се",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Ознака",
     "learn_more": "Сазнајте више",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Више",
     "new": "Нова",
@@ -43,6 +45,7 @@
     "search": "Претрага",
     "send": "Пошаљи",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Почетак",
     "starting": "Starting",
     "stop": "Зауставити",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Унесите команду или претражите…",
     "we_use_cookies": "Користимо колачиће",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Шта је ново?",
+    "see_whats_new": "See what’s new",
     "wiki": "Вики"
   },
   "auth": {
     "account_exists": "Налог постоји са различитим акредитивима - Пријавите се да бисте повезали оба налога",
     "all_sign_in_options": "Све опције пријављивања",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Наставите са е -поштом",
     "continue_with_github": "Наставите са ГитХуб -ом",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Наставите са Гоогле -ом",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "Емаил",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Лозинка",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Токен",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Измени збирку",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Наведите важећи назив збирке",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Изаберите колекцију",
     "select_location": "Изаберите локацију",
+    "details": "Details",
     "select_team": "Изаберите тим",
     "team_collections": "Збирке тима"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Јесте ли сигурни да желите да искључите Телеметрију?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Јесте ли сигурни да желите да синхронизујете овај радни простор?"
+    "sync": "Јесте ли сигурни да желите да синхронизујете овај радни простор?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "There are no pending invites for this team",
     "profile": "Login to view your profile",
     "protocols": "Протоколи су празни",
+    "request_variables": "This request does not have any request variables",
     "schema": "Повежите се са ГрапхКЛ крајњом тачком",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Назив тима празан",
     "teams": "Тимови су празни",
     "tests": "Нема тестова за овај захтев",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Изаберите окружење",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Листа променљивих"
+    "variables": "Variables",
+    "variable_list": "Листа променљивих",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Празан назив захтева",
     "f12_details": "(Ф12 за детаље)",
     "gql_prettify_invalid_query": "Није могуће унапредити неважећи упит, решити грешке у синтакси упита и покушати поново",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Није могуће унапредити неважеће тело, решити грешке у синтакси јсон -а и покушати поново",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Није могуће извршити скрипту пре захтева",
     "something_went_wrong": "Нешто није у реду",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Извези као ЈСОН",
     "create_secret_gist": "Направите тајну суштину",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Суштина створена",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Пријавите се са ГитХуб -ом да бисте креирали тајну суштину",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Суштина створена"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Мутације",
     "schema": "Схема",
     "subscriptions": "Претплате",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Увоз"
+    "title": "Увоз",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Сирово тело захтева",
     "rename": "Rename Request",
     "renamed": "Захтев је преименован",
+    "request_variables": "Request variables",
     "run": "Трцати",
     "save": "сачувати",
     "save_as": "Сачувај као",
@@ -557,6 +613,7 @@
     "title": "Захтев",
     "type": "Врста Захтева",
     "url": "УРЛ",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Променљиве",
     "view_my_links": "View my links",
     "copy_link": "Копирај везу"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Постављајте питања и добијте одговоре",
     "github": "Follow us on Github",
     "shortcuts": "Брже прегледајте апликацију",
-    "team": "Ступите у контакт са тимом",
     "title": "Подршка",
-    "twitter": "Пратите нас на Твиттер -у"
+    "twitter": "Пратите нас на Твиттер -у",
+    "team": "Ступите у контакт са тимом"
   },
   "tab": {
     "authorization": "Овлашћење",
@@ -889,6 +953,9 @@
     "query": "Упит",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Соцкет.ИО",
     "sse": "ССЕ",
     "tests": "Тестови",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite people to this workspace",
     "invited_to_team": "{owner} invited you to join {team}",
     "join": "Invitation accepted",
-    "join_beta": "Придружите се бета програму да бисте приступили тимовима.",
     "join_team": "Join {team}",
     "joined_team": "You have joined {team}",
     "joined_team_description": "You are now a member of this team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Тимови",
     "we_sent_invite_link": "We sent an invite link to all invitees!",
-    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Придружите се бета програму да бисте приступили тимовима."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/sv.json
+++ b/packages/hoppscotch-common/locales/sv.json
@@ -24,8 +24,10 @@
     "go_back": "Gå tillbaka",
     "go_forward": "Go forward",
     "group_by": "Group by",
+    "hide_secret": "Hide secret",
     "label": "Märka",
     "learn_more": "Läs mer",
+    "download_here": "Download here",
     "less": "Less",
     "more": "Mer",
     "new": "Ny",
@@ -43,6 +45,7 @@
     "search": "Sök",
     "send": "Skicka",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Start",
     "starting": "Starting",
     "stop": "Sluta",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Skriv ett kommando eller sök ...",
     "we_use_cookies": "Vi använder cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Vad är nytt?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Kontot finns med olika uppgifter - Logga in för att länka båda kontona",
     "all_sign_in_options": "Alla inloggningsalternativ",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Fortsätt med e -post",
     "continue_with_github": "Fortsätt med GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Fortsätt med Google",
     "continue_with_microsoft": "Continue with Microsoft",
     "email": "E-post",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Pass by",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Lösenord",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Tecken",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Redigera samling",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Ange ett giltigt namn för samlingen",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Välj en samling",
     "select_location": "Välj plats",
+    "details": "Details",
     "select_team": "Välj ett lag",
     "team_collections": "Lagsamlingar"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Är du säker på att du vill välja bort telemetri?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Är du säker på att du vill synkronisera den här arbetsytan?"
+    "sync": "Är du säker på att du vill synkronisera den här arbetsytan?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "There are no pending invites for this team",
     "profile": "Login to view your profile",
     "protocols": "Protokoll är tomma",
+    "request_variables": "This request does not have any request variables",
     "schema": "Anslut till en GraphQL -slutpunkt",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Subscriptions are empty",
     "team_name": "Lagets namn är tomt",
     "teams": "Lag är tomma",
     "tests": "Det finns inga tester för denna begäran",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes are empty"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Välj miljö",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Environment updation",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Variabel lista"
+    "variables": "Variables",
+    "variable_list": "Variabel lista",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Danger zone",
     "delete_account": "Your account is currently an owner in these teams:",
     "delete_account_description": "You must either remove yourself, transfer ownership, or delete these teams before you can delete your account.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Tom förfrågningsnamn",
     "f12_details": "(F12 för detaljer)",
     "gql_prettify_invalid_query": "Det gick inte att pryda en ogiltig fråga, lösa frågesyntaxfel och försök igen",
@@ -296,6 +336,7 @@
     "incorrect_email": "Incorrect email",
     "invalid_link": "Invalid link",
     "invalid_link_description": "The link you clicked is invalid or expired.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Det gick inte att pryda en ogiltig kropp, lösa json -syntaxfel och försök igen",
     "network_error": "There seems to be a network error. Please try again.",
@@ -307,17 +348,25 @@
     "page_not_found": "This page could not be found",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Det gick inte att köra skriptet för förhandsbegäran",
     "something_went_wrong": "Något gick fel",
-    "test_script_fail": "Could not execute post-request script"
+    "test_script_fail": "Could not execute post-request script",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Exportera som JSON",
     "create_secret_gist": "Skapa hemlig Gist",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist skapad",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Logga in med GitHub för att skapa hemlig information",
-    "title": "Export"
+    "title": "Export",
+    "success": "Successfully exported",
+    "gist_created": "Gist skapad"
   },
   "filter": {
     "all": "All",
@@ -339,7 +388,8 @@
     "mutations": "Mutationer",
     "schema": "Schema",
     "subscriptions": "Prenumerationer",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Importera"
+    "title": "Importera",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Raw Request Body",
     "rename": "Rename Request",
     "renamed": "Begäran bytt namn",
+    "request_variables": "Request variables",
     "run": "Springa",
     "save": "Spara",
     "save_as": "Spara som",
@@ -557,6 +613,7 @@
     "title": "Begäran",
     "type": "Typ av förfrågan",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variabler",
     "view_my_links": "View my links",
     "copy_link": "Kopiera länk"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Ställ frågor och få svar",
     "github": "Follow us on Github",
     "shortcuts": "Bläddra snabbare i appen",
-    "team": "Ta kontakt med laget",
     "title": "Stöd",
-    "twitter": "Följ oss på Twitter"
+    "twitter": "Följ oss på Twitter",
+    "team": "Ta kontakt med laget"
   },
   "tab": {
     "authorization": "Tillstånd",
@@ -889,6 +953,9 @@
     "query": "Fråga",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Tester",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Invite people to this workspace",
     "invited_to_team": "{owner} invited you to join {team}",
     "join": "Invitation accepted",
-    "join_beta": "Gå med i betaprogrammet för att komma åt team.",
     "join_team": "Join {team}",
     "joined_team": "You have joined {team}",
     "joined_team_description": "You are now a member of this team",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Lag",
     "we_sent_invite_link": "We sent an invite link to all invitees!",
-    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Ask all invitees to check their inbox. Click on the link to join the team.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Gå med i betaprogrammet för att komma åt team."
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/tr.json
+++ b/packages/hoppscotch-common/locales/tr.json
@@ -45,8 +45,8 @@
     "search": "Arama",
     "send": "Gönder",
     "share": "Paylaş",
-    "start": "Başla",
     "show_secret": "Show secret",
+    "start": "Başla",
     "starting": "Starting",
     "stop": "Dur",
     "to_close": "kapatmak için",
@@ -98,7 +98,9 @@
     "twitter": "Twitter",
     "type_a_command_search": "Bir komut yazın veya arayın…",
     "we_use_cookies": "Çerezleri kullanıyoruz",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Ne var ne yok?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
@@ -175,7 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Koleksiyonu düzenle",
     "import_or_create": "Koleksiyon oluşturun veya içe aktarın",
-    "import_collection":"Koleksiyonu İçe Aktar",
+    "import_collection": "Koleksiyonu İçe Aktar",
     "invalid_name": "Lütfen koleksiyon için geçerli bir ad girin",
     "invalid_root_move": "Collection already in the root",
     "moved": "Başarıyla taşındı",
@@ -191,7 +193,8 @@
     "save_as": "Farklı kaydet",
     "save_to_collection": "Save to Collection",
     "select": "Bir koleksiyon Seçin",
-    "select_location": "Konum seçin"
+    "select_location": "Konum seçin",
+    "details": "Details"
   },
   "confirm": {
     "close_unsaved_tab": "Are you sure you want to close this tab?",
@@ -208,7 +211,8 @@
     "remove_telemetry": "Telemetriden çıkmak istediğinizden emin misiniz?",
     "request_change": "Are you sure you want to discard current request, unsaved changes will be lost.",
     "save_unsaved_tab": "Bu sekmede yapılan değişiklikleri kaydetmek istiyor musunuz?",
-    "sync": "Bu çalışma alanını senkronize etmek istediğinizden emin misiniz?"
+    "sync": "Bu çalışma alanını senkronize etmek istediğinizden emin misiniz?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -270,7 +274,8 @@
     "subscription": "Subscriptions are empty",
     "team_name": "Takım adı boş",
     "teams": "Takımlar boş",
-    "tests": "Bu istek için test yok"
+    "tests": "Bu istek için test yok",
+    "access_tokens": "Access tokens are empty"
   },
   "environment": {
     "add_to_global": "Globale ekle",
@@ -307,7 +312,9 @@
     "value": "Değer",
     "variable": "Değişken",
     "variables": "Değişkenler",
-    "variable_list": "Değişken listesi"
+    "variable_list": "Değişken listesi",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -342,17 +349,20 @@
     "script_fail": "Ön istek komut dosyası çalıştırılamadı",
     "something_went_wrong": "Bir şeyler yanlış gitti",
     "test_script_fail": "Could not execute post-request script",
-    "reading_files": "Error while reading one or more files."
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "JSON olarak dışa aktar",
     "create_secret_gist": "Gizli Gist oluştur",
     "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "require_github": "Gizli Gist oluşturmak için GitHub ile giriş yapın",
     "secret_gist_success": "Successfully exported as secret Gist",
-    "success": "Successfully exported",
-    "title": "Dışarı Aktar"
+    "require_github": "Gizli Gist oluşturmak için GitHub ile giriş yapın",
+    "title": "Dışarı Aktar",
+    "success": "Successfully exported"
   },
   "filter": {
     "all": "Tümü",
@@ -415,8 +425,6 @@
     "environments_from_gist": "Import From Gist",
     "environments_from_gist_description": "Import Hoppscotch Environments From Gist",
     "failed": "İçe aktarılamadı",
-    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
-    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
     "from_file": "Import from File",
     "from_gist": "Gist'ten içe aktar",
     "from_gist_description": "Gist ile içe aktar",
@@ -443,8 +451,10 @@
     "json_description": "Import collections from a Hoppscotch Collections JSON file",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "success": "Successfully imported",
-    "title": "İçe aktar"
+    "title": "İçe aktar",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
@@ -767,11 +777,6 @@
     "more": "Daha fazla göster",
     "sidebar": "Kenar çubuğunu göster"
   },
-  "site_protection": {
-      "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status",
-      "login_to_continue": "Login to continue",
-      "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance."
-  },
   "socketio": {
     "communication": "İletişim",
     "connection_not_authorized": "This SocketIO connection does not use any authentication.",
@@ -808,13 +813,6 @@
     "miscellaneous": {
       "invite": "Invite your friends to Hoppscotch",
       "title": "Miscellaneous"
-    },
-    "phrases": {
-        "create_environment": "Create environment",
-        "create_workspace": "Create workspace",
-        "import_collections": "Import collections",
-        "share_request": "Share request",
-        "try": "Try"
     },
     "request": {
       "save_as_new": "Save as new request",
@@ -864,6 +862,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -940,8 +945,10 @@
     "queries": "Sorgular",
     "query": "Sorgu",
     "schema": "Schema",
-    "share_tab_request": "Share tab request",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Testler",
@@ -998,12 +1005,15 @@
     "permissions": "İzinler",
     "same_target_destination": "Same target and destination",
     "saved": "Takım kaydedildi",
-    "search_title": "Team Requests",
     "select_a_team": "Takım seç",
     "success_invites": "Success invites",
     "title": "Başlık",
     "we_sent_invite_link": "Tüm davetlilere bir davet bağlantısı gönderdik!",
-    "we_sent_invite_link_description": "Tüm davetlilerden gelen kutularını kontrol etmelerini isteyin. Ekibe katılmak için bağlantıya tıklayın."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Tüm davetlilerden gelen kutularını kontrol etmelerini isteyin. Ekibe katılmak için bağlantıya tıklayın.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests"
   },
   "team_environment": {
     "deleted": "Environment Deleted",
@@ -1029,10 +1039,50 @@
   },
   "workspace": {
     "change": "Change workspace",
-    "other_workspaces": "My Workspaces",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Actions",

--- a/packages/hoppscotch-common/locales/tw.json
+++ b/packages/hoppscotch-common/locales/tw.json
@@ -24,8 +24,10 @@
     "go_back": "返回",
     "go_forward": "向前",
     "group_by": "分組方式",
+    "hide_secret": "Hide secret",
     "label": "標籤",
     "learn_more": "瞭解更多",
+    "download_here": "Download here",
     "less": "更少",
     "more": "更多",
     "new": "新增",
@@ -43,6 +45,7 @@
     "search": "搜尋",
     "send": "傳送",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "開始",
     "starting": "正在開始",
     "stop": "停止",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "輸入命令或搜尋內容……",
     "we_use_cookies": "我們使用 cookies",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "新功能",
+    "see_whats_new": "See what’s new",
     "wiki": "維基"
   },
   "auth": {
     "account_exists": "帳號存在不同的憑證 - 登入後可連結兩個帳號",
     "all_sign_in_options": "所有登入選項",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "使用電子信箱登入",
     "continue_with_github": "使用 GitHub 登入",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "使用 Google 登入",
     "continue_with_microsoft": "使用 Microsoft 登入",
     "email": "電子信箱地址",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "傳遞方式",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "密碼",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "權杖",
@@ -149,6 +177,7 @@
     "different_parent": "無法為父集合不同的集合重新排序",
     "edit": "編輯集合",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "請提供有效的集合名稱",
     "invalid_root_move": "集合已在根目錄",
     "moved": "移動成功",
@@ -165,6 +194,7 @@
     "save_to_collection": "儲存到集合",
     "select": "選擇一個集合",
     "select_location": "選擇位置",
+    "details": "Details",
     "select_team": "選擇一個團隊",
     "team_collections": "團隊集合"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "您確定要退出遙測服務嗎？",
     "request_change": "您確定要捨棄目前的請求嗎？未儲存的變更將遺失。",
     "save_unsaved_tab": "您要儲存在此分頁做出的改動嗎？",
-    "sync": "您想從雲端恢復您的工作區嗎？這將丟棄您的本地進度。"
+    "sync": "您想從雲端恢復您的工作區嗎？這將丟棄您的本地進度。",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "新增至參數",
@@ -237,13 +268,16 @@
     "pending_invites": "這個團隊沒有待定的邀請",
     "profile": "登入以檢視您的設定檔",
     "protocols": "協定為空",
+    "request_variables": "This request does not have any request variables",
     "schema": "連線至 GraphQL 端點",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "訂閱為空",
     "team_name": "團隊名稱為空",
     "teams": "團隊為空",
     "tests": "沒有針對該請求的測試",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Shortcodes 為空"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "快速預覽環境",
     "replace_with_variable": "以變數替代",
     "scope": "範圍",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "選擇環境",
     "set": "設定環境",
     "set_as_environment": "設為環境",
@@ -278,7 +314,10 @@
     "updated": "更新環境",
     "value": "數值",
     "variable": "變數",
-    "variable_list": "變數列表"
+    "variables": "Variables",
+    "variable_list": "變數列表",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "危險地帶",
     "delete_account": "您的帳號目前為這些團隊的擁有者：",
     "delete_account_description": "您在刪除帳號前必須先將您自己從團隊中移除、轉移擁有權，或是刪除團隊。",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "空請求名稱",
     "f12_details": "（按下 F12 以獲悉詳情）",
     "gql_prettify_invalid_query": "無法美化無效的查詢，處理查詢語法錯誤並重試",
@@ -296,6 +336,7 @@
     "incorrect_email": "錯誤的電子信箱",
     "invalid_link": "連結無效",
     "invalid_link_description": "您點擊的連結無效或已過期。",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "JSON 無效",
     "json_prettify_invalid_body": "無法美化無效的請求主體，處理 JSON 語法錯誤並重試",
     "network_error": "似乎有網路錯誤。請再試一次。",
@@ -307,17 +348,25 @@
     "page_not_found": "找不到此頁面",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy 錯誤",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "無法執行預請求指令碼",
     "something_went_wrong": "發生了一些錯誤",
-    "test_script_fail": "無法執行測試指令碼"
+    "test_script_fail": "無法執行測試指令碼",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "匯出為 JSON",
     "create_secret_gist": "建立私密 Gist",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "已建立 Gist",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "使用 GitHub 登入以建立私密 Gist",
-    "title": "匯出"
+    "title": "匯出",
+    "success": "Successfully exported",
+    "gist_created": "已建立 Gist"
   },
   "filter": {
     "all": "全部",
@@ -339,7 +388,8 @@
     "mutations": "變體",
     "schema": "綱要",
     "subscriptions": "訂閱",
-    "switch_connection": "切換連線"
+    "switch_connection": "切換連線",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "從 Hoppscotch 集合 JSON 檔匯入集合",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "匯入"
+    "title": "匯入",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "檢查潛在錯誤",
     "environment": {
       "add_environment": "新增至環境",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "找不到環境變數 “{environment}”。"
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "原始請求本體",
     "rename": "重新命名請求",
     "renamed": "請求已重新命名",
+    "request_variables": "Request variables",
     "run": "執行",
     "save": "儲存",
     "save_as": "另存為",
@@ -557,6 +613,7 @@
     "title": "請求",
     "type": "請求類型",
     "url": "網址",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "變數",
     "view_my_links": "檢視我的連結",
     "copy_link": "複製連結"
@@ -811,6 +868,13 @@
       "new": "建立新團隊",
       "switch_to_personal": "切換至您的個人工作區",
       "title": "團隊"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "答疑解惑",
     "github": "在 GitHub 關注我們",
     "shortcuts": "更快瀏覽應用程式",
-    "team": "與團隊保持聯絡",
     "title": "支援",
-    "twitter": "在 Twitter 關注我們"
+    "twitter": "在 Twitter 關注我們",
+    "team": "與團隊保持聯絡"
   },
   "tab": {
     "authorization": "授權",
@@ -889,6 +953,9 @@
     "query": "查詢",
     "schema": "綱要",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "測試",
@@ -917,7 +984,6 @@
     "invite_tooltip": "邀請他人到這個工作區",
     "invited_to_team": "{owner} 邀請您加入 {team}",
     "join": "已接受邀請",
-    "join_beta": "加入 Beta 計畫以存取團隊。",
     "join_team": "加入 {team}",
     "joined_team": "您已加入 {team}",
     "joined_team_description": "您現在是這個團隊的成員",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "團隊",
     "we_sent_invite_link": "我們向所有受邀者傳送了邀請連結！",
-    "we_sent_invite_link_description": "請所有受邀者檢查他們的收件匣。點擊連結加入團隊。"
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "請所有受邀者檢查他們的收件匣。點擊連結加入團隊。",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "加入 Beta 計畫以存取團隊。"
   },
   "team_environment": {
     "deleted": "已刪除環境",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "切換工作區",
     "personal": "我的工作區",
+    "other_workspaces": "My Workspaces",
     "team": "團隊工作區",
     "title": "工作區"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "操作",

--- a/packages/hoppscotch-common/locales/uk.json
+++ b/packages/hoppscotch-common/locales/uk.json
@@ -24,8 +24,10 @@
     "go_back": "Повернутись",
     "go_forward": "Go forward",
     "group_by": "Групувати за",
+    "hide_secret": "Hide secret",
     "label": "Мітка",
     "learn_more": "Дізнатись більше",
+    "download_here": "Download here",
     "less": "Менше",
     "more": "Більше",
     "new": "Новий",
@@ -43,6 +45,7 @@
     "search": "Пошук",
     "send": "Надіслати",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Почати",
     "starting": "Розпочинається",
     "stop": "Зупити",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Введіть команду або виконайте пошук…",
     "we_use_cookies": "Ми використовуємо файли cookie",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Що нового?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Обліковий запис існує з різними обліковими даними - увійдіть, щоб зв'язати обидва облікові записи",
     "all_sign_in_options": "Усі параметри входу",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Продовжити з електронною поштою",
     "continue_with_github": "Продовжити з GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Продовжити з Google",
     "continue_with_microsoft": "Продовжити з Microsoft",
     "email": "Електронна пошта",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Пропустити",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Пароль",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Токен",
@@ -149,6 +177,7 @@
     "different_parent": "Cannot reorder collection with different parent",
     "edit": "Редагувати колекцію",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Укажіть дійсну назву колекції",
     "invalid_root_move": "Collection already in the root",
     "moved": "Moved Successfully",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Виберіть колекцію",
     "select_location": "Виберіть місце розташування",
+    "details": "Details",
     "select_team": "Виберіть команду",
     "team_collections": "Колекції команд"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Ви впевнені, що хочете відмовитися від телеметрії?",
     "request_change": "Ви дійсно бажаєте скасувати поточний запит? Незбережені зміни будуть втрачені.",
     "save_unsaved_tab": "Do you want to save changes made in this tab?",
-    "sync": "Ви впевнені, що хочете синхронізувати цю робочу область?"
+    "sync": "Ви впевнені, що хочете синхронізувати цю робочу область?",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "Немає запрошень в очікуванні для цієї команди",
     "profile": "Увійдіть для перегляду вашого профілю",
     "protocols": "Протоколи порожні",
+    "request_variables": "This request does not have any request variables",
     "schema": "Підключіться до кінцевої точки GraphQL",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Підписки порожні",
     "team_name": "Назва команди порожня",
     "teams": "Команди порожні",
     "tests": "Для цього запиту немає тестів",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Короткі коди порожні"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Виберіть середовище",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Оновлення середовища",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Список змінних"
+    "variables": "Variables",
+    "variable_list": "Список змінних",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Небезпечна зона",
     "delete_account": "Ваш обліковий запис на разі володіє цими командами:",
     "delete_account_description": "Ви повинні або видалити себе, або передати право власності, або видалити ці команди, перш ніж ви зможете видалити свій обліковий запис.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Пуста назва запиту",
     "f12_details": "(F12 для деталей)",
     "gql_prettify_invalid_query": "Не вдалося попередньо визначити недійсний запит, вирішити синтаксичні помилки запиту та повторити спробу",
@@ -296,6 +336,7 @@
     "incorrect_email": "Невірна електронна адреса",
     "invalid_link": "Невірне посилання",
     "invalid_link_description": "Посилання, яке ви натиснули, є недійсним або застарілим.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "Неправильний JSON",
     "json_prettify_invalid_body": "Не вдалося заздалегідь визначити недійсне тіло, вирішити синтаксичні помилки json і повторити спробу",
     "network_error": "Здається, виникла мережева помилка. Будь ласка, спробуйте ще раз.",
@@ -307,17 +348,25 @@
     "page_not_found": "Ця сторінка не знайдена",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Не вдалося виконати сценарій попереднього запиту",
     "something_went_wrong": "Щось пішло не так",
-    "test_script_fail": "Не вдалося виконати скрипт після запиту"
+    "test_script_fail": "Не вдалося виконати скрипт після запиту",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Експортувати як JSON",
     "create_secret_gist": "Створити секретний GitHub Gist",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist створений",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Увійдіть за допомогою GitHub, щоб створити секретний Gist",
-    "title": "Експортувати"
+    "title": "Експортувати",
+    "success": "Successfully exported",
+    "gist_created": "Gist створений"
   },
   "filter": {
     "all": "Всі",
@@ -339,7 +388,8 @@
     "mutations": "Мутації",
     "schema": "Схема",
     "subscriptions": "Підписки",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Імпортувати колекції з колекцій Hoppscotch JSON файлу",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Імпортувати"
+    "title": "Імпортувати",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Сировина запиту",
     "rename": "Rename Request",
     "renamed": "Запит перейменовано",
+    "request_variables": "Request variables",
     "run": "Біжи",
     "save": "Зберегти",
     "save_as": "Зберегти як",
@@ -557,6 +613,7 @@
     "title": "Запит",
     "type": "Тип запиту",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Змінні",
     "view_my_links": "Переглянути мої посилання",
     "copy_link": "Скопіювати посилання"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Задавайте питання і отримуйте відповіді",
     "github": "Слідкуйте за нами на Github",
     "shortcuts": "Швидше переглядайте програми",
-    "team": "Зв'яжіться з командою",
     "title": "Підтримка",
-    "twitter": "Слідкуйте за нами у Twitter"
+    "twitter": "Слідкуйте за нами у Twitter",
+    "team": "Зв'яжіться з командою"
   },
   "tab": {
     "authorization": "Авторизація",
@@ -889,6 +953,9 @@
     "query": "Запит",
     "schema": "Схема",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Тести",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Запросити людей в це робоче середовище",
     "invited_to_team": "{owner} запросив вас приєднатися до {team}",
     "join": "Запрошення прийнято",
-    "join_beta": "Приєднуйтесь до бета -програми, щоб отримати доступ до команд.",
     "join_team": "Приєднатися до {team}",
     "joined_team": "Ви приєдналися до {team}",
     "joined_team_description": "Ви тепер учасник цієї команди",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Команди",
     "we_sent_invite_link": "Ми надіслали запрошення всім запрошеним!",
-    "we_sent_invite_link_description": "Попросіть всіх запрошених перевірити свої поштові скриньки. Перейдіть за посиланням, щоб приєднатися до команди."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Попросіть всіх запрошених перевірити свої поштові скриньки. Перейдіть за посиланням, щоб приєднатися до команди.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Приєднуйтесь до бета -програми, щоб отримати доступ до команд."
   },
   "team_environment": {
     "deleted": "Середовище видалено",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Change workspace",
     "personal": "My Workspace",
+    "other_workspaces": "My Workspaces",
     "team": "Team Workspace",
     "title": "Workspaces"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Дії",

--- a/packages/hoppscotch-common/locales/vi.json
+++ b/packages/hoppscotch-common/locales/vi.json
@@ -24,8 +24,10 @@
     "go_back": "Quay lại",
     "go_forward": "Tiến về phía trước",
     "group_by": "Nhóm theo",
+    "hide_secret": "Hide secret",
     "label": "Nhãn",
     "learn_more": "Tìm hiểu thêm",
+    "download_here": "Download here",
     "less": "Ít hơn",
     "more": "Thêm",
     "new": "Mới",
@@ -43,6 +45,7 @@
     "search": "Tìm kiếm",
     "send": "Gửi",
     "share": "Share",
+    "show_secret": "Show secret",
     "start": "Bắt đầu",
     "starting": "Đang bắt đầu",
     "stop": "Dừng",
@@ -95,14 +98,18 @@
     "twitter": "Twitter",
     "type_a_command_search": "Nhập một lệnh hoặc tìm kiếm...",
     "we_use_cookies": "Chúng tôi sử dụng cookie",
+    "updated_text": "Hoppscotch has been updated to v{version} 🎉",
     "whats_new": "Có gì mới?",
+    "see_whats_new": "See what’s new",
     "wiki": "Wiki"
   },
   "auth": {
     "account_exists": "Tài khoản đã tồn tại với thông tin đăng nhập khác - Đăng nhập để liên kết hai tài khoản",
     "all_sign_in_options": "Tất cả các tùy chọn đăng nhập",
+    "continue_with_auth_provider": "Continue with {provider}",
     "continue_with_email": "Tiếp tục bằng Email",
     "continue_with_github": "Tiếp tục bằng GitHub",
+    "continue_with_github_enterprise": "Continue with GitHub Enterprise",
     "continue_with_google": "Tiếp tục bằng Google",
     "continue_with_microsoft": "Tiếp tục bằng Microsoft",
     "email": "Email",
@@ -135,9 +142,30 @@
       "redirect_no_token_endpoint": "No Token Endpoint Defined",
       "something_went_wrong_on_oauth_redirect": "Something went wrong during OAuth Redirect",
       "something_went_wrong_on_token_generation": "Something went wrong on token generation",
-      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed"
+      "token_generation_oidc_discovery_failed": "Failure on token generation: OpenID Connect Discovery Failed",
+      "grant_type": "Grant Type",
+      "grant_type_auth_code": "Authorization Code",
+      "token_fetched_successfully": "Token fetched successfully",
+      "token_fetch_failed": "Failed to fetch token",
+      "validation_failed": "Validation Failed, please check the form fields",
+      "label_authorization_endpoint": "Authorization Endpoint",
+      "label_client_id": "Client ID",
+      "label_client_secret": "Client Secret",
+      "label_code_challenge": "Code Challenge",
+      "label_code_challenge_method": "Code Challenge Method",
+      "label_code_verifier": "Code Verifier",
+      "label_scopes": "Scopes",
+      "label_token_endpoint": "Token Endpoint",
+      "label_use_pkce": "Use PKCE",
+      "label_implicit": "Implicit",
+      "label_password": "Password",
+      "label_username": "Username",
+      "label_auth_code": "Authorization Code",
+      "label_client_credentials": "Client Credentials"
     },
     "pass_key_by": "Truyền qua",
+    "pass_by_query_params_label": "Query Parameters",
+    "pass_by_headers_label": "Headers",
     "password": "Mật khẩu",
     "save_to_inherit": "Please save this request in any collection to inherit the authorization",
     "token": "Token",
@@ -149,6 +177,7 @@
     "different_parent": "Không thể sắp xếp lại bộ sưu tập với cha khác",
     "edit": "Chỉnh sửa bộ sưu tập",
     "import_or_create": "Import or create a collection",
+    "import_collection": "Import Collection",
     "invalid_name": "Vui lòng cung cấp tên cho bộ sưu tập",
     "invalid_root_move": "Bộ sưu tập đã nằm trong thư mục gốc",
     "moved": "Di chuyển thành công",
@@ -165,6 +194,7 @@
     "save_to_collection": "Save to Collection",
     "select": "Chọn một bộ sưu tập",
     "select_location": "Chọn vị trí",
+    "details": "Details",
     "select_team": "Chọn một nhóm",
     "team_collections": "Bộ sưu tập của nhóm"
   },
@@ -183,7 +213,8 @@
     "remove_telemetry": "Bạn có chắc chắn muốn tắt Telemetry?",
     "request_change": "Bạn có chắc chắn muốn hủy request hiện tại? Những thay đổi chưa được lưu sẽ bị mất.",
     "save_unsaved_tab": "Bạn có muốn lưu các thay đổi đã được thực hiện trong tab này?",
-    "sync": "Bạn có muốn khôi phục không gian làm việc từ đám mây? Điều này sẽ xóa bỏ tiến trình địa phương của bạn."
+    "sync": "Bạn có muốn khôi phục không gian làm việc từ đám mây? Điều này sẽ xóa bỏ tiến trình địa phương của bạn.",
+    "delete_access_token": "Are you sure you want to delete the access token {tokenLabel}?"
   },
   "context_menu": {
     "add_parameters": "Add to parameters",
@@ -237,13 +268,16 @@
     "pending_invites": "Không có lời mời đang chờ cho nhóm này",
     "profile": "Đăng nhập để xem hồ sơ của bạn",
     "protocols": "Danh sách giao thức trống rỗng",
+    "request_variables": "This request does not have any request variables",
     "schema": "Kết nối với điểm cuối GraphQL để xem lược đồ",
+    "secret_environments": "Secrets are not synced to Hoppscotch",
     "shared_requests": "Shared requests are empty",
     "shared_requests_logout": "Login to view your shared requests or create a new one",
     "subscription": "Danh sách đăng ký trống rỗng",
     "team_name": "Tên nhóm trống rỗng",
     "teams": "Bạn không thuộc bất kỳ nhóm nào",
     "tests": "Không có bài kiểm tra cho request này",
+    "access_tokens": "Access tokens are empty",
     "shortcodes": "Danh sách mã ngắn trống rỗng"
   },
   "environment": {
@@ -270,6 +304,8 @@
     "quick_peek": "Environment Quick Peek",
     "replace_with_variable": "Replace with variable",
     "scope": "Scope",
+    "secrets": "Secrets",
+    "secret_value": "Secret value",
     "select": "Chọn môi trường",
     "set": "Set environment",
     "set_as_environment": "Set as environment",
@@ -278,7 +314,10 @@
     "updated": "Cập nhật môi trường thành công",
     "value": "Value",
     "variable": "Variable",
-    "variable_list": "Danh sách biến"
+    "variables": "Variables",
+    "variable_list": "Danh sách biến",
+    "properties": "Environment Properties",
+    "details": "Details"
   },
   "error": {
     "authproviders_load_error": "Unable to load auth providers",
@@ -289,6 +328,7 @@
     "danger_zone": "Vùng nguy hiểm",
     "delete_account": "Tài khoản của bạn hiện là chủ sở hữu trong các nhóm sau:",
     "delete_account_description": "Bạn phải xóa bản thân, chuyển quyền sở hữu hoặc xóa các nhóm này trước khi bạn có thể xóa tài khoản của mình.",
+    "empty_profile_name": "Profile name cannot be empty",
     "empty_req_name": "Tên request trống",
     "f12_details": "(Nhấn F12 để xem chi tiết)",
     "gql_prettify_invalid_query": "Không thể định dạng đẹp một truy vấn không hợp lệ, giải quyết lỗi cú pháp truy vấn và thử lại",
@@ -296,6 +336,7 @@
     "incorrect_email": "Email không chính xác",
     "invalid_link": "Liên kết không hợp lệ",
     "invalid_link_description": "Liên kết bạn đã nhấp vào không hợp lệ hoặc đã hết hạn.",
+    "invalid_embed_link": "The embed does not exist or is invalid.",
     "json_parsing_failed": "JSON không hợp lệ",
     "json_prettify_invalid_body": "Không thể định dạng đẹp một phần thân không hợp lệ, giải quyết lỗi cú pháp JSON và thử lại",
     "network_error": "Có vẻ như có lỗi mạng. Vui lòng thử lại.",
@@ -307,17 +348,25 @@
     "page_not_found": "Không tìm thấy trang này",
     "please_install_extension": "Please install the extension and add origin to the extension.",
     "proxy_error": "Proxy error",
+    "same_profile_name": "Updated profile name is same as the current profile name",
     "script_fail": "Không thể thực thi kịch bản trước request",
     "something_went_wrong": "Đã xảy ra lỗi",
-    "test_script_fail": "Không thể thực thi kịch bản sau request"
+    "test_script_fail": "Không thể thực thi kịch bản sau request",
+    "reading_files": "Error while reading one or more files.",
+    "fetching_access_tokens_list": "Something went wrong while fetching the list of tokens",
+    "generate_access_token": "Something went wrong while generating the access token",
+    "delete_access_token": "Something went wrong while deleting the access token"
   },
   "export": {
     "as_json": "Xuất dưới dạng JSON",
     "create_secret_gist": "Tạo Gist bí mật",
+    "create_secret_gist_tooltip_text": "Export as secret Gist",
     "failed": "Something went wrong while exporting",
-    "gist_created": "Gist đã được tạo",
+    "secret_gist_success": "Successfully exported as secret Gist",
     "require_github": "Đăng nhập bằng GitHub để tạo Gist bí mật",
-    "title": "Xuất"
+    "title": "Xuất",
+    "success": "Successfully exported",
+    "gist_created": "Gist đã được tạo"
   },
   "filter": {
     "all": "Tất cả",
@@ -339,7 +388,8 @@
     "mutations": "Mutations",
     "schema": "Schema",
     "subscriptions": "Subscriptions",
-    "switch_connection": "Switch connection"
+    "switch_connection": "Switch connection",
+    "url_placeholder": "Enter a GraphQL endpoint URL"
   },
   "graphql_collections": {
     "title": "GraphQL Collections"
@@ -405,12 +455,17 @@
     "json_description": "Nhập bộ sưu tập từ tệp JSON Hoppscotch",
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
-    "title": "Nhập"
+    "title": "Nhập",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "success": "Successfully imported"
   },
   "inspections": {
     "description": "Inspect possible errors",
     "environment": {
       "add_environment": "Add to Environment",
+      "add_environment_value": "Add value",
+      "empty_value": "Environment value is empty for the variable '{variable}' ",
       "not_found": "Environment variable “{environment}” not found."
     },
     "header": {
@@ -546,6 +601,7 @@
     "raw_body": "Nội dung thô",
     "rename": "Rename Request",
     "renamed": "Đã đổi tên",
+    "request_variables": "Request variables",
     "run": "Chạy",
     "save": "Lưu",
     "save_as": "Lưu như",
@@ -557,6 +613,7 @@
     "title": "Request",
     "type": "Loại request",
     "url": "URL",
+    "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Biến",
     "view_my_links": "Xem các liên kết của tôi",
     "copy_link": "Sao chép liên kết"
@@ -811,6 +868,13 @@
       "new": "Create new team",
       "switch_to_personal": "Switch to your personal workspace",
       "title": "Teams"
+    },
+    "phrases": {
+      "try": "Try",
+      "import_collections": "Import collections",
+      "create_environment": "Create environment",
+      "create_workspace": "Create workspace",
+      "share_request": "Share request"
     }
   },
   "sse": {
@@ -867,9 +931,9 @@
     "forum": "Hỏi câu hỏi và nhận câu trả lời",
     "github": "Theo dõi chúng tôi trên Github",
     "shortcuts": "Duyệt ứng dụng nhanh hơn",
-    "team": "Liên hệ với nhóm",
     "title": "Hỗ trợ",
-    "twitter": "Theo dõi chúng tôi trên Twitter"
+    "twitter": "Theo dõi chúng tôi trên Twitter",
+    "team": "Liên hệ với nhóm"
   },
   "tab": {
     "authorization": "Xác thực",
@@ -889,6 +953,9 @@
     "query": "Truy vấn",
     "schema": "Schema",
     "shared_requests": "Shared Requests",
+    "codegen": "Generate Code",
+    "code_snippet": "Code snippet",
+    "share_tab_request": "Share tab request",
     "socketio": "Socket.IO",
     "sse": "SSE",
     "tests": "Kiểm tra",
@@ -917,7 +984,6 @@
     "invite_tooltip": "Mời người khác vào không gian làm việc này",
     "invited_to_team": "{owner} đã mời bạn tham gia {team}",
     "join": "Đã chấp nhận lời mời",
-    "join_beta": "Tham gia chương trình beta để truy cập vào nhóm.",
     "join_team": "Tham gia {team}",
     "joined_team": "Bạn đã tham gia {team}",
     "joined_team_description": "Bạn hiện là thành viên của nhóm này",
@@ -950,7 +1016,12 @@
     "success_invites": "Success invites",
     "title": "Nhóm",
     "we_sent_invite_link": "Chúng tôi đã gửi một liên kết mời đến tất cả người được mời!",
-    "we_sent_invite_link_description": "Yêu cầu tất cả người được mời kiểm tra hộp thư đến của họ. Nhấp vào liên kết để tham gia nhóm."
+    "invite_sent_smtp_disabled": "Invite links generated",
+    "we_sent_invite_link_description": "Yêu cầu tất cả người được mời kiểm tra hộp thư đến của họ. Nhấp vào liên kết để tham gia nhóm.",
+    "invite_sent_smtp_disabled_description": "Sending invite emails is disabled for this instance of Hoppscotch. Please use the Copy link button to copy and share the invite link manually.",
+    "copy_invite_link": "Copy Invite Link",
+    "search_title": "Team Requests",
+    "join_beta": "Tham gia chương trình beta để truy cập vào nhóm."
   },
   "team_environment": {
     "deleted": "Môi trường đã bị xóa",
@@ -977,8 +1048,49 @@
   "workspace": {
     "change": "Thay đổi không gian làm việc",
     "personal": "Không gian làm việc của tôi",
+    "other_workspaces": "My Workspaces",
     "team": "Không gian làm việc nhóm",
     "title": "Không gian làm việc"
+  },
+  "site_protection": {
+    "login_to_continue": "Login to continue",
+    "login_to_continue_description": "You need to be logged in to access this Hoppscotch Enterprise Instance.",
+    "error_fetching_site_protection_status": "Something Went Wrong While Fetching Site Protection Status"
+  },
+  "access_tokens": {
+    "tab_title": "Tokens",
+    "section_title": "Personal Access Tokens",
+    "section_description": "Personal access tokens currently helps you connect the CLI to your Hoppscotch account",
+    "last_used_on": "Last used on",
+    "expires_on": "Expires on",
+    "no_expiration": "No expiration",
+    "expired": "Expired",
+    "copy_token_warning": "Make sure to copy your personal access token now. You won't be able to see it again!",
+    "token_purpose": "What's this token for?",
+    "expiration_label": "Expiration",
+    "scope_label": "Scope",
+    "workspace_read_only_access": "Read-only access to workspace data.",
+    "personal_workspace_access_limitation": "Personal Access Tokens can't access your personal workspace.",
+    "generate_token": "Generate Token",
+    "invalid_label": "Please provide a label for the token",
+    "no_expiration_verbose": "This token will never expire!",
+    "token_expires_on": "This token will expire on",
+    "generate_new_token": "Generate new token",
+    "generate_modal_title": "New Personal Access Token",
+    "deletion_success": "The access token {label} has been deleted"
+  },
+  "collection_runner": {
+    "collection_id": "Collection ID",
+    "environment_id": "Environment ID",
+    "cli_collection_id_description": "This collection ID will be used by the CLI collection runner for Hoppscotch.",
+    "cli_environment_id_description": "This environment ID will be used by the CLI collection runner for Hoppscotch.",
+    "include_active_environment": "Include active environment:",
+    "cli": "CLI",
+    "ui": "Runner (coming soon)",
+    "cli_command_generation_description_cloud": "Copy the below command and run it from the CLI. Please specify a personal access token.",
+    "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
+    "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
+    "run_collection": "Run collection"
   },
   "shortcodes": {
     "actions": "Hành động",


### PR DESCRIPTION
Closes HFE-528, #4165

This PR purges the en.js with all other locale files

### What's changed
Adds the missing keys in locale files
