### PR TITLE
chore: add analytics event for ai experiments

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/EditRequest.vue
@@ -115,6 +115,11 @@ const generateRequestName = async () => {
 
   isGenerateRequestNamePending.value = true
 
+  platform.analytics?.logEvent({
+    type: "EXPERIMENTS_GENERATE_REQUEST_NAME_WITH_AI",
+    platform: "rest",
+  })
+
   const result = await generateRequestNameForPlatform(
     JSON.stringify(props.requestContext)
   )

--- a/packages/hoppscotch-common/src/components/collections/graphql/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/EditRequest.vue
@@ -114,6 +114,11 @@ const generateRequestName = async () => {
 
   isGenerateRequestNamePending.value = true
 
+  platform.analytics?.logEvent({
+    type: "EXPERIMENTS_GENERATE_REQUEST_NAME_WITH_AI",
+    platform: "gql",
+  })
+
   const result = await generateRequestNameForPlatform(
     JSON.stringify(props.requestContext)
   )

--- a/packages/hoppscotch-common/src/platform/analytics.ts
+++ b/packages/hoppscotch-common/src/platform/analytics.ts
@@ -63,6 +63,10 @@ export type AnalyticsEvent =
   | ({
       type: "HOPP_SPOTLIGHT_SESSION"
     } & HoppSpotlightSessionEventData)
+  | {
+      type: "EXPERIMENTS_GENERATE_REQUEST_NAME_WITH_AI"
+      platform: "rest" | "gql"
+    }
 
 export type AnalyticsPlatformDef = {
   initAnalytics: () => void


### PR DESCRIPTION
**Changes**

This PR introduces a new analytics event `EXPERIMENTS_GENERATE_REQUEST_NAME_WITH_AI` to track the usage of renaming requests with AI.