### PR TITLE
feat: add loading state for import actions

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -98,7 +98,7 @@ const showImportFailedError = () => {
 const handleImportToStore = async (collections: HoppCollection[]) => {
   const importResult =
     props.collectionsType.type === "my-collections"
-      ? await importToPersonalWorkspace(collections)
+      ? importToPersonalWorkspace(collections)
       : await importToTeamsWorkspace(collections)
 
   if (E.isRight(importResult)) {

--- a/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
@@ -231,7 +231,7 @@ const showImportFailedError = () => {
   toast.error(t("import.failed"))
 }
 
-const handleImportToStore = async (gqlCollections: HoppCollection[]) => {
+const handleImportToStore = (gqlCollections: HoppCollection[]) => {
   appendGraphqlCollections(gqlCollections)
   toast.success(t("state.file_imported"))
 }

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -63,6 +63,7 @@ const currentUser = useReadonlyStream(
 const isPostmanImporterInProgress = ref(false)
 const isInsomniaImporterInProgress = ref(false)
 const isRESTImporterInProgress = ref(false)
+const isGistImporterInProgress = ref(false)
 
 const isEnvironmentGistExportInProgress = ref(false)
 
@@ -217,21 +218,26 @@ const EnvironmentsImportFromGIST: ImporterOrExporter = {
         return
       }
 
+      isGistImporterInProgress.value = true
+
       const res = await hoppEnvImporter(environments.right)()
 
-      if (E.isLeft(res)) {
+      if (E.isRight(res)) {
+        await handleImportToStore(res.right)
+
+        platform.analytics?.logEvent({
+          type: "HOPP_IMPORT_ENVIRONMENT",
+          platform: "rest",
+          workspaceType: isTeamEnvironment.value ? "team" : "personal",
+        })
+        emit("hide-modal")
+      } else {
         showImportFailedError()
-        return
       }
 
-      handleImportToStore(res.right)
-      platform.analytics?.logEvent({
-        type: "HOPP_IMPORT_ENVIRONMENT",
-        platform: "rest",
-        workspaceType: workspaceType.value,
-      })
-      emit("hide-modal")
+      isGistImporterInProgress.value = false
     },
+    isLoading: isGistImporterInProgress,
   }),
 }
 

--- a/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
@@ -45,9 +45,10 @@
     </p>
     <div>
       <HoppButtonPrimary
-        class="w-full"
+        :disabled="disableImportCTA"
         :label="t('import.title')"
-        :disabled="!hasFile || showFileSizeLimitExceededWarning"
+        :loading="loading"
+        class="w-full"
         @click="emit('importFromFile', fileContent)"
       />
     </div>
@@ -55,14 +56,20 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
+import { computed, ref } from "vue"
 
-defineProps<{
-  caption: string
-  acceptedFileTypes: string
-}>()
+const props = withDefaults(
+  defineProps<{
+    caption: string
+    acceptedFileTypes: string
+    loading?: boolean
+  }>(),
+  {
+    loading: false,
+  }
+)
 
 const t = useI18n()
 const toast = useToast()
@@ -80,6 +87,12 @@ const inputChooseFileToImportFrom = ref<HTMLInputElement | any>()
 const emit = defineEmits<{
   (e: "importFromFile", content: string[]): void
 }>()
+
+// Disable the import CTA if no file is selected, the file size limit is exceeded, or during an import action indicated by the `isLoading` prop
+const disableImportCTA = computed(
+  () =>
+    !hasFile.value || showFileSizeLimitExceededWarning.value || props.loading
+)
 
 const onFileChange = async () => {
   // Reset the state on entering the handler to avoid any stale state

--- a/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/MyCollectionImport.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/MyCollectionImport.vue
@@ -24,7 +24,8 @@
     <HoppButtonPrimary
       class="w-full"
       :label="t('import.title')"
-      :disabled="!hasSelectedCollectionID"
+      :loading="loading"
+      :disabled="!hasSelectedCollectionID || loading"
       @click="fetchCollectionFromMyCollections"
     />
   </div>
@@ -38,6 +39,10 @@ import { useReadonlyStream } from "~/composables/stream"
 import { getRESTCollection, restCollections$ } from "~/newstore/collections"
 
 const t = useI18n()
+
+defineProps<{
+  loading: boolean
+}>()
 
 const mySelectedCollectionID = ref<number | undefined>(undefined)
 

--- a/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/UrlImport.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/UrlImport.vue
@@ -26,8 +26,8 @@
       <HoppButtonPrimary
         class="w-full"
         :label="t('import.title')"
-        :disabled="!hasURL"
-        :loading="isFetchingUrl"
+        :disabled="disableImportCTA"
+        :loading="isFetchingUrl || loading"
         @click="fetchUrlData"
       />
     </div>
@@ -35,7 +35,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue"
+import { computed, ref, watch } from "vue"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "~/composables/toast"
 import axios, { AxiosResponse } from "axios"
@@ -44,10 +44,14 @@ const t = useI18n()
 
 const toast = useToast()
 
-const props = defineProps<{
-  caption: string
-  fetchLogic?: (url: string) => Promise<AxiosResponse<any>>
-}>()
+const props = withDefaults(
+  defineProps<{
+    caption: string
+    fetchLogic?: (url: string) => Promise<AxiosResponse<any>>
+    loading?: boolean
+  }>(),
+  { fetchLogic: undefined, loading: false }
+)
 
 const emit = defineEmits<{
   (e: "importFromURL", content: unknown): void
@@ -61,6 +65,8 @@ const isFetchingUrl = ref(false)
 watch(inputChooseGistToImportFrom, (url) => {
   hasURL.value = !!url
 })
+
+const disableImportCTA = computed(() => !hasURL.value || props.loading)
 
 const urlFetchLogic =
   props.fetchLogic ??

--- a/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/FileSource.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/FileSource.ts
@@ -2,11 +2,13 @@ import FileImportVue from "~/components/importExport/ImportExportSteps/FileImpor
 import { defineStep } from "~/composables/step-components"
 
 import { v4 as uuidv4 } from "uuid"
+import { Ref } from "vue"
 
 export function FileSource(metadata: {
   acceptedFileTypes: string
   caption: string
   onImportFromFile: (content: string[]) => any | Promise<any>
+  isLoading?: Ref<boolean>
 }) {
   const stepID = uuidv4()
 
@@ -14,5 +16,6 @@ export function FileSource(metadata: {
     acceptedFileTypes: metadata.acceptedFileTypes,
     caption: metadata.caption,
     onImportFromFile: metadata.onImportFromFile,
+    loading: metadata.isLoading?.value,
   }))
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/GistSource.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/GistSource.ts
@@ -6,18 +6,20 @@ import * as E from "fp-ts/Either"
 import { z } from "zod"
 
 import { v4 as uuidv4 } from "uuid"
+import { Ref } from "vue"
 
 export function GistSource(metadata: {
   caption: string
   onImportFromGist: (
     importResult: E.Either<string, string[]>
   ) => any | Promise<any>
+  isLoading?: Ref<boolean>
 }) {
   const stepID = uuidv4()
 
   return defineStep(stepID, UrlImport, () => ({
     caption: metadata.caption,
-    onImportFromURL: (gistResponse: Record<string, unknown>) => {
+    onImportFromURL: (gistResponse: unknown) => {
       const fileSchema = z.object({
         files: z.record(z.object({ content: z.string() })),
       })
@@ -36,6 +38,7 @@ export function GistSource(metadata: {
       metadata.onImportFromGist(E.right(contents))
     },
     fetchLogic: fetchGistFromUrl,
+    loading: metadata.isLoading?.value,
   }))
 }
 

--- a/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/UrlSource.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/UrlSource.ts
@@ -2,11 +2,13 @@ import UrlImport from "~/components/importExport/ImportExportSteps/UrlImport.vue
 import { defineStep } from "~/composables/step-components"
 
 import { v4 as uuidv4 } from "uuid"
+import { Ref } from "vue"
 
 export function UrlSource(metadata: {
   caption: string
   onImportFromURL: (content: string) => any | Promise<any>
   fetchLogic?: (url: string) => Promise<any>
+  isLoading?: Ref<boolean>
 }) {
   const stepID = uuidv4()
 
@@ -17,5 +19,6 @@ export function UrlSource(metadata: {
         metadata.onImportFromURL(content)
       }
     },
+    loading: metadata.isLoading?.value,
   }))
 }


### PR DESCRIPTION
This PR addresses the need for a loading state in the `Import/Export` modals that includes collections and environments in scope.

Closes #4145 HFE-594.

### What's changed

- Introduce state variables to keep track of the loading status during a network call while importing to the data store applicable to the team workspace. The `handleImportToStore` function promise resolution is awaited.
- Introduce a `loading` prop to the `FileImport` & `UrlImport` components that default to `false` - toggles the `Import` CTA loading state accordingly. The import CTA stays disabled during a loading state.
- Adds a `loading` prop to the `MyCollectionImport` component to handle the loading state with import from personal collections flow while at a team workspace.
- The `FileSource()` & `UrlSource()` functions now include a new `isLoading` parameter via which the above state variables are supplied from the respective component.

### Note to reviewers

Please verify the import collections/environments flow e2e.