### PR TITLE
feat(cli): add support for request variables

### DIFF
--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoppscotch/cli",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "A CLI to run Hoppscotch test scripts in CI environments.",
   "homepage": "https://hoppscotch.io",
   "type": "module",

--- a/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
@@ -335,6 +335,7 @@ describe("hopp test [options] <file_path_or_id>", () => {
             "secret-envs-persistence-scripting-envs.json",
             "environment"
           );
+
           const args = `test ${COLL_PATH} --env ${ENVS_PATH}`;
 
           const { error } = await runCLI(args);
@@ -343,6 +344,45 @@ describe("hopp test [options] <file_path_or_id>", () => {
       },
       { timeout: 20000 }
     );
+
+    describe("Request variables", () => {
+      test("Picks active request variables and ignores inactive entries", async () => {
+        const COLL_PATH = getTestJsonFilePath(
+          "request-vars-coll.json",
+          "collection"
+        );
+
+        const args = `test ${COLL_PATH}`;
+
+        const { error } = await runCLI(args);
+        expect(error).toBeNull();
+      });
+
+      test("Supports the usage of request variables along with environment variables", async () => {
+        const env = {
+          ...process.env,
+          secretBasicAuthUsernameEnvVar: "username",
+          secretBasicAuthPasswordEnvVar: "password",
+        };
+
+        const COLL_PATH = getTestJsonFilePath(
+          "request-vars-coll.json",
+          "collection"
+        );
+        const ENVS_PATH = getTestJsonFilePath(
+          "request-vars-envs.json",
+          "environment"
+        );
+
+        const args = `test ${COLL_PATH} --env ${ENVS_PATH}`;
+
+        const { error, stdout } = await runCLI(args, { env });
+        expect(stdout).toContain(
+          "https://echo.hoppscotch.io/********/********"
+        );
+        expect(error).toBeNull();
+      });
+    });
   });
 
   describe("Test `hopp test <file_path_or_id> --delay <delay_in_ms>` command:", () => {

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/request-vars-coll.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/request-vars-coll.json
@@ -1,0 +1,188 @@
+{
+  "v": 2,
+  "name": "Request variables",
+  "folders": [],
+  "requests": [
+    {
+      "v": "6",
+      "auth": {
+        "authType": "inherit",
+        "authActive": true
+      },
+      "body": {
+        "body": "{\n  \"<<httpBodyRawKey>>\": \"<<httpBodyRawValue>>\"\n}",
+        "contentType": "application/json"
+      },
+      "name": "request-variables-basic-usage",
+      "method": "POST",
+      "params": [
+        {
+          "key": "<<queryParamKey>>",
+          "value": "<<queryParamValue>>",
+          "active": true
+        },
+        {
+          "key": "inactive-query-param-key",
+          "value": "<<inactiveQueryParamValue>>",
+          "active": true
+        }
+      ],
+      "headers": [
+        {
+          "key": "<<customHeaderKey>>",
+          "value": "<<customHeaderValue>>",
+          "active": true
+        },
+        {
+          "key": "inactive-header-key",
+          "value": "<<inactiveHeaderValue>>",
+          "active": true
+        }
+      ],
+      "endpoint": "<<url>>",
+      "testScript": "pw.test(\"Accounts for active request variables\", ()=> {\n  pw.expect(pw.response.body.args[\"query-param-key\"]).toBe(\"query-param-value\");\n\n  const data = JSON.parse(pw.response.body.data)\n\n  pw.expect(data[\"http-body-raw-key\"]).toBe(\"http-body-raw-value\")\n\n  pw.expect(pw.response.body.headers[\"custom-header-key\"]).toBe(\"custom-header-value\");\n});\n\npw.test(\"Ignores inactive request variables\", () => {\n  pw.expect(pw.response.body.args[\"inactive-query-param-key\"]).toBe(\"\")\n  pw.expect(pw.response.body.args[\"inactive-header-key\"]).toBe(undefined)\n})",
+      "preRequestScript": "",
+      "requestVariables": [
+        {
+          "key": "url",
+          "value": "https://echo.hoppscotch.io",
+          "active": true
+        },
+        {
+          "key": "method",
+          "value": "POST",
+          "active": true
+        },
+        {
+          "key": "httpBodyRawKey",
+          "value": "http-body-raw-key",
+          "active": true
+        },
+        {
+          "key": "httpBodyRawValue",
+          "value": "http-body-raw-value",
+          "active": true
+        },
+        {
+          "key": "customHeaderKey",
+          "value": "custom-header-key",
+          "active": true
+        },
+        {
+          "key": "customHeaderValue",
+          "value": "custom-header-value",
+          "active": true
+        },
+        {
+          "key": "queryParamKey",
+          "value": "query-param-key",
+          "active": true
+        },
+        {
+          "key": "queryParamValue",
+          "value": "query-param-value",
+          "active": true
+        },
+        {
+          "key": "inactiveQueryParamValue",
+          "value": "inactive-query-param-value",
+          "active": false
+        },
+        {
+          "key": "inactiveHeaderValue",
+          "value": "inactive-header-value",
+          "active": false
+        }
+      ]
+    },
+    {
+      "v": "6",
+      "auth": {
+        "authType": "none",
+        "password": "<<password>>",
+        "username": "<<username>>",
+        "authActive": true
+      },
+      "body": {
+        "body": "{\n  \"username\": \"<<username>>\",\n  \"password\": \"<<password>>\"\n}",
+        "contentType": "application/json"
+      },
+      "name": "request-variables-alongside-environment-variables",
+      "method": "POST",
+      "params": [
+        {
+          "key": "method",
+          "value": "<<method>>",
+          "active": true
+        }
+      ],
+      "headers": [
+        {
+          "key": "test-header-key",
+          "value": "<<testHeaderValue>>",
+          "active": true
+        }
+      ],
+      "endpoint": "<<url>>/<<path>>",
+      "testScript": "pw.test(\"The first occurrence is picked for multiple request variable occurrences with the same key.\", () => {\n  pw.expect(pw.response.body.args.method).toBe(\"post\");\n});\n\npw.test(\"Request variables support recursive resolution and pick values from secret environment variables\", () => {\n  const { username, password } = JSON.parse(pw.response.body.data)\n\n  pw.expect(username).toBe(\"username\")\n  pw.expect(password).toBe(\"password\")\n\n})\n\npw.test(\"Resolves request variables that are clubbed together\", () => {\n  pw.expect(pw.response.body.path).toBe(\"/username/password\")\n})\n\npw.test(\"Request variables are prioritised over environment variables\", () => {\n  pw.expect(pw.response.body.headers.host).toBe(\"echo.hoppscotch.io\")\n})\n\npw.test(\"Environment variable is picked if the request variable under the same name is empty\", () => {\n  pw.expect(pw.response.body.headers[\"test-header-key\"]).toBe(\"test-header-value\")\n})",
+      "preRequestScript": "",
+      "requestVariables": [
+        {
+          "key": "url",
+          "value": "https://echo.hoppscotch.io",
+          "active": true
+        },
+        {
+          "key": "username",
+          "value": "<<recursiveBasicAuthUsernameReqVar>>",
+          "active": true
+        },
+        {
+          "key": "recursiveBasicAuthUsernameReqVar",
+          "value": "<<secretBasicAuthUsernameEnvVar>>",
+          "active": true
+        },
+        {
+          "key": "password",
+          "value": "<<recursiveBasicAuthPasswordReqVar>>",
+          "active": true
+        },
+        {
+          "key": "recursiveBasicAuthPasswordReqVar",
+          "value": "<<secretBasicAuthPasswordEnvVar>>",
+          "active": true
+        },
+        {
+          "key": "method",
+          "value": "post",
+          "active": true
+        },
+        {
+          "key": "method",
+          "value": "get",
+          "active": true
+        },
+        {
+          "key": "method",
+          "value": "put",
+          "active": true
+        },
+        {
+          "key": "path",
+          "value": "<<username>>/<<password>>",
+          "active": true
+        },
+        {
+          "key": "testHeaderValue",
+          "value": "",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "auth": {
+    "authType": "inherit",
+    "authActive": true
+  },
+  "headers": []
+}

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/request-vars-envs.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/request-vars-envs.json
@@ -1,0 +1,34 @@
+{
+  "v": 1,
+  "id": "cm00r7kpb0006mbd2nq1560w6",
+  "name": "Request variables alongside environment variables",
+  "variables": [
+    {
+      "key": "url",
+      "value": "https://echo.hoppscotch.io",
+      "secret": false
+    },
+    {
+      "key": "secretBasicAuthPasswordEnvVar",
+      "secret": true
+    },
+    {
+      "key": "secretBasicAuthUsernameEnvVar",
+      "value": "username",
+      "secret": true
+    },
+    {
+      "key": "username",
+      "secret": true
+    },
+    {
+      "key": "password",
+      "secret": true
+    },
+    {
+      "key": "testHeaderValue",
+      "value": "test-header-value",
+      "secret": false
+    }
+  ]
+}

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -4,7 +4,7 @@ import {
   HoppRESTRequest,
   RESTReqSchemaVersion,
 } from "@hoppscotch/data";
-import axios, { AxiosResponse, Method } from "axios";
+import axios, { Method } from "axios";
 import * as A from "fp-ts/Array";
 import * as E from "fp-ts/Either";
 import * as T from "fp-ts/Task";


### PR DESCRIPTION
### Description

This PR adds support for request variables in the CLI. Request variables will have the topmost priority, meaning they will be preferred over any environment variables sharing the same name.

Closes HFE-552.

### Changes

- New `getResolvedVariables()` helper function added under [~/utils/getters.ts](https://github.com/hoppscotch/hoppscotch/pull/4275/files#diff-484af5d66255ca92b321d69e2ad27f54a0323413d566793f2a117e15cceb3261) that takes in the list of request variables and environment variables for a session and returns a resolved list of variables where keys sharing the same name from environment variables are removed ensuring request variables take priority.
- Relevant instances are updated to account for request variables, alongside environment variables via the above helper function.
- Relevant test updates and associated fixture additions.
- Bumps CLI version to `0.11.0`.

### Notes to reviewers

> Steps to verify

Navigate to the `hoppscotch-cli` package path locally, and run `pnpm build`. Run the collection via:

```sh
secretBasicAuthPasswordEnvVar=password  bin/hopp.js test <collection_export_file_path> --env <environment_export_file_path>
```

> `secretBasicAuthPasswordEnvVar` being a secret environment variable, can either be supplied along with environment variables for the session as above or specifying the `value` field in the environment export file.

The [collection](https://github.com/hoppscotch/hoppscotch/pull/4275/files#diff-b30c6de10a80e19976a7b4bd00765268a2270b14fdc633aefa4e561aca7f9de2) and [environment](https://github.com/hoppscotch/hoppscotch/pull/4275/files#diff-dab0020edfa6b4903699f6ae2b091df8f3ad261f8550ad2875011d5c74fa87cf) export files added under test fixtures can be used to verify the behaviour comprising relevant tests covering various scenarios where a request variable comes into play:
- Ignores inactive request variables.
- Usage alongside environment variables where request variables take priority and ensure support for recursive resolution.