### PR TITLE
feat: duplicate global environment under team workspaces

### DIFF
--- a/packages/hoppscotch-backend/src/team-environments/team-environments.service.ts
+++ b/packages/hoppscotch-backend/src/team-environments/team-environments.service.ts
@@ -194,7 +194,7 @@ export class TeamEnvironmentsService {
 
       const result = await this.prisma.teamEnvironment.create({
         data: {
-          name: environment.name,
+          name: `${environment.name} - Duplicate`,
           teamID: environment.teamID,
           variables: environment.variables as Prisma.JsonArray,
         },

--- a/packages/hoppscotch-common/src/components/environments/Add.vue
+++ b/packages/hoppscotch-common/src/components/environments/Add.vue
@@ -71,20 +71,21 @@
 
 <script lang="ts" setup>
 import { Environment } from "@hoppscotch/data"
+import { useService } from "dioc/vue"
+import * as TE from "fp-ts/TaskEither"
+import { pipe } from "fp-ts/function"
 import { ref, watch } from "vue"
 import { useI18n } from "~/composables/i18n"
 import { useToast } from "~/composables/toast"
 import { GQLError } from "~/helpers/backend/GQLClient"
+import { updateTeamEnvironment } from "~/helpers/backend/mutations/TeamEnvironment"
+import { getEnvActionErrorMessage } from "~/helpers/error-messages"
 import { TeamEnvironment } from "~/helpers/teams/TeamEnvironment"
 import {
   addEnvironmentVariable,
   addGlobalEnvVariable,
 } from "~/newstore/environments"
-import * as TE from "fp-ts/TaskEither"
-import { pipe } from "fp-ts/function"
-import { updateTeamEnvironment } from "~/helpers/backend/mutations/TeamEnvironment"
 import { RESTTabService } from "~/services/tab/rest"
-import { useService } from "dioc/vue"
 
 const t = useI18n()
 const toast = useToast()
@@ -181,7 +182,7 @@ const addEnvironment = async () => {
       TE.match(
         (err: GQLError<string>) => {
           console.error(err)
-          toast.error(`${getErrorMessage(err)}`)
+          toast.error(t(getEnvActionErrorMessage(err)))
         },
         () => {
           hideModal()
@@ -202,19 +203,5 @@ const addEnvironment = async () => {
   }
 
   hideModal()
-}
-
-const getErrorMessage = (err: GQLError<string>) => {
-  if (err.type === "network_error") {
-    return t("error.network_error")
-  }
-  switch (err.error) {
-    case "team_environment/not_found":
-      return t("team_environment.not_found")
-    case "Forbidden resource":
-      return t("profile.no_permission")
-    default:
-      return t("error.something_went_wrong")
-  }
 }
 </script>

--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -302,13 +302,16 @@ import { useService } from "dioc/vue"
 import { computed, onMounted, ref, watch } from "vue"
 import { TippyComponent } from "vue-tippy"
 import { useI18n } from "~/composables/i18n"
-import { getEnvActionErrorMessage } from "~/helpers/error-messages"
 import { useReadonlyStream, useStream } from "~/composables/stream"
 import { invokeAction } from "~/helpers/actions"
-import { GQLError } from "~/helpers/backend/GQLClient"
 import { GetMyTeamsQuery } from "~/helpers/backend/graphql"
+import { getEnvActionErrorMessage } from "~/helpers/error-messages"
 import { TeamEnvironment } from "~/helpers/teams/TeamEnvironment"
 import TeamEnvironmentAdapter from "~/helpers/teams/TeamEnvironmentAdapter"
+import {
+  sortPersonalEnvironmentsAlphabetically,
+  sortTeamEnvironmentsAlphabetically,
+} from "~/helpers/utils/sortEnvironmentsAlphabetically"
 import {
   environments$,
   globalEnv$,
@@ -317,10 +320,6 @@ import {
 } from "~/newstore/environments"
 import { useLocalState } from "~/newstore/localstate"
 import { WorkspaceService } from "~/services/workspace.service"
-import {
-  sortPersonalEnvironmentsAlphabetically,
-  sortTeamEnvironmentsAlphabetically,
-} from "~/helpers/utils/sortEnvironmentsAlphabetically"
 import IconCheck from "~icons/lucide/check"
 import IconEdit from "~icons/lucide/edit"
 import IconEye from "~icons/lucide/eye"
@@ -591,23 +590,7 @@ onMounted(() => {
 const envSelectorActions = ref<TippyComponent | null>(null)
 const envQuickPeekActions = ref<TippyComponent | null>(null)
 
-<<<<<<< HEAD
-const getErrorMessage = (err: GQLError<string>) => {
-  if (err.type === "network_error") {
-    return t("error.network_error")
-  }
-  switch (err.error) {
-    case "team_environment/not_found":
-      return t("team_environment.not_found")
-    default:
-      return t("error.something_went_wrong")
-  }
-}
-
 const globalEnvs = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
-=======
-const globalEnvs = useReadonlyStream(globalEnv$, [])
->>>>>>> 6e3b8ac3 (refactor: helper function abstracting error messages)
 
 const environmentVariables = computed(() => {
   if (selectedEnv.value.variables) {

--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -147,7 +147,7 @@
                 class="flex flex-col items-center py-4"
               >
                 <icon-lucide-help-circle class="svg-icons mb-4" />
-                {{ getErrorMessage(teamAdapterError) }}
+                {{ t(getEnvActionErrorMessage(teamAdapterError)) }}
               </div>
             </HoppSmartTab>
           </HoppSmartTabs>
@@ -302,6 +302,7 @@ import { useService } from "dioc/vue"
 import { computed, onMounted, ref, watch } from "vue"
 import { TippyComponent } from "vue-tippy"
 import { useI18n } from "~/composables/i18n"
+import { getEnvActionErrorMessage } from "~/helpers/error-messages"
 import { useReadonlyStream, useStream } from "~/composables/stream"
 import { invokeAction } from "~/helpers/actions"
 import { GQLError } from "~/helpers/backend/GQLClient"
@@ -590,6 +591,7 @@ onMounted(() => {
 const envSelectorActions = ref<TippyComponent | null>(null)
 const envQuickPeekActions = ref<TippyComponent | null>(null)
 
+<<<<<<< HEAD
 const getErrorMessage = (err: GQLError<string>) => {
   if (err.type === "network_error") {
     return t("error.network_error")
@@ -603,6 +605,9 @@ const getErrorMessage = (err: GQLError<string>) => {
 }
 
 const globalEnvs = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
+=======
+const globalEnvs = useReadonlyStream(globalEnv$, [])
+>>>>>>> 6e3b8ac3 (refactor: helper function abstracting error messages)
 
 const environmentVariables = computed(() => {
   if (selectedEnv.value.variables) {

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -220,15 +220,13 @@ const editEnvironment = (environmentIndex: "Global") => {
   displayModalEdit(true)
 }
 
-const duplicateGlobalEnvironment = async (
-  envVariables: EnvironmentVariable[]
-) => {
+const duplicateGlobalEnvironment = async () => {
   if (workspace.value.type === "team") {
     duplicateGlobalEnvironmentLoading.value = true
 
     await pipe(
       createTeamEnvironment(
-        JSON.stringify(envVariables),
+        JSON.stringify(globalEnvironment.value.variables),
         workspace.value.teamID,
         `Global - ${t("action.duplicate")}`
       ),

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -98,7 +98,7 @@ const environmentType = ref<EnvironmentsChooseType>({
 
 const globalEnv = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
 
-const globalEnvironment = computed<GlobalEnvironment>(() => ({
+const globalEnvironment = computed<Environment>(() => ({
   v: 1 as const,
   id: "Global",
   name: "Global",

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -10,6 +10,7 @@
         :duplicate-global-environment-loading="
           duplicateGlobalEnvironmentLoading
         "
+        :show-context-menu-loading-state="workspace.type === 'team'"
         class="border-b border-dividerLight"
         @duplicate-global-environment="duplicateGlobalEnvironment"
         @edit-environment="editEnvironment('Global')"
@@ -235,14 +236,14 @@ const duplicateGlobalEnvironment = async () => {
           console.error(err)
 
           toast.error(t(getEnvActionErrorMessage(err)))
-          duplicateGlobalEnvironmentLoading.value = false
         },
         () => {
           toast.success(t("environment.duplicated"))
-          duplicateGlobalEnvironmentLoading.value = false
         }
       )
     )()
+
+    duplicateGlobalEnvironmentLoading.value = false
 
     return
   }
@@ -251,6 +252,7 @@ const duplicateGlobalEnvironment = async () => {
     `Global - ${t("action.duplicate")}`,
     cloneDeep(getGlobalVariables())
   )
+
   toast.success(`${t("environment.duplicated")}`)
 }
 

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -65,6 +65,7 @@ import {
   createTeamEnvironment,
   deleteTeamEnvironment,
 } from "~/helpers/backend/mutations/TeamEnvironment"
+import { getEnvActionErrorMessage } from "~/helpers/error-messages"
 import TeamEnvironmentAdapter from "~/helpers/teams/TeamEnvironmentAdapter"
 import {
   createEnvironment,
@@ -226,7 +227,7 @@ const duplicateGlobalEnvironment = async (
     duplicateGlobalEnvironmentLoading.value = true
 
     await pipe(
-      await createTeamEnvironment(
+      createTeamEnvironment(
         JSON.stringify(envVariables),
         workspace.value.teamID,
         `Global - ${t("action.duplicate")}`
@@ -235,9 +236,7 @@ const duplicateGlobalEnvironment = async (
         (err: GQLError<string>) => {
           console.error(err)
 
-          // TODO: Expose the below helper function from team context and add loading state for Global environment context menu
-          toast.error(`${getErrorMessage(err)}`)
-
+          toast.error(t(getEnvActionErrorMessage(err)))
           duplicateGlobalEnvironmentLoading.value = false
         },
         () => {

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -76,7 +76,7 @@
               @click="
                 () => {
                   duplicateEnvironments()
-                  hide()
+                  !showContextMenuLoadingState && hide()
                 }
               "
             />
@@ -149,9 +149,11 @@ const props = withDefaults(
     environment: Environment
     environmentIndex: number | "Global" | null
     duplicateGlobalEnvironmentLoading?: boolean
+    showContextMenuLoadingState?: boolean
   }>(),
   {
     duplicateGlobalEnvironmentLoading: false,
+    showContextMenuLoadingState: false,
   }
 )
 
@@ -168,7 +170,7 @@ watch(
   () => props.duplicateGlobalEnvironmentLoading,
   (newDuplicateGlobalEnvironmentLoadingVal) => {
     if (!newDuplicateGlobalEnvironmentLoadingVal) {
-      options.value!.tippy?.hide()
+      options?.value?.tippy?.hide()
     }
   }
 )

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -45,7 +45,7 @@
             tabindex="0"
             role="menu"
             @keyup.e="edit!.$el.click()"
-            @keyup.d="showDuplicateAction ? duplicate!.$el.click() : null"
+            @keyup.d="duplicate!.$el.click()"
             @keyup.j="exportAsJsonEl!.$el.click()"
             @keyup.delete="
               !(environmentIndex === 'Global')
@@ -68,7 +68,6 @@
               "
             />
             <HoppSmartItem
-              v-if="showDuplicateAction"
               ref="duplicate"
               :icon="IconCopy"
               :label="t('action.duplicate')"
@@ -119,7 +118,7 @@
 <script setup lang="ts">
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
-import { Environment, EnvironmentVariable } from "@hoppscotch/data"
+import { Environment } from "@hoppscotch/data"
 import { HoppSmartItem } from "@hoppscotch/ui"
 import { useService } from "dioc/vue"
 import { computed, ref, watch } from "vue"
@@ -144,18 +143,16 @@ const props = withDefaults(
   defineProps<{
     environment: Environment
     environmentIndex: number | "Global" | null
-    showDuplicateAction: boolean
     duplicateGlobalEnvironmentLoading?: boolean
   }>(),
   {
-    showDuplicateAction: true,
     duplicateGlobalEnvironmentLoading: false,
   }
 )
 
 const emit = defineEmits<{
   (e: "edit-environment"): void
-  (e: "duplicate-global-environment", envVariables: EnvironmentVariable[]): void
+  (e: "duplicate-global-environment"): void
 }>()
 
 const confirmRemove = ref(false)
@@ -204,7 +201,7 @@ const duplicateEnvironments = () => {
   }
 
   if (isGlobalEnvironment.value) {
-    emit("duplicate-global-environment", props.environment.variables)
+    emit("duplicate-global-environment")
     return
   }
 

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -73,7 +73,12 @@
               :label="t('action.duplicate')"
               :shortcut="['D']"
               :loading="duplicateGlobalEnvironmentLoading"
-              @click="duplicateEnvironments"
+              @click="
+                () => {
+                  duplicateEnvironments()
+                  hide()
+                }
+              "
             />
             <HoppSmartItem
               ref="exportAsJsonEl"

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -165,6 +165,7 @@ import IconHelpCircle from "~icons/lucide/help-circle"
 import { platform } from "~/platform"
 import { useService } from "dioc/vue"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
+import { getEnvActionErrorMessage } from "~/helpers/error-messages"
 
 type EnvironmentVariable = {
   id: number
@@ -405,7 +406,7 @@ const saveEnvironment = async () => {
         TE.match(
           (err: GQLError<string>) => {
             console.error(err)
-            toast.error(`${getErrorMessage(err)}`)
+            toast.error(t(getEnvActionErrorMessage(err)))
             isLoading.value = false
           },
           (res) => {
@@ -453,7 +454,7 @@ const saveEnvironment = async () => {
         TE.match(
           (err: GQLError<string>) => {
             console.error(err)
-            toast.error(`${getErrorMessage(err)}`)
+            toast.error(t(getEnvActionErrorMessage(err)))
             isLoading.value = false
           },
           () => {
@@ -473,19 +474,5 @@ const hideModal = () => {
   editingName.value = null
   selectedEnvOption.value = "variables"
   emit("hide-modal")
-}
-
-const getErrorMessage = (err: GQLError<string>) => {
-  if (err.type === "network_error") {
-    return t("error.network_error")
-  }
-  switch (err.error) {
-    case "team_environment/not_found":
-      return t("team_environment.not_found")
-    case "team_environment/short_name":
-      return t("environment.short_name")
-    default:
-      return t("error.something_went_wrong")
-  }
 }
 </script>

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -136,6 +136,7 @@ import {
   deleteTeamEnvironment,
   createDuplicateEnvironment as duplicateEnvironment,
 } from "~/helpers/backend/mutations/TeamEnvironment"
+import { getEnvActionErrorMessage } from "~/helpers/error-messages"
 import { exportAsJSON } from "~/helpers/import-export/export/environment"
 import { TeamEnvironment } from "~/helpers/teams/TeamEnvironment"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
@@ -183,7 +184,7 @@ const removeEnvironment = () => {
     TE.match(
       (err: GQLError<string>) => {
         console.error(err)
-        toast.error(`${getErrorMessage(err)}`)
+        toast.error(t(getEnvActionErrorMessage(err)))
       },
       () => {
         toast.success(`${t("team_environment.deleted")}`)
@@ -199,26 +200,12 @@ const duplicateEnvironments = () => {
     TE.match(
       (err: GQLError<string>) => {
         console.error(err)
-        toast.error(`${getErrorMessage(err)}`)
+        toast.error(t(getEnvActionErrorMessage(err)))
       },
       () => {
         toast.success(`${t("environment.duplicated")}`)
       }
     )
   )()
-}
-
-const getErrorMessage = (err: GQLError<string>) => {
-  if (err.type === "network_error") {
-    return t("error.network_error")
-  }
-  switch (err.error) {
-    case "team_environment/not_found":
-      return t("team_environment.not_found")
-    case "team_environment/short_name":
-      return t("environment.short_name")
-    default:
-      return t("error.something_went_wrong")
-  }
 }
 </script>

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -48,6 +48,7 @@
               :icon="IconEdit"
               :label="`${t('action.edit')}`"
               :shortcut="['E']"
+              :disabled="duplicateEnvironmentLoading"
               @click="
                 () => {
                   emit('edit-environment')
@@ -62,12 +63,8 @@
               :icon="IconCopy"
               :label="`${t('action.duplicate')}`"
               :shortcut="['D']"
-              @click="
-                () => {
-                  duplicateEnvironments()
-                  hide()
-                }
-              "
+              :loading="duplicateEnvironmentLoading"
+              @click="duplicateEnvironment"
             />
             <HoppSmartItem
               v-if="!isViewer"
@@ -75,6 +72,7 @@
               :icon="IconEdit"
               :label="`${t('export.as_json')}`"
               :shortcut="['J']"
+              :disabled="duplicateEnvironmentLoading"
               @click="
                 () => {
                   exportEnvironmentAsJSON()
@@ -88,6 +86,7 @@
               :icon="IconTrash2"
               :label="`${t('action.delete')}`"
               :shortcut="['⌫']"
+              :disabled="duplicateEnvironmentLoading"
               @click="
                 () => {
                   confirmRemove = true
@@ -100,6 +99,7 @@
               :icon="IconSettings2"
               :label="t('action.properties')"
               :shortcut="['P']"
+              :disabled="duplicateEnvironmentLoading"
               @click="
                 () => {
                   emit('show-environment-properties')
@@ -134,7 +134,7 @@ import { useI18n } from "~/composables/i18n"
 import { GQLError } from "~/helpers/backend/GQLClient"
 import {
   deleteTeamEnvironment,
-  createDuplicateEnvironment as duplicateEnvironment,
+  createDuplicateEnvironment as duplicateTeamEnvironment,
 } from "~/helpers/backend/mutations/TeamEnvironment"
 import { getEnvActionErrorMessage } from "~/helpers/error-messages"
 import { exportAsJSON } from "~/helpers/import-export/export/environment"
@@ -178,6 +178,8 @@ const deleteAction = ref<typeof HoppSmartItem>()
 const exportAsJsonEl = ref<typeof HoppSmartItem>()
 const propertiesAction = ref<typeof HoppSmartItem>()
 
+const duplicateEnvironmentLoading = ref(false)
+
 const removeEnvironment = () => {
   pipe(
     deleteTeamEnvironment(props.environment.id),
@@ -194,9 +196,11 @@ const removeEnvironment = () => {
   )()
 }
 
-const duplicateEnvironments = () => {
-  pipe(
-    duplicateEnvironment(props.environment.id),
+const duplicateEnvironment = async () => {
+  duplicateEnvironmentLoading.value = true
+
+  await pipe(
+    duplicateTeamEnvironment(props.environment.id),
     TE.match(
       (err: GQLError<string>) => {
         console.error(err)
@@ -207,5 +211,9 @@ const duplicateEnvironments = () => {
       }
     )
   )()
+
+  duplicateEnvironmentLoading.value = false
+
+  options.value!.tippy?.hide()
 }
 </script>

--- a/packages/hoppscotch-common/src/components/environments/teams/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/index.vue
@@ -104,7 +104,7 @@
       class="flex flex-col items-center py-4"
     >
       <icon-lucide-help-circle class="svg-icons mb-4" />
-      {{ getErrorMessage(adapterError) }}
+      {{ t(getEnvActionErrorMessage(adapterError)) }}
     </div>
     <EnvironmentsTeamsDetails
       :show="showModalDetails"
@@ -146,6 +146,7 @@ import IconImport from "~icons/lucide/folder-down"
 import { defineActionHandler } from "~/helpers/actions"
 import { TeamWorkspace } from "~/services/workspace.service"
 import { sortTeamEnvironmentsAlphabetically } from "~/helpers/utils/sortEnvironmentsAlphabetically"
+import { getEnvActionErrorMessage } from "~/helpers/error-messages"
 
 const t = useI18n()
 
@@ -199,18 +200,6 @@ const resetSelectedData = () => {
   editingEnvironment.value = null
   editingVariableName.value = ""
   secretOptionSelected.value = false
-}
-
-const getErrorMessage = (err: GQLError<string>) => {
-  if (err.type === "network_error") {
-    return t("error.network_error")
-  }
-  switch (err.error) {
-    case "team_environment/not_found":
-      return t("team_environment.not_found")
-    default:
-      return t("error.something_went_wrong")
-  }
 }
 
 const showEnvironmentProperties = (environmentID: string) => {

--- a/packages/hoppscotch-common/src/helpers/error-messages/index.ts
+++ b/packages/hoppscotch-common/src/helpers/error-messages/index.ts
@@ -1,0 +1,18 @@
+import { GQLError } from "../backend/GQLClient"
+
+export const getEnvActionErrorMessage = (err: GQLError<string>) => {
+  if (err.type === "network_error") {
+    return "error.network_error"
+  }
+
+  switch (err.error) {
+    case "team_environment/not_found":
+      return "team_environment.not_found"
+    case "team_environment/short_name":
+      return "environment.short_name"
+    case "Forbidden resource":
+      return "profile.no_permission"
+    default:
+      return "error.something_went_wrong"
+  }
+}


### PR DESCRIPTION
The duplicate global environment action was specific to the personal workspace, where the entries were added and hidden while at a team workspace with #4245. This PR re-enables the action under team workspaces and extends support. Also, the following changes are added alongside applicable to team workspaces:

- Loading states addition for duplicate regular & global environment actions via the context menu.
- Adds a `- Duplicate` suffix for duplicated environment entries.

Closes HFE-575.

### Preview

  https://github.com/user-attachments/assets/c406ff47-b191-4857-a1ea-06ca4bd6b567

### What's changed

- Adds new props `duplicateGlobalEnvironmentLoading` (keeps track of the n/w call status and dismisses the context menu) & `showContextMenuLoadingState` (Indicates the context menu is to be displayed during the n/w call in a team workspace) and defines a new event `duplicate-global-environment` under the `EnvironmentsMyEnvironment` component.
- Relevant additions under the root `Environments` component to trigger the `createTeamEnvironment` GQL mutation with the global environment variables in scope.
- Adds a new helper function `getEnvActionErrrorMessage` abstracting the error messages reused for environment-related actions.
- Add `- Duplicate` suffix to duplicated environment names under team workspaces.

### Notes to reviewers

Please ensure to cross-check the error message updates once with the newly added helper function.