### PR TITLE
feat: digest authentication added to the request auth types

### DIFF
--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -46,6 +46,7 @@
     "chalk": "5.3.0",
     "commander": "12.1.0",
     "isolated-vm": "5.0.1",
+    "js-md5": "0.8.3",
     "lodash-es": "4.17.21",
     "qs": "6.13.0",
     "verzod": "0.2.3",

--- a/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
@@ -370,19 +370,7 @@ describe("hopp test [options] <file_path_or_id>", () => {
     );
 
     describe("Request variables", () => {
-      test("Picks active request variables and ignores inactive entries", async () => {
-        const COLL_PATH = getTestJsonFilePath(
-          "request-vars-coll.json",
-          "collection"
-        );
-
-        const args = `test ${COLL_PATH}`;
-
-        const { error } = await runCLI(args);
-        expect(error).toBeNull();
-      });
-
-      test("Supports the usage of request variables along with environment variables", async () => {
+      test("Picks active request variables and ignores inactive entries alongside the usage of environment variables", async () => {
         const env = {
           ...process.env,
           secretBasicAuthPasswordEnvVar: "password",
@@ -431,12 +419,8 @@ describe("hopp test [options] <file_path_or_id>", () => {
       });
     });
 
-    describe("Digest auth type", () => {
+    describe("Digest Authorization type", () => {
       test("Successfully translates the authorization information to headers/query params and sends it along with the request", async () => {
-        const env = {
-          ...process.env,
-        };
-
         const COLL_PATH = getTestJsonFilePath(
           "digest-auth-coll.json",
           "collection"
@@ -447,7 +431,7 @@ describe("hopp test [options] <file_path_or_id>", () => {
         );
 
         const args = `test ${COLL_PATH} -e ${ENVS_PATH}`;
-        const { error } = await runCLI(args, { env });
+        const { error } = await runCLI(args);
 
         expect(error).toBeNull();
       });

--- a/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
@@ -430,6 +430,28 @@ describe("hopp test [options] <file_path_or_id>", () => {
         expect(error).toBeNull();
       });
     });
+
+    describe("Digest auth type", () => {
+      test("Successfully translates the authorization information to headers/query params and sends it along with the request", async () => {
+        const env = {
+          ...process.env,
+        };
+
+        const COLL_PATH = getTestJsonFilePath(
+          "digest-auth-coll.json",
+          "collection"
+        );
+        const ENVS_PATH = getTestJsonFilePath(
+          "digest-auth-envs.json",
+          "environment"
+        );
+
+        const args = `test ${COLL_PATH} -e ${ENVS_PATH}`;
+        const { error } = await runCLI(args, { env });
+
+        expect(error).toBeNull();
+      });
+    });
   });
 
   describe("Test `hopp test <file_path_or_id> --delay <delay_in_ms>` command:", () => {

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/digest-auth-coll.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/digest-auth-coll.json
@@ -1,0 +1,41 @@
+{
+  "v": 3,
+  "name": "Digest Auth - collection",
+  "folders": [],
+  "requests": [
+    {
+      "v": "8",
+      "id": "cm0dm70cw000687bnxi830zz7",
+      "auth": {
+        "authType": "digest",
+        "username": "<<username>>",
+        "password": "<<password>>",
+        "realm": "",
+        "nonce": "",
+        "algorithm": "MD5",
+        "qop": "auth",
+        "nc": "",
+        "cnonce": "",
+        "opaque": "",
+        "disableRetry": false
+      },
+      "body": {
+        "body": null,
+        "contentType": null
+      },
+      "name": "digest-auth-headers",
+      "method": "GET",
+      "params": [],
+      "headers": [],
+      "endpoint": "<<url>>",
+      "testScript": "pw.test(\"Status code is 200\", ()=> { pw.expect(pw.response.status).toBe(200);});",
+      "preRequestScript": "",
+      "requestVariables": []
+    }
+  ],
+  "auth": {
+    "authType": "inherit",
+    "authActive": true
+  },
+  "headers": []
+}

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/digest-auth-coll.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/digest-auth-coll.json
@@ -31,6 +31,7 @@
       "endpoint": "<<url>>",
       "testScript": "pw.test(\"Status code is 200\", ()=> { pw.expect(pw.response.status).toBe(200);});",
       "preRequestScript": "",
+      "responses": {},
       "requestVariables": []
     }
   ],

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/digest-auth-coll.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/digest-auth-coll.json
@@ -8,6 +8,7 @@
       "id": "cm0dm70cw000687bnxi830zz7",
       "auth": {
         "authType": "digest",
+        "authActive": true,
         "username": "<<username>>",
         "password": "<<password>>",
         "realm": "",

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/digest-auth-failure-coll.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/digest-auth-failure-coll.json
@@ -1,6 +1,6 @@
 {
   "v": 3,
-  "name": "Digest Auth - collection",
+  "name": "Digest Auth (failure state) - collection",
   "folders": [],
   "requests": [
     {
@@ -18,7 +18,7 @@
         "nc": "",
         "cnonce": "",
         "opaque": "",
-        "disableRetry": false
+        "disableRetry": true
       },
       "body": {
         "body": null,
@@ -29,7 +29,7 @@
       "params": [],
       "headers": [],
       "endpoint": "<<url>>",
-      "testScript": "pw.test(\"Status code is 200\", ()=> { pw.expect(pw.response.status).toBe(200);}); \n pw.test(\"Receives the www-authenticate header\", ()=> { pw.expect(pw.response.headers['www-authenticate']).toBeType('string');});",
+      "testScript": "pw.test(\"Status code is not 200\", ()=> { pw.expect(pw.response.status).not.toBe(200);}); \n pw.test(\"Receives the www-authenticate header\", ()=> { pw.expect(pw.response.headers['www-authenticate']).not.toBeType('string');});",
       "preRequestScript": "",
       "responses": {},
       "requestVariables": []

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/digest-auth-success-coll.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/digest-auth-success-coll.json
@@ -1,6 +1,6 @@
 {
   "v": 3,
-  "name": "Digest Auth - collection",
+  "name": "Digest Auth (success state) - collection",
   "folders": [],
   "requests": [
     {

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/digest-auth-envs.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/digest-auth-envs.json
@@ -1,0 +1,21 @@
+{
+  "v": 1,
+  "id": "cm0dsn3v70004p4qk3l9b7sjm",
+  "name": "Digest Auth - environments",
+  "variables": [
+    {
+      "key": "username",
+      "value": "admin",
+      "secret": true
+    },
+    {
+      "key": "password",
+      "value": "admin",
+      "secret": true
+    },
+    {
+      "key": "url",
+      "value": "https://test.insightres.org/digest/"
+    }
+  ]
+}

--- a/packages/hoppscotch-cli/src/utils/auth/digest.ts
+++ b/packages/hoppscotch-cli/src/utils/auth/digest.ts
@@ -1,0 +1,130 @@
+import { md5 } from "js-md5";
+import * as E from "fp-ts/Either";
+
+export interface DigestAuthParams {
+  username: string;
+  password: string;
+  realm: string;
+  nonce: string;
+  endpoint: string;
+  method: string;
+  algorithm: string;
+  qop: string;
+  nc?: string;
+  opaque?: string;
+  cnonce?: string; // client nonce (optional but typically required in qop='auth')
+}
+
+// Function to generate Digest Auth Header
+export async function generateDigestAuthHeader(params: DigestAuthParams) {
+  const {
+    username,
+    password,
+    realm,
+    nonce,
+    endpoint,
+    method,
+    algorithm = "MD5",
+    qop,
+    nc = "00000001",
+    opaque,
+    cnonce,
+  } = params;
+
+  const uri = endpoint.replace(/(^\w+:|^)\/\//, "");
+
+  // Generate client nonce if not provided
+  const generatedCnonce = cnonce || md5(`${Math.random()}`);
+
+  // Step 1: Hash the username, realm, and password
+  const ha1 = md5(`${username}:${realm}:${password}`);
+
+  // Step 2: Hash the method and URI
+  const ha2 = md5(`${method}:${uri}`);
+
+  // Step 3: Compute the response hash
+  const response = md5(
+    `${ha1}:${nonce}:${nc}:${generatedCnonce}:${qop}:${ha2}`
+  );
+
+  // Build the Digest header
+  let authHeader = `Digest username="${username}", realm="${realm}", nonce="${nonce}", uri="${uri}", algorithm="${algorithm}", response="${response}", qop=${qop}, nc=${nc}, cnonce="${generatedCnonce}"`;
+
+  if (opaque) {
+    authHeader += `, opaque="${opaque}"`;
+  }
+
+  return authHeader;
+}
+
+export interface DigestAuthInfo {
+  realm: string;
+  nonce: string;
+  qop: string;
+  opaque?: string;
+  algorithm: string;
+}
+
+export async function fetchInitialDigestAuthInfo(
+  url: string,
+  method: string
+): Promise<DigestAuthInfo> {
+  console.log("Fetching initial digest auth info...");
+  try {
+    const service = getService(InterceptorService);
+    const initialResponse = await service.runRequest({
+      url,
+      method,
+    }).response;
+
+    if (E.isLeft(initialResponse))
+      throw new Error(`Unexpected response: ${initialResponse.left}`);
+
+    // Check if the response status is 401 (which is expected in Digest Auth flow)
+    if (initialResponse.right.status === 401) {
+      const authHeader = initialResponse.right.headers["www-authenticate"];
+
+      if (authHeader) {
+        const authParams = parseDigestAuthHeader(authHeader);
+        if (
+          authParams &&
+          authParams.realm &&
+          authParams.nonce &&
+          authParams.qop
+        ) {
+          return {
+            realm: authParams.realm,
+            nonce: authParams.nonce,
+            qop: authParams.qop,
+            opaque: authParams.opaque,
+            algorithm: authParams.algorithm,
+          };
+        }
+      }
+      throw new Error(
+        "Failed to parse authentication parameters from WWW-Authenticate header"
+      );
+    } else {
+      throw new Error(`Unexpected response: ${initialResponse.right.status}`);
+    }
+  } catch (error) {
+    console.error("Error fetching initial digest auth info:", error);
+    throw error; // Re-throw the error to handle it further up the chain if needed
+  }
+}
+
+// Utility function to parse Digest auth header values
+function parseDigestAuthHeader(
+  header: string
+): { [key: string]: string } | null {
+  const matches = header.match(/([a-z0-9]+)="([^"]+)"/gi);
+  if (!matches) return null;
+
+  const authParams: { [key: string]: string } = {};
+  matches.forEach((match) => {
+    const parts = match.split("=");
+    authParams[parts[0]] = parts[1].replace(/"/g, "");
+  });
+
+  return authParams;
+}

--- a/packages/hoppscotch-cli/src/utils/pre-request.ts
+++ b/packages/hoppscotch-cli/src/utils/pre-request.ts
@@ -272,8 +272,6 @@ export async function getEffectiveRESTRequest(
       // Step 3: Generate the Authorization header
       const authHeaderValue = await generateDigestAuthHeader(digestAuthParams);
 
-      console.log("Digest Auth Header:", authHeaderValue);
-
       effectiveFinalHeaders.push({
         active: true,
         key: "Authorization",

--- a/packages/hoppscotch-cli/src/utils/pre-request.ts
+++ b/packages/hoppscotch-cli/src/utils/pre-request.ts
@@ -238,14 +238,13 @@ export async function getEffectiveRESTRequest(
         });
       }
     } else if (request.auth.authType === "digest") {
-      // TODO: Implement Digest Auth
-
       const { method, endpoint } = request as HoppRESTRequest;
 
       // Step 1: Fetch the initial auth info (nonce, realm, etc.)
       const authInfo = await fetchInitialDigestAuthInfo(
         parseTemplateString(endpoint, resolvedVariables),
-        method
+        method,
+        request.auth.disableRetry
       );
 
       // Step 2: Set up the parameters for the digest authentication header

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -240,6 +240,7 @@ export const processRequest =
 
       // Updating report for errors & current result
       report.errors.push(preRequestRes.left);
+      console.error(`Report result is `, report.result);
       report.result = report.result;
     } else {
       // Updating effective-request and consuming updated envs after pre-request script execution

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -227,7 +227,7 @@
       "client_nonce": "Client Nonce",
       "opaque": "Opaque",
       "disable_retry": "Disable Retrying Request",
-      "inspector_warning": "Agent interceptor is recommended when using Digest Authorization"
+      "inspector_warning": "Agent interceptor is recommended when using Digest Authorization."
     }
   },
   "collection": {

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -227,7 +227,8 @@
       "nonce_count": "Nonce Count",
       "client_nonce": "Client Nonce",
       "opaque": "Opaque",
-      "disable_retry": "Disable Retrying Request"
+      "disable_retry": "Disable Retrying Request",
+      "inspector_warning": "Agent interceptor is recommended when using Digest Authorization"
     }
   },
   "collection": {

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -219,7 +219,6 @@
       "service_token": "Service Token"
     },
     "digest": {
-      "initial_fetch_failed": "Fetching initial digest authorization information failed. Please check console more context.",
       "realm": "Realm",
       "nonce": "Nonce",
       "algorithm": "Algorithm",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -209,14 +209,25 @@
     "token": "Token",
     "type": "Authorization Type",
     "username": "Username",
+    "advance_config": "Advanced Configuration",
+    "advance_config_description": "Hoppscotch automatically assigns default values to certain fields if no explicit value is provided",
     "aws_signature": {
       "access_key": "Access Key",
       "secret_key": "Secret Key",
       "service_name": "Service Name",
       "aws_region": "AWS Region",
-      "service_token": "Service Token",
-      "advance_config": "Advanced Configuration",
-      "advance_config_description": "Hoppscotch automatically assigns default values to certain fields if no explicit value is provided"
+      "service_token": "Service Token"
+    },
+    "digest": {
+      "initial_fetch_failed": "Fetching initial digest authorization information failed. Please check console more context.",
+      "realm": "Realm",
+      "nonce": "Nonce",
+      "algorithm": "Algorithm",
+      "qop": "qop",
+      "nonce_count": "Nonce Count",
+      "client_nonce": "Client Nonce",
+      "opaque": "Opaque",
+      "disable_retry": "Disable Retrying Request"
     }
   },
   "collection": {

--- a/packages/hoppscotch-common/package.json
+++ b/packages/hoppscotch-common/package.json
@@ -64,6 +64,7 @@
     "graphql-tag": "2.12.6",
     "insomnia-importers": "3.6.0",
     "io-ts": "2.2.21",
+    "js-md5": "0.8.3",
     "js-yaml": "4.1.0",
     "jsonc-parser": "3.3.1",
     "jsonpath-plus": "10.0.0",

--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -135,6 +135,7 @@ declare module 'vue' {
     HttpAuthorizationASAP: typeof import('./components/http/authorization/ASAP.vue')['default']
     HttpAuthorizationAWSSign: typeof import('./components/http/authorization/AWSSign.vue')['default']
     HttpAuthorizationBasic: typeof import('./components/http/authorization/Basic.vue')['default']
+    HttpAuthorizationDigest: typeof import('./components/http/authorization/Digest.vue')['default']
     HttpAuthorizationHAWK: typeof import('./components/http/authorization/HAWK.vue')['default']
     HttpAuthorizationNTLM: typeof import('./components/http/authorization/NTLM.vue')['default']
     HttpAuthorizationOAuth2: typeof import('./components/http/authorization/OAuth2.vue')['default']

--- a/packages/hoppscotch-common/src/components/app/spotlight/Entry.vue
+++ b/packages/hoppscotch-common/src/components/app/spotlight/Entry.vue
@@ -80,10 +80,11 @@ const props = defineProps<{
   active: boolean
 }>()
 
-const formattedShortcutKeys = computed(() =>
-  props.entry.meta?.keyboardShortcut?.map(
-    (key) => SPECIAL_KEY_CHARS[key] ?? capitalize(key)
-  )
+const formattedShortcutKeys = computed(
+  () =>
+    props.entry.meta?.keyboardShortcut?.map(
+      (key) => SPECIAL_KEY_CHARS[key] ?? capitalize(key)
+    )
 )
 
 const emit = defineEmits<{

--- a/packages/hoppscotch-common/src/components/graphql/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Authorization.vue
@@ -119,7 +119,8 @@
             {{
               t("authorization.inherited_from", {
                 auth: getAuthName(
-                  inheritedProperties.auth.inheritedAuth.authType
+                  (inheritedProperties.auth.inheritedAuth as HoppGQLAuth)
+                    .authType
                 ),
                 collection: inheritedProperties?.auth.parentName,
               })

--- a/packages/hoppscotch-common/src/components/graphql/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Authorization.vue
@@ -39,7 +39,9 @@
                 :active="item.key === authType"
                 @click="
                   () => {
-                    item.handler ? item.handler() : (auth.authType = item.key)
+                    item.handler
+                      ? item.handler()
+                      : (auth = { ...auth, authType: item.key } as HoppGQLAuth)
                     hide()
                   }
                 "
@@ -176,7 +178,11 @@
 import { useI18n } from "@composables/i18n"
 import { pluckRef } from "@composables/ref"
 import { useColorMode } from "@composables/theming"
-import { HoppGQLAuth, HoppGQLAuthOAuth2 } from "@hoppscotch/data"
+import {
+  HoppGQLAuth,
+  HoppGQLAuthOAuth2,
+  HoppGQLAuthAWSSignature,
+} from "@hoppscotch/data"
 import { useVModel } from "@vueuse/core"
 import { computed, onMounted, ref } from "vue"
 
@@ -255,15 +261,23 @@ const selectAPIKeyAuthType = () => {
 }
 
 const selectAWSSignatureAuthType = () => {
+  const {
+    accessKey = "",
+    secretKey = "",
+    region = "",
+    serviceName = "",
+    addTo = "HEADERS",
+  } = auth.value as HoppGQLAuthAWSSignature
+
   auth.value = {
     ...auth.value,
     authType: "aws-signature",
-    addTo: "HEADERS",
-    accessKey: "",
-    secretKey: "",
-    region: "",
-    serviceName: "",
-  } as HoppGQLAuth
+    addTo,
+    accessKey,
+    secretKey,
+    region,
+    serviceName,
+  }
 }
 
 const authTypes: AuthType[] = [

--- a/packages/hoppscotch-common/src/components/graphql/Headers.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Headers.vue
@@ -231,6 +231,7 @@ import { useColorMode } from "@composables/theming"
 import { useToast } from "@composables/toast"
 import {
   GQLHeader,
+  HoppGQLAuth,
   HoppGQLRequest,
   parseRawKeyValueEntriesE,
   rawKeyValueEntriesToString,
@@ -675,7 +676,7 @@ const inheritedProperties = computedAsync(async () => {
 
   const [computedAuthHeader] = await getComputedAuthHeaders(
     request.value,
-    props.inheritedProperties.auth.inheritedAuth
+    props.inheritedProperties.auth.inheritedAuth as HoppGQLAuth
   )
 
   if (

--- a/packages/hoppscotch-common/src/components/http/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/http/Authorization.vue
@@ -149,6 +149,9 @@
         <div v-if="auth.authType === 'aws-signature'">
           <HttpAuthorizationAWSSign v-model="auth" :envs="envs" />
         </div>
+        <div v-if="auth.authType === 'digest'">
+          <HttpAuthorizationDigest v-model="auth" :envs="envs" />
+        </div>
       </div>
       <div
         class="z-[9] sticky top-upperTertiaryStickyFold h-full min-w-[12rem] max-w-1/3 flex-shrink-0 overflow-auto overflow-x-auto bg-primary p-4"
@@ -235,6 +238,15 @@ const selectAPIKeyAuthType = () => {
   } as HoppRESTAuth
 }
 
+const selectDigestAuthType = () => {
+  auth.value = {
+    ...auth.value,
+    authType: "digest",
+    username: "",
+    password: "",
+  } as HoppRESTAuth
+}
+
 const selectAWSSignatureAuthType = () => {
   auth.value = {
     ...auth.value,
@@ -259,6 +271,11 @@ const authTypes: AuthType[] = [
   {
     key: "basic",
     label: "Basic Auth",
+  },
+  {
+    key: "digest",
+    label: "Digest Auth",
+    handler: selectDigestAuthType,
   },
   {
     key: "bearer",

--- a/packages/hoppscotch-common/src/components/http/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/http/Authorization.vue
@@ -39,7 +39,9 @@
                 :active="item.key === authType"
                 @click="
                   () => {
-                    item.handler ? item.handler() : (auth.authType = item.key)
+                    item.handler
+                      ? item.handler()
+                      : (auth = { ...auth, authType: item.key } as HoppRESTAuth)
                     hide()
                   }
                 "
@@ -187,7 +189,12 @@ import IconHelpCircle from "~icons/lucide/help-circle"
 import IconTrash2 from "~icons/lucide/trash-2"
 
 import { getDefaultAuthCodeOauthFlowParams } from "~/services/oauth/flows/authCode"
-import { HoppRESTAuth, HoppRESTAuthOAuth2 } from "@hoppscotch/data"
+import {
+  HoppRESTAuth,
+  HoppRESTAuthAWSSignature,
+  HoppRESTAuthDigest,
+  HoppRESTAuthOAuth2,
+} from "@hoppscotch/data"
 
 const t = useI18n()
 
@@ -238,25 +245,41 @@ const selectAPIKeyAuthType = () => {
   } as HoppRESTAuth
 }
 
-const selectDigestAuthType = () => {
-  auth.value = {
-    ...auth.value,
-    authType: "digest",
-    username: "",
-    password: "",
-    algorithm: "MD5",
-  } as HoppRESTAuth
-}
-
 const selectAWSSignatureAuthType = () => {
+  const {
+    accessKey = "",
+    secretKey = "",
+    region = "",
+    serviceName = "",
+    addTo = "HEADERS",
+  } = auth.value as HoppRESTAuthAWSSignature
+
   auth.value = {
     ...auth.value,
     authType: "aws-signature",
-    addTo: "HEADERS",
-    accessKey: "",
-    secretKey: "",
-    region: "",
-    serviceName: "",
+    addTo,
+    accessKey,
+    secretKey,
+    region,
+    serviceName,
+  }
+}
+
+const selectDigestAuthType = () => {
+  const {
+    username = "",
+    password = "",
+    algorithm = "MD5",
+  } = auth.value as HoppRESTAuthDigest
+
+  console.error(`Auth is `, auth.value)
+
+  auth.value = {
+    ...auth.value,
+    authType: "digest",
+    username,
+    password,
+    algorithm,
   } as HoppRESTAuth
 }
 

--- a/packages/hoppscotch-common/src/components/http/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/http/Authorization.vue
@@ -244,6 +244,7 @@ const selectDigestAuthType = () => {
     authType: "digest",
     username: "",
     password: "",
+    algorithm: "MD5",
   } as HoppRESTAuth
 }
 

--- a/packages/hoppscotch-common/src/components/http/authorization/AWSSign.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/AWSSign.vue
@@ -21,11 +21,11 @@
   <div class="flex flex-col divide-y divide-dividerLight">
     <!-- label as advanced config here -->
     <div class="p-4 flex flex-col space-y-1">
-      <label class="">
-        {{ t("authorization.aws_signature.advance_config") }}
+      <label>
+        {{ t("authorization.advance_config") }}
       </label>
       <p class="text-secondaryLight">
-        {{ t("authorization.aws_signature.advance_config_description") }}
+        {{ t("authorization.advance_config_description") }}
       </p>
     </div>
     <div class="flex flex-1">

--- a/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
@@ -2,18 +2,17 @@
   <div class="flex flex-1 border-b border-dividerLight">
     <SmartEnvInput
       v-model="auth.username"
-      :auto-complete-env="true"
       :placeholder="t('authorization.username')"
+      :auto-complete-env="true"
       :envs="envs"
     />
   </div>
   <div class="flex flex-1 border-b border-dividerLight">
-    <input
+    <SmartEnvInput
       v-model="auth.password"
-      name="password"
       :placeholder="t('authorization.password')"
-      class="flex flex-1 bg-transparent px-4 py-2"
-      type="password"
+      :auto-complete-env="true"
+      :envs="envs"
     />
   </div>
 
@@ -124,7 +123,7 @@
       />
     </div>
 
-    <div class="px-4 mt-4">
+    <div class="px-4 mt-4 pb-6">
       <HoppSmartCheckbox
         :on="auth.disableRetry"
         @change="auth.disableRetry = !auth.disableRetry"

--- a/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
@@ -29,7 +29,102 @@
       </p>
     </div>
 
-    <div class="px-4 mt-6">
+    <div class="flex flex-1 border-b border-dividerLight">
+      <SmartEnvInput
+        v-model="auth.realm"
+        :auto-complete-env="true"
+        placeholder="Realm (e.g. testrealm@example.com)"
+        :envs="envs"
+      />
+    </div>
+
+    <div class="flex flex-1 border-b border-dividerLight">
+      <SmartEnvInput
+        v-model="auth.nonce"
+        :auto-complete-env="true"
+        placeholder="Nonce"
+        :envs="envs"
+      />
+    </div>
+
+    <div class="flex items-center border-b border-dividerLight">
+      <span class="flex items-center">
+        <label class="ml-4 text-secondaryLight"> Algorithm </label>
+        <tippy
+          interactive
+          trigger="click"
+          theme="popover"
+          :on-shown="() => authTippyActions.focus()"
+        >
+          <HoppSmartSelectWrapper>
+            <HoppButtonSecondary
+              :label="auth.algorithm"
+              class="ml-2 rounded-none pr-8"
+            />
+          </HoppSmartSelectWrapper>
+          <template #content="{ hide }">
+            <div
+              ref="authTippyActions"
+              class="flex flex-col focus:outline-none"
+              tabindex="0"
+              @keyup.escape="hide()"
+            >
+              <HoppSmartItem
+                v-for="alg in algorithms"
+                :key="alg"
+                :icon="auth.algorithm === alg ? IconCircleDot : IconCircle"
+                :active="auth.algorithm === alg"
+                :label="alg"
+                @click="
+                  () => {
+                    auth.algorithm = alg
+                    hide()
+                  }
+                "
+              />
+            </div>
+          </template>
+        </tippy>
+      </span>
+    </div>
+
+    <div class="flex flex-1 border-b border-dividerLight">
+      <SmartEnvInput
+        v-model="auth.qop"
+        :auto-complete-env="true"
+        placeholder="qop (e.g. auth-int)"
+        :envs="envs"
+      />
+    </div>
+
+    <div class="flex flex-1 border-b border-dividerLight">
+      <SmartEnvInput
+        v-model="auth.nc"
+        :auto-complete-env="true"
+        placeholder="Nonce Count (e.g. 00000001)"
+        :envs="envs"
+      />
+    </div>
+
+    <div class="flex flex-1 border-b border-dividerLight">
+      <SmartEnvInput
+        v-model="auth.cnonce"
+        :auto-complete-env="true"
+        placeholder="Client Nonce (e.g. Oa4f113b)"
+        :envs="envs"
+      />
+    </div>
+
+    <div class="flex flex-1 border-b border-dividerLight">
+      <SmartEnvInput
+        v-model="auth.opaque"
+        :auto-complete-env="true"
+        placeholder="Opaque"
+        :envs="envs"
+      />
+    </div>
+
+    <div class="px-4 mt-4">
       <HoppSmartCheckbox
         :on="auth.disableRetry"
         @change="auth.disableRetry = !auth.disableRetry"
@@ -41,10 +136,13 @@
 </template>
 
 <script setup lang="ts">
+import IconCircle from "~icons/lucide/circle"
+import IconCircleDot from "~icons/lucide/circle-dot"
 import { useI18n } from "@composables/i18n"
 import { HoppRESTAuthDigest } from "@hoppscotch/data"
 import { useVModel } from "@vueuse/core"
 import { AggregateEnvironment } from "~/newstore/environments"
+import { ref } from "vue"
 
 const t = useI18n()
 
@@ -57,5 +155,9 @@ const emit = defineEmits<{
   (e: "update:modelValue", value: HoppRESTAuthDigest): void
 }>()
 
+const algorithms: HoppRESTAuthDigest["algorithm"][] = ["MD5", "MD5-sess"]
+
 const auth = useVModel(props, "modelValue", emit)
+
+const authTippyActions = ref<any | null>(null)
 </script>

--- a/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="flex flex-1 border-b border-dividerLight">
+    <SmartEnvInput
+      v-model="auth.username"
+      :auto-complete-env="true"
+      :placeholder="t('authorization.username')"
+      :envs="envs"
+    />
+  </div>
+  <div class="flex flex-1 border-b border-dividerLight">
+    <input
+      v-model="auth.password"
+      name="password"
+      :placeholder="t('authorization.password')"
+      class="flex flex-1 bg-transparent px-4 py-2"
+      type="password"
+    />
+  </div>
+
+  <!-- advanced config -->
+
+  <div>
+    <!-- label as advanced config here -->
+    <div class="p-4">
+      <label class="text-secondaryLight"> Advanced Configuration </label>
+      <p>
+        Hoppscotch automatically assigns default values to certain fields if no
+        explicit value is provided.
+      </p>
+    </div>
+
+    <div class="px-4 mt-6">
+      <HoppSmartCheckbox
+        :on="auth.disableRetry"
+        @change="auth.disableRetry = !auth.disableRetry"
+      >
+        Disable Retrying Requset
+      </HoppSmartCheckbox>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from "@composables/i18n"
+import { HoppRESTAuthDigest } from "@hoppscotch/data"
+import { useVModel } from "@vueuse/core"
+import { AggregateEnvironment } from "~/newstore/environments"
+
+const t = useI18n()
+
+const props = defineProps<{
+  modelValue: HoppRESTAuthDigest
+  envs?: AggregateEnvironment[]
+}>()
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: HoppRESTAuthDigest): void
+}>()
+
+const auth = useVModel(props, "modelValue", emit)
+</script>

--- a/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
@@ -18,13 +18,15 @@
 
   <!-- advanced config -->
 
-  <div>
+  <div class="flex flex-col divide-y divide-dividerLight">
     <!-- label as advanced config here -->
-    <div class="p-4">
-      <label class="text-secondaryLight"> Advanced Configuration </label>
-      <p>
-        Hoppscotch automatically assigns default values to certain fields if no
-        explicit value is provided.
+    <div class="p-4 flex flex-col space-y-1">
+      <label>
+        {{ t("authorization.advance_config") }}
+      </label>
+
+      <p class="text-secondaryLight">
+        {{ t("authorization.advance_config_description") }}
       </p>
     </div>
 
@@ -32,7 +34,10 @@
       <SmartEnvInput
         v-model="auth.realm"
         :auto-complete-env="true"
-        placeholder="Realm (e.g. testrealm@example.com)"
+        :placeholder="`${t(
+          'authorization.digest.realm'
+        )} (e.g. testrealm@example.com)
+        `"
         :envs="envs"
       />
     </div>
@@ -41,14 +46,16 @@
       <SmartEnvInput
         v-model="auth.nonce"
         :auto-complete-env="true"
-        placeholder="Nonce"
+        :placeholder="t('authorization.digest.nonce')"
         :envs="envs"
       />
     </div>
 
     <div class="flex items-center border-b border-dividerLight">
       <span class="flex items-center">
-        <label class="ml-4 text-secondaryLight"> Algorithm </label>
+        <label class="ml-4 text-secondaryLight">
+          {{ t("authorization.digest.algorithm") }}
+        </label>
         <tippy
           interactive
           trigger="click"
@@ -91,7 +98,8 @@
       <SmartEnvInput
         v-model="auth.qop"
         :auto-complete-env="true"
-        placeholder="qop (e.g. auth-int)"
+        :placeholder="`${t('authorization.digest.qop')} (e.g. auth-int)
+        `"
         :envs="envs"
       />
     </div>
@@ -100,7 +108,8 @@
       <SmartEnvInput
         v-model="auth.nc"
         :auto-complete-env="true"
-        placeholder="Nonce Count (e.g. 00000001)"
+        :placeholder="`${t('authorization.digest.nonce_count')} (e.g. 00000001)
+        `"
         :envs="envs"
       />
     </div>
@@ -109,7 +118,8 @@
       <SmartEnvInput
         v-model="auth.cnonce"
         :auto-complete-env="true"
-        placeholder="Client Nonce (e.g. Oa4f113b)"
+        :placeholder="`${t('authorization.digest.client_nonce')} (e.g. Oa4f113b)
+        `"
         :envs="envs"
       />
     </div>
@@ -118,7 +128,7 @@
       <SmartEnvInput
         v-model="auth.opaque"
         :auto-complete-env="true"
-        placeholder="Opaque"
+        :placeholder="t('authorization.digest.opaque')"
         :envs="envs"
       />
     </div>
@@ -128,7 +138,7 @@
         :on="auth.disableRetry"
         @change="auth.disableRetry = !auth.disableRetry"
       >
-        Disable Retrying Requset
+        {{ t("authorization.digest.disable_retry") }}
       </HoppSmartCheckbox>
     </div>
   </div>

--- a/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
@@ -133,7 +133,7 @@
       />
     </div>
 
-    <div class="px-4 mt-4 pb-6">
+    <div class="px-4 pt-3 pb-6">
       <HoppSmartCheckbox
         :on="auth.disableRetry"
         @change="auth.disableRetry = !auth.disableRetry"

--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -375,7 +375,7 @@ export function useCodemirror(
       language.of(
         getEditorLanguage(
           options.extendedEditorConfig.useLang
-            ? ((options.extendedEditorConfig.mode as any) ?? "")
+            ? (options.extendedEditorConfig.mode as any) ?? ""
             : "",
           options.linter ?? undefined,
           options.completer ?? undefined
@@ -486,7 +486,7 @@ export function useCodemirror(
         effects: language.reconfigure(
           getEditorLanguage(
             options.extendedEditorConfig.useLang
-              ? ((options.extendedEditorConfig.mode as any) ?? "")
+              ? (options.extendedEditorConfig.mode as any) ?? ""
               : "",
             options.linter ?? undefined,
             options.completer ?? undefined

--- a/packages/hoppscotch-common/src/helpers/auth/digest.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/digest.ts
@@ -1,0 +1,132 @@
+import crypto from "crypto"
+
+export interface DigestAuthParams {
+  username: string
+  password: string
+  realm?: string
+  nonce?: string
+  uri: string
+  method: string
+  qop?: string
+  nc?: string
+  opaque?: string
+  cnonce?: string // client nonce (optional but typically required in qop='auth')
+}
+
+export function generateDigestAuthHeader(params: DigestAuthParams): string {
+  const {
+    username,
+    password,
+    realm = "",
+    nonce = "",
+    uri,
+    method,
+    qop,
+    nc = "00000001", // Nonce count (incrementing in case of multiple requests)
+    opaque,
+    cnonce = crypto.randomBytes(16).toString("hex"), // client nonce
+  } = params
+
+  // HA1 = MD5(username:realm:password)
+  const ha1 = crypto
+    .createHash("md5")
+    .update(`${username}:${realm}:${password}`)
+    .digest("hex")
+
+  // HA2 = MD5(method:uri)
+  const ha2 = crypto.createHash("md5").update(`${method}:${uri}`).digest("hex")
+
+  // Response calculation
+  let response
+  if (qop) {
+    // qop = 'auth' is typically used
+    response = crypto
+      .createHash("md5")
+      .update(`${ha1}:${nonce}:${nc}:${cnonce}:${qop}:${ha2}`)
+      .digest("hex")
+  } else {
+    // Without qop
+    response = crypto
+      .createHash("md5")
+      .update(`${ha1}:${nonce}:${ha2}`)
+      .digest("hex")
+  }
+
+  // Construct the Authorization header
+  const authHeader = [
+    `Digest username="${username}"`,
+    `realm="${realm}"`,
+    `nonce="${nonce}"`,
+    `uri="${uri}"`,
+    `response="${response}"`,
+    qop ? `qop=${qop}` : "",
+    qop ? `nc=${nc}` : "",
+    qop ? `cnonce="${cnonce}"` : "",
+    opaque ? `opaque="${opaque}"` : "",
+  ]
+    .filter(Boolean) // Remove empty strings
+    .join(", ")
+
+  return authHeader
+}
+
+export interface DigestAuthInfo {
+  realm: string
+  nonce: string
+  qop?: string
+  opaque?: string
+}
+
+export async function fetchInitialDigestAuthInfo(
+  url: string,
+  method: string
+): Promise<DigestAuthInfo> {
+  try {
+    const initialResponse = await fetch(url, {
+      method: method,
+    })
+
+    // Check if the response status is 401 (which is expected in Digest Auth flow)
+    if (initialResponse.status === 401) {
+      const authHeader = initialResponse.headers.get("www-authenticate")
+
+      if (authHeader) {
+        const authParams = parseDigestAuthHeader(authHeader)
+        if (authParams && authParams.nonce && authParams.realm) {
+          return {
+            realm: authParams.realm,
+            nonce: authParams.nonce,
+            qop: authParams.qop,
+            opaque: authParams.opaque,
+          }
+        }
+      }
+      throw new Error(
+        "Failed to parse authentication parameters from WWW-Authenticate header"
+      )
+    } else {
+      throw new Error(`Unexpected response: ${initialResponse.status}`)
+    }
+  } catch (error) {
+    console.error("Error fetching initial digest auth info:", error)
+    throw error // Re-throw the error to handle it further up the chain if needed
+  }
+}
+
+// Utility function to parse Digest auth header values
+function parseDigestAuthHeader(
+  header: string
+): { [key: string]: string } | null {
+  const matches = header.match(/([a-z0-9]+)="([^"]+)"/gi)
+  if (!matches) return null
+
+  const authParams: { [key: string]: string } = {}
+  matches.forEach((match) => {
+    const parts = match.split("=")
+    authParams[parts[0]] = parts[1].replace(/"/g, "")
+  })
+
+  console.log("Parsed auth params:", authParams)
+
+  return authParams
+}

--- a/packages/hoppscotch-common/src/helpers/auth/digest.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/digest.ts
@@ -9,7 +9,7 @@ export interface DigestAuthParams {
   password: string
   realm: string
   nonce: string
-  uri: string
+  endpoint: string
   method: string
   algorithm: string
   qop: string
@@ -25,7 +25,7 @@ export async function generateDigestAuthHeader(params: DigestAuthParams) {
     password,
     realm,
     nonce,
-    uri,
+    endpoint,
     method,
     algorithm = "MD5",
     qop,
@@ -33,6 +33,8 @@ export async function generateDigestAuthHeader(params: DigestAuthParams) {
     opaque,
     cnonce,
   } = params
+
+  const uri = endpoint.replace(/(^\w+:|^)\/\//, "")
 
   // Generate client nonce if not provided
   const generatedCnonce = cnonce || md5(`${Math.random()}`)

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomnia.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomnia.ts
@@ -23,8 +23,9 @@ import { replaceInsomniaTemplating } from "./insomniaEnv"
 
 // TODO: Insomnia allows custom prefixes for Bearer token auth, Hoppscotch doesn't. We just ignore the prefix for now
 
-type UnwrapPromise<T extends Promise<any>> =
-  T extends Promise<infer Y> ? Y : never
+type UnwrapPromise<T extends Promise<any>> = T extends Promise<infer Y>
+  ? Y
+  : never
 
 type InsomniaDoc = UnwrapPromise<ReturnType<typeof convert>>
 type InsomniaResource = ImportRequest

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -116,22 +116,29 @@ export const getComputedAuthHeaders = async (
       method
     )
 
-    console.log("Digest Auth Info:", authInfo)
-
     // Step 2: Set up the parameters for the digest authentication header
     const digestAuthParams: DigestAuthParams = {
       username: parseTemplateString(request.auth.username, envVars),
       password: parseTemplateString(request.auth.password, envVars),
-      realm: authInfo.realm,
-      nonce: authInfo.nonce,
+      realm: request.auth.realm
+        ? parseTemplateString(request.auth.realm, envVars)
+        : authInfo.realm,
+      nonce: request.auth.nonce
+        ? parseTemplateString(authInfo.nonce, envVars)
+        : authInfo.nonce,
       uri: parseTemplateString(endpoint, envVars),
       method,
-      qop: authInfo.qop,
-      opaque: authInfo.opaque,
+      algorithm: request.auth.algorithm ?? authInfo.algorithm,
+      qop: request.auth.qop
+        ? parseTemplateString(request.auth.qop, envVars)
+        : authInfo.qop,
+      opaque: request.auth.opaque
+        ? parseTemplateString(request.auth.opaque, envVars)
+        : authInfo.opaque,
     }
 
     // Step 3: Generate the Authorization header
-    const authHeaderValue = generateDigestAuthHeader(digestAuthParams)
+    const authHeaderValue = await generateDigestAuthHeader(digestAuthParams)
 
     console.log("Digest Auth Header:", authHeaderValue)
 

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -108,11 +108,15 @@ export const getComputedAuthHeaders = async (
   } else if (request.auth.authType === "digest") {
     // TODO: Implement Digest Auth
 
+    const { method, endpoint } = request as HoppRESTRequest
+
     // Step 1: Fetch the initial auth info (nonce, realm, etc.)
     const authInfo = await fetchInitialDigestAuthInfo(
-      parseTemplateString(request.endpoint, envVars),
-      request.method
+      parseTemplateString(endpoint, envVars),
+      method
     )
+
+    console.log("Digest Auth Info:", authInfo)
 
     // Step 2: Set up the parameters for the digest authentication header
     const digestAuthParams: DigestAuthParams = {
@@ -120,8 +124,8 @@ export const getComputedAuthHeaders = async (
       password: parseTemplateString(request.auth.password, envVars),
       realm: authInfo.realm,
       nonce: authInfo.nonce,
-      uri: parseTemplateString(request.endpoint, envVars),
-      method: request.method,
+      uri: parseTemplateString(endpoint, envVars),
+      method,
       qop: authInfo.qop,
       opaque: authInfo.opaque,
     }

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -126,7 +126,7 @@ export const getComputedAuthHeaders = async (
       nonce: request.auth.nonce
         ? parseTemplateString(authInfo.nonce, envVars)
         : authInfo.nonce,
-      uri: parseTemplateString(endpoint, envVars),
+      endpoint: parseTemplateString(endpoint, envVars),
       method,
       algorithm: request.auth.algorithm ?? authInfo.algorithm,
       qop: request.auth.qop

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -106,14 +106,13 @@ export const getComputedAuthHeaders = async (
       description: "",
     })
   } else if (request.auth.authType === "digest") {
-    // TODO: Implement Digest Auth
-
     const { method, endpoint } = request as HoppRESTRequest
 
     // Step 1: Fetch the initial auth info (nonce, realm, etc.)
     const authInfo = await fetchInitialDigestAuthInfo(
       parseTemplateString(endpoint, envVars),
-      method
+      method,
+      request.auth.disableRetry
     )
 
     // Step 2: Set up the parameters for the digest authentication header

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -100,6 +100,8 @@ export const getComputedAuthHeaders = async (
       value: `Basic ${btoa(`${username}:${password}`)}`,
       description: "",
     })
+  } else if (request.auth.authType === "digest") {
+    // TODO: Implement Digest Auth
   } else if (
     request.auth.authType === "bearer" ||
     (request.auth.authType === "oauth-2" && request.auth.addTo === "HEADERS")

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -177,7 +177,7 @@ export const getComputedAuthHeaders = async (
               false,
               showKeyIfSecret
             )
-          : (request.auth.value ?? ""),
+          : request.auth.value ?? "",
         description: "",
       })
     }

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -139,8 +139,6 @@ export const getComputedAuthHeaders = async (
     // Step 3: Generate the Authorization header
     const authHeaderValue = await generateDigestAuthHeader(digestAuthParams)
 
-    console.log("Digest Auth Header:", authHeaderValue)
-
     headers.push({
       active: true,
       key: "Authorization",

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -143,6 +143,7 @@ import { cloneDeep } from "lodash-es"
 import { RESTTabService } from "~/services/tab/rest"
 import { HoppTab } from "~/services/tab"
 import { HoppRequestDocument, HoppTabDocument } from "~/helpers/rest/document"
+import { AuthorizationInspectorService } from "~/services/inspection/inspectors/authorization.inspector"
 
 const savingRequest = ref(false)
 const confirmingCloseForTabID = ref<string | null>(null)
@@ -400,6 +401,7 @@ defineActionHandler("tab.open-new", addNewTab)
 useService(HeaderInspectorService)
 useService(EnvironmentInspectorService)
 useService(ResponseInspectorService)
+useService(AuthorizationInspectorService)
 for (const inspectorDef of platform.additionalInspectors ?? []) {
   useService(inspectorDef.service)
 }

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/authorization.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/authorization.inspector.ts
@@ -50,6 +50,7 @@ export class AuthorizationInspectorService
 
       const results: InspectorResult[] = []
 
+      // `Agent` interceptor is recommended while using Digest Auth
       const isUnsupportedInterceptor =
         this.interceptorService.currentInterceptorID.value !==
         this.agentService.interceptorID

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/authorization.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/authorization.inspector.ts
@@ -91,7 +91,7 @@ export class AuthorizationInspectorService
           severity: 2,
           isApplicable: true,
           locations: {
-            type: "response",
+            type: "url",
           },
           doc: {
             text: this.t("action.learn_more"),

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/authorization.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/authorization.inspector.ts
@@ -1,0 +1,80 @@
+import {
+  HoppRESTRequest,
+  HoppRESTResponseOriginalRequest,
+} from "@hoppscotch/data"
+import { Service } from "dioc"
+import { computed, markRaw, Ref } from "vue"
+
+import { getI18n } from "~/modules/i18n"
+import { AgentInterceptorService } from "~/platform/std/interceptors/agent"
+import { InterceptorService } from "~/services/interceptor.service"
+import IconAlertTriangle from "~icons/lucide/alert-triangle"
+import { InspectionService, Inspector, InspectorResult } from ".."
+
+/**
+ * This inspector is responsible for inspecting the response of a request.
+ * It checks if the response is successful and if it contains errors.
+ *
+ * NOTE: Initializing this service registers it as a inspector with the Inspection Service.
+ */
+export class AuthorizationInspectorService
+  extends Service
+  implements Inspector
+{
+  public static readonly ID = "AUTHORIZATION_INSPECTOR_SERVICE"
+
+  private t = getI18n()
+
+  public readonly inspectorID = "authorization"
+
+  private readonly inspection = this.bind(InspectionService)
+  private readonly interceptorService = this.bind(InterceptorService)
+  private readonly agentService = this.bind(AgentInterceptorService)
+
+  override onServiceInit() {
+    this.inspection.registerInspector(this)
+  }
+
+  getInspections(
+    req: Readonly<Ref<HoppRESTRequest | HoppRESTResponseOriginalRequest>>
+  ) {
+    return computed(() => {
+      const currentInterceptorIDValue =
+        this.interceptorService.currentInterceptorID.value
+
+      if (!currentInterceptorIDValue) {
+        return []
+      }
+
+      const auth = req.value.auth
+
+      const results: InspectorResult[] = []
+
+      const isUnsupportedInterceptor =
+        this.interceptorService.currentInterceptorID.value !==
+        this.agentService.interceptorID
+
+      if (auth.authType === "digest" && isUnsupportedInterceptor) {
+        results.push({
+          id: "url",
+          icon: markRaw(IconAlertTriangle),
+          text: {
+            type: "text",
+            text: this.t("authorization.digest.inspector_warning"),
+          },
+          severity: 2,
+          isApplicable: true,
+          locations: {
+            type: "response",
+          },
+          doc: {
+            text: this.t("action.learn_more"),
+            link: "https://docs.hoppscotch.io/documentation/features/inspections",
+          },
+        })
+      }
+
+      return results
+    })
+  }
+}

--- a/packages/hoppscotch-data/src/graphql/index.ts
+++ b/packages/hoppscotch-data/src/graphql/index.ts
@@ -17,7 +17,7 @@ export {
 
 export { HoppGQLAuthAPIKey } from "./v/4"
 
-export { GQLHeader } from "./v/6"
+export { GQLHeader, HoppGQLAuthAWSSignature } from "./v/6"
 export { HoppGQLAuth, HoppGQLAuthOAuth2 } from "./v/7"
 
 export const GQL_REQ_SCHEMA_VERSION = 7

--- a/packages/hoppscotch-data/src/rest/index.ts
+++ b/packages/hoppscotch-data/src/rest/index.ts
@@ -42,12 +42,12 @@ export {
   HoppRESTHeaders,
   HoppRESTParams,
 } from "./v/7"
-export { HoppRESTAuth, HoppRESTAuthDigest } from "./v/8"
 
 export {
   ClientCredentialsGrantTypeParams,
   HoppRESTAuth,
   HoppRESTAuthOAuth2,
+  HoppRESTAuthDigest,
   PasswordGrantTypeParams,
   HoppRESTResponseOriginalRequest,
   HoppRESTRequestResponse,

--- a/packages/hoppscotch-data/src/rest/index.ts
+++ b/packages/hoppscotch-data/src/rest/index.ts
@@ -42,6 +42,7 @@ export {
   HoppRESTHeaders,
   HoppRESTParams,
 } from "./v/7"
+export { HoppRESTAuthDigest } from "./v/8"
 
 export {
   ClientCredentialsGrantTypeParams,

--- a/packages/hoppscotch-data/src/rest/index.ts
+++ b/packages/hoppscotch-data/src/rest/index.ts
@@ -42,7 +42,7 @@ export {
   HoppRESTHeaders,
   HoppRESTParams,
 } from "./v/7"
-export { HoppRESTAuthDigest } from "./v/8"
+export { HoppRESTAuth, HoppRESTAuthDigest } from "./v/8"
 
 export {
   ClientCredentialsGrantTypeParams,

--- a/packages/hoppscotch-data/src/rest/v/8.ts
+++ b/packages/hoppscotch-data/src/rest/v/8.ts
@@ -64,6 +64,8 @@ export const HoppRESTAuthDigest = z.object({
   disableRetry: z.boolean().catch(false),
 })
 
+export type HoppRESTAuthDigest = z.infer<typeof HoppRESTAuthDigest>
+
 export const HoppRESTAuth = z
   .discriminatedUnion("authType", [
     HoppRESTAuthNone,
@@ -73,6 +75,7 @@ export const HoppRESTAuth = z
     HoppRESTAuthOAuth2,
     HoppRESTAuthAPIKey,
     HoppRESTAuthAWSSignature,
+    HoppRESTAuthDigest,
   ])
   .and(
     z.object({

--- a/packages/hoppscotch-data/src/rest/v/8.ts
+++ b/packages/hoppscotch-data/src/rest/v/8.ts
@@ -49,6 +49,21 @@ export const HoppRESTAuthOAuth2 = z.object({
 
 export type HoppRESTAuthOAuth2 = z.infer<typeof HoppRESTAuthOAuth2>
 
+// in this new version, we add a new auth type for Digest authentication
+export const HoppRESTAuthDigest = z.object({
+  authType: z.literal("digest"),
+  username: z.string().catch(""),
+  password: z.string().catch(""),
+  realm: z.string().catch(""),
+  nonce: z.string().catch(""),
+  algorithm: z.enum(["MD5", "MD5-sess"]).catch("MD5"),
+  qop: z.enum(["auth", "auth-int"]).catch("auth"),
+  nc: z.string().catch(""),
+  cnonce: z.string().catch(""),
+  opaque: z.string().catch(""),
+  disableRetry: z.boolean().catch(false),
+})
+
 export const HoppRESTAuth = z
   .discriminatedUnion("authType", [
     HoppRESTAuthNone,

--- a/packages/hoppscotch-js-sandbox/src/shared-utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/shared-utils.ts
@@ -43,9 +43,8 @@ const setEnv = (
       selectedEnv.value = envValue
     }
   } else if (indexInGlobal >= 0) {
-    if ("value" in global[indexInGlobal]) {
-      ;(global[indexInGlobal] as { value: string }).value = envValue
-    }
+    if ("value" in global[indexInGlobal])
+      (global[indexInGlobal] as { value: string }).value = envValue
   } else {
     selected.push({
       key: envName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -570,6 +570,9 @@ importers:
       io-ts:
         specifier: 2.2.21
         version: 2.2.21(fp-ts@2.16.9)
+      js-md5:
+        specifier: 0.8.3
+        version: 0.8.3
       js-yaml:
         specifier: 4.1.0
         version: 4.1.0
@@ -8728,6 +8731,9 @@ packages:
 
   js-base64@3.7.7:
     resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
+
+  js-md5@0.8.3:
+    resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
 
   js-stringify@1.0.2:
     resolution: {integrity: sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==}
@@ -22068,6 +22074,8 @@ snapshots:
   joycon@3.1.1: {}
 
   js-base64@3.7.7: {}
+
+  js-md5@0.8.3: {}
 
   js-stringify@1.0.2:
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,9 @@ importers:
       isolated-vm:
         specifier: 5.0.1
         version: 5.0.1
+      js-md5:
+        specifier: 0.8.3
+        version: 0.8.3
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21


### PR DESCRIPTION
Closes HFE-570

### What's changed
This PR introduces Digest authentication as new request auth types.

The CLI behaviour has been updated so that any failures reported in the pre/post scripts and request execution will result in a non-zero exit code. Previously, this behaviour was exclusive to failed test assertions.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Note for reviewers

Digest auth works in two stages.

First, it requests for an initial response, where we get necessary information like realm, nonce, algorithm, etc., from the server in the header WWW-Authenticate.

Then, we have to parse information from that header. Finally, we have to generate an authorization header and request with that auth header in the Authorization header property.

#### To test digest auth in CLI
`hopp test src/__tests__/e2e/fixtures/collections/digest-auth-coll.json -e src/__tests__/e2e/fixtures/environments/digest-auth-envs.json`
