### PR TITLE
feat: duplicate team and user collections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     build:
       dockerfile: packages/hoppscotch-backend/Dockerfile
       context: .
-      target: dev
+      target: prod
     env_file:
       - ./.env
     restart: always
@@ -122,7 +122,7 @@ services:
       - PORT=3000
     volumes:
       # Uncomment the line below when modifying code. Only applicable when using the "dev" target.
-      - ./packages/hoppscotch-backend/:/usr/src/app
+      # - ./packages/hoppscotch-backend/:/usr/src/app
       - /usr/src/app/node_modules/
     depends_on:
       hoppscotch-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     build:
       dockerfile: packages/hoppscotch-backend/Dockerfile
       context: .
-      target: prod
+      target: dev
     env_file:
       - ./.env
     restart: always
@@ -122,7 +122,7 @@ services:
       - PORT=3000
     volumes:
       # Uncomment the line below when modifying code. Only applicable when using the "dev" target.
-      # - ./packages/hoppscotch-backend/:/usr/src/app
+      - ./packages/hoppscotch-backend/:/usr/src/app
       - /usr/src/app/node_modules/
     depends_on:
       hoppscotch-db:

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.resolver.ts
@@ -331,7 +331,7 @@ export class TeamCollectionResolver {
     return updatedTeamCollection.right;
   }
 
-  @Mutation(() => TeamCollection, {
+  @Mutation(() => Boolean, {
     description: 'Duplicate a Team Collection',
   })
   @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.resolver.ts
@@ -331,6 +331,26 @@ export class TeamCollectionResolver {
     return updatedTeamCollection.right;
   }
 
+  @Mutation(() => TeamCollection, {
+    description: 'Duplicate a Team Collection',
+  })
+  @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)
+  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  async duplicateTeamCollection(
+    @Args({
+      name: 'collectionID',
+      description: 'ID of the collection',
+    })
+    collectionID: string,
+  ) {
+    const duplicatedTeamCollection =
+      await this.teamCollectionService.duplicateTeamCollection(collectionID);
+
+    if (E.isLeft(duplicatedTeamCollection))
+      throwErr(duplicatedTeamCollection.left);
+    return duplicatedTeamCollection.right;
+  }
+
   // Subscriptions
 
   @Subscription(() => TeamCollection, {

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1467,7 +1467,7 @@ export class TeamCollectionService {
       JSON.stringify([
         {
           ...collectionJSONObject.right,
-          name: `${collection.right.title} - duplicated`,
+          name: `${collection.right.title} - duplicate`,
         },
       ]),
       collection.right.teamID,

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1446,4 +1446,35 @@ export class TeamCollectionService {
       return E.left(TEAM_COLL_NOT_FOUND);
     }
   }
+
+  /**
+   * Duplicate a Team Collection
+   *
+   * @param collectionID The Collection ID
+   * @returns Boolean of duplication status
+   */
+  async duplicateTeamCollection(collectionID: string) {
+    const collection = await this.getCollection(collectionID);
+    if (E.isLeft(collection)) return E.left(TEAM_INVALID_COLL_ID);
+
+    const collectionJSONObject = await this.exportCollectionToJSONObject(
+      collection.right.teamID,
+      collectionID,
+    );
+    if (E.isLeft(collectionJSONObject)) return E.left(TEAM_INVALID_COLL_ID);
+
+    const result = await this.importCollectionsFromJSON(
+      JSON.stringify([
+        {
+          ...collectionJSONObject.right,
+          name: `${collection.right.title} - duplicated`,
+        },
+      ]),
+      collection.right.teamID,
+      collection.right.parentID,
+    );
+    if (E.isLeft(result)) return E.left(result.left as string);
+
+    return E.right(true);
+  }
 }

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1467,7 +1467,7 @@ export class TeamCollectionService {
       JSON.stringify([
         {
           ...collectionJSONObject.right,
-          name: `${collection.right.title} - duplicate`,
+          name: `${collection.right.title} - Duplicate`,
         },
       ]),
       collection.right.teamID,

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
@@ -390,6 +390,35 @@ export class UserCollectionResolver {
     return updatedUserCollection.right;
   }
 
+  @Mutation(() => Boolean, {
+    description: 'Duplicate a User Collection',
+  })
+  @UseGuards(GqlAuthGuard)
+  async duplicateUserCollection(
+    @GqlUser() user: AuthUser,
+    @Args({
+      name: 'collectionID',
+      description: 'ID of the collection',
+    })
+    collectionID: string,
+    @Args({
+      name: 'reqType',
+      description: 'Type of UserCollection',
+    })
+    reqType: ReqType,
+  ) {
+    const duplicatedUserCollection =
+      await this.userCollectionService.duplicateUserCollection(
+        collectionID,
+        user.uid,
+        reqType,
+      );
+
+    if (E.isLeft(duplicatedUserCollection))
+      throwErr(duplicatedUserCollection.left);
+    return duplicatedUserCollection.right;
+  }
+
   // Subscriptions
   @Subscription(() => UserCollection, {
     description: 'Listen for User Collection Creation',

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
@@ -404,6 +404,7 @@ export class UserCollectionResolver {
     @Args({
       name: 'reqType',
       description: 'Type of UserCollection',
+      type: () => ReqType,
     })
     reqType: ReqType,
   ) {

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
@@ -1168,7 +1168,7 @@ export class UserCollectionService {
       JSON.stringify([
         {
           ...collectionJSONObject.right,
-          name: `${collection.right.title} - duplicated`,
+          name: `${collection.right.title} - duplicate`,
         },
       ]),
       userID,

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
@@ -1168,7 +1168,7 @@ export class UserCollectionService {
       JSON.stringify([
         {
           ...collectionJSONObject.right,
-          name: `${collection.right.title} - duplicate`,
+          name: `${collection.right.title} - Duplicate`,
         },
       ]),
       userID,

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
@@ -1138,4 +1138,45 @@ export class UserCollectionService {
       return E.left(USER_COLL_NOT_FOUND);
     }
   }
+
+  /**
+   * Duplicate a User Collection
+   *
+   * @param collectionID The Collection ID
+   * @returns Boolean of duplication status
+   */
+  async duplicateUserCollection(
+    collectionID: string,
+    userID: string,
+    reqType: DBReqType,
+  ) {
+    const collection = await this.getUserCollection(collectionID);
+    if (E.isLeft(collection)) return E.left(USER_COLL_NOT_FOUND);
+
+    if (collection.right.userUid !== userID) return E.left(USER_NOT_OWNER);
+    if (collection.right.type !== reqType)
+      return E.left(USER_COLL_NOT_SAME_TYPE);
+
+    const collectionJSONObject = await this.exportUserCollectionToJSONObject(
+      collection.right.userUid,
+      collectionID,
+    );
+    if (E.isLeft(collectionJSONObject))
+      return E.left(collectionJSONObject.left);
+
+    const result = await this.importCollectionsFromJSON(
+      JSON.stringify([
+        {
+          ...collectionJSONObject.right,
+          name: `${collection.right.title} - duplicated`,
+        },
+      ]),
+      userID,
+      collection.right.parentID,
+      reqType,
+    );
+    if (E.isLeft(result)) return E.left(result.left as string);
+
+    return E.right(true);
+  }
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes HSB-425

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
In this PR we are adding a new mutation to duplicate team and user collections.

```
For TeamCollections,

duplicateTeamCollection(collectionID: string) : Boolean

For UserCollections,

duplicateUserCollection(collectionID: string, reqType: ReqType) : Boolean
```

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

### Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behaviour, etc. -->
none
