### PR TITLE
chore: hide duplicate `Global environment` action for a team workspace

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -55,8 +55,7 @@
     "turn_off": "Turn off",
     "turn_on": "Turn on",
     "undo": "Undo",
-    "yes": "Yes",
-    "duplicate_to_personal_workspace": "Duplicate to personal workspace"
+    "yes": "Yes"
   },
   "add": {
     "new": "Add new",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -55,7 +55,8 @@
     "turn_off": "Turn off",
     "turn_on": "Turn on",
     "undo": "Undo",
-    "yes": "Yes"
+    "yes": "Yes",
+    "duplicate_to_personal_workspace": "Duplicate to personal workspace"
   },
   "add": {
     "new": "Add new",

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -7,11 +7,12 @@
       <EnvironmentsMyEnvironment
         environment-index="Global"
         :environment="globalEnvironment"
+        :show-duplicate-action="isPersonalEnvironmentType"
         class="border-b border-dividerLight"
         @edit-environment="editEnvironment('Global')"
       />
     </div>
-    <EnvironmentsMy v-show="environmentType.type === 'my-environments'" />
+    <EnvironmentsMy v-show="isPersonalEnvironmentType" />
     <EnvironmentsTeams
       v-show="environmentType.type === 'team-environments'"
       :team="environmentType.selectedTeam"
@@ -93,6 +94,10 @@ const globalEnvironment = computed(() => ({
   name: "Global",
   variables: globalEnv.value,
 }))
+
+const isPersonalEnvironmentType = computed(
+  () => environmentType.value.type === "my-environments"
+)
 
 const currentUser = useReadonlyStream(
   platform.auth.getCurrentUserStream(),

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="group flex items-stretch"
-    @contextmenu.prevent="options!.tippy.show()"
+    @contextmenu.prevent="options!.tippy?.show()"
   >
     <span
       v-if="environmentIndex === 'Global'"
@@ -69,7 +69,11 @@
             <HoppSmartItem
               ref="duplicate"
               :icon="IconCopy"
-              :label="`${t('action.duplicate')}`"
+              :label="
+                isGlobalEnvironment
+                  ? t('action.duplicate_to_personal_workspace')
+                  : t('action.duplicate')
+              "
               :shortcut="['D']"
               @click="
                 () => {
@@ -117,26 +121,26 @@
 </template>
 
 <script setup lang="ts">
-import IconMoreVertical from "~icons/lucide/more-vertical"
-import IconEdit from "~icons/lucide/edit"
-import IconCopy from "~icons/lucide/copy"
-import IconTrash2 from "~icons/lucide/trash-2"
-import { ref } from "vue"
-import { Environment } from "@hoppscotch/data"
-import { cloneDeep } from "lodash-es"
-import {
-  deleteEnvironment,
-  duplicateEnvironment,
-  createEnvironment,
-  getGlobalVariables,
-} from "~/newstore/environments"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
-import { TippyComponent } from "vue-tippy"
+import { Environment } from "@hoppscotch/data"
 import { HoppSmartItem } from "@hoppscotch/ui"
-import { exportAsJSON } from "~/helpers/import-export/export/environment"
 import { useService } from "dioc/vue"
+import { cloneDeep } from "lodash-es"
+import { computed, ref } from "vue"
+import { TippyComponent } from "vue-tippy"
+import { exportAsJSON } from "~/helpers/import-export/export/environment"
+import {
+  createEnvironment,
+  deleteEnvironment,
+  duplicateEnvironment,
+  getGlobalVariables,
+} from "~/newstore/environments"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
+import IconCopy from "~icons/lucide/copy"
+import IconEdit from "~icons/lucide/edit"
+import IconMoreVertical from "~icons/lucide/more-vertical"
+import IconTrash2 from "~icons/lucide/trash-2"
 
 const t = useI18n()
 const toast = useToast()
@@ -154,6 +158,8 @@ const confirmRemove = ref(false)
 
 const secretEnvironmentService = useService(SecretEnvironmentService)
 
+const isGlobalEnvironment = computed(() => props.environmentIndex === "Global")
+
 const exportEnvironmentAsJSON = () => {
   const { environment, environmentIndex } = props
   exportAsJSON(environment, environmentIndex)
@@ -161,7 +167,7 @@ const exportEnvironmentAsJSON = () => {
     : toast.error(t("state.download_failed"))
 }
 
-const tippyActions = ref<TippyComponent | null>(null)
+const tippyActions = ref<HTMLDivElement | null>(null)
 const options = ref<TippyComponent | null>(null)
 const edit = ref<typeof HoppSmartItem>()
 const duplicate = ref<typeof HoppSmartItem>()
@@ -170,8 +176,8 @@ const deleteAction = ref<typeof HoppSmartItem>()
 
 const removeEnvironment = () => {
   if (props.environmentIndex === null) return
-  if (props.environmentIndex !== "Global") {
-    deleteEnvironment(props.environmentIndex, props.environment.id)
+  if (!isGlobalEnvironment.value) {
+    deleteEnvironment(props.environmentIndex as number, props.environment.id)
     secretEnvironmentService.deleteSecretEnvironment(props.environment.id)
   }
   toast.success(`${t("state.deleted")}`)
@@ -179,12 +185,12 @@ const removeEnvironment = () => {
 
 const duplicateEnvironments = () => {
   if (props.environmentIndex === null) return
-  if (props.environmentIndex === "Global") {
+  if (isGlobalEnvironment.value) {
     createEnvironment(
       `Global - ${t("action.duplicate")}`,
       cloneDeep(getGlobalVariables())
     )
-  } else duplicateEnvironment(props.environmentIndex)
+  } else duplicateEnvironment(props.environmentIndex as number)
 
   toast.success(`${t("environment.duplicated")}`)
 }

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -45,7 +45,7 @@
             tabindex="0"
             role="menu"
             @keyup.e="edit!.$el.click()"
-            @keyup.d="duplicate!.$el.click()"
+            @keyup.d="showDuplicateAction ? duplicate!.$el.click() : null"
             @keyup.j="exportAsJsonEl!.$el.click()"
             @keyup.delete="
               !(environmentIndex === 'Global')
@@ -67,13 +67,10 @@
               "
             />
             <HoppSmartItem
+              v-if="showDuplicateAction"
               ref="duplicate"
               :icon="IconCopy"
-              :label="
-                isGlobalEnvironment
-                  ? t('action.duplicate_to_personal_workspace')
-                  : t('action.duplicate')
-              "
+              :label="t('action.duplicate')"
               :shortcut="['D']"
               @click="
                 () => {
@@ -145,10 +142,16 @@ import IconTrash2 from "~icons/lucide/trash-2"
 const t = useI18n()
 const toast = useToast()
 
-const props = defineProps<{
-  environment: Environment
-  environmentIndex: number | "Global" | null
-}>()
+const props = withDefaults(
+  defineProps<{
+    environment: Environment
+    environmentIndex: number | "Global" | null
+    showDuplicateAction: boolean
+  }>(),
+  {
+    showDuplicateAction: true,
+  }
+)
 
 const emit = defineEmits<{
   (e: "edit-environment"): void


### PR DESCRIPTION
### Description

Duplicating the `Global environment` is an action specific to the personal workspace. The above context isn't conveyed while attempting the action from a team workspace. New environment entries are added under the personal workspace with a success toast. This PR hides the `Global environment` duplicate action while at a team workspace. The same action via spotlight is enabled regardless of the active workspace.

### Preview

https://github.com/user-attachments/assets/0b16eb2c-6c91-446d-9302-13377ec0ef2c

### What's changed

- A new prop `showDuplicateActions` added under the `EnvironmentsMyEnvironment` component that defaults to `true`. It is set based on the active workspace type for the `Global environment` entry.
- Compile repeated checks in computed properties.
- Resolves a few pre-existing type errors found in scope.

### Note to reviewers

Initially, a copy text update was proposed to convey the behavior and later it was decided to be explicit and disable the duplicate action while at a team workspace.