### PR TITLE
chore: add ai renames at more places

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/AddRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/AddRequest.vue
@@ -6,13 +6,28 @@
     @close="$emit('hide-modal')"
   >
     <template #body>
-      <HoppSmartInput
-        v-model="editingName"
-        placeholder=" "
-        :label="t('action.label')"
-        input-styles="floating-input"
-        @submit="addRequest"
-      />
+      <div class="flex gap-1">
+        <HoppSmartInput
+          v-model="editingName"
+          class="flex-grow"
+          placeholder=" "
+          :label="t('action.label')"
+          input-styles="floating-input"
+          @submit="addRequest"
+        />
+        <HoppButtonSecondary
+          v-if="canDoRequestNameGeneration"
+          v-tippy="{ theme: 'tooltip' }"
+          :icon="IconSparkle"
+          :disabled="isGenerateRequestNamePending"
+          class="rounded-md"
+          :class="{
+            'animate-pulse': isGenerateRequestNamePending,
+          }"
+          :title="t('ai_experiments.generate_request_name')"
+          @click="generateRequestName(props.requestContext)"
+        />
+      </div>
     </template>
     <template #footer>
       <span class="flex space-x-2">
@@ -39,6 +54,9 @@ import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
 import { useService } from "dioc/vue"
 import { RESTTabService } from "~/services/tab/rest"
+import { useRequestNameGeneration } from "~/composables/ai-experiments"
+import { HoppRESTRequest } from "@hoppscotch/data"
+import IconSparkle from "~icons/lucide/sparkles"
 
 const toast = useToast()
 const t = useI18n()
@@ -47,10 +65,12 @@ const props = withDefaults(
   defineProps<{
     show: boolean
     loadingState: boolean
+    requestContext: HoppRESTRequest | null
   }>(),
   {
     show: false,
     loadingState: false,
+    requestContext: null,
   }
 )
 
@@ -60,6 +80,12 @@ const emit = defineEmits<{
 }>()
 
 const editingName = ref("")
+
+const {
+  generateRequestName,
+  isGenerateRequestNamePending,
+  canDoRequestNameGeneration,
+} = useRequestNameGeneration(editingName)
 
 const tabs = useService(RESTTabService)
 watch(

--- a/packages/hoppscotch-common/src/components/collections/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/EditRequest.vue
@@ -16,7 +16,7 @@
           @submit="editRequest"
         />
         <HoppButtonSecondary
-          v-if="showGenerateRequestNameButton"
+          v-if="canDoRequestNameGeneration"
           v-tippy="{ theme: 'tooltip' }"
           :icon="IconSparkle"
           :disabled="isGenerateRequestNamePending"
@@ -25,7 +25,7 @@
             'animate-pulse': isGenerateRequestNamePending,
           }"
           :title="t('ai_experiments.generate_request_name')"
-          @click="generateRequestName"
+          @click="generateRequestName(props.requestContext)"
         />
       </div>
     </template>
@@ -53,12 +53,7 @@ import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
 import { HoppRESTRequest } from "@hoppscotch/data"
 import { useVModel } from "@vueuse/core"
-import * as E from "fp-ts/Either"
-import { computed, ref } from "vue"
-
-import { useSetting } from "~/composables/settings"
-import { useReadonlyStream } from "~/composables/stream"
-import { platform } from "~/platform"
+import { useRequestNameGeneration } from "~/composables/ai-experiments"
 import IconSparkle from "~icons/lucide/sparkles"
 
 const toast = useToast()
@@ -84,58 +79,13 @@ const emit = defineEmits<{
   (e: "update:modelValue", value: string): void
 }>()
 
-const ENABLE_AI_EXPERIMENTS = useSetting("ENABLE_AI_EXPERIMENTS")
-
 const editingName = useVModel(props, "modelValue")
 
-const currentUser = useReadonlyStream(
-  platform.auth.getCurrentUserStream(),
-  platform.auth.getCurrentUser()
-)
-
-const isGenerateRequestNamePending = ref(false)
-
-const showGenerateRequestNameButton = computed(() => {
-  // Request generation applies only to the authenticated state
-  if (!currentUser.value) {
-    return false
-  }
-
-  return ENABLE_AI_EXPERIMENTS.value && !!platform.experiments?.aiExperiments
-})
-
-const generateRequestName = async () => {
-  const generateRequestNameForPlatform =
-    platform.experiments?.aiExperiments?.generateRequestName
-
-  if (!props.requestContext || !generateRequestNameForPlatform) {
-    toast.error(t("request.generate_name_error"))
-    return
-  }
-
-  isGenerateRequestNamePending.value = true
-
-  platform.analytics?.logEvent({
-    type: "EXPERIMENTS_GENERATE_REQUEST_NAME_WITH_AI",
-    platform: "rest",
-  })
-
-  const result = await generateRequestNameForPlatform(
-    JSON.stringify(props.requestContext)
-  )
-
-  if (result && E.isLeft(result)) {
-    toast.error(t("request.generate_name_error"))
-
-    isGenerateRequestNamePending.value = false
-
-    return
-  }
-
-  editingName.value = result.right
-
-  isGenerateRequestNamePending.value = false
-}
+const {
+  generateRequestName,
+  canDoRequestNameGeneration,
+  isGenerateRequestNamePending,
+} = useRequestNameGeneration(editingName)
 
 const editRequest = () => {
   if (editingName.value.trim() === "") {

--- a/packages/hoppscotch-common/src/components/collections/graphql/AddRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/AddRequest.vue
@@ -6,13 +6,28 @@
     @close="emit('hide-modal')"
   >
     <template #body>
-      <HoppSmartInput
-        v-model="editingName"
-        placeholder=" "
-        :label="t('action.label')"
-        input-styles="floating-input"
-        @submit="addRequest"
-      />
+      <div class="flex gap-1 items-center">
+        <HoppSmartInput
+          v-model="editingName"
+          class="flex-grow"
+          placeholder=" "
+          :label="t('action.label')"
+          input-styles="floating-input"
+          @submit="addRequest"
+        />
+        <HoppButtonSecondary
+          v-if="canDoRequestNameGeneration"
+          v-tippy="{ theme: 'tooltip' }"
+          :icon="IconSparkle"
+          :disabled="isGenerateRequestNamePending"
+          class="rounded-md"
+          :class="{
+            'animate-pulse': isGenerateRequestNamePending,
+          }"
+          :title="t('ai_experiments.generate_request_name')"
+          @click="generateRequestName(props.requestContext)"
+        />
+      </div>
     </template>
     <template #footer>
       <span class="flex space-x-2">
@@ -33,11 +48,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
+import { HoppRESTRequest } from "@hoppscotch/data"
 import { useService } from "dioc/vue"
+import { ref, watch } from "vue"
+
+import { useRequestNameGeneration } from "~/composables/ai-experiments"
 import { GQLTabService } from "~/services/tab/graphql"
+import IconSparkle from "~icons/lucide/sparkles"
 
 const toast = useToast()
 const t = useI18n()
@@ -47,6 +66,7 @@ const tabs = useService(GQLTabService)
 const props = defineProps<{
   show: boolean
   folderPath?: string
+  requestContext: HoppRESTRequest | null
 }>()
 
 const emit = defineEmits<{
@@ -61,6 +81,12 @@ const emit = defineEmits<{
 }>()
 
 const editingName = ref("")
+
+const {
+  generateRequestName,
+  isGenerateRequestNamePending,
+  canDoRequestNameGeneration,
+} = useRequestNameGeneration(editingName)
 
 watch(
   () => props.show,

--- a/packages/hoppscotch-common/src/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/index.vue
@@ -116,6 +116,7 @@
     <CollectionsGraphqlAddRequest
       :show="showModalAddRequest"
       :folder-path="editingFolderPath"
+      :request-context="requestContext"
       @add-request="onAddRequest($event)"
       @hide-modal="displayModalAddRequest(false)"
     />
@@ -328,6 +329,10 @@ const filteredCollections = computed(() => {
   }
 
   return filteredCollections
+})
+
+const requestContext = computed(() => {
+  return tabs.currentActiveTab.value.document.request
 })
 
 const displayModalAdd = (shouldDisplay: boolean) => {

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -116,7 +116,7 @@
     <CollectionsAddRequest
       :show="showModalAddRequest"
       :loading-state="modalLoadingState"
-      :request-context="addRequestRequestContext"
+      :request-context="requestContext"
       @add-request="onAddRequest"
       @hide-modal="displayModalAddRequest(false)"
     />
@@ -791,7 +791,7 @@ const addRequest = (payload: {
   displayModalAddRequest(true)
 }
 
-const addRequestRequestContext = computed(() => {
+const requestContext = computed(() => {
   return tabs.currentActiveTab.value.document.request
 })
 

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -116,6 +116,7 @@
     <CollectionsAddRequest
       :show="showModalAddRequest"
       :loading-state="modalLoadingState"
+      :request-context="addRequestRequestContext"
       @add-request="onAddRequest"
       @hide-modal="displayModalAddRequest(false)"
     />
@@ -789,6 +790,10 @@ const addRequest = (payload: {
   editingFolderPath.value = path
   displayModalAddRequest(true)
 }
+
+const addRequestRequestContext = computed(() => {
+  return tabs.currentActiveTab.value.document.request
+})
 
 const onAddRequest = (requestName: string) => {
   const newRequest = {

--- a/packages/hoppscotch-common/src/composables/ai-experiments.ts
+++ b/packages/hoppscotch-common/src/composables/ai-experiments.ts
@@ -1,0 +1,78 @@
+import { computed, Ref, ref } from "vue"
+import { useReadonlyStream } from "./stream"
+import { platform } from "~/platform"
+import { useSetting } from "./settings"
+import { HoppGQLRequest, HoppRESTRequest } from "@hoppscotch/data"
+import { useToast } from "@composables/toast"
+import { useI18n } from "@composables/i18n"
+import * as E from "fp-ts/Either"
+import { useRoute } from "vue-router"
+
+export const useRequestNameGeneration = (targetNameRef: Ref<string>) => {
+  const toast = useToast()
+  const t = useI18n()
+  const route = useRoute()
+
+  const targetPage = computed(() => {
+    return route.fullPath.includes("/graphql") ? "gql" : "rest"
+  })
+
+  const isGenerateRequestNamePending = ref(false)
+
+  const generateRequestNameForPlatform =
+    platform.experiments?.aiExperiments?.generateRequestName
+
+  const currentUser = useReadonlyStream(
+    platform.auth.getCurrentUserStream(),
+    platform.auth.getCurrentUser()
+  )
+
+  const ENABLE_AI_EXPERIMENTS = useSetting("ENABLE_AI_EXPERIMENTS")
+
+  const canDoRequestNameGeneration = computed(() => {
+    // Request generation applies only to the authenticated state
+    if (!currentUser.value) {
+      return false
+    }
+
+    return ENABLE_AI_EXPERIMENTS.value && !!platform.experiments?.aiExperiments
+  })
+
+  const generateRequestName = async (
+    requestContext: HoppRESTRequest | HoppGQLRequest | null
+  ) => {
+    if (!requestContext || !generateRequestNameForPlatform) {
+      toast.error(t("request.generate_name_error"))
+      return
+    }
+
+    isGenerateRequestNamePending.value = true
+
+    platform.analytics?.logEvent({
+      type: "EXPERIMENTS_GENERATE_REQUEST_NAME_WITH_AI",
+      platform: targetPage.value,
+    })
+
+    const result = await generateRequestNameForPlatform(
+      JSON.stringify(requestContext)
+    )
+
+    if (result && E.isLeft(result)) {
+      toast.error(t("request.generate_name_error"))
+
+      isGenerateRequestNamePending.value = false
+
+      return
+    }
+
+    targetNameRef.value = result.right
+
+    isGenerateRequestNamePending.value = false
+  }
+
+  return {
+    generateRequestName,
+    isGenerateRequestNamePending,
+    canDoRequestNameGeneration,
+  }
+}

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomnia.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomnia.ts
@@ -126,6 +126,7 @@ const getHoppReqAuth = (req: InsomniaRequestResource): HoppRESTAuth => {
         isPKCE: false,
         tokenEndpoint: replaceVarTemplating(auth.accessTokenUrl ?? ""),
       },
+      addTo: "HEADERS",
     }
   else if (auth.type === "bearer")
     return {


### PR DESCRIPTION
### What's changed

1. move the rename logic to a composable `useRequestNameGeneration` to remove duplication among multiple components having the rename logic
2. adds rename with ai sparkle icons to
    - adding a new request from the sidebar
    - save as request modal
3. detect if the rename is triggered from graphql / rest  using the current route the user is in