### PR TITLE
fix: infra token expriry check on guard

### DIFF
--- a/packages/hoppscotch-backend/src/guards/infra-token.guard.ts
+++ b/packages/hoppscotch-backend/src/guards/infra-token.guard.ts
@@ -38,7 +38,7 @@ export class InfraTokenGuard implements CanActivate {
       throw new UnauthorizedException(INFRA_TOKEN_INVALID_TOKEN);
 
     const currentTime = DateTime.now().toISO();
-    if (currentTime > infraToken.expiresOn.toISOString()) {
+    if (currentTime > infraToken.expiresOn?.toISOString()) {
       throw new UnauthorizedException(INFRA_TOKEN_EXPIRED);
     }
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
This PR resolves an bug on `infra-token.guard.ts` while checking the token is expire or not. `expiryOn` value can be `null`. So, this PR cover that conditions as well.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Nil