### PR TITLE
fix: update copy + improve ux on ai experiments

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1147,6 +1147,7 @@
     "feedback_failure": "Failed to submit feedback",
     "feedback_thank_you": "Thank you for your feedback!",
     "feedback_cta_text_long": "Rate the generation, helps us to improve",
-    "feedback_cta_request_name": "Did you like the generated name?"
+    "feedback_cta_request_name": "Did you like the generated name?",
+    "modify_request_body_error": "Failed to modify request body"
   }
 }

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1140,12 +1140,13 @@
     "generate_request_name": "Generate Request Name Using AI",
     "generate_or_modify_request_body": "Generate or Modify Request Body",
     "modify_with_ai": "Modify with AI",
+    "generate": "Generate",
     "generate_or_modify_request_body_input_placeholder": "Enter your prompt to modify request body",
     "accept_change": "Accept Change",
     "feedback_success": "Feedback submitted successfully",
     "feedback_failure": "Failed to submit feedback",
     "feedback_thank_you": "Thank you for your feedback!",
     "feedback_cta_text_long": "Rate the generation, helps us to improve",
-    "feedback_cta_request_name": "Did you like name generated?"
+    "feedback_cta_request_name": "Did you like the generated name?"
   }
 }

--- a/packages/hoppscotch-common/src/components/aiexperiments/ModifyBodyModal.vue
+++ b/packages/hoppscotch-common/src/components/aiexperiments/ModifyBodyModal.vue
@@ -49,10 +49,10 @@ const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
             )}`"
             class="flex flex-1 bg-transparent px-6 text-base text-secondaryDark"
             @keypress="
-              (e) => {
+              async (e) => {
                 if (e.key === 'Enter') {
+                  await modifyRequestBody()
                   submittedFeedback = false
-                  modifyRequestBody()
                 }
               }
             "
@@ -67,9 +67,9 @@ const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
             :loading="isModifyRequestBodyPending"
             :disabled="!userPrompt || isModifyRequestBodyPending"
             @click="
-              () => {
+              async () => {
+                await modifyRequestBody()
                 submittedFeedback = false
-                modifyRequestBody()
               }
             "
           />

--- a/packages/hoppscotch-common/src/components/aiexperiments/ModifyBodyModal.vue
+++ b/packages/hoppscotch-common/src/components/aiexperiments/ModifyBodyModal.vue
@@ -51,6 +51,7 @@ const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
             @keypress="
               (e) => {
                 if (e.key === 'Enter') {
+                  submittedFeedback = false
                   modifyRequestBody()
                 }
               }
@@ -65,7 +66,12 @@ const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
             filled
             :loading="isModifyRequestBodyPending"
             :disabled="!userPrompt || isModifyRequestBodyPending"
-            @click="modifyRequestBody"
+            @click="
+              () => {
+                submittedFeedback = false
+                modifyRequestBody()
+              }
+            "
           />
         </div>
 
@@ -108,7 +114,14 @@ const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
             <HoppButtonSecondary
               :icon="IconThumbsDown"
               outline
-              @click="submitFeedback('negative', lastTraceID)"
+              @click="
+                async () => {
+                  if (lastTraceID) {
+                    await submitFeedback('negative', lastTraceID)
+                    submittedFeedback = true
+                  }
+                }
+              "
             />
           </template>
 

--- a/packages/hoppscotch-common/src/components/aiexperiments/ModifyBodyModal.vue
+++ b/packages/hoppscotch-common/src/components/aiexperiments/ModifyBodyModal.vue
@@ -48,11 +48,19 @@ const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
               'ai_experiments.generate_or_modify_request_body_input_placeholder'
             )}`"
             class="flex flex-1 bg-transparent px-6 text-base text-secondaryDark"
+            @keypress="
+              (e) => {
+                if (e.key === 'Enter') {
+                  modifyRequestBody()
+                }
+              }
+            "
           />
 
           <HoppButtonSecondary
             :icon="IconArrowRight"
-            class="mr-6 rounded-md"
+            class="mr-6 rounded-md flex flex-col-reverse"
+            :label="t('ai_experiments.generate')"
             outline
             filled
             :loading="isModifyRequestBodyPending"

--- a/packages/hoppscotch-common/src/components/collections/AddRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/AddRequest.vue
@@ -25,7 +25,12 @@
             'animate-pulse': isGenerateRequestNamePending,
           }"
           :title="t('ai_experiments.generate_request_name')"
-          @click="generateRequestName(props.requestContext)"
+          @click="
+            async () => {
+              await generateRequestName(props.requestContext)
+              submittedFeedback = false
+            }
+          "
         />
       </div>
     </template>

--- a/packages/hoppscotch-common/src/components/collections/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/EditRequest.vue
@@ -25,7 +25,12 @@
             'animate-pulse': isGenerateRequestNamePending,
           }"
           :title="t('ai_experiments.generate_request_name')"
-          @click="generateRequestName(props.requestContext)"
+          @click="
+            async () => {
+              await generateRequestName(props.requestContext)
+              submittedFeedback = false
+            }
+          "
         />
       </div>
     </template>

--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -28,7 +28,12 @@
               'animate-pulse': isGenerateRequestNamePending,
             }"
             :title="t('ai_experiments.generate_request_name')"
-            @click="generateRequestName(requestContext)"
+            @click="
+              async () => {
+                await generateRequestName(requestContext)
+                submittedFeedback = false
+              }
+            "
           />
         </div>
 

--- a/packages/hoppscotch-common/src/components/collections/graphql/AddRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/AddRequest.vue
@@ -25,7 +25,12 @@
             'animate-pulse': isGenerateRequestNamePending,
           }"
           :title="t('ai_experiments.generate_request_name')"
-          @click="generateRequestName(props.requestContext)"
+          @click="
+            async () => {
+              await generateRequestName(props.requestContext)
+              submittedFeedback = false
+            }
+          "
         />
       </div>
     </template>

--- a/packages/hoppscotch-common/src/components/collections/graphql/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/EditRequest.vue
@@ -25,7 +25,12 @@
             'animate-pulse': isGenerateRequestNamePending,
           }"
           :title="t('ai_experiments.generate_request_name')"
-          @click="generateRequestName"
+          @click="
+            async () => {
+              await generateRequestName(props.requestContext)
+              submittedFeedback = false
+            }
+          "
         />
       </div>
     </template>

--- a/packages/hoppscotch-common/src/composables/ai-experiments.ts
+++ b/packages/hoppscotch-common/src/composables/ai-experiments.ts
@@ -186,8 +186,6 @@ export const useSubmitFeedback = () => {
 
     isSubmitFeedbackPending.value = false
 
-    toast.success(t("ai_experiments.feedback_success"))
-
     return E.right(undefined)
   }
 

--- a/packages/hoppscotch-common/src/composables/ai-experiments.ts
+++ b/packages/hoppscotch-common/src/composables/ai-experiments.ts
@@ -122,7 +122,7 @@ export const useModifyRequestBody = (
     isModifyRequestBodyPending.value = true
 
     if (!modifyRequestBodyForPlatform) {
-      toast.error(t("request.modify_request_body_error"))
+      toast.error(t("ai_experiments.modify_request_body_error"))
       isModifyRequestBodyPending.value = false
       return
     }
@@ -133,7 +133,7 @@ export const useModifyRequestBody = (
     )
 
     if (result && E.isLeft(result)) {
-      toast.error(t("request.modify_request_body_error"))
+      toast.error(t("ai_experiments.modify_request_body_error"))
       isModifyRequestBodyPending.value = false
       return
     }


### PR DESCRIPTION
**Changes**

1. Updated the copy for requesting feedback after request name generation
2. Remove toast after submitting feedback
3. Submit the modify body prompt on the `Enter` key press.
4. Add a 'Generate' copy to the modify body prompt submit button
5. Ask for feedback following each prompt generation applying to generate request name/modify request body flows.