### PR TITLE
HSB-473 feat: encrypt sensitive data before storing in db

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ SESSION_SECRET='add some secret here'
 # Note: Some auth providers may not support http requests
 ALLOW_SECURE_COOKIES=true
 
+# Sensitive Data Encryption Key while storing in Database (32 character)
+DATA_ENCRYPTION_KEY="data encryption key with 32 char"
+
 # Hoppscotch App Domain Config
 REDIRECT_URL="http://localhost:3000"
 WHITELISTED_ORIGINS="http://localhost:3170,http://localhost:3000,http://localhost:3100"

--- a/packages/hoppscotch-backend/prisma/migrations/20240725043411_infra_config_encryption/migration.sql
+++ b/packages/hoppscotch-backend/prisma/migrations/20240725043411_infra_config_encryption/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "InfraConfig" ADD COLUMN     "isEncrypted" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/hoppscotch-backend/prisma/schema.prisma
+++ b/packages/hoppscotch-backend/prisma/schema.prisma
@@ -214,12 +214,13 @@ enum TeamMemberRole {
 }
 
 model InfraConfig {
-  id        String   @id @default(cuid())
-  name      String   @unique
-  value     String?
-  active    Boolean  @default(true) // Use case: Let's say, Admin wants to disable Google SSO, but doesn't want to delete the config
-  createdOn DateTime @default(now()) @db.Timestamp(3)
-  updatedOn DateTime @updatedAt @db.Timestamp(3)
+  id          String   @id @default(cuid())
+  name        String   @unique
+  value       String?
+  isEncrypted Boolean  @default(false) // Use case: Let's say, Admin wants to store a Secret Key, but doesn't want to store it in plain text in `value` column
+  active      Boolean  @default(true) // Use case: Let's say, Admin wants to disable Google SSO, but doesn't want to delete the config
+  createdOn   DateTime @default(now()) @db.Timestamp(3)
+  updatedOn   DateTime @updatedAt @db.Timestamp(3)
 }
 
 model PersonalAccessToken {

--- a/packages/hoppscotch-backend/src/infra-config/helper.ts
+++ b/packages/hoppscotch-backend/src/infra-config/helper.ts
@@ -5,7 +5,7 @@ import {
 } from 'src/errors';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { InfraConfigEnum } from 'src/types/InfraConfig';
-import { throwErr } from 'src/utils';
+import { decrypt, encrypt, throwErr } from 'src/utils';
 import { randomBytes } from 'crypto';
 
 export enum ServiceStatus {
@@ -60,7 +60,9 @@ export async function loadInfraConfiguration() {
 
     let environmentObject: Record<string, any> = {};
     infraConfigs.forEach((infraConfig) => {
-      environmentObject[infraConfig.name] = infraConfig.value;
+      environmentObject[infraConfig.name] = infraConfig.isEncrypted
+        ? decrypt(infraConfig.value)
+        : infraConfig.value;
     });
 
     return { INFRA: environmentObject };
@@ -76,119 +78,150 @@ export async function loadInfraConfiguration() {
  * @returns Array of default infra configs
  */
 export async function getDefaultInfraConfigs(): Promise<
-  { name: InfraConfigEnum; value: string }[]
+  { name: InfraConfigEnum; value: string; isEncrypted: boolean }[]
 > {
   const prisma = new PrismaService();
 
   // Prepare rows for 'infra_config' table with default values (from .env) for each 'name'
-  const infraConfigDefaultObjs: { name: InfraConfigEnum; value: string }[] = [
+  const infraConfigDefaultObjs: {
+    name: InfraConfigEnum;
+    value: string;
+    isEncrypted: boolean;
+  }[] = [
     {
       name: InfraConfigEnum.MAILER_SMTP_ENABLE,
       value: process.env.MAILER_SMTP_ENABLE ?? 'true',
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.MAILER_USE_CUSTOM_CONFIGS,
       value: process.env.MAILER_USE_CUSTOM_CONFIGS ?? 'false',
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.MAILER_SMTP_URL,
-      value: process.env.MAILER_SMTP_URL,
+      value: encrypt(process.env.MAILER_SMTP_URL),
+      isEncrypted: true,
     },
     {
       name: InfraConfigEnum.MAILER_ADDRESS_FROM,
       value: process.env.MAILER_ADDRESS_FROM,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.MAILER_SMTP_HOST,
       value: process.env.MAILER_SMTP_HOST,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.MAILER_SMTP_PORT,
       value: process.env.MAILER_SMTP_PORT,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.MAILER_SMTP_SECURE,
       value: process.env.MAILER_SMTP_SECURE,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.MAILER_SMTP_USER,
       value: process.env.MAILER_SMTP_USER,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.MAILER_SMTP_PASSWORD,
-      value: process.env.MAILER_SMTP_PASSWORD,
+      value: encrypt(process.env.MAILER_SMTP_PASSWORD),
+      isEncrypted: true,
     },
     {
       name: InfraConfigEnum.MAILER_TLS_REJECT_UNAUTHORIZED,
       value: process.env.MAILER_TLS_REJECT_UNAUTHORIZED,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.GOOGLE_CLIENT_ID,
       value: process.env.GOOGLE_CLIENT_ID,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.GOOGLE_CLIENT_SECRET,
-      value: process.env.GOOGLE_CLIENT_SECRET,
+      value: encrypt(process.env.GOOGLE_CLIENT_SECRET),
+      isEncrypted: true,
     },
     {
       name: InfraConfigEnum.GOOGLE_CALLBACK_URL,
       value: process.env.GOOGLE_CALLBACK_URL,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.GOOGLE_SCOPE,
       value: process.env.GOOGLE_SCOPE,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.GITHUB_CLIENT_ID,
       value: process.env.GITHUB_CLIENT_ID,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.GITHUB_CLIENT_SECRET,
-      value: process.env.GITHUB_CLIENT_SECRET,
+      value: encrypt(process.env.GITHUB_CLIENT_SECRET),
+      isEncrypted: true,
     },
     {
       name: InfraConfigEnum.GITHUB_CALLBACK_URL,
       value: process.env.GITHUB_CALLBACK_URL,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.GITHUB_SCOPE,
       value: process.env.GITHUB_SCOPE,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.MICROSOFT_CLIENT_ID,
       value: process.env.MICROSOFT_CLIENT_ID,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.MICROSOFT_CLIENT_SECRET,
-      value: process.env.MICROSOFT_CLIENT_SECRET,
+      value: encrypt(process.env.MICROSOFT_CLIENT_SECRET),
+      isEncrypted: true,
     },
     {
       name: InfraConfigEnum.MICROSOFT_CALLBACK_URL,
       value: process.env.MICROSOFT_CALLBACK_URL,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.MICROSOFT_SCOPE,
       value: process.env.MICROSOFT_SCOPE,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.MICROSOFT_TENANT,
       value: process.env.MICROSOFT_TENANT,
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS,
       value: getConfiguredSSOProviders(),
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.ALLOW_ANALYTICS_COLLECTION,
       value: false.toString(),
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.ANALYTICS_USER_ID,
       value: generateAnalyticsUserId(),
+      isEncrypted: false,
     },
     {
       name: InfraConfigEnum.IS_FIRST_TIME_INFRA_SETUP,
       value: (await prisma.infraConfig.count()) === 0 ? 'true' : 'false',
+      isEncrypted: false,
     },
   ];
 
@@ -215,11 +248,32 @@ export async function getMissingInfraConfigEntries() {
 }
 
 /**
+ * Get the encryption required entries in the 'infra_config' table
+ * @returns Array of InfraConfig
+ */
+export async function getEncryptionRequiredInfraConfigEntries() {
+  const prisma = new PrismaService();
+  const [dbInfraConfigs, infraConfigDefaultObjs] = await Promise.all([
+    prisma.infraConfig.findMany(),
+    getDefaultInfraConfigs(),
+  ]);
+
+  const requiredEncryption = dbInfraConfigs.filter((dbConfig) => {
+    const defaultConfig = infraConfigDefaultObjs.find(
+      (config) => config.name === dbConfig.name,
+    );
+    if (!defaultConfig) return false;
+    return defaultConfig.isEncrypted !== dbConfig.isEncrypted;
+  });
+
+  return requiredEncryption;
+}
+
+/**
  * Verify if 'infra_config' table is loaded with all entries
  * @returns boolean
  */
 export async function isInfraConfigTablePopulated(): Promise<boolean> {
-  const prisma = new PrismaService();
   try {
     const propsRemainingToInsert = await getMissingInfraConfigEntries();
 

--- a/packages/hoppscotch-backend/src/infra-config/helper.ts
+++ b/packages/hoppscotch-backend/src/infra-config/helper.ts
@@ -142,7 +142,7 @@ export async function getDefaultInfraConfigs(): Promise<
     },
     {
       name: InfraConfigEnum.GOOGLE_CLIENT_ID,
-      value: process.env.GOOGLE_CLIENT_ID,
+      value: encrypt(process.env.GOOGLE_CLIENT_ID),
       isEncrypted: true,
     },
     {
@@ -162,7 +162,7 @@ export async function getDefaultInfraConfigs(): Promise<
     },
     {
       name: InfraConfigEnum.GITHUB_CLIENT_ID,
-      value: process.env.GITHUB_CLIENT_ID,
+      value: encrypt(process.env.GITHUB_CLIENT_ID),
       isEncrypted: true,
     },
     {
@@ -182,7 +182,7 @@ export async function getDefaultInfraConfigs(): Promise<
     },
     {
       name: InfraConfigEnum.MICROSOFT_CLIENT_ID,
-      value: process.env.MICROSOFT_CLIENT_ID,
+      value: encrypt(process.env.MICROSOFT_CLIENT_ID),
       isEncrypted: true,
     },
     {

--- a/packages/hoppscotch-backend/src/infra-config/helper.ts
+++ b/packages/hoppscotch-backend/src/infra-config/helper.ts
@@ -143,7 +143,7 @@ export async function getDefaultInfraConfigs(): Promise<
     {
       name: InfraConfigEnum.GOOGLE_CLIENT_ID,
       value: process.env.GOOGLE_CLIENT_ID,
-      isEncrypted: false,
+      isEncrypted: true,
     },
     {
       name: InfraConfigEnum.GOOGLE_CLIENT_SECRET,
@@ -163,7 +163,7 @@ export async function getDefaultInfraConfigs(): Promise<
     {
       name: InfraConfigEnum.GITHUB_CLIENT_ID,
       value: process.env.GITHUB_CLIENT_ID,
-      isEncrypted: false,
+      isEncrypted: true,
     },
     {
       name: InfraConfigEnum.GITHUB_CLIENT_SECRET,
@@ -183,7 +183,7 @@ export async function getDefaultInfraConfigs(): Promise<
     {
       name: InfraConfigEnum.MICROSOFT_CLIENT_ID,
       value: process.env.MICROSOFT_CLIENT_ID,
-      isEncrypted: false,
+      isEncrypted: true,
     },
     {
       name: InfraConfigEnum.MICROSOFT_CLIENT_SECRET,

--- a/packages/hoppscotch-backend/src/infra-config/helper.ts
+++ b/packages/hoppscotch-backend/src/infra-config/helper.ts
@@ -60,9 +60,11 @@ export async function loadInfraConfiguration() {
 
     let environmentObject: Record<string, any> = {};
     infraConfigs.forEach((infraConfig) => {
-      environmentObject[infraConfig.name] = infraConfig.isEncrypted
-        ? decrypt(infraConfig.value)
-        : infraConfig.value;
+      if (infraConfig.isEncrypted) {
+        environmentObject[infraConfig.name] = decrypt(infraConfig.value);
+      } else {
+        environmentObject[infraConfig.name] = infraConfig.value;
+      }
     });
 
     return { INFRA: environmentObject };

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
@@ -28,6 +28,7 @@ const dbInfraConfigs: dbInfraConfig[] = [
     id: '3',
     name: InfraConfigEnum.GOOGLE_CLIENT_ID,
     value: 'abcdefghijkl',
+    isEncrypted: false,
     active: true,
     createdOn: INITIALIZED_DATE_CONST,
     updatedOn: INITIALIZED_DATE_CONST,
@@ -36,6 +37,7 @@ const dbInfraConfigs: dbInfraConfig[] = [
     id: '4',
     name: InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS,
     value: 'google',
+    isEncrypted: false,
     active: true,
     createdOn: INITIALIZED_DATE_CONST,
     updatedOn: INITIALIZED_DATE_CONST,
@@ -62,10 +64,15 @@ describe('InfraConfigService', () => {
       const name = InfraConfigEnum.GOOGLE_CLIENT_ID;
       const value = 'true';
 
+      // @ts-ignore
+      mockPrisma.infraConfig.findUnique.mockResolvedValueOnce({
+        isEncrypted: false,
+      });
       mockPrisma.infraConfig.update.mockResolvedValueOnce({
         id: '',
         name,
         value,
+        isEncrypted: false,
         active: true,
         createdOn: new Date(),
         updatedOn: new Date(),
@@ -82,10 +89,15 @@ describe('InfraConfigService', () => {
       const name = InfraConfigEnum.GOOGLE_CLIENT_ID;
       const value = 'true';
 
+      // @ts-ignore
+      mockPrisma.infraConfig.findUnique.mockResolvedValueOnce({
+        isEncrypted: false,
+      });
       mockPrisma.infraConfig.update.mockResolvedValueOnce({
         id: '',
         name,
         value,
+        isEncrypted: false,
         active: true,
         createdOn: new Date(),
         updatedOn: new Date(),
@@ -102,10 +114,15 @@ describe('InfraConfigService', () => {
       const name = InfraConfigEnum.GOOGLE_CLIENT_ID;
       const value = 'true';
 
+      // @ts-ignore
+      mockPrisma.infraConfig.findUnique.mockResolvedValueOnce({
+        isEncrypted: false,
+      });
       mockPrisma.infraConfig.update.mockResolvedValueOnce({
         id: '',
         name,
         value,
+        isEncrypted: false,
         active: true,
         createdOn: new Date(),
         updatedOn: new Date(),
@@ -119,6 +136,11 @@ describe('InfraConfigService', () => {
     it('should pass correct params to prisma update', async () => {
       const name = InfraConfigEnum.GOOGLE_CLIENT_ID;
       const value = 'true';
+
+      // @ts-ignore
+      mockPrisma.infraConfig.findUnique.mockResolvedValueOnce({
+        isEncrypted: false,
+      });
 
       jest.spyOn(helper, 'stopApp').mockReturnValueOnce();
 
@@ -151,6 +173,7 @@ describe('InfraConfigService', () => {
         id: '',
         name,
         value,
+        isEncrypted: false,
         active: true,
         createdOn: new Date(),
         updatedOn: new Date(),

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -153,7 +153,10 @@ export class InfraConfigService implements OnModuleInit {
 
     try {
       const isEncrypted = (
-        await this.prisma.infraConfig.findUnique({ where: { name } })
+        await this.prisma.infraConfig.findUnique({
+          where: { name },
+          select: { isEncrypted: true },
+        })
       ).isEncrypted;
 
       const infraConfig = await this.prisma.infraConfig.update({

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -152,12 +152,10 @@ export class InfraConfigService implements OnModuleInit {
     if (E.isLeft(isValidate)) return E.left(isValidate.left);
 
     try {
-      const isEncrypted = (
-        await this.prisma.infraConfig.findUnique({
-          where: { name },
-          select: { isEncrypted: true },
-        })
-      ).isEncrypted;
+      const { isEncrypted } = await this.prisma.infraConfig.findUnique({
+        where: { name },
+        select: { isEncrypted: true },
+      });
 
       const infraConfig = await this.prisma.infraConfig.update({
         where: { name },

--- a/packages/hoppscotch-backend/src/user/user.service.ts
+++ b/packages/hoppscotch-backend/src/user/user.service.ts
@@ -16,7 +16,7 @@ import {
 import { SessionType, User } from './user.model';
 import { USER_UPDATE_FAILED } from 'src/errors';
 import { PubSubService } from 'src/pubsub/pubsub.service';
-import { stringToJson, taskEitherValidateArraySeq } from 'src/utils';
+import { encrypt, stringToJson, taskEitherValidateArraySeq } from 'src/utils';
 import { UserDataHandler } from './user.data.handler';
 import { User as DbUser } from '@prisma/client';
 import { OffsetPaginationArgs } from 'src/types/input-types.args';
@@ -208,8 +208,8 @@ export class UserService {
       data: {
         provider: profile.provider,
         providerAccountId: profile.id,
-        providerRefreshToken: refreshToken ? refreshToken : null,
-        providerAccessToken: accessToken ? accessToken : null,
+        providerRefreshToken: refreshToken ? encrypt(refreshToken) : null,
+        providerAccessToken: accessToken ? encrypt(accessToken) : null,
         user: {
           connect: {
             uid: user.uid,

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -17,6 +17,7 @@ import {
 } from './errors';
 import { TeamMemberRole } from './team/team.model';
 import { RESTError } from './types/RESTError';
+import * as crypto from 'crypto';
 
 /**
  * A workaround to throw an exception in an expression.
@@ -315,4 +316,40 @@ export function transformCollectionData(
   return typeof collectionData === 'string'
     ? collectionData
     : JSON.stringify(collectionData);
+}
+
+// Encrypt and Decrypt functions. InfraConfig and Account table uses these functions to encrypt and decrypt the data.
+const algorithm = 'aes-256-cbc';
+
+/**
+ * Encrypts a text using a key
+ * @param text The text to encrypt
+ * @param key The key to use for encryption
+ * @returns The encrypted text
+ */
+export function encrypt(text: string, key = process.env.DATA_ENCRYPTION_KEY) {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(algorithm, Buffer.from(key), iv);
+  let encrypted = cipher.update(text);
+  encrypted = Buffer.concat([encrypted, cipher.final()]);
+  return iv.toString('hex') + ':' + encrypted.toString('hex');
+}
+
+/**
+ * Decrypts a text using a key
+ * @param text The text to decrypt
+ * @param key The key to use for decryption
+ * @returns The decrypted text
+ */
+export function decrypt(
+  encryptedData: string,
+  key = process.env.DATA_ENCRYPTION_KEY,
+) {
+  const textParts = encryptedData.split(':');
+  const iv = Buffer.from(textParts.shift(), 'hex');
+  const encryptedText = Buffer.from(textParts.join(':'), 'hex');
+  const decipher = crypto.createDecipheriv(algorithm, Buffer.from(key), iv);
+  let decrypted = decipher.update(encryptedText);
+  decrypted = Buffer.concat([decrypted, decipher.final()]);
+  return decrypted.toString();
 }

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -319,7 +319,7 @@ export function transformCollectionData(
 }
 
 // Encrypt and Decrypt functions. InfraConfig and Account table uses these functions to encrypt and decrypt the data.
-const algorithm = 'aes-256-cbc';
+const ENCRYPTION_ALGORITHM = 'aes-256-cbc';
 
 /**
  * Encrypts a text using a key
@@ -331,7 +331,11 @@ export function encrypt(text: string, key = process.env.DATA_ENCRYPTION_KEY) {
   if (text === null || text === undefined) return text;
 
   const iv = crypto.randomBytes(16);
-  const cipher = crypto.createCipheriv(algorithm, Buffer.from(key), iv);
+  const cipher = crypto.createCipheriv(
+    ENCRYPTION_ALGORITHM,
+    Buffer.from(key),
+    iv,
+  );
   let encrypted = cipher.update(text);
   encrypted = Buffer.concat([encrypted, cipher.final()]);
   return iv.toString('hex') + ':' + encrypted.toString('hex');
@@ -354,7 +358,11 @@ export function decrypt(
   const textParts = encryptedData.split(':');
   const iv = Buffer.from(textParts.shift(), 'hex');
   const encryptedText = Buffer.from(textParts.join(':'), 'hex');
-  const decipher = crypto.createDecipheriv(algorithm, Buffer.from(key), iv);
+  const decipher = crypto.createDecipheriv(
+    ENCRYPTION_ALGORITHM,
+    Buffer.from(key),
+    iv,
+  );
   let decrypted = decipher.update(encryptedText);
   decrypted = Buffer.concat([decrypted, decipher.final()]);
   return decrypted.toString();

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -328,6 +328,8 @@ const algorithm = 'aes-256-cbc';
  * @returns The encrypted text
  */
 export function encrypt(text: string, key = process.env.DATA_ENCRYPTION_KEY) {
+  if (text === null || text === undefined) return text;
+
   const iv = crypto.randomBytes(16);
   const cipher = crypto.createCipheriv(algorithm, Buffer.from(key), iv);
   let encrypted = cipher.update(text);
@@ -345,6 +347,10 @@ export function decrypt(
   encryptedData: string,
   key = process.env.DATA_ENCRYPTION_KEY,
 ) {
+  if (encryptedData === null || encryptedData === undefined) {
+    return encryptedData;
+  }
+
   const textParts = encryptedData.split(':');
   const iv = Buffer.from(textParts.shift(), 'hex');
   const encryptedText = Buffer.from(textParts.join(':'), 'hex');


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HSB-473

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

This PR introduces data encryption before storing sensitive data in the database. For example, previously we stored SSO's secret key as plain text in the infraConfig table. From now on, before saving to DB, the value will be encrypted.
Also, after fetching the data from the DB, we decrypt it to the original value to use.

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
In `Account` and `InfraConfig` tables, we added encryption and decryption logic to store/ fetch sensitive data.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Nil