### PR TITLE
fix(cli): remove `postinstall` script

### DIFF
--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoppscotch/cli",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "A CLI to run Hoppscotch test scripts in CI environments.",
   "homepage": "https://hoppscotch.io",
   "type": "module",
@@ -20,11 +20,9 @@
     "debugger": "node debugger.js 9999",
     "prepublish": "pnpm exec tsup",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",
-    "pretest": "pnpm run build",
-    "test": "vitest run",
+    "test": "pnpm run build && vitest run",
     "do-typecheck": "pnpm exec tsc --noEmit",
-    "do-test": "pnpm run test",
-    "postinstall": "pnpm run build"
+    "do-test": "pnpm run test"
   },
   "keywords": [
     "cli",


### PR DESCRIPTION
### What's changed

An attempt to install the CLI was halted due to the addition of the `postinstall` script. This PR removes the same and resolves this behaviour. Follow up of #4189.

The `pretest` script executing `pnpm run build` has been removed and the same is achieved via clubbing it with the `test` script since the `pretest` script was found not to be executed in the CI environment.

CLI version is bumped to `v0.10.1`.

Closes #4227.