### PR TITLE
feat: duplicate REST/GraphQL collections

### DIFF
--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -21,7 +21,11 @@ import {
   TEAM_MEMBER_NOT_FOUND,
 } from '../errors';
 import { PubSubService } from '../pubsub/pubsub.service';
-import { escapeSqlLikeString, isValidLength } from 'src/utils';
+import {
+  escapeSqlLikeString,
+  isValidLength,
+  transformCollectionData,
+} from 'src/utils';
 import * as E from 'fp-ts/Either';
 import * as O from 'fp-ts/Option';
 import {
@@ -134,11 +138,13 @@ export class TeamCollectionService {
       },
     });
 
+    const data = transformCollectionData(collection.right.data);
+
     const result: CollectionFolder = {
       name: collection.right.title,
       folders: childrenCollectionObjects,
       requests: requests.map((x) => x.request),
-      data: JSON.stringify(collection.right.data),
+      data,
     };
 
     return E.right(result);
@@ -309,11 +315,13 @@ export class TeamCollectionService {
    * @returns TeamCollection model
    */
   private cast(teamCollection: DBTeamCollection): TeamCollection {
+    const data = transformCollectionData(teamCollection.data);
+
     return <TeamCollection>{
       id: teamCollection.id,
       title: teamCollection.title,
       parentID: teamCollection.parentID,
-      data: !teamCollection.data ? null : JSON.stringify(teamCollection.data),
+      data,
     };
   }
 

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
@@ -25,7 +25,11 @@ import {
   UserCollectionExportJSONData,
 } from './user-collections.model';
 import { ReqType } from 'src/types/RequestTypes';
-import { isValidLength, stringToJson } from 'src/utils';
+import {
+  isValidLength,
+  stringToJson,
+  transformCollectionData,
+} from 'src/utils';
 import { CollectionFolder } from 'src/types/CollectionFolder';
 
 @Injectable()
@@ -43,13 +47,15 @@ export class UserCollectionService {
    * @returns UserCollection model
    */
   private cast(collection: UserCollection) {
+    const data = transformCollectionData(collection.data);
+
     return <UserCollectionModel>{
       id: collection.id,
       title: collection.title,
       type: collection.type,
       parentID: collection.parentID,
       userID: collection.userUid,
-      data: !collection.data ? null : JSON.stringify(collection.data),
+      data,
     };
   }
 
@@ -871,6 +877,8 @@ export class UserCollectionService {
       },
     });
 
+    const data = transformCollectionData(collection.right.data);
+
     const result: CollectionFolder = {
       id: collection.right.id,
       name: collection.right.title,
@@ -882,7 +890,7 @@ export class UserCollectionService {
           ...(x.request as Record<string, unknown>), // type casting x.request of type Prisma.JSONValue to an object to enable spread
         };
       }),
-      data: JSON.stringify(collection.right.data),
+      data,
     };
 
     return E.right(result);

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -1,21 +1,21 @@
 import { ExecutionContext, HttpException } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
+import { Prisma } from '@prisma/client';
+import * as A from 'fp-ts/Array';
+import * as E from 'fp-ts/Either';
 import { pipe } from 'fp-ts/lib/function';
 import * as O from 'fp-ts/Option';
-import * as TE from 'fp-ts/TaskEither';
 import * as T from 'fp-ts/Task';
-import * as E from 'fp-ts/Either';
-import * as A from 'fp-ts/Array';
-import { TeamMemberRole } from './team/team.model';
-import { User } from './user/user.model';
+import * as TE from 'fp-ts/TaskEither';
+import { AuthProvider } from './auth/helper';
 import {
   ENV_EMPTY_AUTH_PROVIDERS,
   ENV_NOT_FOUND_KEY_AUTH_PROVIDERS,
   ENV_NOT_SUPPORT_AUTH_PROVIDERS,
   JSON_INVALID,
 } from './errors';
-import { AuthProvider } from './auth/helper';
+import { TeamMemberRole } from './team/team.model';
 import { RESTError } from './types/RESTError';
 
 /**
@@ -296,4 +296,23 @@ export function escapeSqlLikeString(str: string) {
 export function calculateExpirationDate(expiresOn: null | number) {
   if (expiresOn === null) return null;
   return new Date(Date.now() + expiresOn * 24 * 60 * 60 * 1000);
+}
+
+/*
+ * Transforms the collection level properties (authorization & headers) under the `data` field.
+ * Preserves `null` values and prevents duplicate stringification.
+ *
+ * @param {Prisma.JsonValue} collectionData - The team collection data to transform.
+ * @returns {string | null} The transformed team collection data as a string.
+ */
+export function transformCollectionData(
+  collectionData: Prisma.JsonValue,
+): string | null {
+  if (!collectionData) {
+    return null;
+  }
+
+  return typeof collectionData === 'string'
+    ? collectionData
+    : JSON.stringify(collectionData);
 }

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -194,7 +194,8 @@
     "save_to_collection": "Save to Collection",
     "select": "Select a Collection",
     "select_location": "Select location",
-    "details": "Details"
+    "details": "Details",
+    "duplicated": "Collection duplicated"
   },
   "confirm": {
     "close_unsaved_tab": "Are you sure you want to close this tab?",

--- a/packages/hoppscotch-common/src/components/collections/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/Collection.vue
@@ -102,6 +102,7 @@
                   @keyup.r="requestAction?.$el.click()"
                   @keyup.n="folderAction?.$el.click()"
                   @keyup.e="edit?.$el.click()"
+                  @keyup.d="duplicateAction?.$el.click()"
                   @keyup.delete="deleteAction?.$el.click()"
                   @keyup.x="exportAction?.$el.click()"
                   @keyup.p="propertiesAction?.$el.click()"
@@ -141,6 +142,19 @@
                       () => {
                         emit('edit-collection')
                         hide()
+                      }
+                    "
+                  />
+                  <HoppSmartItem
+                    ref="duplicateAction"
+                    :icon="IconCopy"
+                    :label="t('action.duplicate')"
+                    :loading="duplicateCollectionLoading"
+                    :shortcut="['D']"
+                    @click="
+                      () => {
+                        emit('duplicate-collection'),
+                          collectionsType === 'my-collections' ? hide() : null
                       }
                     "
                   />
@@ -230,6 +244,7 @@ import {
   currentReorderingStatus$,
 } from "~/newstore/reordering"
 import IconCheckCircle from "~icons/lucide/check-circle"
+import IconCopy from "~icons/lucide/copy"
 import IconDownload from "~icons/lucide/download"
 import IconEdit from "~icons/lucide/edit"
 import IconFilePlus from "~icons/lucide/file-plus"
@@ -263,6 +278,7 @@ const props = withDefaults(
     hasNoTeamAccess?: boolean
     collectionMoveLoading?: string[]
     isLastItem?: boolean
+    duplicateCollectionLoading?: boolean
   }>(),
   {
     id: "",
@@ -274,6 +290,7 @@ const props = withDefaults(
     exportLoading: false,
     hasNoTeamAccess: false,
     isLastItem: false,
+    duplicateLoading: false,
   }
 )
 
@@ -283,6 +300,7 @@ const emit = defineEmits<{
   (event: "add-folder"): void
   (event: "edit-collection"): void
   (event: "edit-properties"): void
+  (event: "duplicate-collection"): void
   (event: "export-data"): void
   (event: "remove-collection"): void
   (event: "drop-event", payload: DataTransfer): void
@@ -297,6 +315,7 @@ const tippyActions = ref<HTMLDivElement | null>(null)
 const requestAction = ref<HTMLButtonElement | null>(null)
 const folderAction = ref<HTMLButtonElement | null>(null)
 const edit = ref<HTMLButtonElement | null>(null)
+const duplicateAction = ref<HTMLButtonElement | null>(null)
 const deleteAction = ref<HTMLButtonElement | null>(null)
 const exportAction = ref<HTMLButtonElement | null>(null)
 const options = ref<TippyComponent | null>(null)
@@ -341,9 +360,9 @@ const collectionName = computed(() => {
 })
 
 watch(
-  () => props.exportLoading,
-  (val) => {
-    if (!val) {
+  () => [props.exportLoading, props.duplicateCollectionLoading],
+  ([newExportLoadingVal, newDuplicateCollectionLoadingVal]) => {
+    if (!newExportLoadingVal || !newDuplicateCollectionLoadingVal) {
       options.value!.tippy?.hide()
     }
   }

--- a/packages/hoppscotch-common/src/components/collections/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/Collection.vue
@@ -362,7 +362,7 @@ const collectionName = computed(() => {
 watch(
   () => [props.exportLoading, props.duplicateCollectionLoading],
   ([newExportLoadingVal, newDuplicateCollectionLoadingVal]) => {
-    if (!newExportLoadingVal || !newDuplicateCollectionLoadingVal) {
+    if (!newExportLoadingVal && !newDuplicateCollectionLoadingVal) {
       options.value!.tippy?.hide()
     }
   }

--- a/packages/hoppscotch-common/src/components/collections/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/Collection.vue
@@ -102,7 +102,11 @@
                   @keyup.r="requestAction?.$el.click()"
                   @keyup.n="folderAction?.$el.click()"
                   @keyup.e="edit?.$el.click()"
-                  @keyup.d="duplicateAction?.$el.click()"
+                  @keyup.d="
+                    showDuplicateCollectionAction
+                      ? duplicateAction?.$el.click()
+                      : null
+                  "
                   @keyup.delete="deleteAction?.$el.click()"
                   @keyup.x="exportAction?.$el.click()"
                   @keyup.p="propertiesAction?.$el.click()"
@@ -146,6 +150,7 @@
                     "
                   />
                   <HoppSmartItem
+                    v-if="showDuplicateCollectionAction"
                     ref="duplicateAction"
                     :icon="IconCopy"
                     :label="t('action.duplicate')"
@@ -243,6 +248,7 @@ import {
   changeCurrentReorderStatus,
   currentReorderingStatus$,
 } from "~/newstore/reordering"
+import { platform } from "~/platform"
 import IconCheckCircle from "~icons/lucide/check-circle"
 import IconCopy from "~icons/lucide/copy"
 import IconDownload from "~icons/lucide/download"
@@ -333,6 +339,11 @@ const currentReorderingStatus = useReadonlyStream(currentReorderingStatus$, {
   parentID: "",
 })
 
+const currentUser = useReadonlyStream(
+  platform.auth.getCurrentUserStream(),
+  platform.auth.getCurrentUser()
+)
+
 // Used to determine if the collection is being dragged to a different destination
 // This is used to make the highlight effect work
 watch(
@@ -357,6 +368,21 @@ const collectionName = computed(() => {
   if ((props.data as HoppCollection).name)
     return (props.data as HoppCollection).name
   return (props.data as TeamCollection).title
+})
+
+const showDuplicateCollectionAction = computed(() => {
+  // Show if the user is not logged in
+  if (!currentUser.value) {
+    return true
+  }
+
+  if (props.collectionsType === "team-collections") {
+    return true
+  }
+
+  // Duplicate collection action is disabled on SH until the issue with syncing is resolved
+  return !platform.platformFeatureFlags
+    .duplicateCollectionDisabledInPersonalWorkspace
 })
 
 watch(

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -418,7 +418,7 @@ const HoppTeamCollectionsExporter: ImporterOrExporter = {
   metadata: {
     id: "hopp_team_collections",
     name: "export.as_json",
-    title: "export.as_json_description",
+    title: "export.as_json",
     icon: IconUser,
     disabled: false,
     applicableTo: ["team-workspace"],
@@ -481,11 +481,6 @@ const HoppGistCollectionsExporter: ImporterOrExporter = {
     }
 
     if (E.isRight(collectionJSON)) {
-      if (!JSON.parse(collectionJSON.right).length) {
-        isHoppGistCollectionExporterInProgress.value = false
-        return toast.error(t("error.no_collections_to_export"))
-      }
-
       const res = await gistExporter(collectionJSON.right, accessToken)
 
       if (E.isLeft(res)) {
@@ -502,6 +497,8 @@ const HoppGistCollectionsExporter: ImporterOrExporter = {
       })
 
       platform.io.openExternalLink(res.right)
+    } else {
+      toast.error(collectionJSON.left)
     }
 
     isHoppGistCollectionExporterInProgress.value = false
@@ -578,9 +575,7 @@ const getCollectionJSON = async () => {
       props.collectionsType.selectedTeam?.teamID
     )
 
-    return E.isRight(res)
-      ? E.right(res.right.exportCollectionsToJSON)
-      : E.left(res.left)
+    return E.isRight(res) ? E.right(res.right) : E.left(res.left)
   }
 
   if (props.collectionsType.type === "my-collections") {

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -435,18 +435,7 @@ const HoppTeamCollectionsExporter: ImporterOrExporter = {
       )
 
       if (E.isRight(res)) {
-        const { exportCollectionsToJSON } = res.right
-
-        if (!JSON.parse(exportCollectionsToJSON).length) {
-          isHoppTeamCollectionExporterInProgress.value = false
-
-          return toast.error(t("error.no_collections_to_export"))
-        }
-
-        initializeDownloadCollection(
-          exportCollectionsToJSON,
-          "team-collections"
-        )
+        initializeDownloadCollection(res.right, "team-collections")
 
         platform.analytics?.logEvent({
           type: "HOPP_EXPORT_COLLECTION",
@@ -454,7 +443,7 @@ const HoppTeamCollectionsExporter: ImporterOrExporter = {
           platform: "rest",
         })
       } else {
-        toast.error(res.left.error.toString())
+        toast.error(res.left)
       }
     }
 

--- a/packages/hoppscotch-common/src/components/collections/MyCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/MyCollections.vue
@@ -71,6 +71,13 @@
                   collection: node.data.data.data,
                 })
             "
+            @duplicate-collection="
+              node.data.type === 'collections' &&
+                emit('duplicate-collection', {
+                  pathOrID: node.id,
+                  collectionSyncID: node.data.data.data.id,
+                })
+            "
             @edit-properties="
               node.data.type === 'collections' &&
                 emit('edit-properties', {
@@ -144,6 +151,13 @@
                 emit('edit-folder', {
                   folderPath: node.id,
                   folder: node.data.data.data,
+                })
+            "
+            @duplicate-collection="
+              node.data.type === 'folders' &&
+                emit('duplicate-collection', {
+                  pathOrID: node.id,
+                  collectionSyncID: node.data.data.data.id,
                 })
             "
             @edit-properties="
@@ -445,6 +459,13 @@ const emit = defineEmits<{
     payload: {
       folderPath: string
       folder: HoppCollection
+    }
+  ): void
+  (
+    event: "duplicate-collection",
+    payload: {
+      pathOrID: string
+      collectionSyncID?: string
     }
   ): void
   (

--- a/packages/hoppscotch-common/src/components/collections/Request.vue
+++ b/packages/hoppscotch-common/src/components/collections/Request.vue
@@ -112,12 +112,11 @@
                   ref="duplicate"
                   :icon="IconCopy"
                   :label="t('action.duplicate')"
-                  :loading="duplicateLoading"
+                  :loading="duplicateRequestLoading"
                   :shortcut="['D']"
                   @click="
                     () => {
-                      emit('duplicate-request'),
-                        collectionsType === 'my-collections' ? hide() : null
+                      emit('duplicate-request')
                     }
                   "
                 />
@@ -211,7 +210,7 @@ const props = defineProps({
     default: "my-collections",
     required: true,
   },
-  duplicateLoading: {
+  duplicateRequestLoading: {
     type: Boolean,
     default: false,
     required: false,
@@ -277,7 +276,7 @@ const currentReorderingStatus = useReadonlyStream(currentReorderingStatus$, {
 })
 
 watch(
-  () => props.duplicateLoading,
+  () => props.duplicateRequestLoading,
   (val) => {
     if (!val) {
       options.value!.tippy.hide()

--- a/packages/hoppscotch-common/src/components/collections/Request.vue
+++ b/packages/hoppscotch-common/src/components/collections/Request.vue
@@ -20,7 +20,7 @@
       @dragover="handleDragOver($event)"
       @dragleave="resetDragState"
       @dragend="resetDragState"
-      @contextmenu.prevent="options?.tippy.show()"
+      @contextmenu.prevent="options?.tippy?.show()"
     >
       <div
         class="pointer-events-auto flex min-w-0 flex-1 cursor-pointer items-center justify-center"
@@ -258,7 +258,7 @@ const emit = defineEmits<{
   (event: "update-last-request-order", payload: DataTransfer): void
 }>()
 
-const tippyActions = ref<TippyComponent | null>(null)
+const tippyActions = ref<HTMLButtonElement | null>(null)
 const edit = ref<HTMLButtonElement | null>(null)
 const deleteAction = ref<HTMLButtonElement | null>(null)
 const options = ref<TippyComponent | null>(null)
@@ -279,7 +279,7 @@ watch(
   () => props.duplicateRequestLoading,
   (val) => {
     if (!val) {
-      options.value!.tippy.hide()
+      options.value!.tippy?.hide()
     }
   }
 )

--- a/packages/hoppscotch-common/src/components/collections/TeamCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/TeamCollections.vue
@@ -61,6 +61,7 @@
             :export-loading="exportLoading"
             :has-no-team-access="hasNoTeamAccess || isShowingSearchResults"
             :collection-move-loading="collectionMoveLoading"
+            :duplicate-collection-loading="duplicateCollectionLoading"
             :is-last-item="node.data.isLastItem"
             :is-selected="
               isSelected({
@@ -87,6 +88,12 @@
                 emit('edit-collection', {
                   collectionIndex: node.id,
                   collection: node.data.data.data,
+                })
+            "
+            @duplicate-collection="
+              node.data.type === 'collections' &&
+                emit('duplicate-collection', {
+                  pathOrID: node.data.data.data.id,
                 })
             "
             @edit-properties="
@@ -149,6 +156,7 @@
             :export-loading="exportLoading"
             :has-no-team-access="hasNoTeamAccess || isShowingSearchResults"
             :collection-move-loading="collectionMoveLoading"
+            :duplicate-collection-loading="duplicateCollectionLoading"
             :is-last-item="node.data.isLastItem"
             :is-selected="
               isSelected({
@@ -174,6 +182,12 @@
               node.data.type === 'folders' &&
                 emit('edit-folder', {
                   folder: node.data.data.data,
+                })
+            "
+            @duplicate-collection="
+              node.data.type === 'folders' &&
+                emit('duplicate-collection', {
+                  pathOrID: node.data.data.data.id,
                 })
             "
             @edit-properties="
@@ -236,7 +250,7 @@
             :request-i-d="node.data.data.data.id"
             :parent-i-d="node.data.data.parentIndex"
             :collections-type="collectionsType.type"
-            :duplicate-loading="duplicateLoading"
+            :duplicate-request-loading="duplicateRequestLoading"
             :is-active="isActiveRequest(node.data.data.data.id)"
             :has-no-team-access="hasNoTeamAccess || isShowingSearchResults"
             :request-move-loading="requestMoveLoading"
@@ -445,7 +459,12 @@ const props = defineProps({
     default: false,
     required: false,
   },
-  duplicateLoading: {
+  duplicateRequestLoading: {
+    type: Boolean,
+    default: false,
+    required: false,
+  },
+  duplicateCollectionLoading: {
     type: Boolean,
     default: false,
     required: false,
@@ -495,6 +514,13 @@ const emit = defineEmits<{
     event: "edit-folder",
     payload: {
       folder: TeamCollection
+    }
+  ): void
+  (
+    event: "duplicate-collection",
+    payload: {
+      pathOrID: string
+      collectionSyncID?: string
     }
   ): void
   (

--- a/packages/hoppscotch-common/src/components/collections/graphql/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Collection.vue
@@ -73,6 +73,7 @@
                 @keyup.r="requestAction.$el.click()"
                 @keyup.n="folderAction.$el.click()"
                 @keyup.e="edit.$el.click()"
+                @keyup.d="duplicateAction.$el.click()"
                 @keyup.delete="deleteAction.$el.click()"
                 @keyup.escape="hide()"
               >
@@ -113,6 +114,21 @@
                     () => {
                       emit('edit-collection')
                       hide()
+                    }
+                  "
+                />
+                <HoppSmartItem
+                  ref="duplicateAction"
+                  :icon="IconCopy"
+                  :label="t('action.duplicate')"
+                  :shortcut="['D']"
+                  @click="
+                    () => {
+                      emit('duplicate-collection', {
+                        path: `${collectionIndex}`,
+                        collectionSyncID: collection.id,
+                      }),
+                        hide()
                     }
                   "
                 />
@@ -168,6 +184,7 @@
           @add-request="$emit('add-request', $event)"
           @add-folder="$emit('add-folder', $event)"
           @edit-folder="$emit('edit-folder', $event)"
+          @duplicate-collection="$emit('duplicate-collection', $event)"
           @edit-request="$emit('edit-request', $event)"
           @duplicate-request="$emit('duplicate-request', $event)"
           @edit-properties="
@@ -229,24 +246,25 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue"
-import IconCheckCircle from "~icons/lucide/check-circle"
-import IconFolder from "~icons/lucide/folder"
-import IconFolderOpen from "~icons/lucide/folder-open"
-import IconFilePlus from "~icons/lucide/file-plus"
-import IconFolderPlus from "~icons/lucide/folder-plus"
-import IconMoreVertical from "~icons/lucide/more-vertical"
-import IconEdit from "~icons/lucide/edit"
-import IconTrash2 from "~icons/lucide/trash-2"
-import IconSettings2 from "~icons/lucide/settings-2"
-import { useToast } from "@composables/toast"
 import { useI18n } from "@composables/i18n"
 import { useColorMode } from "@composables/theming"
-import { removeGraphqlCollection } from "~/newstore/collections"
-import { Picked } from "~/helpers/types/HoppPicked"
-import { useService } from "dioc/vue"
-import { GQLTabService } from "~/services/tab/graphql"
+import { useToast } from "@composables/toast"
 import { HoppCollection } from "@hoppscotch/data"
+import { useService } from "dioc/vue"
+import { computed, ref } from "vue"
+import { Picked } from "~/helpers/types/HoppPicked"
+import { removeGraphqlCollection } from "~/newstore/collections"
+import { GQLTabService } from "~/services/tab/graphql"
+import IconCheckCircle from "~icons/lucide/check-circle"
+import IconCopy from "~icons/lucide/copy"
+import IconEdit from "~icons/lucide/edit"
+import IconFilePlus from "~icons/lucide/file-plus"
+import IconFolder from "~icons/lucide/folder"
+import IconFolderOpen from "~icons/lucide/folder-open"
+import IconFolderPlus from "~icons/lucide/folder-plus"
+import IconMoreVertical from "~icons/lucide/more-vertical"
+import IconSettings2 from "~icons/lucide/settings-2"
+import IconTrash2 from "~icons/lucide/trash-2"
 
 const props = defineProps<{
   picked: Picked | null
@@ -272,6 +290,13 @@ const emit = defineEmits<{
   (e: "add-folder", i: any): void
   (e: "edit-folder", i: any): void
   (
+    e: "duplicate-collection",
+    payload: {
+      path: string
+      collectionSyncID?: string
+    }
+  ): void
+  (
     e: "edit-properties",
     payload: {
       collectionIndex: string | null
@@ -296,6 +321,7 @@ const options = ref<any | null>(null)
 const requestAction = ref<any | null>(null)
 const folderAction = ref<any | null>(null)
 const edit = ref<any | null>(null)
+const duplicateAction = ref<any | null>(null)
 const deleteAction = ref<any | null>(null)
 
 const showChildren = ref(false)

--- a/packages/hoppscotch-common/src/components/collections/graphql/Folder.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Folder.vue
@@ -70,6 +70,7 @@
                 @keyup.r="requestAction.$el.click()"
                 @keyup.n="folderAction.$el.click()"
                 @keyup.e="edit.$el.click()"
+                @keyup.d="duplicateAction.$el.click()"
                 @keyup.delete="deleteAction.$el.click()"
                 @keyup.escape="hide()"
               >
@@ -106,6 +107,21 @@
                     () => {
                       emit('edit-folder', { folder, folderPath })
                       hide()
+                    }
+                  "
+                />
+                <HoppSmartItem
+                  ref="duplicateAction"
+                  :icon="IconCopy"
+                  :label="t('action.duplicate')"
+                  :shortcut="['D']"
+                  @click="
+                    () => {
+                      emit('duplicate-collection', {
+                        path: folderPath,
+                        collectionSyncID: folder.id,
+                      }),
+                        hide()
                     }
                   "
                 />
@@ -162,6 +178,7 @@
           @add-request="emit('add-request', $event)"
           @add-folder="emit('add-folder', $event)"
           @edit-folder="emit('edit-folder', $event)"
+          @duplicate-collection="emit('duplicate-collection', $event)"
           @edit-request="emit('edit-request', $event)"
           @duplicate-request="emit('duplicate-request', $event)"
           @edit-properties="
@@ -213,24 +230,25 @@
 </template>
 
 <script setup lang="ts">
-import IconEdit from "~icons/lucide/edit"
-import IconTrash2 from "~icons/lucide/trash-2"
-import IconFolderPlus from "~icons/lucide/folder-plus"
-import IconFilePlus from "~icons/lucide/file-plus"
-import IconMoreVertical from "~icons/lucide/more-vertical"
-import IconCheckCircle from "~icons/lucide/check-circle"
-import IconFolder from "~icons/lucide/folder"
-import IconFolderOpen from "~icons/lucide/folder-open"
-import IconSettings2 from "~icons/lucide/settings-2"
-import { useToast } from "@composables/toast"
 import { useI18n } from "@composables/i18n"
 import { useColorMode } from "@composables/theming"
-import { removeGraphqlFolder } from "~/newstore/collections"
-import { computed, ref } from "vue"
-import { useService } from "dioc/vue"
-import { GQLTabService } from "~/services/tab/graphql"
-import { Picked } from "~/helpers/types/HoppPicked"
+import { useToast } from "@composables/toast"
 import { HoppCollection } from "@hoppscotch/data"
+import { useService } from "dioc/vue"
+import { computed, ref } from "vue"
+import { Picked } from "~/helpers/types/HoppPicked"
+import { removeGraphqlFolder } from "~/newstore/collections"
+import { GQLTabService } from "~/services/tab/graphql"
+import IconCheckCircle from "~icons/lucide/check-circle"
+import IconCopy from "~icons/lucide/copy"
+import IconEdit from "~icons/lucide/edit"
+import IconFilePlus from "~icons/lucide/file-plus"
+import IconFolder from "~icons/lucide/folder"
+import IconFolderOpen from "~icons/lucide/folder-open"
+import IconFolderPlus from "~icons/lucide/folder-plus"
+import IconMoreVertical from "~icons/lucide/more-vertical"
+import IconSettings2 from "~icons/lucide/settings-2"
+import IconTrash2 from "~icons/lucide/trash-2"
 
 const toast = useToast()
 const t = useI18n()
@@ -255,6 +273,7 @@ const emit = defineEmits([
   "edit-request",
   "add-folder",
   "edit-folder",
+  "duplicate-collection",
   "duplicate-request",
   "edit-properties",
   "select-request",
@@ -267,6 +286,7 @@ const options = ref<any | null>(null)
 const requestAction = ref<any | null>(null)
 const folderAction = ref<any | null>(null)
 const edit = ref<any | null>(null)
+const duplicateAction = ref<any | null>(null)
 const deleteAction = ref<any | null>(null)
 
 const showChildren = ref(false)

--- a/packages/hoppscotch-common/src/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/index.vue
@@ -54,7 +54,7 @@
         @add-request="addRequest($event)"
         @add-folder="addFolder($event)"
         @edit-folder="editFolder($event)"
-        @edit-request="editRequest($event)"
+        @duplicate-collection="duplicateCollection($event)"
         @duplicate-request="duplicateRequest($event)"
         @select-collection="$emit('use-collection', collection)"
         @edit-properties="editProperties($event)"
@@ -167,6 +167,7 @@ import {
   editGraphqlCollection,
   editGraphqlFolder,
   moveGraphqlRequest,
+  duplicateGraphQLCollection,
 } from "~/newstore/collections"
 import IconPlus from "~icons/lucide/plus"
 import IconHelpCircle from "~icons/lucide/help-circle"
@@ -379,6 +380,14 @@ const editCollection = (
   editingCollectionIndex.value = collectionIndex
   displayModalEdit(true)
 }
+
+const duplicateCollection = ({
+  path,
+  collectionSyncID,
+}: {
+  path: string
+  collectionSyncID?: string
+}) => duplicateGraphQLCollection(path, collectionSyncID)
 
 const onAddRequest = ({
   name,

--- a/packages/hoppscotch-common/src/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/index.vue
@@ -55,6 +55,7 @@
         @add-folder="addFolder($event)"
         @edit-folder="editFolder($event)"
         @duplicate-collection="duplicateCollection($event)"
+        @edit-request="editRequest($event)"
         @duplicate-request="duplicateRequest($event)"
         @select-collection="$emit('use-collection', collection)"
         @edit-properties="editProperties($event)"

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -37,6 +37,7 @@
       @add-request="addRequest"
       @edit-collection="editCollection"
       @edit-folder="editFolder"
+      @duplicate-collection="duplicateCollection"
       @edit-properties="editProperties"
       @export-data="exportData"
       @remove-collection="removeCollection"
@@ -67,7 +68,8 @@
       "
       :filter-text="filterTexts"
       :export-loading="exportLoading"
-      :duplicate-loading="duplicateLoading"
+      :duplicate-request-loading="duplicateRequestLoading"
+      :duplicate-collection-loading="duplicateCollectionLoading"
       :save-request="saveRequest"
       :picked="picked"
       :collection-move-loading="collectionMoveLoading"
@@ -76,6 +78,7 @@
       @add-folder="addFolder"
       @edit-collection="editCollection"
       @edit-folder="editFolder"
+      @duplicate-collection="duplicateCollection"
       @edit-properties="editProperties"
       @export-data="exportData"
       @remove-collection="removeCollection"
@@ -208,6 +211,7 @@ import {
   createChildCollection,
   createNewRootCollection,
   deleteCollection,
+  duplicateTeamCollection,
   moveRESTTeamCollection,
   updateOrderRESTTeamCollection,
   updateTeamCollection,
@@ -240,6 +244,7 @@ import {
   addRESTCollection,
   addRESTFolder,
   cascadeParentCollectionForHeaderAuth,
+  duplicateRESTCollection,
   editRESTCollection,
   editRESTFolder,
   editRESTRequest,
@@ -645,7 +650,8 @@ const isSelected = ({
 
 const modalLoadingState = ref(false)
 const exportLoading = ref(false)
-const duplicateLoading = ref(false)
+const duplicateRequestLoading = ref(false)
+const duplicateCollectionLoading = ref(false)
 
 const showModalAdd = ref(false)
 const showModalAddRequest = ref(false)
@@ -1044,6 +1050,34 @@ const updateEditingFolder = (newName: string) => {
   }
 }
 
+const duplicateCollection = async ({
+  pathOrID,
+  collectionSyncID,
+}: {
+  pathOrID: string
+  collectionSyncID?: string
+}) => {
+  if (collectionsType.value.type === "my-collections") {
+    duplicateRESTCollection(pathOrID, collectionSyncID)
+  } else if (hasTeamWriteAccess.value) {
+    duplicateCollectionLoading.value = true
+
+    await pipe(
+      duplicateTeamCollection(pathOrID),
+      TE.match(
+        (err: GQLError<string>) => {
+          toast.error(`${getErrorMessage(err)}`)
+          duplicateCollectionLoading.value = false
+        },
+        () => {
+          toast.success(t("collection.duplicated"))
+          duplicateCollectionLoading.value = false
+        }
+      )
+    )()
+  }
+}
+
 const editRequest = (payload: {
   folderPath: string | undefined
   requestIndex: string
@@ -1149,7 +1183,7 @@ const duplicateRequest = (payload: {
     saveRESTRequestAs(folderPath, newRequest)
     toast.success(t("request.duplicated"))
   } else if (hasTeamWriteAccess.value) {
-    duplicateLoading.value = true
+    duplicateRequestLoading.value = true
 
     if (!collectionsType.value.selectedTeam) return
 
@@ -1164,10 +1198,10 @@ const duplicateRequest = (payload: {
       TE.match(
         (err: GQLError<string>) => {
           toast.error(`${getErrorMessage(err)}`)
-          duplicateLoading.value = false
+          duplicateRequestLoading.value = false
         },
         () => {
-          duplicateLoading.value = false
+          duplicateRequestLoading.value = false
           toast.success(t("request.duplicated"))
           displayModalAddRequest(false)
         }

--- a/packages/hoppscotch-common/src/helpers/backend/gql/mutations/DuplicateTeamCollection.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/mutations/DuplicateTeamCollection.graphql
@@ -1,0 +1,3 @@
+mutation DuplicateTeamCollection($collectionID: String!) {
+  duplicateTeamCollection(collectionID: $collectionID)
+}

--- a/packages/hoppscotch-common/src/helpers/backend/mutations/TeamCollection.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/mutations/TeamCollection.ts
@@ -9,6 +9,9 @@ import {
   DeleteCollectionDocument,
   DeleteCollectionMutation,
   DeleteCollectionMutationVariables,
+  DuplicateTeamCollectionDocument,
+  DuplicateTeamCollectionMutation,
+  DuplicateTeamCollectionMutationVariables,
   ImportFromJsonDocument,
   ImportFromJsonMutation,
   ImportFromJsonMutationVariables,
@@ -139,4 +142,13 @@ export const updateTeamCollection = (
     collectionID,
     data,
     newTitle,
+  })
+
+export const duplicateTeamCollection = (collectionID: string) =>
+  runMutation<
+    DuplicateTeamCollectionMutation,
+    DuplicateTeamCollectionMutationVariables,
+    ""
+  >(DuplicateTeamCollectionDocument, {
+    collectionID,
   })

--- a/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
@@ -324,8 +324,8 @@ export default class NewTeamCollectionAdapter {
 
       if (!parentCollection) return
 
-      // Prevent adding child collections to a collection that has not been expanded yet incoming from GQL subscription,during import, etc
-      // Hence, add entries to the pre-existing list without setting 'children' if it is 'null'
+      // Prevent adding child collections to a collection that has not been expanded yet incoming from GQL subscription, during import, etc
+      // Hence, add entries to the pre-existing list without setting 'children' if it is `null'
       if (parentCollection.children !== null) {
         parentCollection.children.push(collection)
       }

--- a/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
@@ -324,10 +324,10 @@ export default class NewTeamCollectionAdapter {
 
       if (!parentCollection) return
 
+      // Prevent adding child collections to a collection that has not been expanded yet incoming from GQL subscription,during import, etc
+      // Hence, add entries to the pre-existing list without setting 'children' if it is 'null'
       if (parentCollection.children !== null) {
         parentCollection.children.push(collection)
-      } else {
-        parentCollection.children = [collection]
       }
     }
 

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -1,20 +1,21 @@
-import { pluck } from "rxjs/operators"
 import {
-  HoppGQLRequest,
-  HoppRESTRequest,
   HoppCollection,
-  makeCollection,
   HoppGQLAuth,
+  HoppGQLRequest,
+  HoppRESTAuth,
+  HoppRESTHeaders,
+  HoppRESTRequest,
+  makeCollection,
 } from "@hoppscotch/data"
-import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
 import { cloneDeep } from "lodash-es"
+import { pluck } from "rxjs/operators"
 import { resolveSaveContextOnRequestReorder } from "~/helpers/collection/request"
-import { getService } from "~/modules/dioc"
-import { RESTTabService } from "~/services/tab/rest"
-import { HoppInheritedProperty } from "~/helpers/types/HoppInheritedProperties"
-import { HoppRESTAuth } from "@hoppscotch/data"
-import { HoppRESTHeaders } from "@hoppscotch/data"
 import { HoppGQLHeader } from "~/helpers/graphql"
+import { HoppInheritedProperty } from "~/helpers/types/HoppInheritedProperties"
+import { getService } from "~/modules/dioc"
+import { getI18n } from "~/modules/i18n"
+import { RESTTabService } from "~/services/tab/rest"
+import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
 
 const defaultRESTCollectionState = {
   state: [
@@ -494,6 +495,48 @@ const restCollectionDispatchers = defineDispatchers({
     }
   },
 
+  duplicateCollection(
+    { state }: RESTCollectionStoreType,
+    // `collectionSyncID` is used to sync the duplicated collection in `collections.sync.ts`
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    { path, collectionSyncID }: { path: string; collectionSyncID?: string }
+  ) {
+    const t = getI18n()
+
+    const newState = state
+
+    const indexPaths = path.split("/").map((x) => parseInt(x))
+
+    const isRootCollection = indexPaths.length === 1
+
+    const collection = navigateToFolderWithIndexPath(state, [...indexPaths])
+
+    if (collection) {
+      const { id, ...rest } = collection
+
+      const name = `${collection.name} - ${t("action.duplicate")}`
+      const duplicatedCollection = {
+        ...cloneDeep(rest),
+        name,
+      }
+
+      if (isRootCollection) {
+        newState.push(duplicatedCollection)
+      } else {
+        const parentCollectionIndexPath = indexPaths.slice(0, -1)
+
+        const parentCollection = navigateToFolderWithIndexPath(state, [
+          ...parentCollectionIndexPath,
+        ])
+        parentCollection?.folders.push(duplicatedCollection)
+      }
+    }
+
+    return {
+      state: newState,
+    }
+  },
+
   editRequest(
     { state }: RESTCollectionStoreType,
     {
@@ -896,6 +939,48 @@ const gqlCollectionDispatchers = defineDispatchers({
     }
   },
 
+  duplicateCollection(
+    { state }: GraphqlCollectionStoreType,
+    // `collectionSyncID` is used to sync the duplicated collection in `gqlCollections.sync.ts`
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    { path, collectionSyncID }: { path: string; collectionSyncID?: string }
+  ) {
+    const t = getI18n()
+
+    const newState = state
+
+    const indexPaths = path.split("/").map((x) => parseInt(x))
+
+    const isRootCollection = indexPaths.length === 1
+
+    const collection = navigateToFolderWithIndexPath(state, [...indexPaths])
+
+    if (collection) {
+      const { id, ...rest } = collection
+
+      const name = `${collection.name} - ${t("action.duplicate")}`
+      const duplicatedCollection = {
+        ...cloneDeep(rest),
+        name,
+      }
+
+      if (isRootCollection) {
+        newState.push(duplicatedCollection)
+      } else {
+        const parentCollectionIndexPath = indexPaths.slice(0, -1)
+
+        const parentCollection = navigateToFolderWithIndexPath(state, [
+          ...parentCollectionIndexPath,
+        ])
+        parentCollection?.folders.push(duplicatedCollection)
+      }
+    }
+
+    return {
+      state: newState,
+    }
+  },
+
   editRequest(
     { state }: GraphqlCollectionStoreType,
     {
@@ -1162,6 +1247,19 @@ export function moveRESTFolder(path: string, destinationPath: string | null) {
   })
 }
 
+export function duplicateRESTCollection(
+  path: string,
+  collectionSyncID?: string
+) {
+  restCollectionStore.dispatch({
+    dispatcher: "duplicateCollection",
+    payload: {
+      path,
+      collectionSyncID,
+    },
+  })
+}
+
 export function removeDuplicateRESTCollectionOrFolder(
   id: string,
   collectionPath: string,
@@ -1358,6 +1456,19 @@ export function removeGraphqlFolder(path: string, folderID?: string) {
     payload: {
       path,
       folderID,
+    },
+  })
+}
+
+export function duplicateGraphQLCollection(
+  path: string,
+  collectionSyncID?: string
+) {
+  graphqlCollectionStore.dispatch({
+    dispatcher: "duplicateCollection",
+    payload: {
+      path,
+      collectionSyncID,
     },
   })
 }

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -513,9 +513,13 @@ const restCollectionDispatchers = defineDispatchers({
 
     if (collection) {
       const name = `${collection.name} - ${t("action.duplicate")}`
+
       const duplicatedCollection = {
         ...cloneDeep(collection),
         name,
+        ...(collection.id
+          ? { id: `${collection.id}-duplicate-collection` }
+          : {}),
       }
 
       if (isRootCollection) {
@@ -955,9 +959,13 @@ const gqlCollectionDispatchers = defineDispatchers({
 
     if (collection) {
       const name = `${collection.name} - ${t("action.duplicate")}`
+
       const duplicatedCollection = {
         ...cloneDeep(collection),
         name,
+        ...(collection.id
+          ? { id: `${collection.id}-duplicate-collection` }
+          : {}),
       }
 
       if (isRootCollection) {

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -512,11 +512,9 @@ const restCollectionDispatchers = defineDispatchers({
     const collection = navigateToFolderWithIndexPath(state, [...indexPaths])
 
     if (collection) {
-      const { id, ...rest } = collection
-
       const name = `${collection.name} - ${t("action.duplicate")}`
       const duplicatedCollection = {
-        ...cloneDeep(rest),
+        ...cloneDeep(collection),
         name,
       }
 
@@ -956,11 +954,9 @@ const gqlCollectionDispatchers = defineDispatchers({
     const collection = navigateToFolderWithIndexPath(state, [...indexPaths])
 
     if (collection) {
-      const { id, ...rest } = collection
-
       const name = `${collection.name} - ${t("action.duplicate")}`
       const duplicatedCollection = {
-        ...cloneDeep(rest),
+        ...cloneDeep(collection),
         name,
       }
 

--- a/packages/hoppscotch-common/src/platform/index.ts
+++ b/packages/hoppscotch-common/src/platform/index.ts
@@ -52,6 +52,12 @@ export type PlatformDef = {
      * Whether to show the A/B testing workspace switcher click login flow or not
      */
     workspaceSwitcherLogin?: Ref<boolean>
+
+    /**
+     * There's an active issue wrt syncing in personal workspace under SH while duplicating a collection
+     * This is a temporary flag to disable the same
+     */
+    duplicateCollectionDisabledInPersonalWorkspace?: boolean
   }
   infra?: InfraPlatformDef
 }

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -276,7 +276,8 @@ const HoppGQLSaveContextSchema = z.nullable(
       .object({
         originLocation: z.literal("user-collection"),
         folderPath: z.string(),
-        requestIndex: z.number(),
+        // TODO: Investigate why this field is not populated at times
+        requestIndex: z.optional(z.number()),
       })
       .strict(),
     z

--- a/packages/hoppscotch-selfhost-web/src/api/mutations/DuplicateUserCollection.graphql
+++ b/packages/hoppscotch-selfhost-web/src/api/mutations/DuplicateUserCollection.graphql
@@ -1,0 +1,3 @@
+mutation DuplicateUserCollection($collectionID: String!, $reqType: ReqType!) {
+  duplicateUserCollection(collectionID: $collectionID, reqType: $reqType)
+}

--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -40,6 +40,7 @@ createHoppApp("#app", {
   platformFeatureFlags: {
     exportAsGIST: false,
     hasTelemetry: false,
+    duplicateCollectionDisabledInPersonalWorkspace: true,
   },
   infra: InfraPlatform,
 })

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/collections.api.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/collections.api.ts
@@ -68,6 +68,9 @@ import {
   UpdateUserCollectionMutation,
   UpdateUserCollectionMutationVariables,
   UpdateUserCollectionDocument,
+  DuplicateUserCollectionDocument,
+  DuplicateUserCollectionMutation,
+  DuplicateUserCollectionMutationVariables,
 } from "../../api/generated/graphql"
 
 export const createRESTRootUserCollection = (title: string, data?: string) =>
@@ -191,6 +194,19 @@ export const moveUserCollection = (
   >(MoveUserCollectionDocument, {
     userCollectionID: sourceCollectionID,
     destCollectionID: destinationCollectionID,
+  })()
+
+export const duplicateUserCollection = (
+  collectionID: string,
+  reqType: ReqType
+) =>
+  runMutation<
+    DuplicateUserCollectionMutation,
+    DuplicateUserCollectionMutationVariables,
+    ""
+  >(DuplicateUserCollectionDocument, {
+    collectionID,
+    reqType,
   })()
 
 export const editUserRequest = (

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/collections.platform.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/collections.platform.ts
@@ -284,77 +284,18 @@ function setupUserCollectionCreatedSubscription() {
         return
       }
 
-      // Root collection
-      if (!parentCollectionID) {
-        const collectionInsertedViaStoreUpdateIdx =
-          collectionStore.value.state.findIndex(({ id }) =>
-            id?.endsWith("-duplicate-collection")
-          )
+      // While duplicating a collection, the new entry added to the store has an ID with a suffix to be updated after the backend ID is received from the GQL subscription
+      // This is to prevent the new entry from being added to the store again when the GQL subscription
+      // The boolean return value indicates if the GQL subscription was fired because of a duplicate collection action and whether the collection should be added to the store
+      const shouldCreateCollection = issueBackendIDToDuplicatedCollection(
+        collectionStore,
+        collectionType,
+        userCollectionBackendID,
+        parentCollectionID
+      )
 
-        if (collectionInsertedViaStoreUpdateIdx !== -1) {
-          const collectionInsertedViaStoreUpdate =
-            collectionStore.value.state[collectionInsertedViaStoreUpdateIdx]
-
-          runDispatchWithOutSyncing(() => {
-            if (collectionType == ReqType.Rest) {
-              editRESTCollection(collectionInsertedViaStoreUpdateIdx, {
-                ...collectionInsertedViaStoreUpdate,
-                id: userCollectionBackendID,
-              })
-            } else {
-              editGraphqlCollection(collectionInsertedViaStoreUpdateIdx, {
-                ...collectionInsertedViaStoreUpdate,
-                id: userCollectionBackendID,
-              })
-            }
-          })
-
-          // Prevent adding the collection received from GQL subscription to the store
-          return
-        }
-      } else {
-        const parentCollectionPath = getCollectionPathFromCollectionID(
-          parentCollectionID,
-          collectionStore.value.state
-        )
-
-        if (parentCollectionPath) {
-          const parentCollection = navigateToFolderWithIndexPath(
-            collectionStore.value.state,
-            parentCollectionPath.split("/").map((index) => parseInt(index))
-          )
-
-          if (parentCollection) {
-            const collectionInsertedViaStoreUpdateIdx =
-              parentCollection.folders.findIndex(({ id }) =>
-                id.endsWith("-duplicate-collection")
-              )
-
-            if (collectionInsertedViaStoreUpdateIdx !== -1) {
-              runDispatchWithOutSyncing(() => {
-                const collectionInsertedViaStoreUpdate =
-                  parentCollection.folders[collectionInsertedViaStoreUpdateIdx]
-
-                const childCollectionPath = `${parentCollectionPath}/${collectionInsertedViaStoreUpdateIdx}`
-
-                if (collectionType == ReqType.Rest) {
-                  editRESTFolder(childCollectionPath, {
-                    ...collectionInsertedViaStoreUpdate,
-                    id: userCollectionBackendID,
-                  })
-                } else {
-                  editGraphqlFolder(childCollectionPath, {
-                    ...collectionInsertedViaStoreUpdate,
-                    id: userCollectionBackendID,
-                  })
-                }
-              })
-
-              // Prevent adding the collection received from GQL subscription to the store
-              return
-            }
-          }
-        }
+      if (!shouldCreateCollection) {
+        return
       }
 
       const parentCollectionPath =
@@ -900,4 +841,106 @@ function getRequestIndex(
   )
 
   return requestIndex
+}
+
+function issueBackendIDToDuplicatedCollection(
+  collectionStore: ReturnType<
+    typeof getStoreByCollectionType
+  >["collectionStore"],
+  collectionType: ReqType,
+  userCollectionBackendID: string,
+  parentCollectionID?: string
+): boolean {
+  // Collection added to store via duplicating is set an ID with a suffix to be updated after the backend ID is received from the GQL subscription
+  const collectionCreatedFromStoreIDSuffix = "-duplicate-collection"
+
+  // Duplicating a child collection
+  if (parentCollectionID) {
+    // Get the index path for the parent collection
+    const parentCollectionPath = getCollectionPathFromCollectionID(
+      parentCollectionID,
+      collectionStore.value.state
+    )
+
+    if (!parentCollectionPath) {
+      // Indicates the collection received from the GQL subscription should be created in the store
+      return true
+    }
+
+    const parentCollection = navigateToFolderWithIndexPath(
+      collectionStore.value.state,
+      parentCollectionPath.split("/").map((index) => parseInt(index))
+    )
+
+    if (!parentCollection) {
+      // Indicates the collection received from the GQL subscription should be created in the store
+      return true
+    }
+
+    // Grab the child collection inserted via store update with the ID suffix
+    const collectionInsertedViaStoreUpdateIdx =
+      parentCollection.folders.findIndex(({ id }) =>
+        id?.endsWith(collectionCreatedFromStoreIDSuffix)
+      )
+
+    // No entry indicates the GQL subscription was fired not because of a duplicate collection action
+    if (collectionInsertedViaStoreUpdateIdx === -1) {
+      // Indicates the collection received from the GQL subscription should be created in the store
+      return true
+    }
+    const collectionInsertedViaStoreUpdate =
+      parentCollection.folders[collectionInsertedViaStoreUpdateIdx]
+
+    const childCollectionPath = `${parentCollectionPath}/${collectionInsertedViaStoreUpdateIdx}`
+
+    // Update the ID for the child collection already existing in store with the backend ID
+    runDispatchWithOutSyncing(() => {
+      if (collectionType == ReqType.Rest) {
+        editRESTFolder(childCollectionPath, {
+          ...collectionInsertedViaStoreUpdate,
+          id: userCollectionBackendID,
+        })
+      } else {
+        editGraphqlFolder(childCollectionPath, {
+          ...collectionInsertedViaStoreUpdate,
+          id: userCollectionBackendID,
+        })
+      }
+    })
+  } else {
+    // Duplicating a root collection
+
+    // Grab the collection inserted via store update with the ID suffix
+    const collectionInsertedViaStoreUpdateIdx =
+      collectionStore.value.state.findIndex(({ id }) =>
+        id?.endsWith(collectionCreatedFromStoreIDSuffix)
+      )
+
+    // No entry indicates the GQL subscription was fired not because of a duplicate collection action
+    if (collectionInsertedViaStoreUpdateIdx === -1) {
+      // Indicates the collection received from the GQL subscription should be created in the store
+      return true
+    }
+
+    const collectionInsertedViaStoreUpdate =
+      collectionStore.value.state[collectionInsertedViaStoreUpdateIdx]
+
+    // Update the ID for the collection already existing in store with the backend ID
+    runDispatchWithOutSyncing(() => {
+      if (collectionType == ReqType.Rest) {
+        editRESTCollection(collectionInsertedViaStoreUpdateIdx, {
+          ...collectionInsertedViaStoreUpdate,
+          id: userCollectionBackendID,
+        })
+      } else {
+        editGraphqlCollection(collectionInsertedViaStoreUpdateIdx, {
+          ...collectionInsertedViaStoreUpdate,
+          id: userCollectionBackendID,
+        })
+      }
+    })
+  }
+
+  // Prevent adding the collection received from GQL subscription to the store
+  return false
 }

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/collections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/collections.sync.ts
@@ -21,6 +21,7 @@ import {
   createRESTUserRequest,
   deleteUserCollection,
   deleteUserRequest,
+  duplicateUserCollection,
   editUserRequest,
   moveUserCollection,
   moveUserRequest,
@@ -29,6 +30,7 @@ import {
 } from "./collections.api"
 
 import * as E from "fp-ts/Either"
+import { ReqType } from "../../api/generated/graphql"
 
 // restCollectionsMapper uses the collectionPath as the local identifier
 export const restCollectionsMapper = createMapper<string, string>()
@@ -278,6 +280,11 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       if (sourceCollectionID) {
         await moveUserCollection(sourceCollectionID, destinationCollectionID)
       }
+    }
+  },
+  async duplicateCollection({ collectionSyncID }) {
+    if (collectionSyncID) {
+      await duplicateUserCollection(collectionSyncID, ReqType.Rest)
     }
   },
   editRequest({ path, requestIndex, requestNew }) {

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/collections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/collections.sync.ts
@@ -1,6 +1,4 @@
 import {
-  editRESTCollection,
-  editRESTFolder,
   graphqlCollectionStore,
   navigateToFolderWithIndexPath,
   removeDuplicateRESTCollectionOrFolder,
@@ -29,7 +27,6 @@ import {
   updateUserCollectionOrder,
 } from "./collections.api"
 
-import { getI18n } from "@hoppscotch/common/modules/i18n"
 import * as E from "fp-ts/Either"
 import { ReqType } from "../../api/generated/graphql"
 
@@ -283,46 +280,9 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       }
     }
   },
-  async duplicateCollection({ path, collectionSyncID }) {
+  async duplicateCollection({ collectionSyncID }) {
     if (collectionSyncID) {
-      const indexPaths = path.split("/").map((index) => parseInt(index))
-
       await duplicateUserCollection(collectionSyncID, ReqType.Rest)
-
-      // There'll be duplicate entries due to store update followed by GQL subscription during sync
-      removeDuplicateRESTCollectionOrFolder(collectionSyncID, path)
-
-      // After removal, the collection at the original path will have the ` - Duplicate` suffix
-      const originalCollection = navigateToFolderWithIndexPath(
-        restCollectionStore.value.state,
-        indexPaths
-      )
-
-      // The first occurrence of the duplicate entry is removed which corresponds to the original collection being duplicated
-      // Hence, removing the ` - Duplicate` suffix from the name
-      if (originalCollection) {
-        const isRootCollection = indexPaths.length == 1
-
-        const t = getI18n()
-
-        if (isRootCollection) {
-          editRESTCollection(parseInt(path), {
-            ...originalCollection,
-            name: originalCollection.name.replace(
-              ` - ${t("action.duplicate")}`,
-              ""
-            ),
-          })
-        } else {
-          editRESTFolder(path, {
-            ...originalCollection,
-            name: originalCollection.name.replace(
-              ` - ${t("action.duplicate")}`,
-              ""
-            ),
-          })
-        }
-      }
     }
   },
   editRequest({ path, requestIndex, requestNew }) {

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/gqlCollections.sync.ts
@@ -20,11 +20,13 @@ import {
   createGQLUserRequest,
   deleteUserCollection,
   deleteUserRequest,
+  duplicateUserCollection,
   editGQLUserRequest,
   updateUserCollection,
 } from "./collections.api"
 
 import * as E from "fp-ts/Either"
+import { ReqType } from "../../api/generated/graphql"
 import { moveOrReorderRequests } from "./collections.sync"
 
 // gqlCollectionsMapper uses the collectionPath as the local identifier
@@ -259,6 +261,11 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   async removeFolder({ folderID }) {
     if (folderID) {
       await deleteUserCollection(folderID)
+    }
+  },
+  async duplicateCollection({ collectionSyncID }) {
+    if (collectionSyncID) {
+      await duplicateUserCollection(collectionSyncID, ReqType.Gql)
     }
   },
   editRequest({ path, requestIndex, requestNew }) {

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/gqlCollections.sync.ts
@@ -1,7 +1,4 @@
-import { getI18n } from "@hoppscotch/common/modules/i18n"
 import {
-  editGraphqlCollection,
-  editGraphqlFolder,
   graphqlCollectionStore,
   navigateToFolderWithIndexPath,
   removeDuplicateGraphqlCollectionOrFolder,
@@ -266,46 +263,9 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       await deleteUserCollection(folderID)
     }
   },
-  async duplicateCollection({ collectionSyncID, path }) {
+  async duplicateCollection({ collectionSyncID }) {
     if (collectionSyncID) {
-      const indexPaths = path.split("/").map((x) => parseInt(x))
-
       await duplicateUserCollection(collectionSyncID, ReqType.Gql)
-
-      // There'll be duplicate entries due to store update followed by GQL subscription during sync
-      removeDuplicateGraphqlCollectionOrFolder(collectionSyncID, path)
-
-      // After removal, the collection at the original path will have the ` - Duplicate` suffix
-      const originalCollection = navigateToFolderWithIndexPath(
-        graphqlCollectionStore.value.state,
-        indexPaths
-      )
-
-      // The first occurrence of the duplicate entry is removed which corresponds to the original collection being duplicated
-      // Hence, removing the ` - Duplicate` suffix from the name
-      if (originalCollection) {
-        const isRootCollection = indexPaths.length == 1
-
-        const t = getI18n()
-
-        if (isRootCollection) {
-          editGraphqlCollection(parseInt(path), {
-            ...originalCollection,
-            name: originalCollection.name.replace(
-              ` - ${t("action.duplicate")}`,
-              ""
-            ),
-          })
-        } else {
-          editGraphqlFolder(path, {
-            ...originalCollection,
-            name: originalCollection.name.replace(
-              ` - ${t("action.duplicate")}`,
-              ""
-            ),
-          })
-        }
-      }
     }
   },
   editRequest({ path, requestIndex, requestNew }) {


### PR DESCRIPTION
### What's changed

This PR includes the UI changes adding the ability to duplicate REST/GraphQL collections. The context menu for collections (root/child) from the tree will include a new option labelled `Duplicate collection`. This will result in a new collection entry within the same hierarchy, effectively cloning the children and retaining the collection level authorization/header properties. Additionally, while the context menu is open, the duplication action can be initiated by pressing the `d` key.

> The duplication action is disabled under personal workspace in SH for now due to a known issue with syncing and will be revisited in a later iteration.

Closes HFE-491 HFE-545 HFE-547 #2475.

> The BE changes were implemented in #4207.

Apart from that, the following issues are patched:

- The `userCollectionCreated` and `teamCollectionCreated` GQL subscriptions fired after collection create actions (import, create, duplicate) sent collection-level properties (authorization/headers) applying stringification via `JSON.stringify()` multiple times which led to an exception since FE expects it to be parsed via `JSON.parse()` in one pass.
- Bulk export of REST collections from a team workspace results in the export format not confirming to `HoppCollection`. Attempting to export collections existing with authorization/headers set and importing them will result in the respective collection properties not getting populated. This is because the export format doesn't conform to the internal data structure `HoppCollection` and while importing it fails to parse and goes ahead with the defaults. This also led to the CLI rejecting bulk collection exports from a team workspace - [HFE-545](https://linear.app/hoppscotch/issue/HFE-545/bulk-export-of-collections-from-a-team-workspace-and-re-import-doesnt)
- There was an issue specific to team workspaces on cloud, where requests were lost while importing except for the last level. This also extends to the case where child collections/requests are being created for a collection in the non-expanded state having pre-existing children and expanding will reveal only the above additions. There was a change in behaviour in the `teamCollectionAdded` GQL subscription on cloud compared to SH where it was fired post-collection create actions. Child collections at all levels get populated under the imported collection or while creating child collections they get synced straightaway via the subscription. This has been patched at the tree level ensuring collection entries received via GQL subscriptions for a parent collection that is not expanded yet doesn't get populated - [HFE-547](https://linear.app/hoppscotch/issue/HFE-547/bulk-export-of-collections-from-a-team-workspace-and-re-import-doesnt).
- GraphQL collections properties modal can now be opened via the `p` keypress while the context menu is open.

### Preview

  https://github.com/user-attachments/assets/2536c93d-d5b0-4170-846d-fb95286767f7

### Changes

- Relevant changes under `~/packages/hoppscotch-backend/*`, resolving the issue mentioned above where the collection level properties are stringified multiple times while communicating to FE. A new utility function `transformCollectionData()` under `~/src/utils.ts` is added for the purpose.
- Relevant `i18n` string additions.
- Addition of the duplicate action under collection (REST/GQL) nodes in the tree. Similar to the export action in team workspaces where the loading state is toggled back after the GQL mutation, accounting for the same with duplicate action.
- Previously, bulk export of collections resulted in a format not conforming to `HoppCollection` and hence a re-import resulting in the collection level properties (authorization/headers) missing and the CLI rejecting it (An issue mentioned as patched above). On this front, the `getTeamCollectionJSON()` helper function under `~/packages/hoppscotch-common/src/helpers/backend/helpers.ts` has been updated to parse the JSON string, transform each entry and return a stringified representation. Also, the case where there are no collections to export is handled at source and returned as a `left` case.
- Add `DuplicateUserCollection` & `DuplicateTeamCollection` GQL documents and respective updates integrating the same.
- Updates to prop names indicating request loading actions for the relevant components from `duplicateLoading` to `duplicateRequestLoading` since there's a new `duplicateCollectionLoading` prop variant coming in.
- REST/GQL `duplicateCollection` dispatcher function additions under `newstore/collection.ts` along with `duplicateRESTCollection` & `duplicateGQLCollection` helper functions that are exposed for consumption in the outside world.
- A new temporary platform feature flag `duplicateCollectionDisabledInPersonalWorkspace` is added. The naming convention is slightly different `propEnabled` to prevent the need for updates at the `central` platform level config.
- Relevant business logic to support syncing with collection duplication action under personal workspace in SH.

### Note to reviewers

- The business logic about syncing in the personal workspace is kept despite the action being disabled under SH since it will be required while revisiting. Any changes scoped under `~/packages/hoppscotch-selfhost-web/*` can be ignored for now.
- Platform definitions under `selfhost-desktop` will be added alongside revisiting the syncing issue under personal workspace in SH.