### PR TITLE
fix: wrap line button showing inconsistency bug

### DIFF
--- a/packages/hoppscotch-common/src/components/graphql/Headers.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Headers.vue
@@ -25,6 +25,7 @@
         @click="clearContent()"
       />
       <HoppButtonSecondary
+        v-if="bulkMode"
         v-tippy="{ theme: 'tooltip' }"
         :title="t('state.linewrap')"
         :class="{ '!text-accent': WRAP_LINES }"

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -26,7 +26,7 @@
           @click="clearContent()"
         />
         <HoppButtonSecondary
-          v-if="bulkHeaders"
+          v-if="bulkMode"
           v-tippy="{ theme: 'tooltip' }"
           :title="t('state.linewrap')"
           :class="{ '!text-accent': WRAP_LINES }"

--- a/packages/hoppscotch-common/src/components/http/RequestVariables.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestVariables.vue
@@ -21,7 +21,7 @@
           @click="clearContent()"
         />
         <HoppButtonSecondary
-          v-if="bulkVariables"
+          v-if="bulkMode"
           v-tippy="{ theme: 'tooltip' }"
           :title="t('state.linewrap')"
           :class="{ '!text-accent': WRAP_LINES }"


### PR DESCRIPTION
Closes HFE-543

This PR fixes the inconsistency in showing the wrap lines button in Headers in REST and GraphQl, Request Variable in REST  section. Now it only shows when Bulk mode is active.

