### PR TITLE
fix: add fallback for `type` field in `restTabState` schema

### DIFF
--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -533,7 +533,7 @@ export const REST_TAB_STATE_SCHEMA = z
           z.object({
             // !Versioned entity
             request: entityReference(HoppRESTRequest),
-            type: z.literal("request"),
+            type: z.literal("request").catch("request"),
             isDirty: z.boolean(),
             saveContext: z.optional(HoppRESTSaveContextSchema),
             response: z.optional(z.nullable(HoppRESTResponseSchema)),
@@ -544,7 +544,7 @@ export const REST_TAB_STATE_SCHEMA = z
             cancelFunction: z.optional(z.function()),
           }),
           z.object({
-            type: z.literal("example-response"),
+            type: z.literal("example-response").catch("example-response"),
             response: HoppRESTRequestResponse,
             saveContext: z.optional(HoppRESTSaveContextSchema),
             isDirty: z.boolean(),


### PR DESCRIPTION
This PR fixes the issue with rest tab schema where the tab didn't have type property that lead's to app crashing.

### What's changed
A catch was added to the type property where the default value will be set to "request"

