### PR TITLE
fix: add full request as request context

### DIFF
--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -278,7 +278,10 @@ const getTabName = (tab: HoppTab<HoppTabDocument>) => {
 const requestToRename = computed(() => {
   if (!renameTabID.value) return null
   const tab = tabs.getTabRef(renameTabID.value)
-  return getTabName(tab.value)
+
+  return tab.value.document.type === "request"
+    ? tab.value.document.request
+    : null
 })
 
 const openReqRenameModal = (tabID?: string) => {

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/request.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/request.searcher.ts
@@ -47,7 +47,11 @@ export class RequestSpotlightSearcherService extends StaticSpotlightSearcherServ
   private readonly restTab = this.bind(RESTTabService)
 
   private route = useRoute()
-  private isRESTPage = computed(() => this.route.name === "index")
+  private isRESTPage = computed(
+    () =>
+      this.route.name === "index" &&
+      this.restTab.currentActiveTab.value.document.type === "request"
+  )
   private isGQLPage = computed(() => this.route.name === "graphql")
   private isRESTOrGQLPage = computed(
     () => this.isRESTPage.value || this.isGQLPage.value


### PR DESCRIPTION
**Changes**

PR #4382 introduced a change, where we were passing just the tab name as context instead of the full request to the request rename endpoint. This PR overwrites that change.
Also, spotlight actions specific to a request open under the active tab were in context even for response examples. This includes a fix for the same.