### PR TITLE
feat(cli): add support for AWS Signature Authorization type

### DIFF
--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -42,6 +42,7 @@
   "private": false,
   "dependencies": {
     "axios": "1.7.5",
+    "aws4fetch": "1.0.19",
     "chalk": "5.3.0",
     "commander": "11.1.0",
     "isolated-vm": "4.7.2",

--- a/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
@@ -385,7 +385,6 @@ describe("hopp test [options] <file_path_or_id>", () => {
       test("Supports the usage of request variables along with environment variables", async () => {
         const env = {
           ...process.env,
-          secretBasicAuthUsernameEnvVar: "username",
           secretBasicAuthPasswordEnvVar: "password",
         };
 
@@ -404,6 +403,30 @@ describe("hopp test [options] <file_path_or_id>", () => {
         expect(stdout).toContain(
           "https://echo.hoppscotch.io/********/********"
         );
+        expect(error).toBeNull();
+      });
+    });
+
+    describe("AWS Signature Authorization type", () => {
+      test("Successfully translates the authorization information to headers/query params and sends it along with the request", async () => {
+        const env = {
+          ...process.env,
+          secretKey: "test-secret-key",
+          serviceToken: "test-token",
+        };
+
+        const COLL_PATH = getTestJsonFilePath(
+          "aws-signature-auth-coll.json",
+          "collection"
+        );
+        const ENVS_PATH = getTestJsonFilePath(
+          "aws-signature-auth-envs.json",
+          "environment"
+        );
+
+        const args = `test ${COLL_PATH} -e ${ENVS_PATH}`;
+        const { error } = await runCLI(args, { env });
+
         expect(error).toBeNull();
       });
     });

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/aws-signature-auth-coll.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/aws-signature-auth-coll.json
@@ -1,0 +1,101 @@
+{
+  "v": 3,
+  "name": "AWS Signature Auth - collection",
+  "folders": [],
+  "requests": [
+    {
+      "v": "7",
+      "id": "cm0dm70cw000687bnxi830zz7",
+      "auth": {
+        "addTo": "HEADERS",
+        "region": "<<awsRegion>>",
+        "authType": "aws-signature",
+        "accessKey": "<<accessKey>>",
+        "secretKey": "<<secretVarKey>>",
+        "authActive": true,
+        "serviceName": "<<serviceName>>",
+        "serviceToken": "",
+        "grantTypeInfo": {
+          "token": "",
+          "isPKCE": false,
+          "clientID": "",
+          "grantType": "AUTHORIZATION_CODE",
+          "authEndpoint": "",
+          "clientSecret": "",
+          "tokenEndpoint": "",
+          "codeVerifierMethod": "S256"
+        }
+      },
+      "body": {
+        "body": null,
+        "contentType": null
+      },
+      "name": "aws-signature-auth-headers",
+      "method": "GET",
+      "params": [],
+      "headers": [],
+      "endpoint": "<<url>>",
+      "testScript": "pw.test(\"Successfully sends relevant AWS signature information via headers\", ()=> {\n    const { headers } = pw.response.body\n\n  // Dynamic values, hence comparing the type.\n  pw.expect(headers[\"authorization\"]).toBeType(\"string\");\n  pw.expect(headers[\"x-amz-date\"]).toBeType(\"string\");\n  \n  pw.expect(headers[\"x-amz-content-sha256\"]).toBe(\"UNSIGNED-PAYLOAD\")\n  \n  // No session token supplied\n  pw.expect(headers[\"x-amz-security-token\"]).toBe(undefined)\n  \n});",
+      "preRequestScript": "",
+      "requestVariables": [
+        {
+          "key": "secretVarKey",
+          "value": "<<secretKey>>",
+          "active": true
+        }
+      ]
+    },
+    {
+      "v": "7",
+      "id": "cm0dm70cw000687bnxi830zz7",
+      "auth": {
+        "addTo": "QUERY_PARAMS",
+        "region": "<<awsRegion>>",
+        "authType": "aws-signature",
+        "accessKey": "<<accessKey>>",
+        "secretKey": "<<secretKey>>",
+        "authActive": true,
+        "serviceName": "<<serviceName>>",
+        "serviceToken": "<<serviceToken>>",
+        "grantTypeInfo": {
+          "token": "",
+          "isPKCE": false,
+          "clientID": "",
+          "grantType": "AUTHORIZATION_CODE",
+          "authEndpoint": "",
+          "clientSecret": "",
+          "tokenEndpoint": "",
+          "codeVerifierMethod": "S256"
+        }
+      },
+      "body": {
+        "body": null,
+        "contentType": null
+      },
+      "name": "aws-signature-auth-query-params",
+      "method": "GET",
+      "params": [],
+      "headers": [],
+      "endpoint": "<<url>>",
+      "testScript": "pw.test(\"Successfully sends relevant AWS signature information via query params\", ()=> {\n    const { args } = pw.response.body\n    pw.expect(args[\"X-Amz-Algorithm\"]).toBe(\"AWS4-HMAC-SHA256\");\n    pw.expect(args[\"X-Amz-Algorithm\"]).toBe(\"AWS4-HMAC-SHA256\");\n    pw.expect(args[\"X-Amz-Credential\"]).toInclude(\"test-access-key\");\n    pw.expect(args[\"X-Amz-Credential\"]).toInclude(\"eu-west-1/s3\");\n\n  // Dynamic values, hence comparing the type.\n  pw.expect(args[\"X-Amz-Date\"]).toBeType(\"string\");\n  pw.expect(args[\"X-Amz-Signature\"]).toBeType(\"string\");\n\n  pw.expect(args[\"X-Amz-Expires\"]).toBe(\"86400\")\n  pw.expect(args[\"X-Amz-SignedHeaders\"]).toBe(\"host\")\n  pw.expect(args[\"X-Amz-Security-Token\"]).toBe(\"test-token\")\n  \n});",
+      "preRequestScript": "",
+      "requestVariables": [
+        {
+          "key": "awsRegion",
+          "value": "eu-west-1",
+          "active": true
+        },
+        {
+          "key": "secretKey",
+          "value": "test-secret-key-overriden",
+          "active": true
+        }
+      ]
+    }
+  ],
+  "auth": {
+    "authType": "inherit",
+    "authActive": true
+  },
+  "headers": []
+}

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/aws-signature-auth-envs.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/aws-signature-auth-envs.json
@@ -1,0 +1,35 @@
+{
+  "v": 1,
+  "id": "cm0dsn3v70004p4qk3l9b7sjm",
+  "name": "AWS Signature - environments",
+  "variables": [
+    {
+      "key": "awsRegion",
+      "value": "us-east-1",
+      "secret": false
+    },
+    {
+      "key": "serviceName",
+      "value": "s3",
+      "secret": false
+    },
+    {
+      "key": "accessKey",
+      "value": "test-access-key",
+      "secret": true
+    },
+    {
+      "key": "secretKey",
+      "secret": true
+    },
+    {
+      "key": "url",
+      "value": "https://echo.hoppscotch.io",
+      "secret": false
+    },
+    {
+      "key": "serviceToken",
+      "secret": true
+    }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,9 @@ importers:
 
   packages/hoppscotch-cli:
     dependencies:
+      aws4fetch:
+        specifier: 1.0.19
+        version: 1.0.19
       axios:
         specifier: 1.7.5
         version: 1.7.5


### PR DESCRIPTION
#4142 adds support for the AWS Signature Authorization type in the UI. This PR extends support for the same in the CLI.

Closes HFE-568.

### What's changed

- Business logic addition for translating the supplied authorization filed values to headers/query params as opted.
- [aws4fetch](https://www.npmjs.com/package/aws4fetch) is added as a dependency to assist with request signing.
- Relevant test suite updates and fixture additions.

### Notes to reviewers

Save the request used while verifying the UI changes in #4142 to a collection and export it. Switch to this branch navigate to the CLI path locally and build it. Now, supply the collection file path along with the `test` command and ensure the requests report a status code of `200`.