### PR TITLE
fix: ensure cross-platform compatibility with file exports

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -48,7 +48,7 @@ import { getTeamCollectionJSON } from "~/helpers/backend/helpers"
 
 import { platform } from "~/platform"
 
-import { initializeDownloadCollection } from "~/helpers/import-export/export"
+import { initializeDownloadFile } from "~/helpers/import-export/export"
 import { gistExporter } from "~/helpers/import-export/export/gist"
 import { myCollectionsExporter } from "~/helpers/import-export/export/myCollections"
 import { teamCollectionsExporter } from "~/helpers/import-export/export/teamCollections"
@@ -389,27 +389,27 @@ const HoppMyCollectionsExporter: ImporterOrExporter = {
     applicableTo: ["personal-workspace"],
     isLoading: isHoppMyCollectionExporterInProgress,
   },
-  action: () => {
+  action: async () => {
     if (!myCollections.value.length) {
       return toast.error(t("error.no_collections_to_export"))
     }
 
     isHoppMyCollectionExporterInProgress.value = true
 
-    const message = initializeDownloadCollection(
+    const message = await initializeDownloadFile(
       myCollectionsExporter(myCollections.value),
-      "Collections"
+      "hoppscotch-personal-collections"
     )
 
-    if (E.isRight(message)) {
-      toast.success(t(message.right))
+    E.isRight(message)
+      ? toast.success(t(message.right))
+      : toast.error(t(message.left))
 
-      platform.analytics?.logEvent({
-        type: "HOPP_EXPORT_COLLECTION",
-        exporter: "json",
-        platform: "rest",
-      })
-    }
+    platform.analytics?.logEvent({
+      type: "HOPP_EXPORT_COLLECTION",
+      exporter: "json",
+      platform: "rest",
+    })
 
     isHoppMyCollectionExporterInProgress.value = false
   },
@@ -436,7 +436,14 @@ const HoppTeamCollectionsExporter: ImporterOrExporter = {
       )
 
       if (E.isRight(res)) {
-        initializeDownloadCollection(res.right, "team-collections")
+        const message = await initializeDownloadFile(
+          res.right,
+          "hoppscotch-team-collections"
+        )
+
+        E.isRight(message)
+          ? toast.success(t(message.right))
+          : toast.error(t(message.left))
 
         platform.analytics?.logEvent({
           type: "HOPP_EXPORT_COLLECTION",

--- a/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
@@ -21,7 +21,7 @@ import { GistSource } from "~/helpers/import-export/import/import-sources/GistSo
 
 import IconFolderPlus from "~icons/lucide/folder-plus"
 import IconUser from "~icons/lucide/user"
-import { initializeDownloadCollection } from "~/helpers/import-export/export"
+import { initializeDownloadFile } from "~/helpers/import-export/export"
 import { useReadonlyStream } from "~/composables/stream"
 
 import { platform } from "~/platform"
@@ -133,14 +133,14 @@ const GqlCollectionsHoppExporter: ImporterOrExporter = {
     disabled: false,
     applicableTo: ["personal-workspace", "team-workspace"],
   },
-  action: () => {
+  action: async () => {
     if (!gqlCollections.value.length) {
       return toast.error(t("error.no_collections_to_export"))
     }
 
-    const message = initializeDownloadCollection(
+    const message = await initializeDownloadFile(
       gqlCollectionsExporter(gqlCollections.value),
-      "GQLCollections"
+      "hoppscotch-gql-collections"
     )
 
     if (E.isLeft(message)) {

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -13,36 +13,36 @@ import { Environment, NonSecretEnvironment } from "@hoppscotch/data"
 import * as E from "fp-ts/Either"
 import { ref } from "vue"
 
+import { ImporterOrExporter } from "~/components/importExport/types"
 import { useI18n } from "~/composables/i18n"
 import { useToast } from "~/composables/toast"
-import { ImporterOrExporter } from "~/components/importExport/types"
+import { hoppEnvImporter } from "~/helpers/import-export/import/hoppEnv"
 import { FileSource } from "~/helpers/import-export/import/import-sources/FileSource"
 import { GistSource } from "~/helpers/import-export/import/import-sources/GistSource"
-import { hoppEnvImporter } from "~/helpers/import-export/import/hoppEnv"
 
 import {
-  appendEnvironments,
   addGlobalEnvVariable,
+  appendEnvironments,
   environments$,
 } from "~/newstore/environments"
 
-import { createTeamEnvironment } from "~/helpers/backend/mutations/TeamEnvironment"
-import { TeamEnvironment } from "~/helpers/teams/TeamEnvironment"
 import { GQLError } from "~/helpers/backend/GQLClient"
 import { CreateTeamEnvironmentMutation } from "~/helpers/backend/graphql"
-import { postmanEnvImporter } from "~/helpers/import-export/import/postmanEnv"
+import { createTeamEnvironment } from "~/helpers/backend/mutations/TeamEnvironment"
 import { insomniaEnvImporter } from "~/helpers/import-export/import/insomniaEnv"
+import { postmanEnvImporter } from "~/helpers/import-export/import/postmanEnv"
+import { TeamEnvironment } from "~/helpers/teams/TeamEnvironment"
 
-import IconFolderPlus from "~icons/lucide/folder-plus"
-import IconPostman from "~icons/hopp/postman"
-import IconInsomnia from "~icons/hopp/insomnia"
-import IconUser from "~icons/lucide/user"
-import { initializeDownloadCollection } from "~/helpers/import-export/export"
 import { computed } from "vue"
 import { useReadonlyStream } from "~/composables/stream"
+import { initializeDownloadFile } from "~/helpers/import-export/export"
 import { environmentsExporter } from "~/helpers/import-export/export/environments"
 import { gistExporter } from "~/helpers/import-export/export/gist"
 import { platform } from "~/platform"
+import IconInsomnia from "~icons/hopp/insomnia"
+import IconPostman from "~icons/hopp/postman"
+import IconFolderPlus from "~icons/lucide/folder-plus"
+import IconUser from "~icons/lucide/user"
 
 const t = useI18n()
 const toast = useToast()
@@ -67,18 +67,16 @@ const isTeamEnvironment = computed(() => {
 })
 
 const environmentJson = computed(() => {
-  if (
-    props.environmentType === "TEAM_ENV" &&
-    props.teamEnvironments !== undefined
-  ) {
-    const teamEnvironments = props.teamEnvironments.map(
-      (x) => x.environment as Environment
-    )
-    return teamEnvironments
+  if (isTeamEnvironment.value && props.teamEnvironments) {
+    return props.teamEnvironments.map((x) => x.environment)
   }
 
   return myEnvironments.value
 })
+
+const workspaceType = computed(() =>
+  isTeamEnvironment.value ? "team" : "personal"
+)
 
 const HoppEnvironmentsImport: ImporterOrExporter = {
   metadata: {
@@ -105,7 +103,7 @@ const HoppEnvironmentsImport: ImporterOrExporter = {
       platform.analytics?.logEvent({
         type: "HOPP_IMPORT_ENVIRONMENT",
         platform: "rest",
-        workspaceType: isTeamEnvironment.value ? "team" : "personal",
+        workspaceType: workspaceType.value,
       })
 
       emit("hide-modal")
@@ -138,7 +136,7 @@ const PostmanEnvironmentsImport: ImporterOrExporter = {
       platform.analytics?.logEvent({
         type: "HOPP_IMPORT_ENVIRONMENT",
         platform: "rest",
-        workspaceType: isTeamEnvironment.value ? "team" : "personal",
+        workspaceType: workspaceType.value,
       })
 
       emit("hide-modal")
@@ -178,7 +176,7 @@ const insomniaEnvironmentsImport: ImporterOrExporter = {
       platform.analytics?.logEvent({
         type: "HOPP_IMPORT_ENVIRONMENT",
         platform: "rest",
-        workspaceType: isTeamEnvironment.value ? "team" : "personal",
+        workspaceType: workspaceType.value,
       })
 
       emit("hide-modal")
@@ -214,7 +212,7 @@ const EnvironmentsImportFromGIST: ImporterOrExporter = {
       platform.analytics?.logEvent({
         type: "HOPP_IMPORT_ENVIRONMENT",
         platform: "rest",
-        workspaceType: isTeamEnvironment.value ? "team" : "personal",
+        workspaceType: workspaceType.value,
       })
       emit("hide-modal")
     },
@@ -230,14 +228,14 @@ const HoppEnvironmentsExport: ImporterOrExporter = {
     disabled: false,
     applicableTo: ["personal-workspace", "team-workspace"],
   },
-  action: () => {
+  action: async () => {
     if (!environmentJson.value.length) {
       return toast.error(t("error.no_environments_to_export"))
     }
 
-    const message = initializeDownloadCollection(
+    const message = await initializeDownloadFile(
       environmentsExporter(environmentJson.value),
-      "Environments"
+      `hoppscotch-${workspaceType.value}-environments`
     )
 
     if (E.isLeft(message)) {

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -126,6 +126,8 @@ import { useService } from "dioc/vue"
 import { cloneDeep } from "lodash-es"
 import { computed, ref } from "vue"
 import { TippyComponent } from "vue-tippy"
+import * as E from "fp-ts/Either"
+
 import { exportAsJSON } from "~/helpers/import-export/export/environment"
 import {
   createEnvironment,
@@ -163,11 +165,13 @@ const secretEnvironmentService = useService(SecretEnvironmentService)
 
 const isGlobalEnvironment = computed(() => props.environmentIndex === "Global")
 
-const exportEnvironmentAsJSON = () => {
+const exportEnvironmentAsJSON = async () => {
   const { environment, environmentIndex } = props
-  exportAsJSON(environment, environmentIndex)
-    ? toast.success(t("state.download_started"))
-    : toast.error(t("state.download_failed"))
+
+  const message = await exportAsJSON(environment, environmentIndex)
+  E.isRight(message)
+    ? toast.success(t(message.right))
+    : toast.error(t(message.left))
 }
 
 const tippyActions = ref<HTMLDivElement | null>(null)

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -128,6 +128,7 @@ import * as TE from "fp-ts/TaskEither"
 import { pipe } from "fp-ts/function"
 import { ref } from "vue"
 import { TippyComponent } from "vue-tippy"
+import * as E from "fp-ts/Either"
 
 import { useI18n } from "~/composables/i18n"
 import { GQLError } from "~/helpers/backend/GQLClient"
@@ -161,10 +162,12 @@ const secretEnvironmentService = useService(SecretEnvironmentService)
 
 const confirmRemove = ref(false)
 
-const exportEnvironmentAsJSON = () =>
-  exportAsJSON(props.environment)
-    ? toast.success(t("state.download_started"))
-    : toast.error(t("state.download_failed"))
+const exportEnvironmentAsJSON = async () => {
+  const message = await exportAsJSON(props.environment)
+  E.isRight(message)
+    ? toast.success(t(message.right))
+    : toast.error(t(message.left))
+}
 
 const tippyActions = ref<TippyComponent | null>(null)
 const options = ref<TippyComponent | null>(null)

--- a/packages/hoppscotch-common/src/platform/std/io.ts
+++ b/packages/hoppscotch-common/src/platform/std/io.ts
@@ -13,15 +13,17 @@ export const browserIODef: IOPlatformDef = {
     const url = URL.createObjectURL(file)
 
     a.href = url
-    a.download = pipe(
-      url,
-      S.split("/"),
-      RNEA.last,
-      S.split("#"),
-      RNEA.head,
-      S.split("?"),
-      RNEA.head
-    )
+    a.download =
+      opts.suggestedFilename ??
+      pipe(
+        url,
+        S.split("/"),
+        RNEA.last,
+        S.split("#"),
+        RNEA.head,
+        S.split("?"),
+        RNEA.head
+      )
 
     document.body.appendChild(a)
     a.click()


### PR DESCRIPTION
This PR enforces the usage of platform-based API for file exports ensuring compatibility across web and Desktop apps. This accounts for export flows related to collections (REST/GQL) & environments.

Closes #4332 HFE-578.

### What's changed

- The `initializeDownloadCollection()` helper function is renamed to `initializeDownloadFile()` and the implementation has been updated to rely on the platform-level APIs instead of the browser-based behaviour. It now returns a promise.
- For exports in general, there'll be a suggested name having the name computed from the URL (based on contents) as a fallback. The platform-level definition under `hoppscotch-selfhost-web` `saveFileWithDialog()`, is updated to prioritise the name if supplied.
- The `exportAsJSON` helper function compiling the export business logic for environments is refactored to leverage the above helper function.
- Minor code refactors aimed at eliminating redundancy to consume existing computed properties, etc and related cleanup.

### Notes to reviewers

Please verify all the export flows (individual/bulk at the workspace level) for both the web and Desktop apps.