### PR TITLE
chore: export single User/Team Collection

### DIFF
--- a/packages/hoppscotch-backend/src/team-collection/team-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.resolver.ts
@@ -102,6 +102,36 @@ export class TeamCollectionResolver {
     return jsonString.right;
   }
 
+  @Query(() => String, {
+    description:
+      'Returns a JSON string of all the contents of a Team Collection',
+  })
+  @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
+  @RequiresTeamRole(
+    TeamMemberRole.VIEWER,
+    TeamMemberRole.EDITOR,
+    TeamMemberRole.OWNER,
+  )
+  async exportCollectionToJSON(
+    @Args({ name: 'teamID', description: 'ID of the team', type: () => ID })
+    teamID: string,
+    @Args({
+      name: 'collectionID',
+      description: 'ID of the collection',
+      type: () => ID,
+    })
+    collectionID: string,
+  ) {
+    const collectionData =
+      await this.teamCollectionService.exportCollectionToJSONObject(
+        teamID,
+        collectionID,
+      );
+
+    if (E.isLeft(collectionData)) throwErr(collectionData.left as string);
+    return JSON.stringify(collectionData.right);
+  }
+
   @Query(() => [TeamCollection], {
     description: 'Returns the collections of a team',
   })

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -103,10 +103,7 @@ export class TeamCollectionService {
    * @param collectionID The Collection ID
    * @returns A JSON string containing all the contents of a collection
    */
-  private async exportCollectionToJSONObject(
-    teamID: string,
-    collectionID: string,
-  ) {
+  async exportCollectionToJSONObject(teamID: string, collectionID: string) {
     const collection = await this.getCollection(collectionID);
     if (E.isLeft(collection)) return E.left(TEAM_INVALID_COLL_ID);
 

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -103,7 +103,10 @@ export class TeamCollectionService {
    * @param collectionID The Collection ID
    * @returns A JSON string containing all the contents of a collection
    */
-  async exportCollectionToJSONObject(teamID: string, collectionID: string) {
+  async exportCollectionToJSONObject(
+    teamID: string,
+    collectionID: string,
+  ): Promise<E.Right<CollectionFolder> | E.Left<string>> {
     const collection = await this.getCollection(collectionID);
     if (E.isLeft(collection)) return E.left(TEAM_INVALID_COLL_ID);
 

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
@@ -185,6 +185,32 @@ export class UserCollectionResolver {
     return jsonString.right;
   }
 
+  @Query(() => String, {
+    description:
+      'Returns a JSON string of all the contents of a User Collection',
+  })
+  @UseGuards(GqlAuthGuard)
+  async exportUserCollectionToJSON(
+    @GqlUser() user: AuthUser,
+    @Args({
+      type: () => ID,
+      name: 'collectionID',
+      description: 'ID of the user collection',
+      nullable: true,
+      defaultValue: null,
+    })
+    collectionID: string,
+  ) {
+    const jsonString =
+      await this.userCollectionService.exportUserCollectionToJSONObject(
+        user.uid,
+        collectionID,
+      );
+
+    if (E.isLeft(jsonString)) throwErr(jsonString.left as string);
+    return JSON.stringify(jsonString.right);
+  }
+
   // Mutations
   @Mutation(() => UserCollection, {
     description: 'Creates root REST user collection(no parent user collection)',

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
@@ -196,8 +196,6 @@ export class UserCollectionResolver {
       type: () => ID,
       name: 'collectionID',
       description: 'ID of the user collection',
-      nullable: true,
-      defaultValue: null,
     })
     collectionID: string,
   ) {

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
@@ -835,7 +835,7 @@ export class UserCollectionService {
    * @param collectionID The Collection ID
    * @returns A JSON string containing all the contents of a collection
    */
-  private async exportUserCollectionToJSONObject(
+  async exportUserCollectionToJSONObject(
     userUID: string,
     collectionID: string,
   ): Promise<E.Left<string> | E.Right<CollectionFolder>> {

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -125,6 +125,7 @@ export const getGqlArg = <ArgName extends string>(
  * The choice is yours, but beware... once you start, there is no turning back.
  *
  * PLEASE, NO ONE KNOWS HOW THIS WORKS...
+ * -- Balu, whispering from the great beyond... probably still trying to understand this damn thing.
  *
  * Sequences an array of TaskEither values while maintaining an array of all the error values
  * @param arr Array of TaskEithers

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -116,6 +116,16 @@ export const getGqlArg = <ArgName extends string>(
   );
 
 /**
+ * To the daring adventurer who has stumbled upon this relic of code... welcome.
+ * Many have gazed upon its depths, yet few have returned with answers.
+ * I could have deleted it, but that felt... too easy, too final.
+ *
+ * If you're still reading, perhaps you're the one destined to unravel its secrets.
+ * Or, maybe you're like me—content to let it linger, a puzzle for the ages.
+ * The choice is yours, but beware... once you start, there is no turning back.
+ *
+ * PLEASE, NO ONE KNOWS HOW THIS WORKS...
+ *
  * Sequences an array of TaskEither values while maintaining an array of all the error values
  * @param arr Array of TaskEithers
  * @returns A TaskEither saying all the errors possible on the left or all the success values on the right


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes HSB-470

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
In this PR we add 2 new queries that can be used to export a single `UserCollection` and a `TeamCollection`.
The queries are :

- `exportUserCollectionToJSON`
- `exportCollectionToJSON`

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
nil
