### PR TITLE
fix: sidebar codegen crashing and AWS Signature Auth flow

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -292,7 +292,8 @@
     "team_name": "Workspace name empty",
     "teams": "You don't belong to any workspaces",
     "tests": "There are no tests for this request",
-    "access_tokens": "Access tokens are empty"
+    "access_tokens": "Access tokens are empty",
+    "response": "No response received"
   },
   "environment": {
     "add_to_global": "Add to Global",

--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -119,7 +119,7 @@
                 :shortcut="['S']"
                 @click="
                   () => {
-                    invokeAction('response.schema.toggle')
+                    showCodegenModal = !showCodegenModal
                     hide()
                   }
                 "
@@ -218,6 +218,11 @@
       :show="showCurlImportModal"
       @hide-modal="showCurlImportModal = false"
     />
+    <HttpCodegenModal
+      v-if="showCodegenModal"
+      :show="showCodegenModal"
+      @hide-modal="showCodegenModal = false"
+    />
     <CollectionsSaveRequest
       v-if="showSaveRequestModal"
       mode="rest"
@@ -304,6 +309,7 @@ const isTabResponseLoading = computed(
 )
 
 const showCurlImportModal = ref(false)
+const showCodegenModal = ref(false)
 const showSaveRequestModal = ref(false)
 
 // Template refs
@@ -592,6 +598,9 @@ defineActionHandler("request.method.head", () => updateMethod("HEAD"))
 
 defineActionHandler("request.import-curl", () => {
   showCurlImportModal.value = true
+})
+defineActionHandler("request.show-code", () => {
+  showCodegenModal.value = true
 })
 
 const isCustomMethod = computed(() => {

--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -119,7 +119,7 @@
                 :shortcut="['S']"
                 @click="
                   () => {
-                    showCodegenModal = !showCodegenModal
+                    invokeAction('response.schema.toggle')
                     hide()
                   }
                 "
@@ -218,11 +218,6 @@
       :show="showCurlImportModal"
       @hide-modal="showCurlImportModal = false"
     />
-    <HttpCodegenModal
-      v-if="showCodegenModal"
-      :show="showCodegenModal"
-      @hide-modal="showCodegenModal = false"
-    />
     <CollectionsSaveRequest
       v-if="showSaveRequestModal"
       mode="rest"
@@ -309,7 +304,6 @@ const isTabResponseLoading = computed(
 )
 
 const showCurlImportModal = ref(false)
-const showCodegenModal = ref(false)
 const showSaveRequestModal = ref(false)
 
 // Template refs
@@ -598,9 +592,6 @@ defineActionHandler("request.method.head", () => updateMethod("HEAD"))
 
 defineActionHandler("request.import-curl", () => {
   showCurlImportModal.value = true
-})
-defineActionHandler("request.show-code", () => {
-  showCodegenModal.value = true
 })
 
 const isCustomMethod = computed(() => {

--- a/packages/hoppscotch-common/src/components/http/ResponseInterface.vue
+++ b/packages/hoppscotch-common/src/components/http/ResponseInterface.vue
@@ -5,7 +5,7 @@
     @close="close()"
   >
     <template #content>
-      <div class="flex flex-col px-4 flex-1 overflow-y-auto">
+      <div v-if="response" class="flex flex-col px-4 flex-1 overflow-y-auto">
         <div class="flex flex-col">
           <tippy
             interactive
@@ -110,6 +110,14 @@
           </div>
         </div>
       </div>
+
+      <HoppSmartPlaceholder
+        v-else
+        :src="`/images/states/${colorMode.value}/add_files.svg`"
+        :alt="`${t('empty.response')}`"
+        :text="`${t('empty.response')}`"
+      >
+      </HoppSmartPlaceholder>
     </template>
   </HoppSmartSlideOver>
 </template>
@@ -134,8 +142,10 @@ import IconWrapText from "~icons/lucide/wrap-text"
 import jsonToLanguage from "~/helpers/utils/json-to-language"
 import { watch } from "vue"
 import { GQLTabService } from "~/services/tab/graphql"
+import { useColorMode } from "~/composables/theming"
 
 const t = useI18n()
+const colorMode = useColorMode()
 
 defineProps<{
   show: boolean
@@ -189,7 +199,10 @@ const errorState = ref(false)
 const interfaceCode = ref("")
 
 const setInterfaceCode = async () => {
-  const res = await jsonToLanguage(selectedInterface.value, response.value)
+  const res = await jsonToLanguage(
+    selectedInterface.value,
+    response.value || "{}"
+  ) // to avoid possible errors empty object is passed
   interfaceCode.value = res.lines.join("\n")
 }
 

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -247,7 +247,7 @@ export function runRESTRequest$(
       combineEnvVariables(finalEnvs)
     )
 
-    const effectiveRequest = getEffectiveRESTRequest(finalRequest, {
+    const effectiveRequest = await getEffectiveRESTRequest(finalRequest, {
       id: "env-id",
       v: 1,
       name: "Env",
@@ -321,7 +321,7 @@ export function runRESTRequest$(
                 {
                   name: env.name,
                   v: 1,
-                  id: env.id ?? "",
+                  id: "id" in env ? env.id : "",
                   variables: updatedRunResult.envs.selected,
                 }
               )

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -1,30 +1,32 @@
+import {
+  Environment,
+  FormDataKeyValue,
+  HoppRESTAuth,
+  HoppRESTHeader,
+  HoppRESTHeaders,
+  HoppRESTParam,
+  HoppRESTParams,
+  HoppRESTReqBody,
+  HoppRESTRequest,
+  parseBodyEnvVariables,
+  parseRawKeyValueEntriesE,
+  parseTemplateString,
+  parseTemplateStringE,
+} from "@hoppscotch/data"
+import { AwsV4Signer } from "aws4fetch"
 import * as A from "fp-ts/Array"
 import * as E from "fp-ts/Either"
+import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
 import * as RA from "fp-ts/ReadonlyArray"
 import * as S from "fp-ts/string"
 import qs from "qs"
-import { flow, pipe } from "fp-ts/function"
 import { combineLatest, Observable } from "rxjs"
 import { map } from "rxjs/operators"
-import {
-  FormDataKeyValue,
-  HoppRESTReqBody,
-  HoppRESTRequest,
-  parseTemplateString,
-  parseBodyEnvVariables,
-  Environment,
-  HoppRESTHeader,
-  HoppRESTParam,
-  parseRawKeyValueEntriesE,
-  parseTemplateStringE,
-  HoppRESTAuth,
-  HoppRESTHeaders,
-} from "@hoppscotch/data"
+
 import { arrayFlatMap, arraySort } from "../functional/array"
 import { toFormData } from "../functional/formData"
 import { tupleWithSameKeysToRecord } from "../functional/record"
-import { AwsV4Signer } from "aws4fetch"
 
 export interface EffectiveHoppRESTRequest extends HoppRESTRequest {
   /**
@@ -33,8 +35,8 @@ export interface EffectiveHoppRESTRequest extends HoppRESTRequest {
    * This contains path, params and environment variables all applied to it
    */
   effectiveFinalURL: string
-  effectiveFinalHeaders: { key: string; value: string }[]
-  effectiveFinalParams: { key: string; value: string }[]
+  effectiveFinalHeaders: HoppRESTHeaders
+  effectiveFinalParams: HoppRESTParams
   effectiveFinalBody: FormData | string | null
   effectiveFinalRequestVariables: { key: string; value: string }[]
 }
@@ -502,6 +504,7 @@ export async function getEffectiveRESTRequest(
         false,
         showKeyIfSecret
       ),
+      description: x.description,
     }))
   )
 
@@ -525,6 +528,7 @@ export async function getEffectiveRESTRequest(
         false,
         showKeyIfSecret
       ),
+      description: x.description,
     }))
   )
 


### PR DESCRIPTION
Closes #4314 

This PR includes fixes for the following issues:-

- Codegen Sidebar crashes upon opening and shows up as blank.
- Choosing AWS Signature as the Authorization type without populating the relevant fields and attempting to send a request results in an exception. Saving the request to a collection in this state and attempting to run it via the CLI will lead to the same error since they are required fields.

### What's changed

- `getEffectiveRESTRequest` returns a Promise, this was not awaited in the computation for the code generation, leading to a null reference, crashing the sidebar. The correction was to await the promise and evaluate based on that. This has been extended to all places of usage.
- Assign default values (empty string) corresponding to the fields while choosing `AWS Signature` as the Authorization type.
- Resolve type errors.

### Notes to reviewers
N/A
