### PR TITLE
i18n: Fix german translation for "label"

### DIFF
--- a/packages/hoppscotch-common/locales/de.json
+++ b/packages/hoppscotch-common/locales/de.json
@@ -25,7 +25,7 @@
     "go_forward": "Go forward",
     "group_by": "Gruppiere nach",
     "hide_secret": "Hide secret",
-    "label": "Etikett",
+    "label": "Bezeichnung",
     "learn_more": "Mehr erfahren",
     "download_here": "Download here",
     "less": "Weniger",


### PR DESCRIPTION
In #4195 I already fixed this translation.
I don't know why, but in #4196 I somehow overwrote it with the old (wrong) translation.
So now I would like to fix this translation (again).
