### PR TITLE
feat: description field for request parameters and headers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [main, staging, "release/**"]
+    branches: [main, next, patch]
   pull_request:
-    branches: [main, staging, "release/**"]
+    branches: [main, next, patch]
 
 jobs:
   test:

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/multiple-child-collections-auth-headers-coll.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/multiple-child-collections-auth-headers-coll.json
@@ -1,655 +1,655 @@
 {
-    "v": 2,
-    "id": "clx1f86hv000010f8szcfya0t",
-    "name": "Multiple child collections with authorization & headers set at each level",
-    "folders": [
+  "v": 3,
+  "id": "clx1f86hv000010f8szcfya0t",
+  "name": "Multiple child collections with authorization & headers set at each level",
+  "folders": [
+    {
+      "v": 3,
+      "id": "clx1fjgah000110f8a5bs68gd",
+      "name": "folder-1",
+      "folders": [
         {
-            "v": 2,
-            "id": "clx1fjgah000110f8a5bs68gd",
-            "name": "folder-1",
-            "folders": [
-                {
-                    "v": 2,
-                    "id": "clx1fjwmm000410f8l1gkkr1a",
-                    "name": "folder-11",
-                    "folders": [],
-                    "requests": [
-                        {
-                            "v": "4",
-                            "auth": {
-                                "authType": "inherit",
-                                "password": "testpass",
-                                "username": "testuser",
-                                "authActive": true
-                            },
-                            "body": {
-                                "body": null,
-                                "contentType": null
-                            },
-                            "name": "folder-11-request",
-                            "method": "GET",
-                            "params": [],
-                            "headers": [],
-                            "endpoint": "https://httpbin.org/get",
-                            "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-1\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
-                            "preRequestScript": "",
-                            "requestVariables": []
-                        }
-                    ],
-                    "auth": {
-                        "authType": "inherit",
-                        "authActive": true
-                    },
-                    "headers": [
-                        {
-                            "key": "key",
-                            "value": "Set at folder-11",
-                            "active": true
-                        }
-                    ]
-                },
-                {
-                    "v": 2,
-                    "id": "clx1fjyxm000510f8pv90dt43",
-                    "name": "folder-12",
-                    "folders": [],
-                    "requests": [
-                        {
-                            "v": "4",
-                            "auth": {
-                                "authType": "none",
-                                "authActive": true
-                            },
-                            "body": {
-                                "body": null,
-                                "contentType": null
-                            },
-                            "name": "folder-12-request",
-                            "method": "GET",
-                            "params": [],
-                            "headers": [
-                                {
-                                    "key": "Custom-Header",
-                                    "value": "Custom header value overriden at folder-12-request",
-                                    "active": true
-                                },
-                                {
-                                    "key": "key",
-                                    "value": "Overriden at folder-12-request",
-                                    "active": true
-                                }
-                            ],
-                            "endpoint": "https://httpbin.org/get",
-                            "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(undefined)\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-12-request\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n  pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-12-request\")\n})",
-                            "preRequestScript": "",
-                            "requestVariables": []
-                        }
-                    ],
-                    "auth": {
-                        "authType": "none",
-                        "authActive": true
-                    },
-                    "headers": [
-                        {
-                            "key": "Custom-Header",
-                            "value": "Custom header value overriden at folder-12",
-                            "active": true
-                        },
-                        {
-                            "key": "key",
-                            "value": "Set at folder-12",
-                            "active": true
-                        }
-                    ]
-                },
-                {
-                    "v": 2,
-                    "id": "clx1fk1cv000610f88kc3aupy",
-                    "name": "folder-13",
-                    "folders": [],
-                    "requests": [
-                        {
-                            "v": "4",
-                            "auth": {
-                                "key": "api-key",
-                                "addTo": "HEADERS",
-                                "value": "api-key-value",
-                                "authType": "basic",
-                                "password": "testpass",
-                                "username": "testuser",
-                                "authActive": true,
-                                "grantTypeInfo": {
-                                    "token": "",
-                                    "isPKCE": true,
-                                    "clientID": "sfasfa",
-                                    "password": "",
-                                    "username": "",
-                                    "grantType": "AUTHORIZATION_CODE",
-                                    "authEndpoint": "asfafs",
-                                    "clientSecret": "sfasfasf",
-                                    "tokenEndpoint": "asfa",
-                                    "codeVerifierMethod": "S256"
-                                }
-                            },
-                            "body": {
-                                "body": null,
-                                "contentType": null
-                            },
-                            "name": "folder-13-request",
-                            "method": "GET",
-                            "params": [],
-                            "headers": [
-                                {
-                                    "key": "Custom-Header-Request-Level",
-                                    "value": "New custom header added at the folder-13-request level",
-                                    "active": true
-                                },
-                                {
-                                    "key": "key",
-                                    "value": "Overriden at folder-13-request",
-                                    "active": true
-                                }
-                            ],
-                            "endpoint": "https://httpbin.org/get",
-                            "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level with new header addition\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-13\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n    pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-13-request\")\n  pw.expect(pw.response.body.headers[\"Custom-Header-Request-Level\"]).toBe(\"New custom header added at the folder-13-request level\")\n})",
-                            "preRequestScript": "",
-                            "requestVariables": []
-                        }
-                    ],
-                    "auth": {
-                        "token": "test-token",
-                        "authType": "bearer",
-                        "authActive": true
-                    },
-                    "headers": [
-                        {
-                            "key": "Custom-Header",
-                            "value": "Custom header value overriden at folder-13",
-                            "active": true
-                        },
-                        {
-                            "key": "key",
-                            "value": "Set at folder-13",
-                            "active": true
-                        }
-                    ]
-                }
-            ],
-            "requests": [
-                {
-                    "v": "4",
-                    "auth": {
-                        "authType": "inherit",
-                        "authActive": true
-                    },
-                    "body": {
-                        "body": null,
-                        "contentType": null
-                    },
-                    "name": "folder-1-request",
-                    "method": "GET",
-                    "params": [],
-                    "headers": [],
-                    "endpoint": "https://httpbin.org/get",
-                    "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-1\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
-                    "preRequestScript": "",
-                    "requestVariables": []
-                }
-            ],
-            "auth": {
+          "v": 3,
+          "id": "clx1fjwmm000410f8l1gkkr1a",
+          "name": "folder-11",
+          "folders": [],
+          "requests": [
+            {
+              "v": "4",
+              "auth": {
                 "authType": "inherit",
+                "password": "testpass",
+                "username": "testuser",
                 "authActive": true
-            },
-            "headers": [
-                {
-                    "key": "Custom-Header",
-                    "value": "Custom header value overriden at folder-1",
-                    "active": true
-                }
-            ]
+              },
+              "body": {
+                "body": null,
+                "contentType": null
+              },
+              "name": "folder-11-request",
+              "method": "GET",
+              "params": [],
+              "headers": [],
+              "endpoint": "https://httpbin.org/get",
+              "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-1\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
+              "preRequestScript": "",
+              "requestVariables": []
+            }
+          ],
+          "auth": {
+            "authType": "inherit",
+            "authActive": true
+          },
+          "headers": [
+            {
+              "key": "key",
+              "value": "Set at folder-11",
+              "active": true
+            }
+          ]
         },
         {
-            "v": 2,
-            "id": "clx1fjk9o000210f8j0573pls",
-            "name": "folder-2",
-            "folders": [
-                {
-                    "v": 2,
-                    "id": "clx1fk516000710f87sfpw6bo",
-                    "name": "folder-21",
-                    "folders": [],
-                    "requests": [
-                        {
-                            "v": "4",
-                            "auth": {
-                                "authType": "inherit",
-                                "authActive": true
-                            },
-                            "body": {
-                                "body": null,
-                                "contentType": null
-                            },
-                            "name": "folder-21-request",
-                            "method": "GET",
-                            "params": [],
-                            "headers": [],
-                            "endpoint": "https://httpbin.org/get",
-                            "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(undefined)\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-2\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
-                            "preRequestScript": "",
-                            "requestVariables": []
-                        }
-                    ],
-                    "auth": {
-                        "authType": "inherit",
-                        "authActive": true
-                    },
-                    "headers": [
-                        {
-                            "key": "key",
-                            "value": "Set at folder-21",
-                            "active": true
-                        }
-                    ]
-                },
-                {
-                    "v": 2,
-                    "id": "clx1fk72t000810f8gfwkpi5y",
-                    "name": "folder-22",
-                    "folders": [],
-                    "requests": [
-                        {
-                            "v": "4",
-                            "auth": {
-                                "authType": "none",
-                                "authActive": true
-                            },
-                            "body": {
-                                "body": null,
-                                "contentType": null
-                            },
-                            "name": "folder-22-request",
-                            "method": "GET",
-                            "params": [],
-                            "headers": [
-                                {
-                                    "key": "Custom-Header",
-                                    "value": "Custom header value overriden at folder-22-request",
-                                    "active": true
-                                },
-                                {
-                                    "key": "key",
-                                    "value": "Overriden at folder-22-request",
-                                    "active": true
-                                }
-                            ],
-                            "endpoint": "https://httpbin.org/get",
-                            "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(undefined)\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-22-request\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n  pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-22-request\")\n})",
-                            "preRequestScript": "",
-                            "requestVariables": []
-                        }
-                    ],
-                    "auth": {
-                        "authType": "none",
-                        "authActive": true
-                    },
-                    "headers": [
-                        {
-                            "key": "Custom-Header",
-                            "value": "Custom header value overriden at folder-22",
-                            "active": true
-                        },
-                        {
-                            "key": "key",
-                            "value": "Set at folder-22",
-                            "active": true
-                        }
-                    ]
-                },
-                {
-                    "v": 2,
-                    "id": "clx1fk95g000910f8bunhaoo8",
-                    "name": "folder-23",
-                    "folders": [],
-                    "requests": [
-                        {
-                            "v": "4",
-                            "auth": {
-                                "authType": "basic",
-                                "password": "testpass",
-                                "username": "testuser",
-                                "authActive": true
-                            },
-                            "body": {
-                                "body": null,
-                                "contentType": null
-                            },
-                            "name": "folder-23-request",
-                            "method": "GET",
-                            "params": [],
-                            "headers": [
-                                {
-                                    "key": "Custom-Header-Request-Level",
-                                    "value": "New custom header added at the folder-23-request level",
-                                    "active": true
-                                },
-                                {
-                                    "key": "key",
-                                    "value": "Overriden at folder-23-request",
-                                    "active": true
-                                }
-                            ],
-                            "endpoint": "https://httpbin.org/get",
-                            "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level with new header addition\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-23\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n    pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-23-request\")\n  pw.expect(pw.response.body.headers[\"Custom-Header-Request-Level\"]).toBe(\"New custom header added at the folder-23-request level\")\n})",
-                            "preRequestScript": "",
-                            "requestVariables": []
-                        }
-                    ],
-                    "auth": {
-                        "token": "test-token",
-                        "authType": "bearer",
-                        "password": "testpass",
-                        "username": "testuser",
-                        "authActive": true
-                    },
-                    "headers": [
-                        {
-                            "key": "Custom-Header",
-                            "value": "Custom header value overriden at folder-23",
-                            "active": true
-                        },
-                        {
-                            "key": "key",
-                            "value": "Set at folder-23",
-                            "active": true
-                        }
-                    ]
-                }
-            ],
-            "requests": [
-                {
-                    "v": "4",
-                    "auth": {
-                        "authType": "none",
-                        "authActive": true
-                    },
-                    "body": {
-                        "body": null,
-                        "contentType": null
-                    },
-                    "name": "folder-2-request",
-                    "method": "GET",
-                    "params": [],
-                    "headers": [
-                        {
-                            "key": "Custom-Header",
-                            "value": "Custom header value overriden at folder-2-request",
-                            "active": true
-                        }
-                    ],
-                    "endpoint": "https://httpbin.org/get",
-                    "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(undefined)\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-2-request\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
-                    "preRequestScript": "",
-                    "requestVariables": []
-                }
-            ],
-            "auth": {
+          "v": 3,
+          "id": "clx1fjyxm000510f8pv90dt43",
+          "name": "folder-12",
+          "folders": [],
+          "requests": [
+            {
+              "v": "4",
+              "auth": {
                 "authType": "none",
                 "authActive": true
-            },
-            "headers": [
+              },
+              "body": {
+                "body": null,
+                "contentType": null
+              },
+              "name": "folder-12-request",
+              "method": "GET",
+              "params": [],
+              "headers": [
                 {
-                    "key": "Custom-Header",
-                    "value": "Custom header value overriden at folder-2",
-                    "active": true
+                  "key": "Custom-Header",
+                  "value": "Custom header value overriden at folder-12-request",
+                  "active": true
+                },
+                {
+                  "key": "key",
+                  "value": "Overriden at folder-12-request",
+                  "active": true
                 }
-            ]
+              ],
+              "endpoint": "https://httpbin.org/get",
+              "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(undefined)\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-12-request\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n  pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-12-request\")\n})",
+              "preRequestScript": "",
+              "requestVariables": []
+            }
+          ],
+          "auth": {
+            "authType": "none",
+            "authActive": true
+          },
+          "headers": [
+            {
+              "key": "Custom-Header",
+              "value": "Custom header value overriden at folder-12",
+              "active": true
+            },
+            {
+              "key": "key",
+              "value": "Set at folder-12",
+              "active": true
+            }
+          ]
         },
         {
-            "v": 2,
-            "id": "clx1fjmlq000310f86o4d3w2o",
-            "name": "folder-3",
-            "folders": [
-                {
-                    "v": 2,
-                    "id": "clx1iwq0p003e10f8u8zg0p85",
-                    "name": "folder-31",
-                    "folders": [],
-                    "requests": [
-                        {
-                            "v": "4",
-                            "auth": {
-                                "authType": "inherit",
-                                "authActive": true
-                            },
-                            "body": {
-                                "body": null,
-                                "contentType": null
-                            },
-                            "name": "folder-31-request",
-                            "method": "GET",
-                            "params": [],
-                            "headers": [],
-                            "endpoint": "https://httpbin.org/get",
-                            "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-3\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
-                            "preRequestScript": "",
-                            "requestVariables": []
-                        }
-                    ],
-                    "auth": {
-                        "authType": "inherit",
-                        "authActive": true
-                    },
-                    "headers": [
-                        {
-                            "key": "key",
-                            "value": "Set at folder-31",
-                            "active": true
-                        }
-                    ]
-                },
-                {
-                    "v": 2,
-                    "id": "clx1izut7003m10f894ip59zg",
-                    "name": "folder-32",
-                    "folders": [],
-                    "requests": [
-                        {
-                            "v": "4",
-                            "auth": {
-                                "authType": "none",
-                                "authActive": true
-                            },
-                            "body": {
-                                "body": null,
-                                "contentType": null
-                            },
-                            "name": "folder-32-request",
-                            "method": "GET",
-                            "params": [],
-                            "headers": [
-                                {
-                                    "key": "Custom-Header",
-                                    "value": "Custom header value overriden at folder-32-request",
-                                    "active": true
-                                },
-                                {
-                                    "key": "key",
-                                    "value": "Overriden at folder-32-request",
-                                    "active": true
-                                }
-                            ],
-                            "endpoint": "https://httpbin.org/get",
-                            "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(undefined)\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-32-request\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n  pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-32-request\")\n})",
-                            "preRequestScript": "",
-                            "requestVariables": []
-                        }
-                    ],
-                    "auth": {
-                        "authType": "none",
-                        "authActive": true
-                    },
-                    "headers": [
-                        {
-                            "key": "Custom-Header",
-                            "value": "Custom header value overriden at folder-32",
-                            "active": true
-                        },
-                        {
-                            "key": "key",
-                            "value": "Set at folder-32",
-                            "active": true
-                        }
-                    ]
-                },
-                {
-                    "v": 2,
-                    "id": "clx1j2ka9003q10f8cdbzpgpg",
-                    "name": "folder-33",
-                    "folders": [],
-                    "requests": [
-                        {
-                            "v": "4",
-                            "auth": {
-                                "authType": "basic",
-                                "password": "testpass",
-                                "username": "testuser",
-                                "authActive": true
-                            },
-                            "body": {
-                                "body": null,
-                                "contentType": null
-                            },
-                            "name": "folder-33-request",
-                            "method": "GET",
-                            "params": [],
-                            "headers": [
-                                {
-                                    "key": "Custom-Header-Request-Level",
-                                    "value": "New custom header added at the folder-33-request level",
-                                    "active": true
-                                },
-                                {
-                                    "key": "key",
-                                    "value": "Overriden at folder-33-request",
-                                    "active": true
-                                }
-                            ],
-                            "endpoint": "https://httpbin.org/get",
-                            "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level with new header addition\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-33\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n    pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-33-request\")\n  pw.expect(pw.response.body.headers[\"Custom-Header-Request-Level\"]).toBe(\"New custom header added at the folder-33-request level\")\n})",
-                            "preRequestScript": "",
-                            "requestVariables": []
-                        }
-                    ],
-                    "auth": {
-                        "token": "test-token",
-                        "authType": "bearer",
-                        "password": "testpass",
-                        "username": "testuser",
-                        "authActive": true
-                    },
-                    "headers": [
-                        {
-                            "key": "Custom-Header",
-                            "value": "Custom header value overriden at folder-33",
-                            "active": true
-                        },
-                        {
-                            "key": "key",
-                            "value": "Set at folder-33",
-                            "active": true
-                        }
-                    ]
-                }
-            ],
-            "requests": [
-                {
-                    "v": "4",
-                    "auth": {
-                        "authType": "basic",
-                        "password": "testpass",
-                        "username": "testuser",
-                        "authActive": true
-                    },
-                    "body": {
-                        "body": null,
-                        "contentType": null
-                    },
-                    "name": "folder-3-request",
-                    "method": "GET",
-                    "params": [],
-                    "headers": [
-                        {
-                            "key": "Custom-Header-Request-Level",
-                            "value": "New custom header added at the folder-3-request level",
-                            "active": true
-                        },
-                        {
-                            "key": "key",
-                            "value": "Set at folder-3-request",
-                            "active": true
-                        }
-                    ],
-                    "endpoint": "https://httpbin.org/get",
-                    "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level with new header addition\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-3\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n      pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Set at folder-3-request\")\n  pw.expect(pw.response.body.headers[\"Custom-Header-Request-Level\"]).toBe(\"New custom header added at the folder-3-request level\")\n})",
-                    "preRequestScript": "",
-                    "requestVariables": []
-                }
-            ],
-            "auth": {
-                "key": "testuser",
+          "v": 3,
+          "id": "clx1fk1cv000610f88kc3aupy",
+          "name": "folder-13",
+          "folders": [],
+          "requests": [
+            {
+              "v": "4",
+              "auth": {
+                "key": "api-key",
                 "addTo": "HEADERS",
-                "value": "testpass",
+                "value": "api-key-value",
+                "authType": "basic",
+                "password": "testpass",
+                "username": "testuser",
+                "authActive": true,
+                "grantTypeInfo": {
+                  "token": "",
+                  "isPKCE": true,
+                  "clientID": "sfasfa",
+                  "password": "",
+                  "username": "",
+                  "grantType": "AUTHORIZATION_CODE",
+                  "authEndpoint": "asfafs",
+                  "clientSecret": "sfasfasf",
+                  "tokenEndpoint": "asfa",
+                  "codeVerifierMethod": "S256"
+                }
+              },
+              "body": {
+                "body": null,
+                "contentType": null
+              },
+              "name": "folder-13-request",
+              "method": "GET",
+              "params": [],
+              "headers": [
+                {
+                  "key": "Custom-Header-Request-Level",
+                  "value": "New custom header added at the folder-13-request level",
+                  "active": true
+                },
+                {
+                  "key": "key",
+                  "value": "Overriden at folder-13-request",
+                  "active": true
+                }
+              ],
+              "endpoint": "https://httpbin.org/get",
+              "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level with new header addition\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-13\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n    pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-13-request\")\n  pw.expect(pw.response.body.headers[\"Custom-Header-Request-Level\"]).toBe(\"New custom header added at the folder-13-request level\")\n})",
+              "preRequestScript": "",
+              "requestVariables": []
+            }
+          ],
+          "auth": {
+            "token": "test-token",
+            "authType": "bearer",
+            "authActive": true
+          },
+          "headers": [
+            {
+              "key": "Custom-Header",
+              "value": "Custom header value overriden at folder-13",
+              "active": true
+            },
+            {
+              "key": "key",
+              "value": "Set at folder-13",
+              "active": true
+            }
+          ]
+        }
+      ],
+      "requests": [
+        {
+          "v": "4",
+          "auth": {
+            "authType": "inherit",
+            "authActive": true
+          },
+          "body": {
+            "body": null,
+            "contentType": null
+          },
+          "name": "folder-1-request",
+          "method": "GET",
+          "params": [],
+          "headers": [],
+          "endpoint": "https://httpbin.org/get",
+          "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-1\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
+          "preRequestScript": "",
+          "requestVariables": []
+        }
+      ],
+      "auth": {
+        "authType": "inherit",
+        "authActive": true
+      },
+      "headers": [
+        {
+          "key": "Custom-Header",
+          "value": "Custom header value overriden at folder-1",
+          "active": true
+        }
+      ]
+    },
+    {
+      "v": 3,
+      "id": "clx1fjk9o000210f8j0573pls",
+      "name": "folder-2",
+      "folders": [
+        {
+          "v": 3,
+          "id": "clx1fk516000710f87sfpw6bo",
+          "name": "folder-21",
+          "folders": [],
+          "requests": [
+            {
+              "v": "4",
+              "auth": {
+                "authType": "inherit",
+                "authActive": true
+              },
+              "body": {
+                "body": null,
+                "contentType": null
+              },
+              "name": "folder-21-request",
+              "method": "GET",
+              "params": [],
+              "headers": [],
+              "endpoint": "https://httpbin.org/get",
+              "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(undefined)\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-2\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
+              "preRequestScript": "",
+              "requestVariables": []
+            }
+          ],
+          "auth": {
+            "authType": "inherit",
+            "authActive": true
+          },
+          "headers": [
+            {
+              "key": "key",
+              "value": "Set at folder-21",
+              "active": true
+            }
+          ]
+        },
+        {
+          "v": 3,
+          "id": "clx1fk72t000810f8gfwkpi5y",
+          "name": "folder-22",
+          "folders": [],
+          "requests": [
+            {
+              "v": "4",
+              "auth": {
+                "authType": "none",
+                "authActive": true
+              },
+              "body": {
+                "body": null,
+                "contentType": null
+              },
+              "name": "folder-22-request",
+              "method": "GET",
+              "params": [],
+              "headers": [
+                {
+                  "key": "Custom-Header",
+                  "value": "Custom header value overriden at folder-22-request",
+                  "active": true
+                },
+                {
+                  "key": "key",
+                  "value": "Overriden at folder-22-request",
+                  "active": true
+                }
+              ],
+              "endpoint": "https://httpbin.org/get",
+              "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(undefined)\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-22-request\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n  pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-22-request\")\n})",
+              "preRequestScript": "",
+              "requestVariables": []
+            }
+          ],
+          "auth": {
+            "authType": "none",
+            "authActive": true
+          },
+          "headers": [
+            {
+              "key": "Custom-Header",
+              "value": "Custom header value overriden at folder-22",
+              "active": true
+            },
+            {
+              "key": "key",
+              "value": "Set at folder-22",
+              "active": true
+            }
+          ]
+        },
+        {
+          "v": 3,
+          "id": "clx1fk95g000910f8bunhaoo8",
+          "name": "folder-23",
+          "folders": [],
+          "requests": [
+            {
+              "v": "4",
+              "auth": {
                 "authType": "basic",
                 "password": "testpass",
                 "username": "testuser",
                 "authActive": true
-            },
-            "headers": [
-                {
-                    "key": "Custom-Header",
-                    "value": "Custom header value overriden at folder-3",
-                    "active": true
-                }
-            ]
-        }
-    ],
-    "requests": [
-        {
-            "v": "4",
-            "auth": {
-                "authType": "inherit",
-                "authActive": true
-            },
-            "body": {
+              },
+              "body": {
                 "body": null,
                 "contentType": null
+              },
+              "name": "folder-23-request",
+              "method": "GET",
+              "params": [],
+              "headers": [
+                {
+                  "key": "Custom-Header-Request-Level",
+                  "value": "New custom header added at the folder-23-request level",
+                  "active": true
+                },
+                {
+                  "key": "key",
+                  "value": "Overriden at folder-23-request",
+                  "active": true
+                }
+              ],
+              "endpoint": "https://httpbin.org/get",
+              "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level with new header addition\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-23\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n    pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-23-request\")\n  pw.expect(pw.response.body.headers[\"Custom-Header-Request-Level\"]).toBe(\"New custom header added at the folder-23-request level\")\n})",
+              "preRequestScript": "",
+              "requestVariables": []
+            }
+          ],
+          "auth": {
+            "token": "test-token",
+            "authType": "bearer",
+            "password": "testpass",
+            "username": "testuser",
+            "authActive": true
+          },
+          "headers": [
+            {
+              "key": "Custom-Header",
+              "value": "Custom header value overriden at folder-23",
+              "active": true
             },
-            "name": "root-collection-request",
-            "method": "GET",
-            "params": [],
-            "headers": [],
-            "endpoint": "https://httpbin.org/get",
-            "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value set at the root collection\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
-            "preRequestScript": "",
-            "requestVariables": []
+            {
+              "key": "key",
+              "value": "Set at folder-23",
+              "active": true
+            }
+          ]
         }
-    ],
-    "auth": {
+      ],
+      "requests": [
+        {
+          "v": "4",
+          "auth": {
+            "authType": "none",
+            "authActive": true
+          },
+          "body": {
+            "body": null,
+            "contentType": null
+          },
+          "name": "folder-2-request",
+          "method": "GET",
+          "params": [],
+          "headers": [
+            {
+              "key": "Custom-Header",
+              "value": "Custom header value overriden at folder-2-request",
+              "active": true
+            }
+          ],
+          "endpoint": "https://httpbin.org/get",
+          "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(undefined)\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-2-request\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
+          "preRequestScript": "",
+          "requestVariables": []
+        }
+      ],
+      "auth": {
+        "authType": "none",
+        "authActive": true
+      },
+      "headers": [
+        {
+          "key": "Custom-Header",
+          "value": "Custom header value overriden at folder-2",
+          "active": true
+        }
+      ]
+    },
+    {
+      "v": 3,
+      "id": "clx1fjmlq000310f86o4d3w2o",
+      "name": "folder-3",
+      "folders": [
+        {
+          "v": 3,
+          "id": "clx1iwq0p003e10f8u8zg0p85",
+          "name": "folder-31",
+          "folders": [],
+          "requests": [
+            {
+              "v": "4",
+              "auth": {
+                "authType": "inherit",
+                "authActive": true
+              },
+              "body": {
+                "body": null,
+                "contentType": null
+              },
+              "name": "folder-31-request",
+              "method": "GET",
+              "params": [],
+              "headers": [],
+              "endpoint": "https://httpbin.org/get",
+              "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-3\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
+              "preRequestScript": "",
+              "requestVariables": []
+            }
+          ],
+          "auth": {
+            "authType": "inherit",
+            "authActive": true
+          },
+          "headers": [
+            {
+              "key": "key",
+              "value": "Set at folder-31",
+              "active": true
+            }
+          ]
+        },
+        {
+          "v": 3,
+          "id": "clx1izut7003m10f894ip59zg",
+          "name": "folder-32",
+          "folders": [],
+          "requests": [
+            {
+              "v": "4",
+              "auth": {
+                "authType": "none",
+                "authActive": true
+              },
+              "body": {
+                "body": null,
+                "contentType": null
+              },
+              "name": "folder-32-request",
+              "method": "GET",
+              "params": [],
+              "headers": [
+                {
+                  "key": "Custom-Header",
+                  "value": "Custom header value overriden at folder-32-request",
+                  "active": true
+                },
+                {
+                  "key": "key",
+                  "value": "Overriden at folder-32-request",
+                  "active": true
+                }
+              ],
+              "endpoint": "https://httpbin.org/get",
+              "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(undefined)\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-32-request\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n  pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-32-request\")\n})",
+              "preRequestScript": "",
+              "requestVariables": []
+            }
+          ],
+          "auth": {
+            "authType": "none",
+            "authActive": true
+          },
+          "headers": [
+            {
+              "key": "Custom-Header",
+              "value": "Custom header value overriden at folder-32",
+              "active": true
+            },
+            {
+              "key": "key",
+              "value": "Set at folder-32",
+              "active": true
+            }
+          ]
+        },
+        {
+          "v": 3,
+          "id": "clx1j2ka9003q10f8cdbzpgpg",
+          "name": "folder-33",
+          "folders": [],
+          "requests": [
+            {
+              "v": "4",
+              "auth": {
+                "authType": "basic",
+                "password": "testpass",
+                "username": "testuser",
+                "authActive": true
+              },
+              "body": {
+                "body": null,
+                "contentType": null
+              },
+              "name": "folder-33-request",
+              "method": "GET",
+              "params": [],
+              "headers": [
+                {
+                  "key": "Custom-Header-Request-Level",
+                  "value": "New custom header added at the folder-33-request level",
+                  "active": true
+                },
+                {
+                  "key": "key",
+                  "value": "Overriden at folder-33-request",
+                  "active": true
+                }
+              ],
+              "endpoint": "https://httpbin.org/get",
+              "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level with new header addition\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-33\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n    pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Overriden at folder-33-request\")\n  pw.expect(pw.response.body.headers[\"Custom-Header-Request-Level\"]).toBe(\"New custom header added at the folder-33-request level\")\n})",
+              "preRequestScript": "",
+              "requestVariables": []
+            }
+          ],
+          "auth": {
+            "token": "test-token",
+            "authType": "bearer",
+            "password": "testpass",
+            "username": "testuser",
+            "authActive": true
+          },
+          "headers": [
+            {
+              "key": "Custom-Header",
+              "value": "Custom header value overriden at folder-33",
+              "active": true
+            },
+            {
+              "key": "key",
+              "value": "Set at folder-33",
+              "active": true
+            }
+          ]
+        }
+      ],
+      "requests": [
+        {
+          "v": "4",
+          "auth": {
+            "authType": "basic",
+            "password": "testpass",
+            "username": "testuser",
+            "authActive": true
+          },
+          "body": {
+            "body": null,
+            "contentType": null
+          },
+          "name": "folder-3-request",
+          "method": "GET",
+          "params": [],
+          "headers": [
+            {
+              "key": "Custom-Header-Request-Level",
+              "value": "New custom header added at the folder-3-request level",
+              "active": true
+            },
+            {
+              "key": "key",
+              "value": "Set at folder-3-request",
+              "active": true
+            }
+          ],
+          "endpoint": "https://httpbin.org/get",
+          "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits/overrides authorization/header set at the parent collection level with new header addition\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value overriden at folder-3\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n      pw.expect(pw.response.body.headers[\"Key\"]).toBe(\"Set at folder-3-request\")\n  pw.expect(pw.response.body.headers[\"Custom-Header-Request-Level\"]).toBe(\"New custom header added at the folder-3-request level\")\n})",
+          "preRequestScript": "",
+          "requestVariables": []
+        }
+      ],
+      "auth": {
+        "key": "testuser",
+        "addTo": "HEADERS",
+        "value": "testpass",
         "authType": "basic",
         "password": "testpass",
         "username": "testuser",
         "authActive": true
-    },
-    "headers": [
+      },
+      "headers": [
         {
-            "key": "Custom-Header",
-            "value": "Custom header value set at the root collection",
-            "active": true
-        },
-        {
-            "key": "Inherited-Header",
-            "value": "Inherited header at all levels",
-            "active": true
+          "key": "Custom-Header",
+          "value": "Custom header value overriden at folder-3",
+          "active": true
         }
-    ]
+      ]
+    }
+  ],
+  "requests": [
+    {
+      "v": "4",
+      "auth": {
+        "authType": "inherit",
+        "authActive": true
+      },
+      "body": {
+        "body": null,
+        "contentType": null
+      },
+      "name": "root-collection-request",
+      "method": "GET",
+      "params": [],
+      "headers": [],
+      "endpoint": "https://httpbin.org/get",
+      "testScript": "// Check status code is 200\npw.test(\"Status code is 200\", ()=> {\n    pw.expect(pw.response.status).toBe(200);\n});\n\npw.test(\"Successfully inherits authorization/header set at the parent collection level\", () => {\n  pw.expect(pw.response.body.headers[\"Authorization\"]).toBe(\"Basic dGVzdHVzZXI6dGVzdHBhc3M=\")\n  \n  pw.expect(pw.response.body.headers[\"Custom-Header\"]).toBe(\"Custom header value set at the root collection\")\n  pw.expect(pw.response.body.headers[\"Inherited-Header\"]).toBe(\"Inherited header at all levels\")\n})",
+      "preRequestScript": "",
+      "requestVariables": []
+    }
+  ],
+  "auth": {
+    "authType": "basic",
+    "password": "testpass",
+    "username": "testuser",
+    "authActive": true
+  },
+  "headers": [
+    {
+      "key": "Custom-Header",
+      "value": "Custom header value set at the root collection",
+      "active": true
+    },
+    {
+      "key": "Inherited-Header",
+      "value": "Inherited header at all levels",
+      "active": true
+    }
+  ]
 }

--- a/packages/hoppscotch-cli/src/__tests__/unit/fixtures/workspace-access.mock.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/fixtures/workspace-access.mock.ts
@@ -15,7 +15,7 @@ export const WORKSPACE_DEEPLY_NESTED_COLLECTIONS_WITH_AUTH_HEADERS_MOCK: Workspa
   [
     {
       id: "clx1ldkzs005t10f8rp5u60q7",
-      data: '{"auth":{"token":"BearerToken","authType":"bearer","authActive":true},"headers":[{"key":"X-Test-Header","value":"Set at root collection","active":true}]}',
+      data: '{"auth":{"token":"BearerToken","authType":"bearer","authActive":true},"headers":[{"key":"X-Test-Header","value":"Set at root collection","active":true,"description":""}]}',
       title: "CollectionA",
       parentID: null,
       folders: [
@@ -245,6 +245,7 @@ export const TRANSFORMED_DEEPLY_NESTED_COLLECTIONS_WITH_AUTH_HEADERS_MOCK: HoppC
           key: "X-Test-Header",
           value: "Set at root collection",
           active: true,
+          description: "",
         },
       ],
     },
@@ -547,12 +548,12 @@ export const WORKSPACE_COLLECTIONS_WITHOUT_AUTH_HEADERS_AT_CERTAIN_LEVELS_MOCK: 
 export const TRANSFORMED_COLLECTIONS_WITHOUT_AUTH_HEADERS_AT_CERTAIN_LEVELS_MOCK: HoppCollection[] =
   [
     {
-      v: 2,
+      v: CollectionSchemaVersion,
       id: "clx1kxvao005m10f8luqivrf1",
       name: "Collection with no authorization/headers set",
       folders: [
         {
-          v: 2,
+          v: CollectionSchemaVersion,
           id: "clx1kygjt005n10f8m1nkhjux",
           name: "folder-1",
           folders: [],
@@ -584,7 +585,7 @@ export const TRANSFORMED_COLLECTIONS_WITHOUT_AUTH_HEADERS_AT_CERTAIN_LEVELS_MOCK
           headers: [],
         },
         {
-          v: 2,
+          v: CollectionSchemaVersion,
           id: "clx1kym98005o10f8qg17t9o2",
           name: "folder-2",
           folders: [],
@@ -622,7 +623,7 @@ export const TRANSFORMED_COLLECTIONS_WITHOUT_AUTH_HEADERS_AT_CERTAIN_LEVELS_MOCK
           ],
         },
         {
-          v: 2,
+          v: CollectionSchemaVersion,
           id: "clx1l2bu6005r10f8daynohge",
           name: "folder-3",
           folders: [],
@@ -634,7 +635,7 @@ export const TRANSFORMED_COLLECTIONS_WITHOUT_AUTH_HEADERS_AT_CERTAIN_LEVELS_MOCK
           headers: [],
         },
         {
-          v: 2,
+          v: CollectionSchemaVersion,
           id: "clx1l2eaz005s10f8loetbbeb",
           name: "folder-4",
           folders: [],

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -61,6 +61,7 @@ describe("getters", () => {
               active: true,
               key: "<<UNKNOWN_KEY>>",
               value: "<<UNKNOWN_VALUE>>",
+              description: "",
             },
           ],
           environmentVariables
@@ -71,7 +72,7 @@ describe("getters", () => {
     test("Inactive list of meta-data", () => {
       expect(
         getEffectiveFinalMetaData(
-          [{ active: false, key: "KEY", value: "<<PARAM>>" }],
+          [{ active: false, key: "KEY", value: "<<PARAM>>", description: "" }],
           environmentVariables
         )
       ).toSubsetEqualRight([]);
@@ -80,7 +81,7 @@ describe("getters", () => {
     test("Active list of meta-data", () => {
       expect(
         getEffectiveFinalMetaData(
-          [{ active: true, key: "PARAM", value: "<<PARAM>>" }],
+          [{ active: true, key: "PARAM", value: "<<PARAM>>", description: "" }],
           environmentVariables
         )
       ).toSubsetEqualRight([

--- a/packages/hoppscotch-cli/src/__tests__/unit/workspace-access.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/workspace-access.spec.ts
@@ -15,9 +15,6 @@ import {
 } from "./fixtures/workspace-access.mock";
 
 import TRANSFORMED_MULTIPLE_CHILD_COLLECTIONS_WITH_AUTH_HEADERS_MOCK from "../e2e/fixtures/collections/multiple-child-collections-auth-headers-coll.json";
-import { HoppCollection } from "@hoppscotch/data";
-import { entityReference } from "verzod";
-import { z } from "zod";
 
 describe("workspace-access", () => {
   describe("transformWorkspaceCollection", () => {

--- a/packages/hoppscotch-cli/src/__tests__/unit/workspace-access.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/workspace-access.spec.ts
@@ -15,6 +15,9 @@ import {
 } from "./fixtures/workspace-access.mock";
 
 import TRANSFORMED_MULTIPLE_CHILD_COLLECTIONS_WITH_AUTH_HEADERS_MOCK from "../e2e/fixtures/collections/multiple-child-collections-auth-headers-coll.json";
+import { HoppCollection } from "@hoppscotch/data";
+import { entityReference } from "verzod";
+import { z } from "zod";
 
 describe("workspace-access", () => {
   describe("transformWorkspaceCollection", () => {

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -242,6 +242,8 @@
     "header": "Header {count}",
     "message": "Message {count}",
     "parameter": "Parameter {count}",
+    "key": "Key {count}",
+    "description": "Description {count}",
     "protocol": "Protocol {count}",
     "value": "Value {count}",
     "variable": "Variable {count}"

--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -136,6 +136,7 @@ declare module 'vue' {
     HttpCodegenModal: typeof import('./components/http/CodegenModal.vue')['default']
     HttpHeaders: typeof import('./components/http/Headers.vue')['default']
     HttpImportCurl: typeof import('./components/http/ImportCurl.vue')['default']
+    HttpKeyValue: typeof import('./components/http/KeyValue.vue')['default']
     HttpOAuth2Authorization: typeof import('./components/http/OAuth2Authorization.vue')['default']
     HttpParameters: typeof import('./components/http/Parameters.vue')['default']
     HttpPreRequestScript: typeof import('./components/http/PreRequestScript.vue')['default']

--- a/packages/hoppscotch-common/src/components/collections/Properties.vue
+++ b/packages/hoppscotch-common/src/components/collections/Properties.vue
@@ -4,6 +4,7 @@
     dialog
     :title="t('collection.properties')"
     :full-width-body="true"
+    styles="sm:max-w-2xl"
     @close="hideModal"
   >
     <template #body>

--- a/packages/hoppscotch-common/src/components/graphql/Headers.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Headers.vue
@@ -98,16 +98,27 @@
               tabindex="-1"
             />
           </span>
+
           <SmartEnvInput
             v-model="header.header.key"
             :placeholder="`${t('count.value', { count: index + 1 })}`"
             readonly
           />
+
           <SmartEnvInput
             :model-value="mask(header)"
             :placeholder="`${t('count.value', { count: index + 1 })}`"
             readonly
           />
+
+          <input
+            :value="header.header.description"
+            :placeholder="t('count.description')"
+            class="flex flex-1 bg-transparent px-4"
+            type="text"
+            readonly
+          />
+
           <span>
             <HoppButtonSecondary
               v-if="header.source === 'auth'"
@@ -156,11 +167,13 @@
               tabindex="-1"
             />
           </span>
+
           <SmartEnvInput
             v-model="header.header.key"
             :placeholder="`${t('count.value', { count: index + 1 })}`"
             readonly
           />
+
           <SmartEnvInput
             :model-value="
               header.source === 'auth' ? mask(header) : header.header.value
@@ -168,6 +181,14 @@
             :placeholder="`${t('count.value', { count: index + 1 })}`"
             readonly
           />
+          <input
+            :value="header.header.description"
+            :placeholder="t('count.description')"
+            class="flex flex-1 bg-transparent px-4"
+            type="text"
+            readonly
+          />
+
           <HoppButtonSecondary
             v-if="header.source === 'auth'"
             v-tippy="{ theme: 'tooltip' }"

--- a/packages/hoppscotch-common/src/components/graphql/Headers.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Headers.vue
@@ -114,7 +114,7 @@
           <input
             :value="header.header.description"
             :placeholder="t('count.description')"
-            class="flex flex-1 bg-transparent px-4"
+            class="flex flex-1 px-4 bg-transparent text-secondaryLight"
             type="text"
             readonly
           />
@@ -184,7 +184,7 @@
           <input
             :value="header.header.description"
             :placeholder="t('count.description')"
-            class="flex flex-1 bg-transparent px-4"
+            class="flex flex-1 px-4 bg-transparent text-secondaryLight"
             type="text"
             readonly
           />
@@ -616,16 +616,21 @@ const inheritedProperties = computed(() => {
         header.inheritedHeader !== undefined &&
         header.inheritedHeader.active
     )
-    .map((header, index) => ({
-      inheritedFrom: props.inheritedProperties?.headers[index].parentName,
-      source: "headers",
-      id: `header-${index}`,
-      header: {
-        key: header.inheritedHeader?.key,
-        value: header.inheritedHeader?.value,
-        active: header.inheritedHeader?.active,
-      },
-    }))
+    .map((header, index) => {
+      const { key, value, active, description } = header.inheritedHeader
+
+      return {
+        inheritedFrom: props.inheritedProperties?.headers[index].parentName,
+        source: "headers",
+        id: `header-${index}`,
+        header: {
+          key,
+          value,
+          active,
+          description,
+        },
+      }
+    })
 
   let auth = [] as {
     inheritedFrom: string

--- a/packages/hoppscotch-common/src/components/graphql/Headers.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Headers.vue
@@ -61,91 +61,19 @@
       drag-class="cursor-grabbing"
     >
       <template #item="{ element: header, index }">
-        <div
-          class="draggable-content group flex divide-x divide-dividerLight border-b border-dividerLight"
-        >
-          <span>
-            <HoppButtonSecondary
-              v-tippy="{
-                theme: 'tooltip',
-                delay: [500, 20],
-                content:
-                  index !== workingHeaders?.length - 1
-                    ? t('action.drag_to_reorder')
-                    : null,
-              }"
-              :icon="IconGripVertical"
-              class="opacity-0"
-              :class="{
-                'draggable-handle cursor-grab group-hover:opacity-100':
-                  index !== workingHeaders?.length - 1,
-              }"
-              tabindex="-1"
-            />
-          </span>
-          <SmartEnvInput
-            v-model="header.key"
-            :placeholder="`${t('count.header', { count: index + 1 })}`"
-            :auto-complete-source="commonHeaders"
-            @change="
-              updateHeader(index, {
-                id: header.id,
-                key: $event,
-                value: header.value,
-                active: header.active,
-              })
-            "
-          />
-          <SmartEnvInput
-            v-model="header.value"
-            :placeholder="`${t('count.value', { count: index + 1 })}`"
-            @change="
-              updateHeader(index, {
-                id: header.id,
-                key: header.key,
-                value: $event,
-                active: header.active,
-              })
-            "
-          />
-          <span>
-            <HoppButtonSecondary
-              v-tippy="{ theme: 'tooltip' }"
-              :title="
-                header.hasOwnProperty('active')
-                  ? header.active
-                    ? t('action.turn_off')
-                    : t('action.turn_on')
-                  : t('action.turn_off')
-              "
-              :icon="
-                header.hasOwnProperty('active')
-                  ? header.active
-                    ? IconCheckCircle
-                    : IconCircle
-                  : IconCheckCircle
-              "
-              color="green"
-              @click="
-                updateHeader(index, {
-                  id: header.id,
-                  key: header.key,
-                  value: header.value,
-                  active: !header.active,
-                })
-              "
-            />
-          </span>
-          <span>
-            <HoppButtonSecondary
-              v-tippy="{ theme: 'tooltip' }"
-              :title="t('action.remove')"
-              :icon="IconTrash"
-              color="red"
-              @click="deleteHeader(index)"
-            />
-          </span>
-        </div>
+        <HttpKeyValue
+          v-model:name="header.key"
+          v-model:value="header.value"
+          v-model:description="header.description"
+          :total="workingHeaders.length"
+          :index="index"
+          :entity-id="header.id"
+          :entity-active="header.active"
+          :is-active="header.hasOwnProperty('active')"
+          :key-auto-complete-source="commonHeaders"
+          @update-entity="updateHeader($event.index, $event.payload)"
+          @delete-entity="deleteHeader($event)"
+        />
       </template>
     </draggable>
 
@@ -280,47 +208,44 @@
 </template>
 
 <script setup lang="ts">
-import IconHelpCircle from "~icons/lucide/help-circle"
-import IconTrash2 from "~icons/lucide/trash-2"
-import IconEdit from "~icons/lucide/edit"
-import IconPlus from "~icons/lucide/plus"
-import IconGripVertical from "~icons/lucide/grip-vertical"
-import IconCheckCircle from "~icons/lucide/check-circle"
-import IconTrash from "~icons/lucide/trash"
-import IconCircle from "~icons/lucide/circle"
-import IconWrapText from "~icons/lucide/wrap-text"
-import IconArrowUpRight from "~icons/lucide/arrow-up-right"
-import IconLock from "~icons/lucide/lock"
-import IconEye from "~icons/lucide/eye"
-import IconEyeOff from "~icons/lucide/eye-off"
-import IconInfo from "~icons/lucide/info"
-import { computed, reactive, ref, watch } from "vue"
-import * as E from "fp-ts/Either"
-import * as O from "fp-ts/Option"
-import * as A from "fp-ts/Array"
-import * as RA from "fp-ts/ReadonlyArray"
-import { pipe, flow } from "fp-ts/function"
+import { useCodemirror } from "@composables/codemirror"
+import { useI18n } from "@composables/i18n"
+import { useColorMode } from "@composables/theming"
+import { useToast } from "@composables/toast"
 import {
   GQLHeader,
-  rawKeyValueEntriesToString,
-  parseRawKeyValueEntriesE,
-  RawKeyValueEntry,
   HoppGQLRequest,
+  parseRawKeyValueEntriesE,
+  rawKeyValueEntriesToString,
+  RawKeyValueEntry,
 } from "@hoppscotch/data"
-import draggable from "vuedraggable-es"
-import { clone, cloneDeep, isEqual } from "lodash-es"
-import { useColorMode } from "@composables/theming"
-import { useI18n } from "@composables/i18n"
-import { useToast } from "@composables/toast"
-import { commonHeaders } from "~/helpers/headers"
-import { useCodemirror } from "@composables/codemirror"
-import { objRemoveKey } from "~/helpers/functional/object"
 import { useVModel } from "@vueuse/core"
+import * as A from "fp-ts/Array"
+import * as E from "fp-ts/Either"
+import * as O from "fp-ts/Option"
+import * as RA from "fp-ts/ReadonlyArray"
+import { flow, pipe } from "fp-ts/function"
+import { clone, cloneDeep, isEqual } from "lodash-es"
+import { computed, reactive, ref, watch } from "vue"
+import draggable from "vuedraggable-es"
+
 import { useNestedSetting } from "~/composables/settings"
-import { toggleNestedSetting } from "~/newstore/settings"
-import { HoppGQLHeader } from "~/helpers/graphql"
 import { throwError } from "~/helpers/functional/error"
+import { objRemoveKey } from "~/helpers/functional/object"
+import { HoppGQLHeader } from "~/helpers/graphql"
+import { commonHeaders } from "~/helpers/headers"
 import { HoppInheritedProperty } from "~/helpers/types/HoppInheritedProperties"
+import { toggleNestedSetting } from "~/newstore/settings"
+import IconArrowUpRight from "~icons/lucide/arrow-up-right"
+import IconEdit from "~icons/lucide/edit"
+import IconEye from "~icons/lucide/eye"
+import IconEyeOff from "~icons/lucide/eye-off"
+import IconHelpCircle from "~icons/lucide/help-circle"
+import IconInfo from "~icons/lucide/info"
+import IconLock from "~icons/lucide/lock"
+import IconPlus from "~icons/lucide/plus"
+import IconTrash2 from "~icons/lucide/trash-2"
+import IconWrapText from "~icons/lucide/wrap-text"
 
 const colorMode = useColorMode()
 const t = useI18n()

--- a/packages/hoppscotch-common/src/components/http/Body.vue
+++ b/packages/hoppscotch-common/src/components/http/Body.vue
@@ -181,6 +181,7 @@ const contentTypeOverride = (tab: RESTOptionTabs) => {
       key: "Content-Type",
       value: "",
       active: true,
+      description: "",
     })
   }
 }

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -106,16 +106,27 @@
                 tabindex="-1"
               />
             </span>
+
             <SmartEnvInput
               v-model="header.header.key"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               readonly
             />
+
             <SmartEnvInput
               :model-value="mask(header)"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               readonly
             />
+
+            <input
+              :value="header.header.description"
+              :placeholder="t('count.description')"
+              type="text"
+              readonly
+              class="flex flex-1 bg-transparent px-4"
+            />
+
             <span>
               <HoppButtonSecondary
                 v-if="header.source === 'auth'"
@@ -159,11 +170,13 @@
                 tabindex="-1"
               />
             </span>
+
             <SmartEnvInput
               v-model="header.header.key"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               readonly
             />
+
             <SmartEnvInput
               :model-value="
                 header.source === 'auth' ? mask(header) : header.header.value
@@ -171,6 +184,15 @@
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               readonly
             />
+
+            <input
+              :value="header.header.description"
+              :placeholder="t('count.description')"
+              type="text"
+              readonly
+              class="flex flex-1 bg-transparent px-4"
+            />
+
             <HoppButtonSecondary
               v-if="header.source === 'auth'"
               v-tippy="{ theme: 'tooltip' }"

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -124,7 +124,7 @@
               :placeholder="t('count.description')"
               type="text"
               readonly
-              class="flex flex-1 bg-transparent px-4"
+              class="flex flex-1 px-4 bg-transparent text-secondaryLight"
             />
 
             <span>
@@ -190,7 +190,7 @@
               :placeholder="t('count.description')"
               type="text"
               readonly
-              class="flex flex-1 bg-transparent px-4"
+              class="flex flex-1 px-4 bg-transparent text-secondaryLight"
             />
 
             <HoppButtonSecondary
@@ -568,16 +568,21 @@ const inheritedProperties = computed(() => {
         header.inheritedHeader !== undefined &&
         header.inheritedHeader.active
     )
-    .map((header, index) => ({
-      inheritedFrom: props.inheritedProperties?.headers[index].parentName,
-      source: "headers",
-      id: `header-${index}`,
-      header: {
-        key: header.inheritedHeader?.key,
-        value: header.inheritedHeader?.value,
-        active: header.inheritedHeader?.active,
-      },
-    }))
+    .map((header, index) => {
+      const { key, value, active, description } = header.inheritedHeader
+
+      return {
+        inheritedFrom: props.inheritedProperties?.headers[index].parentName,
+        source: "headers",
+        id: `header-${index}`,
+        header: {
+          key,
+          value,
+          active,
+          description,
+        },
+      }
+    })
 
   let auth = [] as {
     inheritedFrom: string

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -78,6 +78,7 @@
             :inspection-value-result="
               getInspectorResult(headerValueResults, index)
             "
+            :key-auto-complete-source="commonHeaders"
             @update-entity="updateHeader($event.index, $event.payload)"
             @delete-entity="deleteHeader($event)"
           />
@@ -234,10 +235,12 @@ import * as RA from "fp-ts/ReadonlyArray"
 import { cloneDeep, isEqual } from "lodash-es"
 import { computed, reactive, ref, toRefs, watch } from "vue"
 import draggable from "vuedraggable-es"
+
 import { useNestedSetting } from "~/composables/settings"
 import linter from "~/helpers/editor/linting/rawKeyValue"
 import { throwError } from "~/helpers/functional/error"
 import { objRemoveKey } from "~/helpers/functional/object"
+import { commonHeaders } from "~/helpers/headers"
 import { HoppInheritedProperty } from "~/helpers/types/HoppInheritedProperties"
 import {
   ComputedHeader,

--- a/packages/hoppscotch-common/src/components/http/KeyValue.vue
+++ b/packages/hoppscotch-common/src/components/http/KeyValue.vue
@@ -21,6 +21,7 @@
     <SmartEnvInput
       :model-value="name"
       :placeholder="t('count.key')"
+      :auto-complete-source="keyAutoCompleteSource"
       :auto-complete-env="true"
       :envs="envs"
       :inspection-results="inspectionKeyResult"
@@ -132,6 +133,7 @@ defineProps<{
   inspectionValueResult?: InspectorResult[]
   description?: string
   envs?: AggregateEnvironment[]
+  keyAutoCompleteSource?: string[]
 }>()
 
 const emit = defineEmits<{
@@ -143,7 +145,6 @@ const emit = defineEmits<{
 }>()
 
 function updateEntity(index: number, payload: any) {
-  console.log(payload)
   emit("updateEntity", {
     index,
     payload,

--- a/packages/hoppscotch-common/src/components/http/KeyValue.vue
+++ b/packages/hoppscotch-common/src/components/http/KeyValue.vue
@@ -24,6 +24,7 @@
       :placeholder="t('count.key')"
       :auto-complete-env="true"
       :envs="envs"
+      :inspection-results="inspectionKeyResult"
       @change="
         updateEntity(index, {
           id: entityId,
@@ -39,6 +40,7 @@
       :placeholder="t('count.value')"
       :auto-complete-env="true"
       :envs="envs"
+      :inspection-results="inspectionValueResult"
       @change="
         updateEntity(index, {
           id: entityId,
@@ -103,10 +105,11 @@ import IconCircle from "~icons/lucide/circle"
 import IconTrash from "~icons/lucide/trash"
 import { useI18n } from "~/composables/i18n"
 import { AggregateEnvironment } from "~/newstore/environments"
+import { InspectorResult } from "~/services/inspection"
 
 const t = useI18n()
 
-const props = defineProps<{
+defineProps<{
   total: number
   index: number
   entityId: number
@@ -114,6 +117,8 @@ const props = defineProps<{
   entityActive: boolean
   name: string
   value: string
+  inspectionKeyResult?: InspectorResult[]
+  inspectionValueResult?: InspectorResult[]
   description?: string
   envs?: AggregateEnvironment[]
 }>()

--- a/packages/hoppscotch-common/src/components/http/KeyValue.vue
+++ b/packages/hoppscotch-common/src/components/http/KeyValue.vue
@@ -144,14 +144,14 @@ const emit = defineEmits<{
   (e: "updateEntity", { index, payload }: { index: number; payload: any }): void
 }>()
 
-function updateEntity(index: number, payload: any) {
+const updateEntity = (index: number, payload: any) => {
   emit("updateEntity", {
     index,
     payload,
   })
 }
 
-function deleteEntity(index: number) {
+const deleteEntity = (index: number) => {
   emit("deleteEntity", index)
 }
 </script>

--- a/packages/hoppscotch-common/src/components/http/KeyValue.vue
+++ b/packages/hoppscotch-common/src/components/http/KeyValue.vue
@@ -20,43 +20,54 @@
     </span>
     <SmartEnvInput
       :model-value="name"
-      @update:model-value="emit('update:name', $event)"
       :placeholder="t('count.key')"
       :auto-complete-env="true"
       :envs="envs"
       :inspection-results="inspectionKeyResult"
+      @update:model-value="emit('update:name', $event)"
       @change="
         updateEntity(index, {
           id: entityId,
           key: $event,
           value: value,
           active: entityActive,
+          description: description ?? '',
         })
       "
     />
     <SmartEnvInput
       :model-value="value"
-      @update:model-value="emit('update:value', $event)"
       :placeholder="t('count.value')"
       :auto-complete-env="true"
       :envs="envs"
       :inspection-results="inspectionValueResult"
+      @update:model-value="emit('update:value', $event)"
       @change="
         updateEntity(index, {
           id: entityId,
           key: name,
           value: $event,
           active: entityActive,
+          description: description ?? '',
         })
       "
     />
 
     <input
-      :model-value="description"
-      @update:model-value="emit('update:description', $event.target.value)"
+      :value="description"
       :placeholder="t('count.description')"
       class="flex flex-1 bg-transparent px-4"
       type="text"
+      @update:value="emit('update:description', $event.target.value)"
+      @input="
+        updateEntity(index, {
+          id: entityId,
+          key: name,
+          value,
+          active: entityActive,
+          description: ($event.target as HTMLInputElement).value,
+        })
+      "
     />
     <span>
       <HoppButtonSecondary

--- a/packages/hoppscotch-common/src/components/http/KeyValue.vue
+++ b/packages/hoppscotch-common/src/components/http/KeyValue.vue
@@ -1,0 +1,140 @@
+<template>
+  <div
+    class="draggable-content group flex divide-x divide-dividerLight border-b border-dividerLight"
+  >
+    <span>
+      <HoppButtonSecondary
+        v-tippy="{
+          theme: 'tooltip',
+          delay: [500, 20],
+          content: index !== total - 1 ? t('action.drag_to_reorder') : null,
+        }"
+        :icon="IconGripVertical"
+        class="opacity-0"
+        :class="{
+          'draggable-handle cursor-grab group-hover:opacity-100':
+            index !== total - 1,
+        }"
+        tabindex="-1"
+      />
+    </span>
+    <SmartEnvInput
+      :model-value="name"
+      @update:model-value="emit('update:name', $event)"
+      :placeholder="t('count.key')"
+      :auto-complete-env="true"
+      :envs="envs"
+      @change="
+        updateEntity(index, {
+          id: entityId,
+          key: $event,
+          value: value,
+          active: entityActive,
+        })
+      "
+    />
+    <SmartEnvInput
+      :model-value="value"
+      @update:model-value="emit('update:value', $event)"
+      :placeholder="t('count.value')"
+      :auto-complete-env="true"
+      :envs="envs"
+      @change="
+        updateEntity(index, {
+          id: entityId,
+          key: name,
+          value: $event,
+          active: entityActive,
+        })
+      "
+    />
+
+    <input
+      :model-value="description"
+      @update:model-value="emit('update:description', $event.target.value)"
+      :placeholder="t('count.description')"
+      class="flex flex-1 bg-transparent px-4"
+      type="text"
+    />
+    <span>
+      <HoppButtonSecondary
+        v-tippy="{ theme: 'tooltip' }"
+        :title="
+          isActive
+            ? entityActive
+              ? t('action.turn_off')
+              : t('action.turn_on')
+            : t('action.turn_off')
+        "
+        :icon="
+          isActive
+            ? entityActive
+              ? IconCheckCircle
+              : IconCircle
+            : IconCheckCircle
+        "
+        color="green"
+        @click="
+          updateEntity(index, {
+            id: entityId,
+            key: name,
+            value: value,
+            active: isActive ? !entityActive : false,
+          })
+        "
+      />
+    </span>
+    <span>
+      <HoppButtonSecondary
+        v-tippy="{ theme: 'tooltip' }"
+        :title="t('action.remove')"
+        :icon="IconTrash"
+        color="red"
+        @click="deleteEntity(index)"
+      />
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import IconGripVertical from "~icons/lucide/grip-vertical"
+import IconCheckCircle from "~icons/lucide/check-circle"
+import IconCircle from "~icons/lucide/circle"
+import IconTrash from "~icons/lucide/trash"
+import { useI18n } from "~/composables/i18n"
+import { AggregateEnvironment } from "~/newstore/environments"
+
+const t = useI18n()
+
+const props = defineProps<{
+  total: number
+  index: number
+  entityId: number
+  isActive: boolean
+  entityActive: boolean
+  name: string
+  value: string
+  description?: string
+  envs?: AggregateEnvironment[]
+}>()
+
+const emit = defineEmits<{
+  (e: "update:name", value: string): void
+  (e: "update:value", value: string): void
+  (e: "update:description", value: string): void
+  (e: "deleteEntity", value: number): void
+  (e: "updateEntity", { index, payload }: { index: number; payload: any }): void
+}>()
+
+function updateEntity(index: number, payload: any) {
+  console.log(payload)
+  emit("updateEntity", {
+    index,
+    payload,
+  })
+}
+
+function deleteEntity(index: number) {
+  emit("deleteEntity", index)
+}
+</script>

--- a/packages/hoppscotch-common/src/components/http/KeyValue.vue
+++ b/packages/hoppscotch-common/src/components/http/KeyValue.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="draggable-content group flex divide-x divide-dividerLight border-b border-dividerLight"
+    class="flex border-b divide-x draggable-content group divide-dividerLight border-dividerLight"
   >
     <span>
       <HoppButtonSecondary
@@ -57,7 +57,7 @@
     <input
       :value="description"
       :placeholder="t('count.description')"
-      class="flex flex-1 bg-transparent px-4"
+      class="flex flex-1 px-4 bg-transparent"
       type="text"
       @update:value="emit('update:description', $event.target.value)"
       @input="

--- a/packages/hoppscotch-common/src/components/http/Parameters.vue
+++ b/packages/hoppscotch-common/src/components/http/Parameters.vue
@@ -233,8 +233,16 @@ watch(
       )
     }
 
-    if (!isEqual(newParamsList, filteredBulkParams)) {
-      bulkParams.value = rawKeyValueEntriesToString(newParamsList)
+    const newParamsListKeyValuePairs = newParamsList.map(
+      ({ key, value, active }) => ({
+        key,
+        value,
+        active,
+      })
+    )
+
+    if (!isEqual(newParamsListKeyValuePairs, filteredBulkParams)) {
+      bulkParams.value = rawKeyValueEntriesToString(newParamsListKeyValuePairs)
     }
   },
   { immediate: true }
@@ -268,20 +276,18 @@ watch(bulkParams, (newBulkParams) => {
     E.getOrElse(() => [] as RawKeyValueEntry[])
   )
 
-  let paramsWithoutDescriptionField = params.value.map(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    ({ description, ...rest }) => rest
-  )
+  const paramKeyValuePairs = params.value.map(({ key, value, active }) => ({
+    key,
+    value,
+    active,
+  }))
 
-  if (!isEqual(paramsWithoutDescriptionField, filteredBulkParams)) {
-    paramsWithoutDescriptionField = filteredBulkParams
-
-    params.value.forEach((param, idx) => {
-      param = {
-        ...paramsWithoutDescriptionField[idx],
-        description: param.description,
-      }
-    })
+  if (!isEqual(paramKeyValuePairs, filteredBulkParams)) {
+    params.value = filteredBulkParams.map((param, idx) => ({
+      ...param,
+      // Adding a new key-value pair in the bulk edit context won't have a corresponding entry under `params.value`, hence the fallback
+      description: params.value[idx]?.description ?? "",
+    }))
   }
 })
 

--- a/packages/hoppscotch-common/src/components/http/Parameters.vue
+++ b/packages/hoppscotch-common/src/components/http/Parameters.vue
@@ -59,102 +59,24 @@
         drag-class="cursor-grabbing"
       >
         <template #item="{ element: param, index }">
-          <div
-            class="draggable-content group flex divide-x divide-dividerLight border-b border-dividerLight"
-          >
-            <span>
-              <HoppButtonSecondary
-                v-tippy="{
-                  theme: 'tooltip',
-                  delay: [500, 20],
-                  content:
-                    index !== workingParams?.length - 1
-                      ? t('action.drag_to_reorder')
-                      : null,
-                }"
-                :icon="IconGripVertical"
-                class="opacity-0"
-                :class="{
-                  'draggable-handle cursor-grab group-hover:opacity-100':
-                    index !== workingParams?.length - 1,
-                }"
-                tabindex="-1"
-              />
-            </span>
-            <SmartEnvInput
-              v-model="param.key"
-              :placeholder="`${t('count.parameter', { count: index + 1 })}`"
-              :inspection-results="
-                getInspectorResult(parameterKeyResults, index)
-              "
-              :auto-complete-env="true"
-              :envs="envs"
-              @change="
-                updateParam(index, {
-                  id: param.id,
-                  key: $event,
-                  value: param.value,
-                  active: param.active,
-                })
-              "
-            />
-            <SmartEnvInput
-              v-model="param.value"
-              :placeholder="`${t('count.value', { count: index + 1 })}`"
-              :inspection-results="
-                getInspectorResult(parameterValueResults, index)
-              "
-              :auto-complete-env="true"
-              :envs="envs"
-              @change="
-                updateParam(index, {
-                  id: param.id,
-                  key: param.key,
-                  value: $event,
-                  active: param.active,
-                })
-              "
-            />
-            <span>
-              <HoppButtonSecondary
-                v-tippy="{ theme: 'tooltip' }"
-                :title="
-                  param.hasOwnProperty('active')
-                    ? param.active
-                      ? t('action.turn_off')
-                      : t('action.turn_on')
-                    : t('action.turn_off')
-                "
-                :icon="
-                  param.hasOwnProperty('active')
-                    ? param.active
-                      ? IconCheckCircle
-                      : IconCircle
-                    : IconCheckCircle
-                "
-                color="green"
-                @click="
-                  updateParam(index, {
-                    id: param.id,
-                    key: param.key,
-                    value: param.value,
-                    active: param.hasOwnProperty('active')
-                      ? !param.active
-                      : false,
-                  })
-                "
-              />
-            </span>
-            <span>
-              <HoppButtonSecondary
-                v-tippy="{ theme: 'tooltip' }"
-                :title="t('action.remove')"
-                :icon="IconTrash"
-                color="red"
-                @click="deleteParam(index)"
-              />
-            </span>
-          </div>
+          <HttpKeyValue
+            :total="workingParams.length"
+            :index="index"
+            :entity-id="param.id"
+            :entity-active="param.active"
+            :envs="envs"
+            :is-active="param.hasOwnProperty('active')"
+            v-model:name="param.key"
+            v-model:value="param.value"
+            :inspection-key-result="
+              getInspectorResult(parameterKeyResults, index)
+            "
+            :inspection-value-result="
+              getInspectorResult(parameterValueResults, index)
+            "
+            @update-entity="updateParam($event.index, $event.payload)"
+            @delete-entity="deleteParam($event)"
+          />
         </template>
       </draggable>
       <HoppSmartPlaceholder
@@ -181,10 +103,6 @@ import IconHelpCircle from "~icons/lucide/help-circle"
 import IconTrash2 from "~icons/lucide/trash-2"
 import IconEdit from "~icons/lucide/edit"
 import IconPlus from "~icons/lucide/plus"
-import IconGripVertical from "~icons/lucide/grip-vertical"
-import IconCheckCircle from "~icons/lucide/check-circle"
-import IconCircle from "~icons/lucide/circle"
-import IconTrash from "~icons/lucide/trash"
 import IconWrapText from "~icons/lucide/wrap-text"
 import { reactive, ref, watch } from "vue"
 import { flow, pipe } from "fp-ts/function"

--- a/packages/hoppscotch-common/src/components/http/Parameters.vue
+++ b/packages/hoppscotch-common/src/components/http/Parameters.vue
@@ -60,14 +60,15 @@
       >
         <template #item="{ element: param, index }">
           <HttpKeyValue
+            v-model:name="param.key"
+            v-model:value="param.value"
+            v-model:description="param.description"
             :total="workingParams.length"
             :index="index"
             :entity-id="param.id"
             :entity-active="param.active"
             :envs="envs"
             :is-active="param.hasOwnProperty('active')"
-            v-model:name="param.key"
-            v-model:value="param.value"
             :inspection-key-result="
               getInspectorResult(parameterKeyResults, index)
             "
@@ -182,6 +183,7 @@ const workingParams = ref<Array<HoppRESTParam & { id: number }>>([
     key: "",
     value: "",
     active: true,
+    description: "",
   },
 ])
 
@@ -193,6 +195,7 @@ watch(workingParams, (paramsList) => {
       key: "",
       value: "",
       active: true,
+      description: "",
     })
   }
 })
@@ -265,8 +268,20 @@ watch(bulkParams, (newBulkParams) => {
     E.getOrElse(() => [] as RawKeyValueEntry[])
   )
 
-  if (!isEqual(params.value, filteredBulkParams)) {
-    params.value = filteredBulkParams
+  let paramsWithoutDescriptionField = params.value.map(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    ({ description, ...rest }) => rest
+  )
+
+  if (!isEqual(paramsWithoutDescriptionField, filteredBulkParams)) {
+    paramsWithoutDescriptionField = filteredBulkParams
+
+    params.value.forEach((param, idx) => {
+      param = {
+        ...paramsWithoutDescriptionField[idx],
+        description: param.description,
+      }
+    })
   }
 })
 
@@ -276,6 +291,7 @@ const addParam = () => {
     key: "",
     value: "",
     active: true,
+    description: "",
   })
 }
 
@@ -332,6 +348,7 @@ const clearContent = () => {
       key: "",
       value: "",
       active: true,
+      description: "",
     },
   ]
 

--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -2,7 +2,11 @@
 // ^^^ Enables Type Checking by the TypeScript compiler
 
 import { describe, expect, test } from "vitest"
-import { makeRESTRequest, rawKeyValueEntriesToString } from "@hoppscotch/data"
+import {
+  HoppRESTRequest,
+  makeRESTRequest,
+  rawKeyValueEntriesToString,
+} from "@hoppscotch/data"
 import { parseCurlToHoppRESTReq } from ".."
 
 const samples = [
@@ -112,31 +116,37 @@ const samples = [
           key: "User-Agent",
           value:
             "Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",
+          description: "",
         },
         {
           active: true,
           key: "Accept",
           value: "application/json, text/plain, */*",
+          description: "",
         },
         {
           active: true,
           key: "Accept-Language",
           value: "en",
+          description: "",
         },
         {
           active: true,
           key: "Origin",
           value: "http://localhost:3012",
+          description: "",
         },
         {
           active: true,
           key: "Connection",
           value: "keep-alive",
+          description: "",
         },
         {
           active: true,
           key: "Referer",
           value: "http://localhost:3012/crm/company/4",
+          description: "",
         },
       ],
       params: [],
@@ -180,6 +190,7 @@ const samples = [
           active: true,
           key: "bar",
           value: "baz",
+          description: "",
         },
       ],
       preRequestScript: "",
@@ -204,11 +215,13 @@ const samples = [
           active: true,
           key: "tool",
           value: "curl",
+          description: "",
         },
         {
           active: true,
           key: "age",
           value: "old",
+          description: "",
         },
       ],
       preRequestScript: "",
@@ -270,6 +283,7 @@ const samples = [
           active: true,
           key: "Accept",
           value: "application/json",
+          description: "",
         },
       ],
       preRequestScript: "",
@@ -366,11 +380,13 @@ const samples = [
           active: true,
           key: "tool",
           value: "curl",
+          description: "",
         },
         {
           active: true,
           key: "platform",
           value: "hoppscotch",
+          description: "",
         },
       ],
       headers: [],
@@ -415,11 +431,13 @@ const samples = [
           active: true,
           key: "and",
           value: "params",
+          description: "",
         },
         {
           active: true,
           key: "stay",
           value: "tuned",
+          description: "",
         },
       ],
       headers: [
@@ -427,16 +445,19 @@ const samples = [
           active: true,
           key: "user-agent",
           value: "Mozilla/5.0",
+          description: "",
         },
         {
           active: true,
           key: "accept",
           value: "text/html",
+          description: "",
         },
         {
           active: true,
           key: "cookie",
           value: "cookie-cookie",
+          description: "",
         },
       ],
       preRequestScript: "",
@@ -497,33 +518,39 @@ const samples = [
           active: true,
           key: "authority",
           value: "hoppscotch.io",
+          description: "",
         },
         {
           active: true,
           key: "sec-ch-ua",
           value:
             '" Not A;Brand";v="99", "Chromium";v="98", "Google Chrome";v="98"',
+          description: "",
         },
         {
           active: true,
           key: "accept",
           value: "*/*",
+          description: "",
         },
         {
           active: true,
           key: "user-agent",
           value:
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36",
+          description: "",
         },
         {
           active: true,
           key: "sec-ch-ua-platform",
           value: '"Windows"',
+          description: "",
         },
         {
           active: true,
           key: "accept-language",
           value: "en-US,en;q=0.9,ml;q=0.8",
+          description: "",
         },
       ],
       preRequestScript: "",
@@ -563,6 +590,7 @@ const samples = [
           active: true,
           key: "hello",
           value: "there",
+          description: "",
         },
       ],
       headers: [
@@ -570,6 +598,7 @@ const samples = [
           active: true,
           key: "something",
           value: "other-thing",
+          description: "",
         },
       ],
       preRequestScript: "",
@@ -594,6 +623,7 @@ const samples = [
           active: true,
           key: "something",
           value: "other-thing",
+          description: "",
         },
       ],
       body: {
@@ -618,6 +648,7 @@ const samples = [
           active: true,
           key: "hello",
           value: "there",
+          description: "",
         },
       ],
       preRequestScript: "",
@@ -695,6 +726,7 @@ const samples = [
           active: true,
           key: "User-Agent",
           value: "pinephone",
+          description: "",
         },
       ],
       body: {
@@ -742,6 +774,7 @@ const samples = [
           active: true,
           key: "tool",
           value: "hopp",
+          description: "",
         },
       ],
       preRequestScript: "",
@@ -893,6 +926,7 @@ data2: {"type":"test2","typeId":"123"}`,
           active: true,
           key: "Accept",
           value: "application/vnd.test-data.v2.1+json",
+          description: "",
         },
       ],
       preRequestScript: "",

--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -2,11 +2,7 @@
 // ^^^ Enables Type Checking by the TypeScript compiler
 
 import { describe, expect, test } from "vitest"
-import {
-  HoppRESTRequest,
-  makeRESTRequest,
-  rawKeyValueEntriesToString,
-} from "@hoppscotch/data"
+import { makeRESTRequest, rawKeyValueEntriesToString } from "@hoppscotch/data"
 import { parseCurlToHoppRESTReq } from ".."
 
 const samples = [

--- a/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
@@ -5,8 +5,6 @@
  */
 import {
   FormDataKeyValue,
-  HoppRESTHeader,
-  HoppRESTParam,
   HoppRESTReqBody,
   makeRESTRequest,
 } from "@hoppscotch/data"
@@ -197,10 +195,8 @@ export const parseCurlCommand = (curlCommand: string) => {
     name: defaultRESTReq.name,
     endpoint: urlString,
     method: (method || defaultRESTReq.method).toUpperCase(),
-    params:
-      (queries as HoppRESTParam[]) ??
-      (defaultRESTReq.params as HoppRESTParam[]),
-    headers: hoppHeaders as HoppRESTHeader[],
+    params: queries ?? defaultRESTReq.params,
+    headers: hoppHeaders,
     preRequestScript: defaultRESTReq.preRequestScript,
     testScript: defaultRESTReq.testScript,
     auth,

--- a/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
@@ -3,28 +3,30 @@
  * just adding the /browser import as a fix for now, which does not have type info on DefinitelyTyped.
  * remove/update this comment before merging the vue3 port.
  */
-import parser from "yargs-parser/browser"
-import * as O from "fp-ts/Option"
-import * as A from "fp-ts/Array"
-import { pipe, flow } from "fp-ts/function"
 import {
   FormDataKeyValue,
+  HoppRESTHeader,
+  HoppRESTParam,
   HoppRESTReqBody,
   makeRESTRequest,
 } from "@hoppscotch/data"
+import * as A from "fp-ts/Array"
+import { flow, pipe } from "fp-ts/function"
+import * as O from "fp-ts/Option"
+import parser from "yargs-parser/browser"
 import { getAuthObject } from "./sub_helpers/auth"
 import { getHeaders, recordToHoppHeaders } from "./sub_helpers/headers"
 // import { getCookies } from "./sub_helpers/cookies"
-import { getQueries } from "./sub_helpers/queries"
-import { getMethod } from "./sub_helpers/method"
-import { concatParams, getURLObject } from "./sub_helpers/url"
-import { preProcessCurlCommand } from "./sub_helpers/preproc"
-import { getBody, getFArgumentMultipartData } from "./sub_helpers/body"
-import { getDefaultRESTRequest } from "../rest/default"
 import {
-  objHasProperty,
   objHasArrayProperty,
+  objHasProperty,
 } from "~/helpers/functional/object"
+import { getDefaultRESTRequest } from "../rest/default"
+import { getBody, getFArgumentMultipartData } from "./sub_helpers/body"
+import { getMethod } from "./sub_helpers/method"
+import { preProcessCurlCommand } from "./sub_helpers/preproc"
+import { getQueries } from "./sub_helpers/queries"
+import { concatParams, getURLObject } from "./sub_helpers/url"
 
 const defaultRESTReq = getDefaultRESTRequest()
 
@@ -195,8 +197,10 @@ export const parseCurlCommand = (curlCommand: string) => {
     name: defaultRESTReq.name,
     endpoint: urlString,
     method: (method || defaultRESTReq.method).toUpperCase(),
-    params: queries ?? defaultRESTReq.params,
-    headers: hoppHeaders,
+    params:
+      (queries as HoppRESTParam[]) ??
+      (defaultRESTReq.params as HoppRESTParam[]),
+    headers: hoppHeaders as HoppRESTHeader[],
     preRequestScript: defaultRESTReq.preRequestScript,
     testScript: defaultRESTReq.testScript,
     auth,

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -1,14 +1,14 @@
-import parser from "yargs-parser"
-import { pipe, flow } from "fp-ts/function"
 import { HoppRESTHeader } from "@hoppscotch/data"
 import * as A from "fp-ts/Array"
-import * as S from "fp-ts/string"
+import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import { tupleToRecord } from "~/helpers/functional/record"
+import * as S from "fp-ts/string"
+import parser from "yargs-parser"
 import {
-  objHasProperty,
   objHasArrayProperty,
+  objHasProperty,
 } from "~/helpers/functional/object"
+import { tupleToRecord } from "~/helpers/functional/record"
 
 const getHeaderPair = flow(
   S.split(": "),
@@ -66,6 +66,7 @@ export const recordToHoppHeaders = (
       key,
       value: headers[key],
       active: true,
+      description: "",
     })),
     A.filter(
       (header) =>

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/queries.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/queries.ts
@@ -1,8 +1,8 @@
-import { pipe, flow } from "fp-ts/function"
-import * as O from "fp-ts/Option"
-import * as A from "fp-ts/Array"
-import * as Sep from "fp-ts/Separated"
 import { HoppRESTParam } from "@hoppscotch/data"
+import * as A from "fp-ts/Array"
+import { flow, pipe } from "fp-ts/function"
+import * as O from "fp-ts/Option"
+import * as Sep from "fp-ts/Separated"
 
 const isDangling = ([, value]: [string, string]) => !value
 
@@ -26,6 +26,7 @@ export function getQueries(params: Array<[string, string]>): {
             key,
             value,
             active: true,
+            description: "",
           })),
           A.map(([key]) => key)
         ),

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomnia.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomnia.ts
@@ -5,10 +5,10 @@ import {
   HoppRESTParam,
   HoppRESTReqBody,
   HoppRESTRequest,
+  HoppRESTRequestVariable,
   knownContentTypes,
   makeCollection,
   makeRESTRequest,
-  HoppRESTRequestVariable,
 } from "@hoppscotch/data"
 
 import * as A from "fp-ts/Array"
@@ -16,6 +16,7 @@ import * as TE from "fp-ts/TaskEither"
 import * as TO from "fp-ts/TaskOption"
 import { pipe } from "fp-ts/function"
 import { ImportRequest, convert } from "insomnia-importers"
+import { Header, Parameter } from "insomnia-importers/dist/src/entities"
 
 import { IMPORTER_INVALID_FILE_FORMAT } from "."
 import { replaceInsomniaTemplating } from "./insomniaEnv"
@@ -36,10 +37,13 @@ type InsomniaPathParameter = {
 }
 
 type InsomniaFolderResource = ImportRequest & { _type: "request_group" }
-type InsomniaRequestResource = ImportRequest & {
+type InsomniaRequestResource = Omit<ImportRequest, "headers" | "parameters"> & {
   _type: "request"
 } & {
   pathParameters?: InsomniaPathParameter[]
+} & {
+  headers: (Header & { description: string })[]
+  parameters: (Parameter & { description: string })[]
 }
 
 const parseInsomniaDoc = (content: string) =>
@@ -192,6 +196,7 @@ const getHoppReqHeaders = (req: InsomniaRequestResource): HoppRESTHeader[] =>
     key: replaceVarTemplating(header.name),
     value: replaceVarTemplating(header.value),
     active: !header.disabled,
+    description: header.description ?? "",
   })) ?? []
 
 const getHoppReqParams = (req: InsomniaRequestResource): HoppRESTParam[] =>
@@ -199,6 +204,7 @@ const getHoppReqParams = (req: InsomniaRequestResource): HoppRESTParam[] =>
     key: replaceVarTemplating(param.name),
     value: replaceVarTemplating(param.value ?? ""),
     active: !(param.disabled ?? false),
+    description: param.description ?? "",
   })) ?? []
 
 const getHoppReqVariables = (

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
@@ -79,6 +79,7 @@ const parseOpenAPIParams = (params: OpenAPIParamsType[]): HoppRESTParam[] =>
               key: param.name,
               value: "", // TODO: Can we do anything more ? (parse default values maybe)
               active: true,
+              description: param.description ?? "",
             }
         )
       )
@@ -119,6 +120,7 @@ const parseOpenAPIHeaders = (params: OpenAPIParamsType[]): HoppRESTHeader[] =>
               key: header.name,
               value: "", // TODO: Can we do anything more ? (parse default values maybe)
               active: true,
+              description: header.description ?? "",
             }
         )
       )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
@@ -114,15 +114,14 @@ const parseOpenAPIHeaders = (params: OpenAPIParamsType[]): HoppRESTHeader[] =>
     A.filterMap(
       flow(
         O.fromPredicate((param) => param.in === "header"),
-        O.map(
-          (header) =>
-            <HoppRESTParam>{
-              key: header.name,
-              value: "", // TODO: Can we do anything more ? (parse default values maybe)
-              active: true,
-              description: header.description ?? "",
-            }
-        )
+        O.map((header) => {
+          return <HoppRESTParam>{
+            key: header.name,
+            value: "", // TODO: Can we do anything more ? (parse default values maybe)
+            active: true,
+            description: header.description ?? "",
+          }
+        })
       )
     )
   )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -1,34 +1,35 @@
 import {
-  Collection as PMCollection,
-  Item,
-  ItemGroup,
-  QueryParam,
-  RequestAuthDefinition,
-  VariableDefinition,
-  Variable,
-} from "postman-collection"
-import {
+  FormDataKeyValue,
+  HoppCollection,
   HoppRESTAuth,
   HoppRESTHeader,
   HoppRESTParam,
   HoppRESTReqBody,
   HoppRESTRequest,
-  makeRESTRequest,
-  HoppCollection,
-  makeCollection,
-  ValidContentTypes,
-  knownContentTypes,
-  FormDataKeyValue,
   HoppRESTRequestVariable,
+  knownContentTypes,
+  makeCollection,
+  makeRESTRequest,
+  ValidContentTypes,
 } from "@hoppscotch/data"
-import { pipe, flow } from "fp-ts/function"
-import * as S from "fp-ts/string"
 import * as A from "fp-ts/Array"
+import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
+import * as S from "fp-ts/string"
 import * as TE from "fp-ts/TaskEither"
-import { IMPORTER_INVALID_FILE_FORMAT } from "."
-import { PMRawLanguage } from "~/types/pm-coll-exts"
+import {
+  DescriptionDefinition,
+  Item,
+  ItemGroup,
+  Collection as PMCollection,
+  QueryParam,
+  RequestAuthDefinition,
+  Variable,
+  VariableDefinition,
+} from "postman-collection"
 import { stringArrayJoin } from "~/helpers/functional/array"
+import { PMRawLanguage } from "~/types/pm-coll-exts"
+import { IMPORTER_INVALID_FILE_FORMAT } from "."
 
 const safeParseJSON = (jsonStr: string) => O.tryCatch(() => JSON.parse(jsonStr))
 
@@ -64,14 +65,29 @@ const readPMCollection = (def: string) =>
     )
   )
 
+const parseDescription = (descField?: string | DescriptionDefinition) => {
+  if (!descField) {
+    return ""
+  }
+
+  if (typeof descField === "string") {
+    return descField
+  }
+
+  return descField.content
+}
+
 const getHoppReqHeaders = (item: Item): HoppRESTHeader[] =>
   pipe(
     item.request.headers.all(),
     A.map((header) => {
+      const description = parseDescription(header.description)
+
       return <HoppRESTHeader>{
         key: replacePMVarTemplating(header.key),
         value: replacePMVarTemplating(header.value),
         active: !header.disabled,
+        description,
       }
     })
   )
@@ -84,10 +100,13 @@ const getHoppReqParams = (item: Item): HoppRESTParam[] => {
         param.key !== undefined && param.key !== null && param.key.length > 0
     ),
     A.map((param) => {
+      const description = parseDescription(param.description)
+
       return <HoppRESTHeader>{
         key: replacePMVarTemplating(param.key),
         value: replacePMVarTemplating(param.value ?? ""),
         active: !param.disabled,
+        description,
       }
     })
   )

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -93,6 +93,7 @@ export const getComputedAuthHeaders = (
       active: true,
       key: "Authorization",
       value: `Basic ${btoa(`${username}:${password}`)}`,
+      description: "",
     })
   } else if (
     request.auth.authType === "bearer" ||
@@ -111,6 +112,7 @@ export const getComputedAuthHeaders = (
           ? parseTemplateString(token, envVars, false, showKeyIfSecret)
           : token
       }`,
+      description: "",
     })
   } else if (request.auth.authType === "api-key") {
     const { key, addTo } = request.auth
@@ -126,6 +128,7 @@ export const getComputedAuthHeaders = (
               showKeyIfSecret
             )
           : request.auth.value ?? "",
+        description: "",
       })
     }
   }
@@ -164,6 +167,7 @@ export const getComputedBodyHeaders = (
       active: true,
       key: "content-type",
       value: req.body.contentType,
+      description: "",
     },
   ]
 }
@@ -249,6 +253,7 @@ export const getComputedParams = (
           active: true,
           key: parseTemplateString(req.auth.key, envVars, false, true),
           value: parseTemplateString(req.auth.value, envVars, false, true),
+          description: "",
         },
       },
     ]
@@ -263,6 +268,7 @@ export const getComputedParams = (
         active: true,
         key: "access_token",
         value: parseTemplateString(grantTypeInfo.token, envVars, false, true),
+        description: "",
       },
     },
   ]

--- a/packages/hoppscotch-common/src/services/context-menu/menu/parameter.menu.ts
+++ b/packages/hoppscotch-common/src/services/context-menu/menu/parameter.menu.ts
@@ -92,7 +92,7 @@ export class ParameterMenuService extends Service implements ContextMenu {
     // add the parameters to the current request parameters
     tabService.currentActiveTab.value.document.request.params = [
       ...tabService.currentActiveTab.value.document.request.params,
-      ...queryParams,
+      ...queryParams.map((param) => ({ ...param, description: "" })),
     ]
 
     if (newURL) {

--- a/packages/hoppscotch-common/src/services/persistence/__tests__/__mocks__/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/__tests__/__mocks__/index.ts
@@ -24,7 +24,7 @@ const DEFAULT_SETTINGS = getDefaultSettings()
 
 export const REST_COLLECTIONS_MOCK: HoppCollection[] = [
   {
-    v: 2,
+    v: 3,
     name: "Echo",
     folders: [],
     requests: [
@@ -49,7 +49,7 @@ export const REST_COLLECTIONS_MOCK: HoppCollection[] = [
 
 export const GQL_COLLECTIONS_MOCK: HoppCollection[] = [
   {
-    v: 2,
+    v: 3,
     name: "Echo",
     folders: [],
     requests: [

--- a/packages/hoppscotch-common/src/services/persistence/__tests__/__mocks__/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/__tests__/__mocks__/index.ts
@@ -54,7 +54,7 @@ export const GQL_COLLECTIONS_MOCK: HoppCollection[] = [
     folders: [],
     requests: [
       {
-        v: 5,
+        v: 6,
         name: "Echo test",
         url: "https://echo.hoppscotch.io/graphql",
         headers: [],
@@ -154,7 +154,7 @@ export const GQL_HISTORY_MOCK: GQLHistoryEntry[] = [
   {
     v: 1,
     request: {
-      v: 5,
+      v: 6,
       name: "Untitled",
       url: "https://echo.hoppscotch.io/graphql",
       query: "query Request { url }",
@@ -175,7 +175,7 @@ export const GQL_TAB_STATE_MOCK: PersistableTabState<HoppGQLDocument> = {
       tabID: "5edbe8d4-65c9-4381-9354-5f1bf05d8ccc",
       doc: {
         request: {
-          v: 5,
+          v: 6,
           name: "Untitled",
           url: "https://echo.hoppscotch.io/graphql",
           headers: [],

--- a/packages/hoppscotch-data/src/collection/index.ts
+++ b/packages/hoppscotch-data/src/collection/index.ts
@@ -2,6 +2,7 @@ import { InferredEntity, createVersionedEntity } from "verzod"
 
 import V1_VERSION from "./v/1"
 import V2_VERSION from "./v/2"
+import V3_VERSION from "./v/3"
 
 import { z } from "zod"
 import { translateToNewRequest } from "../rest"
@@ -12,10 +13,11 @@ const versionedObject = z.object({
 })
 
 export const HoppCollection = createVersionedEntity({
-  latestVersion: 2,
+  latestVersion: 3,
   versionMap: {
     1: V1_VERSION,
     2: V2_VERSION,
+    3: V3_VERSION,
   },
   getVersion(data) {
     const versionCheck = versionedObject.safeParse(data)
@@ -31,7 +33,7 @@ export const HoppCollection = createVersionedEntity({
 
 export type HoppCollection = InferredEntity<typeof HoppCollection>
 
-export const CollectionSchemaVersion = 2
+export const CollectionSchemaVersion = 3
 
 /**
  * Generates a Collection object. This ignores the version number object

--- a/packages/hoppscotch-data/src/collection/v/2.ts
+++ b/packages/hoppscotch-data/src/collection/v/2.ts
@@ -1,9 +1,13 @@
 import { defineVersion, entityReference } from "verzod"
 import { z } from "zod"
-import { HoppRESTRequest, HoppRESTAuth } from "../../rest"
-import { HoppGQLRequest, HoppGQLAuth, GQLHeader } from "../../graphql"
-import { V1_SCHEMA } from "./1"
+
+import { HoppGQLRequest } from "../../graphql"
+import { GQLHeader } from "../../graphql/v/1"
+import { HoppGQLAuth } from "../../graphql/v/5"
+import { HoppRESTRequest } from "../../rest"
 import { HoppRESTHeaders } from "../../rest/v/1"
+import { HoppRESTAuth } from "../../rest/v/5"
+import { V1_SCHEMA } from "./1"
 
 const baseCollectionSchema = z.object({
   v: z.literal(2),
@@ -31,9 +35,10 @@ type Output = z.output<typeof baseCollectionSchema> & {
   folders: Output[]
 }
 
-export const V2_SCHEMA: z.ZodType<Output, z.ZodTypeDef, Input> = baseCollectionSchema.extend({
-  folders: z.lazy(() => z.array(V2_SCHEMA)),
-})
+export const V2_SCHEMA: z.ZodType<Output, z.ZodTypeDef, Input> =
+  baseCollectionSchema.extend({
+    folders: z.lazy(() => z.array(V2_SCHEMA)),
+  })
 
 export default defineVersion({
   initial: false,

--- a/packages/hoppscotch-data/src/collection/v/2.ts
+++ b/packages/hoppscotch-data/src/collection/v/2.ts
@@ -9,7 +9,7 @@ import { HoppRESTHeaders } from "../../rest/v/1"
 import { HoppRESTAuth } from "../../rest/v/5"
 import { V1_SCHEMA } from "./1"
 
-const baseCollectionSchema = z.object({
+export const v2_baseCollectionSchema = z.object({
   v: z.literal(2),
   id: z.optional(z.string()), // For Firestore ID data
 
@@ -27,16 +27,16 @@ const baseCollectionSchema = z.object({
   headers: z.union([HoppRESTHeaders, z.array(GQLHeader)]),
 })
 
-type Input = z.input<typeof baseCollectionSchema> & {
+type Input = z.input<typeof v2_baseCollectionSchema> & {
   folders: Input[]
 }
 
-type Output = z.output<typeof baseCollectionSchema> & {
+type Output = z.output<typeof v2_baseCollectionSchema> & {
   folders: Output[]
 }
 
 export const V2_SCHEMA: z.ZodType<Output, z.ZodTypeDef, Input> =
-  baseCollectionSchema.extend({
+  v2_baseCollectionSchema.extend({
     folders: z.lazy(() => z.array(V2_SCHEMA)),
   })
 

--- a/packages/hoppscotch-data/src/collection/v/3.ts
+++ b/packages/hoppscotch-data/src/collection/v/3.ts
@@ -1,42 +1,27 @@
-import { defineVersion, entityReference } from "verzod"
+import { defineVersion } from "verzod"
 import { z } from "zod"
 
-import { HoppGQLAuth, HoppGQLRequest } from "../../graphql"
-import { GQLHeader as GQLHeaderV2 } from "../../graphql/v/6"
 import { GQLHeader as GQLHeaderV1 } from "../../graphql/v/1"
-import { HoppRESTAuth, HoppRESTRequest } from "../../rest"
-import { HoppRESTHeaders as HoppRESTHeadersV1 } from "../../rest/v/1"
-import { HoppRESTHeaders as HoppRESTHeadersV2 } from "../../rest/v/7"
-import { V2_SCHEMA } from "./2"
+import { GQLHeader as GQLHeaderV2 } from "../../graphql/v/6"
+import { HoppRESTHeaders as V1_HoppRESTHeaders } from "../../rest/v/1"
+import { HoppRESTHeaders as V2_HoppRESTHeaders } from "../../rest/v/7"
+import { v2_baseCollectionSchema, V2_SCHEMA } from "./2"
 
-const baseCollectionSchema = z.object({
+const v3_baseCollectionSchema = v2_baseCollectionSchema.extend({
   v: z.literal(3),
-  id: z.optional(z.string()), // For Firestore ID data
-
-  name: z.string(),
-  requests: z.array(
-    z.lazy(() =>
-      z.union([
-        entityReference(HoppRESTRequest),
-        entityReference(HoppGQLRequest),
-      ])
-    )
-  ),
-
-  auth: z.union([HoppRESTAuth, HoppGQLAuth]),
-  headers: z.union([HoppRESTHeadersV2, z.array(GQLHeaderV2)]),
+  headers: z.union([V2_HoppRESTHeaders, z.array(GQLHeaderV2)]),
 })
 
-type Input = z.input<typeof baseCollectionSchema> & {
+type Input = z.input<typeof v3_baseCollectionSchema> & {
   folders: Input[]
 }
 
-type Output = z.output<typeof baseCollectionSchema> & {
+type Output = z.output<typeof v3_baseCollectionSchema> & {
   folders: Output[]
 }
 
 export const V3_SCHEMA: z.ZodType<Output, z.ZodTypeDef, Input> =
-  baseCollectionSchema.extend({
+  v3_baseCollectionSchema.extend({
     folders: z.lazy(() => z.array(V3_SCHEMA)),
   })
 
@@ -44,7 +29,7 @@ export default defineVersion({
   initial: false,
   schema: V3_SCHEMA,
   up(old: z.infer<typeof V2_SCHEMA>) {
-    const headers = (old.headers as HoppRESTHeadersV1 | GQLHeaderV1[]).map(
+    const headers = (old.headers as V1_HoppRESTHeaders | GQLHeaderV1[]).map(
       (header) => ({
         ...header,
         description: "",

--- a/packages/hoppscotch-data/src/collection/v/3.ts
+++ b/packages/hoppscotch-data/src/collection/v/3.ts
@@ -1,0 +1,63 @@
+import { defineVersion, entityReference } from "verzod"
+import { z } from "zod"
+
+import { HoppGQLAuth, HoppGQLRequest } from "../../graphql"
+import { GQLHeader as GQLHeaderV2 } from "../../graphql/v/6"
+import { GQLHeader as GQLHeaderV1 } from "../../graphql/v/1"
+import { HoppRESTAuth, HoppRESTRequest } from "../../rest"
+import { HoppRESTHeaders as HoppRESTHeadersV1 } from "../../rest/v/1"
+import { HoppRESTHeaders as HoppRESTHeadersV2 } from "../../rest/v/7"
+import { V2_SCHEMA } from "./2"
+
+const baseCollectionSchema = z.object({
+  v: z.literal(3),
+  id: z.optional(z.string()), // For Firestore ID data
+
+  name: z.string(),
+  requests: z.array(
+    z.lazy(() =>
+      z.union([
+        entityReference(HoppRESTRequest),
+        entityReference(HoppGQLRequest),
+      ])
+    )
+  ),
+
+  auth: z.union([HoppRESTAuth, HoppGQLAuth]),
+  headers: z.union([HoppRESTHeadersV2, z.array(GQLHeaderV2)]),
+})
+
+type Input = z.input<typeof baseCollectionSchema> & {
+  folders: Input[]
+}
+
+type Output = z.output<typeof baseCollectionSchema> & {
+  folders: Output[]
+}
+
+export const V3_SCHEMA: z.ZodType<Output, z.ZodTypeDef, Input> =
+  baseCollectionSchema.extend({
+    folders: z.lazy(() => z.array(V3_SCHEMA)),
+  })
+
+export default defineVersion({
+  initial: false,
+  schema: V3_SCHEMA,
+  up(old: z.infer<typeof V2_SCHEMA>) {
+    const headers = (old.headers as HoppRESTHeadersV1 | GQLHeaderV1[]).map(
+      (header) => ({
+        ...header,
+        description: "",
+      })
+    )
+
+    // @ts-expect-error
+    const result: z.infer<typeof V3_SCHEMA> = {
+      ...old,
+      v: 3,
+      headers,
+    }
+
+    return result
+  },
+})

--- a/packages/hoppscotch-data/src/graphql/index.ts
+++ b/packages/hoppscotch-data/src/graphql/index.ts
@@ -5,33 +5,35 @@ import V2_VERSION from "./v/2"
 import V3_VERSION from "./v/3"
 import V4_VERSION from "./v/4"
 import V5_VERSION from "./v/5"
+import V6_VERSION from "./v/6"
 
-export { GQLHeader } from "./v/1"
 export {
   HoppGQLAuthBasic,
   HoppGQLAuthBearer,
-  HoppGQLAuthNone,
   HoppGQLAuthInherit,
+  HoppGQLAuthNone,
 } from "./v/2"
+export { GQLHeader } from "./v/6"
 
-export { HoppGQLAuthOAuth2, HoppGQLAuth } from "./v/5"
+export { HoppGQLAuth, HoppGQLAuthOAuth2 } from "./v/5"
 
 export { HoppGQLAuthAPIKey } from "./v/4"
 
-export const GQL_REQ_SCHEMA_VERSION = 5
+export const GQL_REQ_SCHEMA_VERSION = 6
 
 const versionedObject = z.object({
   v: z.number(),
 })
 
 export const HoppGQLRequest = createVersionedEntity({
-  latestVersion: 5,
+  latestVersion: 6,
   versionMap: {
     1: V1_VERSION,
     2: V2_VERSION,
     3: V3_VERSION,
     4: V4_VERSION,
     5: V5_VERSION,
+    6: V6_VERSION,
   },
   getVersion(x) {
     const result = versionedObject.safeParse(x)

--- a/packages/hoppscotch-data/src/graphql/v/6.ts
+++ b/packages/hoppscotch-data/src/graphql/v/6.ts
@@ -1,0 +1,37 @@
+import { defineVersion } from "verzod"
+import { z } from "zod"
+
+import { V5_SCHEMA } from "./5"
+
+export const GQLHeader = z.object({
+  key: z.string().catch(""),
+  value: z.string().catch(""),
+  active: z.boolean().catch(true),
+  description: z.string().catch(""),
+})
+
+export type GQLHeader = z.infer<typeof GQLHeader>
+
+export const V6_SCHEMA = V5_SCHEMA.extend({
+  v: z.literal(6),
+  headers: z.array(GQLHeader).catch([]),
+})
+
+export default defineVersion({
+  schema: V6_SCHEMA,
+  initial: false,
+  up(old: z.infer<typeof V6_SCHEMA>) {
+    const headers = old.headers.map((header) => {
+      return {
+        ...header,
+        description: "",
+      }
+    })
+
+    return {
+      ...old,
+      v: 6 as const,
+      headers,
+    }
+  },
+})

--- a/packages/hoppscotch-data/src/rest/index.ts
+++ b/packages/hoppscotch-data/src/rest/index.ts
@@ -12,7 +12,7 @@ import V2_VERSION from "./v/2"
 import V3_VERSION from "./v/3"
 import V4_VERSION from "./v/4"
 import V5_VERSION from "./v/5"
-import { HoppRESTReqBody } from "./v/6"
+import V6_VERSION, { HoppRESTReqBody } from "./v/6"
 
 import { HoppRESTHeaders, HoppRESTParams } from "./v/7"
 import V7_VERSION from "./v/7"
@@ -64,6 +64,7 @@ export const HoppRESTRequest = createVersionedEntity({
     3: V3_VERSION,
     4: V4_VERSION,
     5: V5_VERSION,
+    6: V6_VERSION,
     7: V7_VERSION,
   },
   getVersion(data) {

--- a/packages/hoppscotch-data/src/rest/index.ts
+++ b/packages/hoppscotch-data/src/rest/index.ts
@@ -12,9 +12,10 @@ import V2_VERSION from "./v/2"
 import V3_VERSION from "./v/3"
 import V4_VERSION from "./v/4"
 import V5_VERSION from "./v/5"
-import V6_VERSION, { HoppRESTReqBody } from "./v/6"
+import { HoppRESTReqBody } from "./v/6"
 
-import { HoppRESTHeaders, HoppRESTParams } from "./v/1"
+import { HoppRESTHeaders, HoppRESTParams } from "./v/7"
+import V7_VERSION from "./v/7"
 
 import { HoppRESTRequestVariables } from "./v/2"
 import { HoppRESTAuth } from "./v/5"
@@ -27,7 +28,6 @@ export {
   HoppRESTAuthBearer,
   HoppRESTAuthInherit,
   HoppRESTAuthNone,
-  HoppRESTHeaders,
   HoppRESTReqBodyFormData,
 } from "./v/1"
 
@@ -48,6 +48,7 @@ export { HoppRESTAuthAPIKey } from "./v/4"
 export { HoppRESTRequestVariables } from "./v/2"
 
 export { HoppRESTReqBody } from "./v/6"
+export { HoppRESTHeaders } from "./v/7"
 
 const versionedObject = z.object({
   // v is a stringified number
@@ -55,7 +56,7 @@ const versionedObject = z.object({
 })
 
 export const HoppRESTRequest = createVersionedEntity({
-  latestVersion: 6,
+  latestVersion: 7,
   versionMap: {
     0: V0_VERSION,
     1: V1_VERSION,
@@ -63,7 +64,7 @@ export const HoppRESTRequest = createVersionedEntity({
     3: V3_VERSION,
     4: V4_VERSION,
     5: V5_VERSION,
-    6: V6_VERSION,
+    7: V7_VERSION,
   },
   getVersion(data) {
     // For V1 onwards we have the v string storing the number
@@ -105,7 +106,7 @@ const HoppRESTRequestEq = Eq.struct<HoppRESTRequest>({
   ),
 })
 
-export const RESTReqSchemaVersion = "6"
+export const RESTReqSchemaVersion = "7"
 
 export type HoppRESTParam = HoppRESTRequest["params"][number]
 export type HoppRESTHeader = HoppRESTRequest["headers"][number]

--- a/packages/hoppscotch-data/src/rest/v/7.ts
+++ b/packages/hoppscotch-data/src/rest/v/7.ts
@@ -1,0 +1,59 @@
+import { defineVersion } from "verzod"
+import { z } from "zod"
+
+import { V6_SCHEMA } from "./6"
+
+export const HoppRESTParams = z.array(
+  z.object({
+    key: z.string().catch(""),
+    value: z.string().catch(""),
+    active: z.boolean().catch(true),
+    description: z.string().catch(""),
+  })
+)
+
+export type HoppRESTParams = z.infer<typeof HoppRESTParams>
+
+export const HoppRESTHeaders = z.array(
+  z.object({
+    key: z.string().catch(""),
+    value: z.string().catch(""),
+    active: z.boolean().catch(true),
+    description: z.string().catch(""),
+  })
+)
+
+export type HoppRESTHeaders = z.infer<typeof HoppRESTHeaders>
+
+export const V7_SCHEMA = V6_SCHEMA.extend({
+  v: z.literal("7"),
+  params: HoppRESTParams,
+  headers: HoppRESTHeaders,
+})
+
+export default defineVersion({
+  schema: V7_SCHEMA,
+  initial: false,
+  up(old: z.infer<typeof V6_SCHEMA>) {
+    const params = old.headers.map((param) => {
+      return {
+        ...param,
+        description: "",
+      }
+    })
+
+    const headers = old.headers.map((header) => {
+      return {
+        ...header,
+        description: "",
+      }
+    })
+
+    return {
+      ...old,
+      v: "7" as const,
+      params,
+      headers,
+    }
+  },
+})

--- a/packages/hoppscotch-data/src/rest/v/7.ts
+++ b/packages/hoppscotch-data/src/rest/v/7.ts
@@ -35,7 +35,7 @@ export default defineVersion({
   schema: V7_SCHEMA,
   initial: false,
   up(old: z.infer<typeof V6_SCHEMA>) {
-    const params = old.headers.map((param) => {
+    const params = old.params.map((param) => {
       return {
         ...param,
         description: "",


### PR DESCRIPTION
### Description

This PR introduces a new `description` field for both request parameters and headers in the API documentation. This allows developers to provide clear and concise explanations for each parameter and header, enhancing the readability and usability of the documentation. It is also added for headers at the collection level.

The `description` field is also accounted for while importing from external sources (`Postman`, `Insomnia` & `OpenAPI`).

A pre-existing issue where edits made to headers from the bulk edit context are not immediately reflected in the default view is resolved.

Closes HFE-535 HFE-538.

### Preview

![image](https://github.com/user-attachments/assets/d4b2edde-486b-4c83-ba8e-003049494ea2)

> For the auto-generated `Authorization` and `Content-Type` headers, the `description` field will stay disabled and the value will appear empty; while for inherited headers the value specified will be populated.

![header-desc](https://github.com/user-attachments/assets/1a40e2dc-040c-4759-8da0-7e94d5ca9457)

### Changes

- Adds a new `HttpKeyValue` component abstracting the active headers UI and related business logic for reuse across request `Parameters` & `Headers` tabs.
- Update bulk edit context and the default view synchronization logic accounting for the newly added `description` field. The `description` field is excluded while comparing against the key-value pairs from the bulk edit context since it isn't applicable.
- Changes to versioned entities:
  - `HoppCollection` schema `v3` - Headers at the collection level have an additional `description` field. Also, the `v2` schema is updated to consume `HoppRESTHeaders` & `GQLHeader` schema definitions without the `description` field addition. Also, `HoppRESTAuth` & `HoppGQLAuth` schema definitions are consumed from the `HoppRESTRequest` & `HoppGQLRequest` `v5` schemas instead of from the entry point. This is done so that any field additions at the child level (`auth`, `headers`, etc) will require adding a new version for `HoppCollection` to stay consistent and won't be implicitly supported by the existing latest version as was the case.

    > Reasoning: Consider the pre-existing scenario where a new field is added under headers `HoppRESTHeaders`. Assume `HoppCollection` `v2` points to the entry point where the latest version of the above is exported. For an incoming collection conforming to the `v2` schema, there is no proper migration mechanism accounting for the `description` field addition and making it point to the specific `HoppRESTHeaders` schema and introducing `HoppCollection` `v3` with the relevant migration mechanism adding `description` field falling back to the value of an empty string ensures proper migration mechanism comes into play and data conforming to the latest version is dealt with.

  - `HoppRESTRequest` schema `v7` - New `description` field for headers and parameters.
  - `HoppGQLRequest` schema `v6` - New `description` field for headers.
- Importer module updates to include the `description` field from external sources.
- Updates to test suites and associated fixtures accounting for the internal data structure updates.
- Relevant `i18n` string additions.
- Update `Node.js CI` GH Action workflow config to include `next` & `patch` branches as triggers on `push` & `pull_request` events.

### Note to reviewers

Ensure to verify the following flows:

- Specify a description under request parameters/headers for an unsaved request and ensure it persists across page reloads.
- Save the request (`REST`/`GQL`) under a collection and observe the behaviour. Try exporting (individual/workspace level exports) and importing the same and verify if the `description` fields are populated. This applies to both personal and team workspaces.
- Navigate to the `Authorization` tab, change the type and observe the `Authorization` header addition with the `description` field appearing empty and staying disabled.
- Navigate to the bulk edit view and verify edits are synced to and fro.
- Open the collection properties modal, specify a description and ensure it persists. For a request inheriting the authorization/header properties, ensure the `description` field gets populated. Try changing the value at the collection level and verify it gets reflected. Inherited headers will stay disabled at a request level.
- Import Postman, Insomnia & OpenAPI collections with descriptions set for request parameters/headers and observe them getting populated while importing.

We're following the convention where any changes under `@hoppscotch/data` will require a CLI version bump (`@hoppscotch/data` contents get inlined in the CLI bundle), especially in this case where a new schema definition is added and the CLI would reject a collection conforming to the latest version without publishing the latest changes. The bump is done in #4275 scheduled for the next major release, hence not done in this PR.