### PR TITLE
feat: persist HTML response preview preference

### DIFF
--- a/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
+++ b/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
@@ -143,7 +143,8 @@ const readableResponseSize = computed(() => {
     props.response.type === "loading" ||
     props.response.type === "network_fail" ||
     props.response.type === "script_fail" ||
-    props.response.type === "fail"
+    props.response.type === "fail" ||
+    props.response.type === "extension_error"
   )
     return undefined
 
@@ -162,7 +163,8 @@ const statusCategory = computed(() => {
     props.response.type === "loading" ||
     props.response.type === "network_fail" ||
     props.response.type === "script_fail" ||
-    props.response.type === "fail"
+    props.response.type === "fail" ||
+    props.response.type === "extension_error"
   )
     return {
       name: "error",

--- a/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
@@ -59,25 +59,26 @@
 </template>
 
 <script setup lang="ts">
-import IconWrapText from "~icons/lucide/wrap-text"
-import IconEye from "~icons/lucide/eye"
-import IconEyeOff from "~icons/lucide/eye-off"
-import { ref, reactive } from "vue"
-import {
-  usePreview,
-  useResponseBody,
-  useCopyResponse,
-  useDownloadResponse,
-} from "@composables/lens-actions"
 import { useCodemirror } from "@composables/codemirror"
 import { useI18n } from "@composables/i18n"
-import type { HoppRESTResponse } from "~/helpers/types/HoppRESTResponse"
+import {
+  useCopyResponse,
+  useDownloadResponse,
+  usePreview,
+  useResponseBody,
+} from "@composables/lens-actions"
+import { useService } from "dioc/vue"
+import { reactive, ref } from "vue"
+
+import { useNestedSetting } from "~/composables/settings"
 import { defineActionHandler } from "~/helpers/actions"
 import { getPlatformSpecialKey as getSpecialKey } from "~/helpers/platformutils"
-import { useNestedSetting } from "~/composables/settings"
+import type { HoppRESTResponse } from "~/helpers/types/HoppRESTResponse"
 import { toggleNestedSetting } from "~/newstore/settings"
 import { PersistenceService } from "~/services/persistence"
-import { useService } from "dioc/vue"
+import IconEye from "~icons/lucide/eye"
+import IconEyeOff from "~icons/lucide/eye-off"
+import IconWrapText from "~icons/lucide/wrap-text"
 
 const t = useI18n()
 const persistenceService = useService(PersistenceService)

--- a/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
@@ -8,7 +8,7 @@
       </label>
       <div class="flex">
         <HoppButtonSecondary
-          v-if="response.body"
+          v-if="response.body && !previewEnabled"
           v-tippy="{ theme: 'tooltip' }"
           :title="t('state.linewrap')"
           :class="{ '!text-accent': WRAP_LINES }"
@@ -44,8 +44,8 @@
         />
       </div>
     </div>
-    <div v-show="!previewEnabled" class="h-full">
-      <div ref="htmlResponse" class="flex flex-1 flex-col"></div>
+    <div v-show="!previewEnabled" class="h-full relative flex flex-col flex-1">
+      <div ref="htmlResponse" class="absolute inset-0"></div>
     </div>
     <iframe
       v-show="previewEnabled"

--- a/packages/hoppscotch-common/src/composables/lens-actions.ts
+++ b/packages/hoppscotch-common/src/composables/lens-actions.ts
@@ -164,7 +164,8 @@ export function useResponseBody(response: HoppRESTResponse): {
       response.type === "loading" ||
       response.type === "network_fail" ||
       response.type === "script_fail" ||
-      response.type === "fail"
+      response.type === "fail" ||
+      response.type === "extension_error"
     )
       return ""
     if (typeof response.body === "string") return response.body

--- a/packages/hoppscotch-common/src/composables/lens-actions.ts
+++ b/packages/hoppscotch-common/src/composables/lens-actions.ts
@@ -110,11 +110,11 @@ export function usePreview(
   previewEnabledDefault: boolean,
   responseBodyText: Ref<string>
 ): {
-  previewFrame: any
+  previewFrame: Ref<HTMLIFrameElement | null>
   previewEnabled: Ref<boolean>
   togglePreview: () => void
 } {
-  const previewFrame = ref<any | null>(null)
+  const previewFrame: Ref<HTMLIFrameElement | null> = ref(null)
   const previewEnabled = ref(previewEnabledDefault)
   const url = ref("")
 
@@ -124,11 +124,15 @@ export function usePreview(
 
   // Prevent updating the `iframe` element attributes during preview toggle actions after they are set initially
   const shouldUpdatePreviewFrame = computed(
-    () => previewFrame.value.getAttribute("data-previewing-url") !== url.value
+    () => previewFrame.value?.getAttribute("data-previewing-url") !== url.value
   )
 
   const updatePreviewFrame = () => {
-    if (previewEnabled.value && shouldUpdatePreviewFrame.value) {
+    if (
+      previewEnabled.value &&
+      previewFrame.value &&
+      shouldUpdatePreviewFrame.value
+    ) {
       // Use DOMParser to parse document HTML.
       const previewDocument = new DOMParser().parseFromString(
         responseBodyText.value,

--- a/packages/hoppscotch-common/src/helpers/lenses/lenses.ts
+++ b/packages/hoppscotch-common/src/helpers/lenses/lenses.ts
@@ -33,7 +33,8 @@ export function getSuitableLenses(response: HoppRESTResponse): Lens[] {
     response.type === "loading" ||
     response.type === "network_fail" ||
     response.type === "script_fail" ||
-    response.type === "fail"
+    response.type === "fail" ||
+    response.type === "extension_error"
   )
     return []
 


### PR DESCRIPTION
Closes HFE-532

This pull request adds functionality to persist the HTML preview configuration. Previously, the configuration was not saved and had to be set every time the application was launched. With this change, the configuration will be saved locally, allowing the user's preference to persist.