### PR TITLE
chore(backend): configure CORS for development and production environments

### DIFF
--- a/packages/hoppscotch-backend/src/main.ts
+++ b/packages/hoppscotch-backend/src/main.ts
@@ -41,7 +41,7 @@ async function bootstrap() {
 
   const configService = app.get(ConfigService);
 
-  console.log(`Running in production:  ${configService.get('PRODUCTION')}`);
+  console.log(`Running in production: ${configService.get('PRODUCTION')}`);
   console.log(`Port: ${configService.get('PORT')}`);
 
   checkEnvironmentAuthProvider(
@@ -62,19 +62,19 @@ async function bootstrap() {
     }),
   );
 
-if (configService.get('PRODUCTION') === 'false') { 
-  console.log('Enabling CORS with development settings'); 
-  app.enableCors({
-    origin: configService.get('DEV_WHITELISTED_ORIGINS').split(','), 
-    credentials: true,
-  }); 
-} else { 
-  console.log('Enabling CORS with production settings'); 
-  app.enableCors({
-    origin: configService.get('PROD_WHITELISTED_ORIGINS'), 
-    credentials: true,
-  });
-}
+  if (configService.get('PRODUCTION') === 'true') {
+    console.log('Enabling CORS with production settings');
+    app.enableCors({
+      origin: configService.get('WHITELISTED_ORIGINS').split(','),
+      credentials: true,
+    });
+  } else {
+    console.log('Enabling CORS with development settings');
+    app.enableCors({
+      origin: true,
+      credentials: true,
+    });
+  }
 
   app.enableVersioning({
     type: VersioningType.URI,

--- a/packages/hoppscotch-backend/src/main.ts
+++ b/packages/hoppscotch-backend/src/main.ts
@@ -62,21 +62,20 @@ async function bootstrap() {
     }),
   );
 
-  if (configService.get('PRODUCTION') === 'false') {
-    console.log('Enabling CORS with development settings');
+if (configService.get('PRODUCTION') === 'false') { 
+  console.log('Enabling CORS with development settings'); 
+  app.enableCors({
+    origin: configService.get('DEV_WHITELISTED_ORIGINS').split(','), 
+    credentials: true,
+  }); 
+} else { 
+  console.log('Enabling CORS with production settings'); 
+  app.enableCors({
+    origin: configService.get('PROD_WHITELISTED_ORIGINS'), 
+    credentials: true,
+  });
+}
 
-    app.enableCors({
-      origin: configService.get('WHITELISTED_ORIGINS').split(','),
-      credentials: true,
-    });
-  } else {
-    console.log('Enabling CORS with production settings');
-
-    app.enableCors({
-      origin: configService.get('WHITELISTED_ORIGINS').split(','),
-      credentials: true,
-    });
-  }
   app.enableVersioning({
     type: VersioningType.URI,
   });


### PR DESCRIPTION
Closes #4199

### Introduction
This pull request addresses the issue of identical CORS settings being used in both development and production environments. It refines the logic in the backend to differentiate the CORS configuration based on the environment (development vs. production).

### What's changed
- [x] **Modified CORS settings**: Updated the `if` and `else` blocks in the file `hoppscotch-backend/src/main.ts` to ensure the CORS settings are differentiated for development and production.
  - In development (`if` block), more permissive CORS settings are applied for easier testing.
  - In production (`else` block), restricted CORS settings are applied to enhance security.
- [x] **Code cleanup**: Removed redundant code that caused identical settings to be applied for both environments.

### Notes to reviewers
- The changes maintain backward compatibility by ensuring the development environment retains flexibility while securing the production environment.
- Tested locally to ensure proper CORS behavior for both environments.
- Let me know if additional changes are needed, or if there are any specific configurations you'd like to refine further!