### PR TITLE
fix: preserve description while toggling field enabled status

### DIFF
--- a/packages/hoppscotch-common/src/components/http/KeyValue.vue
+++ b/packages/hoppscotch-common/src/components/http/KeyValue.vue
@@ -94,6 +94,7 @@
             key: name,
             value: value,
             active: isActive ? !entityActive : false,
+            description: description ?? '',
           })
         "
       />

--- a/packages/hoppscotch-common/src/components/http/KeyValue.vue
+++ b/packages/hoppscotch-common/src/components/http/KeyValue.vue
@@ -120,6 +120,14 @@ import { useI18n } from "~/composables/i18n"
 import { AggregateEnvironment } from "~/newstore/environments"
 import { InspectorResult } from "~/services/inspection"
 
+type Entity = {
+  id: number
+  key: string
+  value: string
+  active: boolean
+  description: string
+}
+
 const t = useI18n()
 
 defineProps<{
@@ -142,10 +150,13 @@ const emit = defineEmits<{
   (e: "update:value", value: string): void
   (e: "update:description", value: string): void
   (e: "deleteEntity", value: number): void
-  (e: "updateEntity", { index, payload }: { index: number; payload: any }): void
+  (
+    e: "updateEntity",
+    { index, payload }: { index: number; payload: Entity }
+  ): void
 }>()
 
-const updateEntity = (index: number, payload: any) => {
+const updateEntity = (index: number, payload: Entity) => {
   emit("updateEntity", {
     index,
     payload,


### PR DESCRIPTION
When turning a query parameter/header or header on/off, the `Description` field gets cleared.

### What's changed
- Account for the `description` field value while toggling the field enabled status by supplying it alongside the `updateEntity()` function call.
- Enforce stricter types.