### PR TITLE
feat(common): introducing ability to set custom collection import size limit

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -513,8 +513,8 @@
     "postman_environment": "Postman Environment",
     "postman_environment_description": "Import Postman Environment from a JSON file",
     "title": "Import",
-    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of 10MB. Only the first {files} selected will be imported",
-    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of 10MB. Please select another file.",
+    "file_size_limit_exceeded_warning_multiple_files": "Chosen files exceed the recommended limit of {sizeLimit}MB. Only the first {files} selected will be imported",
+    "file_size_limit_exceeded_warning_single_file": "The currently chosen file exceeds the recommended limit of {sizeLimit}MB. Please select another file.",
     "success": "Successfully imported"
   },
   "inspections": {

--- a/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
@@ -33,6 +33,7 @@
       <template v-if="importFilesCount">
         {{
           t("import.file_size_limit_exceeded_warning_multiple_files", {
+            sizeLimit: ALLOWED_FILE_SIZE_LIMIT,
             files:
               importFilesCount === 1 ? "file" : `${importFilesCount} files`,
           })
@@ -40,7 +41,11 @@
       </template>
 
       <template v-else>
-        {{ t("import.file_size_limit_exceeded_warning_single_file") }}
+        {{
+          t("import.file_size_limit_exceeded_warning_single_file", {
+            sizeLimit: ALLOWED_FILE_SIZE_LIMIT,
+          })
+        }}
       </template>
     </p>
     <div>

--- a/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
@@ -59,6 +59,7 @@
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
 import { computed, ref } from "vue"
+import { platform } from "~/platform"
 
 const props = withDefaults(
   defineProps<{
@@ -74,7 +75,8 @@ const props = withDefaults(
 const t = useI18n()
 const toast = useToast()
 
-const ALLOWED_FILE_SIZE_LIMIT = 10 // 10 MB
+const ALLOWED_FILE_SIZE_LIMIT =
+  platform.platformFeatureFlags.collectionImportSizeLimit ?? 10 // Default to 10 MB
 
 const importFilesCount = ref(0)
 

--- a/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/FileImport.vue
@@ -80,8 +80,7 @@ const props = withDefaults(
 const t = useI18n()
 const toast = useToast()
 
-const ALLOWED_FILE_SIZE_LIMIT =
-  platform.platformFeatureFlags.collectionImportSizeLimit ?? 10 // Default to 10 MB
+const ALLOWED_FILE_SIZE_LIMIT = platform.limits?.collectionImportSizeLimit ?? 10 // Default to 10 MB
 
 const importFilesCount = ref(0)
 

--- a/packages/hoppscotch-common/src/platform/index.ts
+++ b/packages/hoppscotch-common/src/platform/index.ts
@@ -53,6 +53,11 @@ export type PlatformDef = {
      * Whether to show the A/B testing workspace switcher click login flow or not
      */
     workspaceSwitcherLogin?: Ref<boolean>
+
+    /**
+     * Assign an import size limit when importing collections
+     */
+    collectionImportSizeLimit?: number
   }
   infra?: InfraPlatformDef
   experiments?: ExperimentsPlatformDef

--- a/packages/hoppscotch-common/src/platform/index.ts
+++ b/packages/hoppscotch-common/src/platform/index.ts
@@ -1,19 +1,20 @@
-import { AuthPlatformDef } from "./auth"
-import { UIPlatformDef } from "./ui"
-import { EnvironmentsPlatformDef } from "./environments"
-import { CollectionsPlatformDef } from "./collections"
-import { SettingsPlatformDef } from "./settings"
-import { HistoryPlatformDef } from "./history"
-import { AnalyticsPlatformDef } from "./analytics"
-import { InterceptorsPlatformDef } from "./interceptors"
-import { HoppModule } from "~/modules"
-import { InspectorsPlatformDef } from "./inspectors"
 import { ServiceClassInstance } from "dioc"
-import { IOPlatformDef } from "./io"
-import { SpotlightPlatformDef } from "./spotlight"
-import { InfraPlatformDef } from "./infra"
-import { ExperimentsPlatformDef } from "./experiments"
 import { Ref } from "vue"
+import { HoppModule } from "~/modules"
+import { AnalyticsPlatformDef } from "./analytics"
+import { AuthPlatformDef } from "./auth"
+import { CollectionsPlatformDef } from "./collections"
+import { EnvironmentsPlatformDef } from "./environments"
+import { ExperimentsPlatformDef } from "./experiments"
+import { HistoryPlatformDef } from "./history"
+import { InfraPlatformDef } from "./infra"
+import { InspectorsPlatformDef } from "./inspectors"
+import { InterceptorsPlatformDef } from "./interceptors"
+import { IOPlatformDef } from "./io"
+import { LimitsPlatformDef } from "./limits"
+import { SettingsPlatformDef } from "./settings"
+import { SpotlightPlatformDef } from "./spotlight"
+import { UIPlatformDef } from "./ui"
 
 export type PlatformDef = {
   ui?: UIPlatformDef
@@ -53,12 +54,8 @@ export type PlatformDef = {
      * Whether to show the A/B testing workspace switcher click login flow or not
      */
     workspaceSwitcherLogin?: Ref<boolean>
-
-    /**
-     * Assign an import size limit when importing collections
-     */
-    collectionImportSizeLimit?: number
   }
+  limits?: LimitsPlatformDef
   infra?: InfraPlatformDef
   experiments?: ExperimentsPlatformDef
 }

--- a/packages/hoppscotch-common/src/platform/limits.ts
+++ b/packages/hoppscotch-common/src/platform/limits.ts
@@ -1,0 +1,7 @@
+// Define various limits for the platform
+export type LimitsPlatformDef = {
+  /**
+   * Assign an import size limit when importing collections
+   */
+  collectionImportSizeLimit?: number
+}

--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -42,6 +42,7 @@ createHoppApp("#app", {
   platformFeatureFlags: {
     exportAsGIST: false,
     hasTelemetry: false,
+    collectionImportSizeLimit: 50,
   },
   infra: InfraPlatform,
 })

--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -42,6 +42,8 @@ createHoppApp("#app", {
   platformFeatureFlags: {
     exportAsGIST: false,
     hasTelemetry: false,
+  },
+  limits: {
     collectionImportSizeLimit: 50,
   },
   infra: InfraPlatform,


### PR DESCRIPTION
### Ticket
- Closes HFE-615
- Fixes #4139 

### Description
This PR adds the ability to set custom collection import size limit and change it from the default value of 10MB. The size limit for selfhost-web will now be 50MB.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed