### PR TITLE
chore: addition of new GQL subscription for `UserCollection` duplication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
     build:
       dockerfile: packages/hoppscotch-backend/Dockerfile
       context: .
-      target: prod
+      target: dev
     env_file:
       - ./.env
     restart: always
@@ -121,7 +121,7 @@ services:
       - PORT=3000
     volumes:
       # Uncomment the line below when modifying code. Only applicable when using the "dev" target.
-      # - ./packages/hoppscotch-backend/:/usr/src/app
+      - ./packages/hoppscotch-backend/:/usr/src/app
       - /usr/src/app/node_modules/
     depends_on:
       hoppscotch-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
     build:
       dockerfile: packages/hoppscotch-backend/Dockerfile
       context: .
-      target: dev
+      target: prod
     env_file:
       - ./.env
     restart: always
@@ -121,7 +121,7 @@ services:
       - PORT=3000
     volumes:
       # Uncomment the line below when modifying code. Only applicable when using the "dev" target.
-      - ./packages/hoppscotch-backend/:/usr/src/app
+      # - ./packages/hoppscotch-backend/:/usr/src/app
       - /usr/src/app/node_modules/
     depends_on:
       hoppscotch-db:

--- a/packages/hoppscotch-backend/src/pubsub/topicsDefs.ts
+++ b/packages/hoppscotch-backend/src/pubsub/topicsDefs.ts
@@ -46,7 +46,11 @@ export type TopicDef = {
     topic: `user_history/${string}/${'created' | 'updated' | 'deleted'}`
   ]: UserHistory;
   [
-    topic: `user_coll/${string}/${'created' | 'updated' | 'moved'}`
+    topic: `user_coll/${string}/${
+      | 'created'
+      | 'updated'
+      | 'moved'
+      | 'duplicated'}`
   ]: UserCollection;
   [topic: `user_coll/${string}/${'deleted'}`]: UserCollectionRemovedData;
   [topic: `user_coll/${string}/${'order_updated'}`]: UserCollectionReorderData;

--- a/packages/hoppscotch-backend/src/pubsub/topicsDefs.ts
+++ b/packages/hoppscotch-backend/src/pubsub/topicsDefs.ts
@@ -23,6 +23,7 @@ import { TeamInvitation } from 'src/team-invitation/team-invitation.model';
 import { InvitedUser } from '../admin/invited-user.model';
 import {
   UserCollection,
+  UserCollectionDuplicatedData,
   UserCollectionRemovedData,
   UserCollectionReorderData,
 } from 'src/user-collection/user-collections.model';
@@ -46,12 +47,9 @@ export type TopicDef = {
     topic: `user_history/${string}/${'created' | 'updated' | 'deleted'}`
   ]: UserHistory;
   [
-    topic: `user_coll/${string}/${
-      | 'created'
-      | 'updated'
-      | 'moved'
-      | 'duplicated'}`
+    topic: `user_coll/${string}/${'created' | 'updated' | 'moved'}`
   ]: UserCollection;
+  [topic: `user_coll/${string}/${'duplicated'}`]: UserCollectionDuplicatedData;
   [topic: `user_coll/${string}/${'deleted'}`]: UserCollectionRemovedData;
   [topic: `user_coll/${string}/${'order_updated'}`]: UserCollectionReorderData;
   [topic: `team/${string}/member_removed`]: string;

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
@@ -37,7 +37,6 @@ import { ReqType } from 'src/types/RequestTypes';
 import * as E from 'fp-ts/Either';
 import { GqlThrottlerGuard } from 'src/guards/gql-throttler.guard';
 import { SkipThrottle } from '@nestjs/throttler';
-import { any } from 'jest-mock-extended';
 
 @UseGuards(GqlThrottlerGuard)
 @Resolver(() => UserCollection)

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
@@ -16,6 +16,7 @@ import { AuthUser } from 'src/types/AuthUser';
 import { UserCollectionService } from './user-collection.service';
 import {
   UserCollection,
+  UserCollectionDuplicatedData,
   UserCollectionExportJSONData,
   UserCollectionRemovedData,
   UserCollectionReorderData,
@@ -36,6 +37,7 @@ import { ReqType } from 'src/types/RequestTypes';
 import * as E from 'fp-ts/Either';
 import { GqlThrottlerGuard } from 'src/guards/gql-throttler.guard';
 import { SkipThrottle } from '@nestjs/throttler';
+import { any } from 'jest-mock-extended';
 
 @UseGuards(GqlThrottlerGuard)
 @Resolver(() => UserCollection)
@@ -471,7 +473,7 @@ export class UserCollectionResolver {
     return this.pubSub.asyncIterator(`user_coll/${user.uid}/order_updated`);
   }
 
-  @Subscription(() => UserCollection, {
+  @Subscription(() => UserCollectionDuplicatedData, {
     description: 'Listen to when a User Collection has been duplicated',
     resolve: (value) => value,
   })

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
@@ -470,4 +470,14 @@ export class UserCollectionResolver {
   userCollectionOrderUpdated(@GqlUser() user: AuthUser) {
     return this.pubSub.asyncIterator(`user_coll/${user.uid}/order_updated`);
   }
+
+  @Subscription(() => UserCollection, {
+    description: 'Listen to when a User Collection has been duplicated',
+    resolve: (value) => value,
+  })
+  @SkipThrottle()
+  @UseGuards(GqlAuthGuard)
+  userCollectionDuplicated(@GqlUser() user: AuthUser) {
+    return this.pubSub.asyncIterator(`user_coll/${user.uid}/duplicated`);
+  }
 }

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
@@ -1228,7 +1228,7 @@ export class UserCollectionService {
       orderBy: { orderIndex: 'asc' },
     });
 
-    const childCollectionData = await Promise.all(
+    const childCollectionDataList = await Promise.all(
       childCollections.map(async (child) => {
         const result = await this.fetchCollectionData(child.id);
         if (E.isLeft(result)) return E.left(result.left);
@@ -1236,7 +1236,7 @@ export class UserCollectionService {
       }),
     );
 
-    const failedChildData = childCollectionData.find(E.isLeft);
+    const failedChildData = childCollectionDataList.find(E.isLeft);
     if (failedChildData) return E.left(failedChildData.left);
 
     return E.right(<UserCollectionDuplicatedData>{
@@ -1246,7 +1246,11 @@ export class UserCollectionService {
       type: collection.right.type,
       parentID: collection.right.parentID,
       userID: collection.right.userUid,
-      childCollections: JSON.stringify(childCollectionData),
+      childCollections: JSON.stringify(
+        childCollectionDataList.map((childCollection) => {
+          if (E.isRight(childCollection)) return childCollection.right;
+        }),
+      ),
       requests: requests.map((request) => {
         return {
           ...request,

--- a/packages/hoppscotch-backend/src/user-collection/user-collections.model.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collections.model.ts
@@ -1,5 +1,7 @@
 import { ObjectType, Field, ID, registerEnumType } from '@nestjs/graphql';
+import { User } from '@prisma/client';
 import { ReqType } from 'src/types/RequestTypes';
+import { UserRequest } from 'src/user-request/user-request.model';
 
 @ObjectType()
 export class UserCollection {
@@ -77,14 +79,46 @@ export class UserCollectionExportJSONData {
 @ObjectType()
 export class UserCollectionDuplicatedData {
   @Field(() => ID, {
-    description: 'ID of duplicated User Collection',
+    description: 'ID of the user collection',
   })
   id: string;
+
+  @Field({
+    description: 'Displayed title of the user collection',
+  })
+  title: string;
+
+  @Field({
+    description: 'JSON string representing the collection data',
+    nullable: true,
+  })
+  data: string;
 
   @Field(() => ReqType, {
     description: 'Type of the user collection',
   })
   type: ReqType;
+
+  @Field({
+    description: 'Parent ID of the duplicated User Collection',
+    nullable: true,
+  })
+  parentID: string | null;
+
+  @Field({
+    description: 'User ID of the duplicated User Collection',
+  })
+  userID: string;
+
+  @Field(() => [UserCollectionDuplicatedData], {
+    description: 'Child collections of the duplicated User Collection',
+  })
+  childCollections: UserCollectionDuplicatedData[];
+
+  @Field(() => [UserRequest], {
+    description: 'Requests of the duplicated User Collection',
+  })
+  requests: UserRequest[];
 }
 
 registerEnumType(ReqType, {

--- a/packages/hoppscotch-backend/src/user-collection/user-collections.model.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collections.model.ts
@@ -110,10 +110,10 @@ export class UserCollectionDuplicatedData {
   })
   userID: string;
 
-  @Field(() => [UserCollectionDuplicatedData], {
+  @Field({
     description: 'Child collections of the duplicated User Collection',
   })
-  childCollections: UserCollectionDuplicatedData[];
+  childCollections: string;
 
   @Field(() => [UserRequest], {
     description: 'Requests of the duplicated User Collection',

--- a/packages/hoppscotch-backend/src/user-collection/user-collections.model.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collections.model.ts
@@ -73,3 +73,20 @@ export class UserCollectionExportJSONData {
   })
   collectionType: ReqType;
 }
+
+@ObjectType()
+export class UserCollectionDuplicatedData {
+  @Field(() => ID, {
+    description: 'ID of duplicated User Collection',
+  })
+  id: string;
+
+  @Field(() => ReqType, {
+    description: 'Type of the user collection',
+  })
+  type: ReqType;
+}
+
+registerEnumType(ReqType, {
+  name: 'CollType',
+});


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes HSB-476

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
In this PR we add a new GQL subscription `userCollectionDuplicated` which returns the entire UserCollection tree when subscribed to.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Nil
