### PR TITLE
fix: resolve personal environments correctly while editing via quick peek

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/index.vue
@@ -135,12 +135,11 @@ defineActionHandler(
   "modals.my.environment.edit",
   ({ envName, variableName, isSecret }) => {
     if (variableName) editingVariableName.value = variableName
-    const envIndex: number =
-      alphabeticallySortedPersonalEnvironments.value.findIndex(({ env }) => {
-        return env.name === envName
-      })
+    const env: number = alphabeticallySortedPersonalEnvironments.value.find(
+      ({ env }) => env.name === envName
+    )
     if (envName !== "Global") {
-      editEnvironment(envIndex)
+      editEnvironment(env.index)
       secretOptionSelected.value = isSecret ?? false
     }
   }

--- a/packages/hoppscotch-common/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/index.vue
@@ -135,10 +135,10 @@ defineActionHandler(
   "modals.my.environment.edit",
   ({ envName, variableName, isSecret }) => {
     if (variableName) editingVariableName.value = variableName
-    const env: number = alphabeticallySortedPersonalEnvironments.value.find(
+    const env = alphabeticallySortedPersonalEnvironments.value.find(
       ({ env }) => env.name === envName
     )
-    if (envName !== "Global") {
+    if (envName !== "Global" && env) {
       editEnvironment(env.index)
       secretOptionSelected.value = isSecret ?? false
     }


### PR DESCRIPTION
Previously, attempting to edit the active environment under personal workspace entry via `Environment Quick Peek` will result in the modal getting displayed with variables from another environment entry. This PR includes a fix for the same.

Closes #4380

### What's changed
Fixed a function to define current env by name

- [ ] Not Completed
- [x] Completed