### PR TITLE
fix: path not taken into account for socket.io connection without token auth

### DIFF
--- a/packages/hoppscotch-common/src/helpers/realtime/SIOClients.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/SIOClients.ts
@@ -5,7 +5,7 @@ import { io as ClientV3, Socket as SocketV3 } from "socket.io-client-v3"
 
 type Options = {
   path: string
-  auth: {
+  auth?: {
     token: string | undefined
   }
 }

--- a/packages/hoppscotch-common/src/helpers/realtime/SIOConnection.ts
+++ b/packages/hoppscotch-common/src/helpers/realtime/SIOConnection.ts
@@ -69,7 +69,7 @@ export class SIOConnection {
           },
         })
       } else {
-        this.socket.connect(url)
+        this.socket.connect(url, { path })
       }
 
       this.socket.on("connect", () => {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Closes #  Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
Socket.IO connection was failing for the server deployed on a custom path.
The reason being that path was not passed to the client implementations unless there was bearer token configured.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
The bug appeared in https://github.com/hoppscotch/hoppscotch/pull/2228 when for some reason path option was not handed over to the `SIOClient` anymore after the refactor

| Before https://github.com/hoppscotch/hoppscotch/pull/2228 |      After https://github.com/hoppscotch/hoppscotch/pull/2228   |
|----------|:-------------:|
| ![Code_QWfE1zRfaJ](https://github.com/user-attachments/assets/2832b605-be82-4844-b7d3-52f29d3bd707) | ![Code_AGgl6wthbA](https://github.com/user-attachments/assets/a71e4b70-2e52-4e0c-991e-8882a2b6e790) |
