### PR TITLE
fix: sync all settings actions in SH

### DIFF
--- a/packages/hoppscotch-selfhost-desktop/src/lib/sync/index.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/lib/sync/index.ts
@@ -80,7 +80,7 @@ export const getSyncInitFunction = <T extends DispatchingStore<any, any>>(
       )
     }
 
-    stopSubscriptions = startSubscriptions()
+    stopSubscriptions = startSubscriptions?.()
   }
 
   function stopListeningToSubscriptions() {
@@ -90,7 +90,7 @@ export const getSyncInitFunction = <T extends DispatchingStore<any, any>>(
       )
     }
 
-    stopSubscriptions()
+    stopSubscriptions?.()
   }
 
   return {

--- a/packages/hoppscotch-selfhost-desktop/src/platform/settings/settings.sync.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/platform/settings/settings.sync.ts
@@ -9,7 +9,16 @@ import { updateUserSettings } from "./settings.api"
 export const settingsSyncDefinition: StoreSyncDefinitionOf<
   typeof settingsStore
 > = {
+  toggleSetting() {
+    updateUserSettings(JSON.stringify(settingsStore.value))
+  },
+  toggleNestedSetting() {
+    updateUserSettings(JSON.stringify(settingsStore.value))
+  },
   applySetting() {
+    updateUserSettings(JSON.stringify(settingsStore.value))
+  },
+  applyNestedSetting() {
     updateUserSettings(JSON.stringify(settingsStore.value))
   },
 }

--- a/packages/hoppscotch-selfhost-web/src/lib/sync/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/lib/sync/index.ts
@@ -80,7 +80,7 @@ export const getSyncInitFunction = <T extends DispatchingStore<any, any>>(
       )
     }
 
-    stopSubscriptions = startSubscriptions()
+    stopSubscriptions = startSubscriptions?.()
   }
 
   function stopListeningToSubscriptions() {
@@ -90,7 +90,7 @@ export const getSyncInitFunction = <T extends DispatchingStore<any, any>>(
       )
     }
 
-    stopSubscriptions()
+    stopSubscriptions?.()
   }
 
   return {

--- a/packages/hoppscotch-selfhost-web/src/platform/settings/settings.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/settings/settings.sync.ts
@@ -9,7 +9,16 @@ import { updateUserSettings } from "./settings.api"
 export const settingsSyncDefinition: StoreSyncDefinitionOf<
   typeof settingsStore
 > = {
+  toggleSetting() {
+    updateUserSettings(JSON.stringify(settingsStore.value))
+  },
+  toggleNestedSetting() {
+    updateUserSettings(JSON.stringify(settingsStore.value))
+  },
   applySetting() {
+    updateUserSettings(JSON.stringify(settingsStore.value))
+  },
+  applyNestedSetting() {
     updateUserSettings(JSON.stringify(settingsStore.value))
   },
 }


### PR DESCRIPTION
### What's changed

Previously, the following settings were not getting synced in SH:

- `Expand navigation` & `Sidebar on left` under `Experiments`.
- Spotlight open status.
- Wrap lines preference under request params, headers in bulk mode, etc.
- `Collections`, `Environments` & `History` synchronization settings under the profile page.

This was the case since the relevant store dispatcher methods were not present under the store sync definition maintained at the platform level. This PR resolves this behaviour by extending the above definition accordingly. There was also a known issue with toggling the synchronization settings (Collections, Environments & History) under the profile page resulting in an exception which is fixed by adding safeguards with the usage of `startSubscriptions()` & `stopSubscriptions()` function calls from the syncing context.

Closes HFE-324 HFE-561.

### Notes to reviewers

While verifying the wrap lines preference toggle sync behaviour, make sure to check all request tabs applicable to the action.

https://github.com/hoppscotch/hoppscotch/blob/3f78bf10621eb2c6574f3a19f6169aeda016d69b/packages/hoppscotch-common/src/newstore/settings.ts#L32-L49