### PR TITLE
Add Open Containers Initiative (OCI) labels

### DIFF
--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -95,6 +95,11 @@ ENV PORT=8080
 ENV APP_PORT=${PORT}
 ENV DB_URL=${DATABASE_URL}
 
+# Open Containers Initiative (OCI) labels - useful for bots like Renovate
+LABEL org.opencontainers.image.source="https://github.com/hoppscotch/hoppscotch" \
+  org.opencontainers.image.url="https://docs.hoppscotch.io" \
+  org.opencontainers.image.licenses="MIT"
+
 # Run this separately to use the cache from backend
 RUN apk add caddy
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This Pull Requests adds the Open Containers Initiative (OCI) labels to the Docker image. This is useful for tools like Renovate Bot to be able to add changelog/release note information to a Pull Request.

As you can see on this PR (https://github.com/DevSecNinja/home/pull/596), Renovate can't find the change log for Hoppschotch while it can for PRs like this: https://github.com/DevSecNinja/home/pull/627

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
- [x] Added the minimal labels from the OCI spec
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
See the following docs:

Renovate Doc: https://docs.renovatebot.com/modules/datasource/docker/#description
Example from Renovate: https://github.com/renovatebot/renovate/blob/main/tools/docker/Dockerfile#L78C1-L81C52
OCI spec sheet: https://specs.opencontainers.org/image-spec/annotations/