### PR TITLE
fix: comments being stripped out of json request body

### DIFF
--- a/packages/hoppscotch-common/package.json
+++ b/packages/hoppscotch-common/package.json
@@ -67,6 +67,7 @@
     "insomnia-importers": "3.6.0",
     "io-ts": "2.2.20",
     "js-yaml": "4.1.0",
+    "jsonc": "2.0.0",
     "jsonpath-plus": "7.2.0",
     "lodash-es": "4.17.21",
     "lossless-json": "3.0.2",

--- a/packages/hoppscotch-common/package.json
+++ b/packages/hoppscotch-common/package.json
@@ -67,7 +67,7 @@
     "insomnia-importers": "3.6.0",
     "io-ts": "2.2.20",
     "js-yaml": "4.1.0",
-    "jsonc": "2.0.0",
+    "jsonc-parser": "3.3.1",
     "jsonpath-plus": "7.2.0",
     "lodash-es": "4.17.21",
     "lossless-json": "3.0.2",

--- a/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
@@ -1,6 +1,7 @@
 import { convertIndexToLineCh } from "../utils"
 import { LinterDefinition, LinterResult } from "./linter"
 import jsoncParse from "~/helpers/jsoncParse"
+import { jsonc } from "jsonc"
 
 const linter: LinterDefinition = (text) => {
   try {
@@ -23,23 +24,8 @@ const linter: LinterDefinition = (text) => {
  * @param jsonString The JSON string with comments.
  * @returns The JSON string without comments.
  */
-
-const singleLineCommentPattern = /\/\/.*$/gm
-const multiLineCommentPattern = /\/\*[\s\S]*?\*\//gm
-
 export function removeComments(jsonString: string): string {
-  // Remove single-line comments
-  jsonString = jsonString.replace(singleLineCommentPattern, "")
-  // Remove multi-line comments
-  jsonString = jsonString.replace(multiLineCommentPattern, "")
-
-  jsonString = removeTrailingCommas(jsonString)
-
-  return jsonString
-}
-
-export function removeTrailingCommas(jsonString: string): string {
-  return jsonString.replace(/,(?=\s*?[\]}])/g, "")
+  return jsonc.stripComments(jsonString)
 }
 
 export default linter

--- a/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
@@ -1,7 +1,7 @@
 import { convertIndexToLineCh } from "../utils"
 import { LinterDefinition, LinterResult } from "./linter"
 import jsoncParse from "~/helpers/jsoncParse"
-import { jsonc } from "jsonc"
+import { stripComments } from "jsonc-parser"
 
 const linter: LinterDefinition = (text) => {
   try {
@@ -25,7 +25,7 @@ const linter: LinterDefinition = (text) => {
  * @returns The JSON string without comments.
  */
 export function removeComments(jsonString: string): string {
-  return jsonc.stripComments(jsonString)
+  return stripComments(jsonString)
 }
 
 export default linter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,6 +586,9 @@ importers:
       js-yaml:
         specifier: 4.1.0
         version: 4.1.0
+      jsonc:
+        specifier: 2.0.0
+        version: 2.0.0
       jsonpath-plus:
         specifier: 7.2.0
         version: 7.2.0
@@ -9141,6 +9144,10 @@ packages:
   jsonc-parser@3.2.1:
     resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
 
+  jsonc@2.0.0:
+    resolution: {integrity: sha512-B281bLCT2TRMQa+AQUQY5AGcqSOXBOKaYGP4wDzoA/+QswUfN8sODektbPEs9Baq7LGKun5jQbNFpzwGuVYKhw==}
+    engines: {node: '>=8'}
+
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
@@ -10724,6 +10731,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.11.0:
@@ -23740,6 +23748,15 @@ snapshots:
   jsonc-parser@3.2.0: {}
 
   jsonc-parser@3.2.1: {}
+
+  jsonc@2.0.0:
+    dependencies:
+      fast-safe-stringify: 2.1.1
+      graceful-fs: 4.2.11
+      mkdirp: 0.5.6
+      parse-json: 4.0.0
+      strip-bom: 4.0.0
+      strip-json-comments: 3.1.1
 
   jsonfile@6.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,9 +586,9 @@ importers:
       js-yaml:
         specifier: 4.1.0
         version: 4.1.0
-      jsonc:
-        specifier: 2.0.0
-        version: 2.0.0
+      jsonc-parser:
+        specifier: 3.3.1
+        version: 3.3.1
       jsonpath-plus:
         specifier: 7.2.0
         version: 7.2.0
@@ -9144,9 +9144,8 @@ packages:
   jsonc-parser@3.2.1:
     resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
 
-  jsonc@2.0.0:
-    resolution: {integrity: sha512-B281bLCT2TRMQa+AQUQY5AGcqSOXBOKaYGP4wDzoA/+QswUfN8sODektbPEs9Baq7LGKun5jQbNFpzwGuVYKhw==}
-    engines: {node: '>=8'}
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -23749,14 +23748,7 @@ snapshots:
 
   jsonc-parser@3.2.1: {}
 
-  jsonc@2.0.0:
-    dependencies:
-      fast-safe-stringify: 2.1.1
-      graceful-fs: 4.2.11
-      mkdirp: 0.5.6
-      parse-json: 4.0.0
-      strip-bom: 4.0.0
-      strip-json-comments: 3.1.1
+  jsonc-parser@3.3.1: {}
 
   jsonfile@6.1.0:
     dependencies:
@@ -26922,7 +26914,7 @@ snapshots:
   terser@5.31.0:
     dependencies:
       '@jridgewell/source-map': 0.3.6
-      acorn: 8.11.3
+      acorn: 8.12.1
       commander: 2.20.3
       source-map-support: 0.5.21
 


### PR DESCRIPTION
This PR intends to fix the issue where the new JSONC system strips parts of URLs when it strips comments.

The `removeComments` function converts the following string erroneously:
Input:
```json
{
  "hello": "https://echo.hoppscotch.io"
}
```
Output:
```
{
  "hello": "https
}
```

### What's changed
1.  Add `jsonc-parser` NPM package as a dependency
2. Use `jsonc-parser` implementation to strip comments instead of the current implementation.