### PR TITLE
fix: issues with port binding in different container runtimes

### DIFF
--- a/aio-multiport-setup.Caddyfile
+++ b/aio-multiport-setup.Caddyfile
@@ -1,6 +1,6 @@
 {
-  admin off
-  persist_config off
+	admin off
+	persist_config off
 }
 
 :3000 {

--- a/aio-multiport-setup.Caddyfile
+++ b/aio-multiport-setup.Caddyfile
@@ -1,3 +1,7 @@
+{
+  admin off
+}
+
 :3000 {
 	try_files {path} /
 	root * /site/selfhost-web

--- a/aio-multiport-setup.Caddyfile
+++ b/aio-multiport-setup.Caddyfile
@@ -1,5 +1,6 @@
 {
   admin off
+  persist_config off
 }
 
 :3000 {

--- a/aio-subpath-access.Caddyfile
+++ b/aio-subpath-access.Caddyfile
@@ -1,3 +1,7 @@
+{
+  admin off
+}
+
 :3000 {
 	respond 404
 }

--- a/aio-subpath-access.Caddyfile
+++ b/aio-subpath-access.Caddyfile
@@ -1,5 +1,6 @@
 {
   admin off
+  persist_config off
 }
 
 :3000 {

--- a/packages/hoppscotch-backend/backend.Caddyfile
+++ b/packages/hoppscotch-backend/backend.Caddyfile
@@ -1,5 +1,6 @@
 {
   admin off
+  persist_config off
 }
 
 :80 :3170 {

--- a/packages/hoppscotch-backend/backend.Caddyfile
+++ b/packages/hoppscotch-backend/backend.Caddyfile
@@ -1,6 +1,6 @@
 {
-  admin off
-  persist_config off
+	admin off
+	persist_config off
 }
 
 :80 :3170 {

--- a/packages/hoppscotch-backend/backend.Caddyfile
+++ b/packages/hoppscotch-backend/backend.Caddyfile
@@ -1,3 +1,7 @@
+{
+  admin off
+}
+
 :80 :3170 {
 	reverse_proxy localhost:8080
 }

--- a/packages/hoppscotch-selfhost-web/Caddyfile
+++ b/packages/hoppscotch-selfhost-web/Caddyfile
@@ -1,6 +1,6 @@
 {
-  admin off
-  persist_config off
+	admin off
+	persist_config off
 }
 
 :8080 {

--- a/packages/hoppscotch-selfhost-web/Caddyfile
+++ b/packages/hoppscotch-selfhost-web/Caddyfile
@@ -1,3 +1,7 @@
+{
+  admin off
+}
+
 :8080 {
 	try_files {path} /
 	root * /site

--- a/packages/hoppscotch-selfhost-web/Caddyfile
+++ b/packages/hoppscotch-selfhost-web/Caddyfile
@@ -1,5 +1,6 @@
 {
   admin off
+  persist_config off
 }
 
 :8080 {

--- a/packages/hoppscotch-selfhost-web/selfhost-web.Caddyfile
+++ b/packages/hoppscotch-selfhost-web/selfhost-web.Caddyfile
@@ -1,5 +1,6 @@
 {
   admin off
+  persist_config off
 }
 
 :80 :3000 {

--- a/packages/hoppscotch-selfhost-web/selfhost-web.Caddyfile
+++ b/packages/hoppscotch-selfhost-web/selfhost-web.Caddyfile
@@ -1,3 +1,7 @@
+{
+  admin off
+}
+
 :80 :3000 {
 	try_files {path} /
 	root * /site/selfhost-web

--- a/packages/hoppscotch-sh-admin/Caddyfile
+++ b/packages/hoppscotch-sh-admin/Caddyfile
@@ -1,3 +1,7 @@
+{
+  admin off
+}
+
 :8080 {
 	try_files {path} /
 	root * /site

--- a/packages/hoppscotch-sh-admin/Caddyfile
+++ b/packages/hoppscotch-sh-admin/Caddyfile
@@ -1,5 +1,6 @@
 {
   admin off
+  persist_config off
 }
 
 :8080 {

--- a/packages/hoppscotch-sh-admin/sh-admin-multiport-setup.Caddyfile
+++ b/packages/hoppscotch-sh-admin/sh-admin-multiport-setup.Caddyfile
@@ -1,3 +1,7 @@
+{
+  admin off
+}
+
 :80 :3100 {
 	try_files {path} /
 	root * /site/sh-admin-multiport-setup

--- a/packages/hoppscotch-sh-admin/sh-admin-multiport-setup.Caddyfile
+++ b/packages/hoppscotch-sh-admin/sh-admin-multiport-setup.Caddyfile
@@ -1,5 +1,6 @@
 {
   admin off
+  persist_config off
 }
 
 :80 :3100 {

--- a/packages/hoppscotch-sh-admin/sh-admin-subpath-access.Caddyfile
+++ b/packages/hoppscotch-sh-admin/sh-admin-subpath-access.Caddyfile
@@ -1,5 +1,6 @@
 {
   admin off
+  persist_config off
 }
 
 :80 :3100 {

--- a/packages/hoppscotch-sh-admin/sh-admin-subpath-access.Caddyfile
+++ b/packages/hoppscotch-sh-admin/sh-admin-subpath-access.Caddyfile
@@ -1,3 +1,7 @@
+{
+  admin off
+}
+
 :80 :3100 {
 	handle_path /admin* {
 		root * /site/sh-admin-subpath-access


### PR DESCRIPTION
Closes #4257 #4264 

This PR aims to fix the issues caused due to the introduction of non-root users in the selfhost containers introduced in #4233. The removal of the root user from the container execution scope is still something we will try to pursue later on once we have more understanding of the implications.

### What's changed
1. Revert the docker commands to make a non-root user that executes the container and returns it back to the default.
2. Remove Caddy Admin Endpoint (this endpoint is not exposed so shouldn't affect anyways) and config persistence

### Notes to reviewers
N/A
