### PR TITLE
fix(desktop): content security policy config preventing app launch

### DIFF
--- a/packages/hoppscotch-selfhost-desktop/src-tauri/tauri.conf.json
+++ b/packages/hoppscotch-selfhost-desktop/src-tauri/tauri.conf.json
@@ -49,7 +49,7 @@
       "targets": "all"
     },
     "security": {
-      "csp": "none"
+      "csp": null
     },
     "updater": {
       "active": false


### PR DESCRIPTION
# Fix Content Security Policy (CSP) Configuration Preventing Desktop App Launch

## Issue Description
The desktop application was failing to launch across multiple operating systems and build types. Users reported a perpetual loading spinner.

Closes HFE-598, Closes #4348 , Closes #4100 

## Current Status
- The application now launches successfully on all tested platforms and build types.
- Loading spinner issue is resolved.
- JavaScript compilation errors and EvalErrors related to CSP are no longer occurring.
- GraphQL connections are successful.