### PR TITLE
fix: reset currentEnv if there is a shared workspace change

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -141,13 +141,22 @@ const workspace = workspaceService.currentWorkspace
 watch(workspace, (newWorkspace) => {
   if (newWorkspace.type === "personal") {
     switchToMyEnvironments()
-    if (selectedEnvironmentIndex.value.type !== "MY_ENV") {
-      setSelectedEnvironmentIndex({
-        type: "NO_ENV_SELECTED",
-      })
-    }
   } else if (newWorkspace.type === "team") {
     updateSelectedTeam(newWorkspace)
+  }
+
+  const newSharedWorkspaceID =
+    newWorkspace.type === "team" ? newWorkspace.teamID : undefined
+
+  //update the selected environment index to no env selected
+  //if the shared workspace is changed
+  if (
+    selectedEnvironmentIndex.value.type === "TEAM_ENV" &&
+    selectedEnvironmentIndex.value.teamID !== newSharedWorkspaceID
+  ) {
+    setSelectedEnvironmentIndex({
+      type: "NO_ENV_SELECTED",
+    })
   }
 })
 

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -139,20 +139,22 @@ const workspace = workspaceService.currentWorkspace
 // Switch to my environments if workspace is personal and to team environments if workspace is team
 // also resets selected environment if workspace is personal and the previous selected environment was a team environment
 watch(workspace, (newWorkspace) => {
-  if (newWorkspace.type === "personal") {
+  const { type: newWorkspaceType } = newWorkspace
+
+  if (newWorkspaceType === "personal") {
     switchToMyEnvironments()
-  } else if (newWorkspace.type === "team") {
+  } else {
     updateSelectedTeam(newWorkspace)
   }
 
-  const newSharedWorkspaceID =
-    newWorkspace.type === "team" ? newWorkspace.teamID : undefined
+  const newTeamID =
+    newWorkspaceType === "team" ? newWorkspace.teamID : undefined
 
-  //update the selected environment index to no env selected
-  //if the shared workspace is changed
+  // Set active environment to the `No environment` state
+  // if navigating away from a team workspace
   if (
     selectedEnvironmentIndex.value.type === "TEAM_ENV" &&
-    selectedEnvironmentIndex.value.teamID !== newSharedWorkspaceID
+    selectedEnvironmentIndex.value.teamID !== newTeamID
   ) {
     setSelectedEnvironmentIndex({
       type: "NO_ENV_SELECTED",

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -1,6 +1,5 @@
 import { Service } from "dioc"
-import { reactive } from "vue"
-import { computed } from "vue"
+import { reactive, computed } from "vue"
 
 /**
  * Defines a secret environment variable.


### PR DESCRIPTION
Closes HFE-560

This PR fixes the a bug in the environment selector where the current environment was not getting invalidated while switching shared workspaces.

The current environment flow will be as following - 

- user has a personal env selected, changes to a shared workspace - selected env does not change
- user has a team env selected, changes to another shared workspace or personal workspace- change current env to `NO_ENV_SELECTED`

### What's changed
Current selected environment switches to `NO_ENV_SELECTED` if there is switch in shared workspace.

