### PR TITLE
fix: resolve multiple UI issues and account for `description` field in syncing context

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/Properties.vue
+++ b/packages/hoppscotch-common/src/components/collections/Properties.vue
@@ -17,6 +17,7 @@
           <HttpHeaders
             v-model="editableCollection"
             :is-collection-property="true"
+            @change-tab="changeOptionTab"
           />
           <div
             class="bg-bannerInfo px-4 py-2 flex items-center sticky bottom-0"
@@ -136,6 +137,7 @@ import { PersistenceService } from "~/services/persistence"
 import IconCheck from "~icons/lucide/check"
 import IconCopy from "~icons/lucide/copy"
 import IconHelpCircle from "~icons/lucide/help-circle"
+import { RESTOptionTabs } from "../http/RequestOptions.vue"
 
 const persistenceService = useService(PersistenceService)
 const t = useI18n()
@@ -266,6 +268,10 @@ const saveEditedCollection = () => {
 const hideModal = () => {
   persistenceService.removeLocalConfig("unsaved_collection_properties")
   emit("hide-modal")
+}
+
+const changeOptionTab = (e: RESTOptionTabs) => {
+  activeTab.value = e
 }
 
 const copyCollectionID = () => {

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -354,7 +354,9 @@ const saveEnvironment = async () => {
   isLoading.value = true
 
   if (!editingName.value) {
+    isLoading.value = false
     toast.error(`${t("environment.invalid_name")}`)
+
     return
   }
 

--- a/packages/hoppscotch-common/src/components/graphql/Headers.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Headers.vue
@@ -127,19 +127,15 @@
               :icon="masking ? IconEye : IconEyeOff"
               @click="toggleMask()"
             />
-            <HoppButtonSecondary
-              v-else
-              v-tippy="{ theme: 'tooltip' }"
-              :icon="IconArrowUpRight"
-              :title="t('request.go_to_authorization_tab')"
-              class="cursor-auto text-primary hover:text-primary"
-            />
+            <div v-else class="aspect-square w-8"></div>
           </span>
+
           <span>
             <HoppButtonSecondary
               v-tippy="{ theme: 'tooltip' }"
               :icon="IconArrowUpRight"
               :title="t('request.go_to_authorization_tab')"
+              @click="changeTab"
             />
           </span>
         </div>
@@ -235,6 +231,7 @@ import { useColorMode } from "@composables/theming"
 import { useToast } from "@composables/toast"
 import {
   GQLHeader,
+  HoppGQLAuth,
   HoppGQLRequest,
   parseRawKeyValueEntriesE,
   rawKeyValueEntriesToString,
@@ -267,6 +264,7 @@ import IconLock from "~icons/lucide/lock"
 import IconPlus from "~icons/lucide/plus"
 import IconTrash2 from "~icons/lucide/trash-2"
 import IconWrapText from "~icons/lucide/wrap-text"
+import { GQLOptionTabs } from "./RequestOptions.vue"
 
 const colorMode = useColorMode()
 const t = useI18n()
@@ -281,6 +279,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: "update:modelValue", value: HoppGQLRequest): void
+  (e: "change-tab", value: GQLOptionTabs): void
 }>()
 
 const request = useVModel(props, "modelValue", emit)
@@ -645,7 +644,7 @@ const inheritedProperties = computed(() => {
 
   const computedAuthHeader = getComputedAuthHeaders(
     request.value,
-    props.inheritedProperties.auth.inheritedAuth
+    props.inheritedProperties.auth.inheritedAuth as HoppGQLAuth
   )[0]
 
   if (
@@ -678,8 +677,5 @@ const mask = (header: any) => {
   return header.header.value
 }
 
-// const changeTab = (tab: ComputedHeader["source"]) => {
-//   if (tab === "auth") emit("change-tab", "authorization")
-//   else emit("change-tab", "bodyParams")
-// }
+const changeTab = () => emit("change-tab", "authorization")
 </script>

--- a/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
@@ -37,6 +37,7 @@
         <GraphqlHeaders
           v-model="request"
           :inherited-properties="inheritedProperties"
+          @change-tab="changeOptionTab"
         />
       </HoppSmartTab>
       <HoppSmartTab :id="'authorization'" :label="`${t('tab.authorization')}`">
@@ -261,6 +262,11 @@ const saveRequest = () => {
 const clearGQLQuery = () => {
   request.value.query = ""
 }
+
+const changeOptionTab = (e: GQLOptionTabs) => {
+  selectedOptionTab.value = e
+}
+
 defineActionHandler("request.send-cancel", runQuery)
 defineActionHandler("request.save", saveRequest)
 defineActionHandler("request.save-as", () => {

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -49,8 +49,14 @@
         />
       </div>
     </div>
+
     <div v-if="bulkMode" class="h-full relative w-full flex flex-col flex-1">
-      <div ref="bulkEditor" class="absolute inset-0"></div>
+      <div
+        ref="bulkEditor"
+        :class="{
+          'absolute inset-0': !isCollectionProperty,
+        }"
+      ></div>
     </div>
     <div v-else>
       <draggable


### PR DESCRIPTION
This PR includes a fix for the following issues:-

- Bulk mode editor wasn't visible in the collection properties modal.
- Attempting to create an environment from a team workspace without specifying a name will result in an infinite loading state regardless of reopening the modal since the component doesn't unmount.
- The `Go to Authorization tab` action from the headers view under the REST/GQL collection properties modal and under the GQL request didn't have an effect.

Also, a few type errors are resolved and proper migrations are added while resolving the `headers` field in the syncing context.

### What's changed

- The `absolute` property for the header bulk editor is disabled for the collection property modal.
- The latest version of `HoppCollection` is specified while pulling collections from upstream to update the store in the syncing context. Also, a relevant migration step is added to ensure the addition of a `description` under the REST/GQL `headers` (collection/request level) & REST params fields via a new `addDescriptionField()` helper function.
- Toggle back the loading state if attempting to create an environment from a team workspace without specifying a name.
- Bind action handler for the `Go to Authorization tab` action in the collection properties modal and GraphQL request headers view.