### PR TITLE
fix: add to parameters regex

### DIFF
--- a/packages/hoppscotch-common/src/services/context-menu/menu/parameter.menu.ts
+++ b/packages/hoppscotch-common/src/services/context-menu/menu/parameter.menu.ts
@@ -61,7 +61,7 @@ export class ParameterMenuService extends Service implements ContextMenu {
       text = url.search.slice(1)
     }
 
-    const regex = /(\w+)=(\w+)/g
+    const regex = /([^&=]+)=([^&]+)/g
     const matches = text.matchAll(regex)
     const params: Param = {}
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4234

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
- The regex for parsing parameters has changed to support more valid url parameters
- It is able to parse more complicated key values like a lot of online parsers

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
The key can contain any character expect  '&' and a '='
A value can contain any character expect a '&' (which will start the next key) - it can include a '='

Reference: https://semalt.tools/en/url-parser
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
