### PR TITLE
fix: close context menu when no text is selected

### DIFF
--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -254,7 +254,6 @@ export function useCodemirror(
 
   function handleTextSelection() {
     const selection = view.value?.state.selection.main
-    console.log("selection", selection)
     if (selection) {
       const { from, to } = selection
 

--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -242,11 +242,28 @@ export function useCodemirror(
     ? new HoppEnvironmentPlugin(subscribeToStream, view)
     : null
 
+  const closeContextMenu = () => {
+    invokeAction("contextmenu.open", {
+      position: {
+        top: 0,
+        left: 0,
+      },
+      text: null,
+    })
+  }
+
   function handleTextSelection() {
     const selection = view.value?.state.selection.main
+    console.log("selection", selection)
     if (selection) {
       const { from, to } = selection
-      if (from === to) return
+
+      // If the selection is empty, hide the context menu
+      if (from === to) {
+        closeContextMenu()
+        return
+      }
+
       const text = view.value?.state.doc.sliceString(from, to)
       const coords = view.value?.coordsAtPos(from)
       const top = coords?.top ?? 0
@@ -260,13 +277,7 @@ export function useCodemirror(
           text,
         })
       } else {
-        invokeAction("contextmenu.open", {
-          position: {
-            top,
-            left,
-          },
-          text: null,
-        })
+        closeContextMenu()
       }
     }
   }


### PR DESCRIPTION
Closes #4327 HFE-577

This PR fixes the issue wherewith context menu where it fails to close while there is a key press and no text selection is present.

