### PR TITLE
feat: hoppscotch-common & platform additions for ai experiments

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -612,7 +612,8 @@
     "url": "URL",
     "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variables",
-    "view_my_links": "View my links"
+    "view_my_links": "View my links",
+    "generate_name_error": "Failed to generate request name."
   },
   "response": {
     "audio": "Audio",
@@ -672,6 +673,7 @@
     "short_codes": "Short codes",
     "short_codes_description": "Short codes which were created by you.",
     "sidebar_on_left": "Sidebar on left",
+    "ai_experiments": "AI Experiments",
     "sync": "Synchronise",
     "sync_collections": "Collections",
     "sync_description": "These settings are synced to cloud.",
@@ -1084,5 +1086,9 @@
     "cli_command_generation_description_sh": "Copy the below command and run it from the CLI. Please specify a personal access token and verify the generated SH instance server URL.",
     "cli_command_generation_description_sh_with_server_url_placeholder": "Copy the below command and run it from the CLI. Please specify a personal access token and the SH instance server URL.",
     "run_collection": "Run collection"
+  },
+  "ai_experiments": {
+    "generate_request_name": "Generate Request Name Using AI",
+    "generate_or_modify_request_body": "Generate or Modify Request Body"
   }
 }

--- a/packages/hoppscotch-common/src/components/collections/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/EditRequest.vue
@@ -51,13 +51,15 @@
 <script setup lang="ts">
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
-import { useVModel } from "@vueuse/core"
-import { computed, ref } from "vue"
-import IconSparkle from "~icons/lucide/sparkles"
-import * as E from "fp-ts/Either"
-import { platform } from "~/platform"
 import { HoppRESTRequest } from "@hoppscotch/data"
+import { useVModel } from "@vueuse/core"
+import * as E from "fp-ts/Either"
+import { computed, ref } from "vue"
+
 import { useSetting } from "~/composables/settings"
+import { useReadonlyStream } from "~/composables/stream"
+import { platform } from "~/platform"
+import IconSparkle from "~icons/lucide/sparkles"
 
 const toast = useToast()
 const t = useI18n()
@@ -86,9 +88,19 @@ const ENABLE_AI_EXPERIMENTS = useSetting("ENABLE_AI_EXPERIMENTS")
 
 const editingName = useVModel(props, "modelValue")
 
+const currentUser = useReadonlyStream(
+  platform.auth.getCurrentUserStream(),
+  platform.auth.getCurrentUser()
+)
+
 const isGenerateRequestNamePending = ref(false)
 
 const showGenerateRequestNameButton = computed(() => {
+  // Request generation applies only to the authenticated state
+  if (!currentUser.value) {
+    return false
+  }
+
   return ENABLE_AI_EXPERIMENTS.value && !!platform.experiments?.aiExperiments
 })
 

--- a/packages/hoppscotch-common/src/components/collections/graphql/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/EditRequest.vue
@@ -6,13 +6,28 @@
     @close="hideModal"
   >
     <template #body>
-      <HoppSmartInput
-        v-model="requestUpdateData.name"
-        placeholder=" "
-        :label="t('action.label')"
-        input-styles="floating-input"
-        @submit="saveRequest"
-      />
+      <div class="flex gap-1">
+        <HoppSmartInput
+          v-model="requestUpdateData.name"
+          class="flex-grow"
+          placeholder=" "
+          :label="t('action.label')"
+          input-styles="floating-input"
+          @submit="saveRequest"
+        />
+        <HoppButtonSecondary
+          v-if="showGenerateRequestNameButton"
+          v-tippy="{ theme: 'tooltip' }"
+          :icon="IconSparkle"
+          :disabled="isGenerateRequestNamePending"
+          class="rounded-md"
+          :class="{
+            'animate-pulse': isGenerateRequestNamePending,
+          }"
+          :title="t('ai_experiments.generate_request_name')"
+          @click="generateRequestName"
+        />
+      </div>
     </template>
     <template #footer>
       <span class="flex space-x-2">
@@ -33,11 +48,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue"
+import { computed, ref, watch } from "vue"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
 import { HoppGQLRequest } from "@hoppscotch/data"
 import { editGraphqlRequest } from "~/newstore/collections"
+import { useSetting } from "~/composables/settings"
+import { platform } from "~/platform"
+import * as E from "fp-ts/Either"
+import IconSparkle from "~icons/lucide/sparkles"
 
 const t = useI18n()
 const toast = useToast()
@@ -48,6 +67,7 @@ const props = defineProps<{
   requestIndex: number | null
   request: HoppGQLRequest | null
   editingRequestName: string
+  requestContext: HoppGQLRequest | null
 }>()
 
 const emit = defineEmits<{
@@ -62,6 +82,42 @@ watch(
     requestUpdateData.value.name = val
   }
 )
+
+const ENABLE_AI_EXPERIMENTS = useSetting("ENABLE_AI_EXPERIMENTS")
+
+const isGenerateRequestNamePending = ref(false)
+
+const showGenerateRequestNameButton = computed(() => {
+  return ENABLE_AI_EXPERIMENTS.value && !!platform.experiments?.aiExperiments
+})
+
+const generateRequestName = async () => {
+  const generateRequestNameForPlatform =
+    platform.experiments?.aiExperiments?.generateRequestName
+
+  if (!props.requestContext || !generateRequestNameForPlatform) {
+    toast.error(t("request.generate_name_error"))
+    return
+  }
+
+  isGenerateRequestNamePending.value = true
+
+  const result = await generateRequestNameForPlatform(
+    JSON.stringify(props.requestContext)
+  )
+
+  if (result && E.isLeft(result)) {
+    toast.error(t("request.generate_name_error"))
+
+    isGenerateRequestNamePending.value = false
+
+    return
+  }
+
+  requestUpdateData.value.name = result.right
+
+  isGenerateRequestNamePending.value = false
+}
 
 const saveRequest = () => {
   if (!requestUpdateData.value.name) {

--- a/packages/hoppscotch-common/src/components/collections/graphql/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/EditRequest.vue
@@ -48,14 +48,16 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
 import { HoppGQLRequest } from "@hoppscotch/data"
-import { editGraphqlRequest } from "~/newstore/collections"
-import { useSetting } from "~/composables/settings"
-import { platform } from "~/platform"
 import * as E from "fp-ts/Either"
+import { computed, ref, watch } from "vue"
+
+import { useSetting } from "~/composables/settings"
+import { useReadonlyStream } from "~/composables/stream"
+import { editGraphqlRequest } from "~/newstore/collections"
+import { platform } from "~/platform"
 import IconSparkle from "~icons/lucide/sparkles"
 
 const t = useI18n()
@@ -85,9 +87,19 @@ watch(
 
 const ENABLE_AI_EXPERIMENTS = useSetting("ENABLE_AI_EXPERIMENTS")
 
+const currentUser = useReadonlyStream(
+  platform.auth.getCurrentUserStream(),
+  platform.auth.getCurrentUser()
+)
+
 const isGenerateRequestNamePending = ref(false)
 
 const showGenerateRequestNameButton = computed(() => {
+  // Request generation applies only to the authenticated state
+  if (!currentUser.value) {
+    return false
+  }
+
   return ENABLE_AI_EXPERIMENTS.value && !!platform.experiments?.aiExperiments
 })
 

--- a/packages/hoppscotch-common/src/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/index.vue
@@ -139,6 +139,7 @@
       :folder-path="editingFolderPath"
       :request="editingRequest"
       :request-index="editingRequestIndex"
+      :request-context="editingRequest"
       :editing-request-name="editingRequest ? editingRequest.name : ''"
       @hide-modal="displayModalEditRequest(false)"
     />

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -129,7 +129,6 @@
       :show="showModalEditCollection"
       :editing-collection-name="editingCollectionName ?? ''"
       :loading-state="modalLoadingState"
-      :request-context="editingRequest"
       @hide-modal="displayModalEditCollection(false)"
       @submit="updateEditingCollection"
     />

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -129,6 +129,7 @@
       :show="showModalEditCollection"
       :editing-collection-name="editingCollectionName ?? ''"
       :loading-state="modalLoadingState"
+      :request-context="editingRequest"
       @hide-modal="displayModalEditCollection(false)"
       @submit="updateEditingCollection"
     />

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -143,6 +143,7 @@
     <CollectionsEditRequest
       v-model="editingRequestName"
       :show="showModalEditRequest"
+      :request-context="editingRequest"
       :loading-state="modalLoadingState"
       @submit="updateEditingRequest"
       @hide-modal="displayModalEditRequest(false)"

--- a/packages/hoppscotch-common/src/newstore/settings.ts
+++ b/packages/hoppscotch-common/src/newstore/settings.ts
@@ -66,6 +66,7 @@ export type SettingsDef = {
   COLUMN_LAYOUT: boolean
 
   HAS_OPENED_SPOTLIGHT: boolean
+  ENABLE_AI_EXPERIMENTS: boolean
 }
 
 export const getDefaultSettings = (): SettingsDef => ({
@@ -113,6 +114,7 @@ export const getDefaultSettings = (): SettingsDef => ({
   COLUMN_LAYOUT: true,
 
   HAS_OPENED_SPOTLIGHT: false,
+  ENABLE_AI_EXPERIMENTS: false,
 })
 
 type ApplySettingPayload = {

--- a/packages/hoppscotch-common/src/pages/graphql.vue
+++ b/packages/hoppscotch-common/src/pages/graphql.vue
@@ -62,6 +62,7 @@
     <CollectionsEditRequest
       v-model="editReqModalReqName"
       :show="showRenamingReqNameModalForTabID !== undefined"
+      :request-context="requestToRename"
       @submit="renameReqName"
       @hide-modal="showRenamingReqNameModalForTabID = undefined"
     />
@@ -183,6 +184,12 @@ onBeforeUnmount(() => {
 
 const editReqModalReqName = ref("")
 const showRenamingReqNameModalForTabID = ref<string>()
+
+const requestToRename = computed(() => {
+  if (!showRenamingReqNameModalForTabID.value) return null
+  const tab = tabs.getTabRef(showRenamingReqNameModalForTabID.value)
+  return tab.value.document.request
+})
 
 const openReqRenameModal = (tab: HoppTab<HoppGQLDocument>) => {
   editReqModalReqName.value = tab.document.request.name

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -60,6 +60,7 @@
     </AppPaneLayout>
     <CollectionsEditRequest
       v-model="reqName"
+      :request-context="requestToRename"
       :show="showRenamingReqNameModal"
       @submit="renameReqName"
       @hide-modal="showRenamingReqNameModal = false"
@@ -118,7 +119,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, onMounted } from "vue"
+import { ref, onMounted, computed } from "vue"
 import { safelyExtractRESTRequest } from "@hoppscotch/data"
 import { translateExtURLParams } from "~/helpers/RESTExtURLParams"
 import { useRoute } from "vue-router"
@@ -255,6 +256,12 @@ const onResolveConfirmCloseAllTabs = () => {
   if (exceptedTabID.value) tabs.closeOtherTabs(exceptedTabID.value)
   confirmingCloseAllTabs.value = false
 }
+
+const requestToRename = computed(() => {
+  if (!renameTabID.value) return null
+  const tab = tabs.getTabRef(renameTabID.value)
+  return tab.value.document.request
+})
 
 const openReqRenameModal = (tabID?: string) => {
   if (tabID) {

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -269,7 +269,10 @@ const openReqRenameModal = (tabID?: string) => {
     reqName.value = tab.value.document.request.name
     renameTabID.value = tabID
   } else {
-    reqName.value = tabs.currentActiveTab.value.document.request.name
+    const { id, document } = tabs.currentActiveTab.value
+
+    reqName.value = document.request.name
+    renameTabID.value = id
   }
   showRenamingReqNameModal.value = true
 }

--- a/packages/hoppscotch-common/src/pages/settings.vue
+++ b/packages/hoppscotch-common/src/pages/settings.vue
@@ -83,6 +83,14 @@
                   {{ t("settings.sidebar_on_left") }}
                 </HoppSmartToggle>
               </div>
+              <div v-if="hasAIExperimentsSupport" class="flex items-center">
+                <HoppSmartToggle
+                  :on="ENABLE_AI_EXPERIMENTS"
+                  @change="toggleSetting('ENABLE_AI_EXPERIMENTS')"
+                >
+                  {{ t("settings.ai_experiments") }}
+                </HoppSmartToggle>
+              </div>
             </div>
           </section>
         </div>
@@ -179,6 +187,7 @@ const PROXY_URL = useSetting("PROXY_URL")
 const TELEMETRY_ENABLED = useSetting("TELEMETRY_ENABLED")
 const EXPAND_NAVIGATION = useSetting("EXPAND_NAVIGATION")
 const SIDEBAR_ON_LEFT = useSetting("SIDEBAR_ON_LEFT")
+const ENABLE_AI_EXPERIMENTS = useSetting("ENABLE_AI_EXPERIMENTS")
 
 const hasPlatformTelemetry = Boolean(platform.platformFeatureFlags.hasTelemetry)
 
@@ -187,6 +196,9 @@ const confirmRemove = ref(false)
 const proxySettings = computed(() => ({
   url: PROXY_URL.value,
 }))
+
+const hasAIExperimentsSupport =
+  !!platform.experiments?.aiExperiments?.enableAIExperiments
 
 watch(
   proxySettings,

--- a/packages/hoppscotch-common/src/platform/experiments.ts
+++ b/packages/hoppscotch-common/src/platform/experiments.ts
@@ -1,0 +1,10 @@
+import * as E from "fp-ts/Either"
+
+export type ExperimentsPlatformDef = {
+  aiExperiments?: {
+    enableAIExperiments: boolean
+    generateRequestName: (
+      requestInfo: string
+    ) => Promise<E.Either<string, string>>
+  }
+}

--- a/packages/hoppscotch-common/src/platform/index.ts
+++ b/packages/hoppscotch-common/src/platform/index.ts
@@ -12,6 +12,7 @@ import { ServiceClassInstance } from "dioc"
 import { IOPlatformDef } from "./io"
 import { SpotlightPlatformDef } from "./spotlight"
 import { InfraPlatformDef } from "./infra"
+import { ExperimentsPlatformDef } from "./experiments"
 import { Ref } from "vue"
 
 export type PlatformDef = {
@@ -60,6 +61,7 @@ export type PlatformDef = {
     duplicateCollectionDisabledInPersonalWorkspace?: boolean
   }
   infra?: InfraPlatformDef
+  experiments?: ExperimentsPlatformDef
 }
 
 export let platform: PlatformDef

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -68,6 +68,7 @@ const SettingsDefSchema = z.object({
   ),
 
   HAS_OPENED_SPOTLIGHT: z.optional(z.boolean()),
+  ENABLE_AI_EXPERIMENTS: z.optional(z.boolean()),
 })
 
 // Common properties shared across REST & GQL collections


### PR DESCRIPTION
**Changes**

1. This PR adds a new platform definition entry `Experiments` to add support for bringing ai experiments into hoppscotch platforms. right now the features are enabled only for our cloud instance. but these changes enable ai experiments to be enabled when needed across platforms.

2. The initial feature we bring as part of our AI experiments is the ability to generate automatic names for any request. this PR also adds code that enables this feature to corresponding components.

note: there's duplication between the GQL & REST components currently. we could move the request rename logic into a seperate service. but differing this for now.