### PR TITLE
bug: .env.example fix comments formatting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,10 @@ DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch
 JWT_SECRET="secret1233"
 TOKEN_SALT_COMPLEXITY=10
 MAGIC_LINK_TOKEN_VALIDITY= 3
-REFRESH_TOKEN_VALIDITY="604800000" # Default validity is 7 days (604800000 ms) in ms
-ACCESS_TOKEN_VALIDITY="86400000" # Default validity is 1 day (86400000 ms) in ms
+# Default validity is 7 days (604800000 ms) in ms
+REFRESH_TOKEN_VALIDITY="604800000"
+# Default validity is 1 day (86400000 ms) in ms
+ACCESS_TOKEN_VALIDITY="86400000"
 SESSION_SECRET='add some secret here'
 # Reccomended to be true, set to false if you are using http
 # Note: Some auth providers may not support http requests


### PR DESCRIPTION
Closes #4205

In the official Hoppscotch documentation or the `.env.example` file in the GitHub repo, only these two variables had inline comments:

```
REFRESH_TOKEN_VALIDITY=604800000 # Default validity is 7 days (604800000 ms) in ms
ACCESS_TOKEN_VALIDITY=86400000 # Default validity is 1 day (86400000 ms) in ms
```

But environment variables can’t use inline comments.

Some people who are not familiar with this common sense including me, maybe troubled by this problem when copying the contents of an env file from the github repo.
