### PR TITLE
fix: correct SVG rendering issue by adjusting blob type (#3565)

### DIFF
--- a/packages/hoppscotch-common/src/components/lenses/renderers/ImageLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/ImageLensRenderer.vue
@@ -77,7 +77,7 @@ watch(props.response, () => {
   imageSource.value = ""
   const buf = props.response.body
   const bytes = new Uint8Array(buf)
-  const blob = new Blob([bytes.buffer])
+  const blob = new Blob([bytes.buffer], { type: responseType.value })
 
   const reader = new FileReader()
   reader.onload = ({ target }) => {
@@ -91,7 +91,7 @@ onMounted(() => {
   imageSource.value = ""
   const buf = props.response.body
   const bytes = new Uint8Array(buf)
-  const blob = new Blob([bytes.buffer])
+  const blob = new Blob([bytes.buffer], { type: responseType.value })
 
   const reader = new FileReader()
   reader.onload = ({ target }) => {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #3565

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed

This update specifies the MIME type when creating the blob, which resolves the issue with the incorrect Base64 header.
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
