### PR TITLE
HSB-494 fix: downgrade eslint related package

### DIFF
--- a/packages/hoppscotch-backend/package.json
+++ b/packages/hoppscotch-backend/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/parser": "8.8.1",
     "cross-env": "7.0.3",
     "eslint": "8.57.0",
-    "eslint-config-prettier": "8.10.0",
+    "eslint-config-prettier": "9.1.0",
     "eslint-plugin-prettier": "5.2.1",
     "jest": "29.7.0",
     "jest-mock-extended": "4.0.0-beta1",

--- a/packages/hoppscotch-backend/package.json
+++ b/packages/hoppscotch-backend/package.json
@@ -94,8 +94,8 @@
     "@typescript-eslint/eslint-plugin": "8.8.1",
     "@typescript-eslint/parser": "8.8.1",
     "cross-env": "7.0.3",
-    "eslint": "9.12.0",
-    "eslint-config-prettier": "9.1.0",
+    "eslint": "8.57.0",
+    "eslint-config-prettier": "8.10.0",
     "eslint-plugin-prettier": "5.2.1",
     "jest": "29.7.0",
     "jest-mock-extended": "4.0.0-beta1",
@@ -107,7 +107,7 @@
     "ts-loader": "9.5.1",
     "ts-node": "10.9.2",
     "tsconfig-paths": "4.2.0",
-    "typescript": "5.6.3"
+    "typescript": "5.5.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
         version: 4.11.0(graphql@16.9.0)
       '@nestjs-modules/mailer':
         specifier: 2.0.2
-        version: 2.0.2(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.4)(reflect-metadata@0.2.2)(rxjs@7.8.1))(nodemailer@6.9.15)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+        version: 2.0.2(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.4)(reflect-metadata@0.2.2)(rxjs@7.8.1))(nodemailer@6.9.15)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
       '@nestjs/apollo':
         specifier: 12.2.0
         version: 12.2.0(@apollo/server@4.11.0(graphql@16.9.0))(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.4)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/graphql@12.2.0(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.4)(reflect-metadata@0.2.2)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.1)(graphql@16.9.0)(reflect-metadata@0.2.2))(graphql@16.9.0)
@@ -277,7 +277,7 @@ importers:
         version: 10.4.5(@swc/core@1.7.26)
       '@nestjs/schematics':
         specifier: 10.1.4
-        version: 10.1.4(chokidar@3.6.0)(typescript@5.6.3)
+        version: 10.1.4(chokidar@3.6.0)(typescript@5.5.4)
       '@nestjs/testing':
         specifier: 10.4.4
         version: 10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.4)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.4))
@@ -325,28 +325,28 @@ importers:
         version: 6.0.2
       '@typescript-eslint/eslint-plugin':
         specifier: 8.8.1
-        version: 8.8.1(@typescript-eslint/parser@8.8.1(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
+        version: 8.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)
       '@typescript-eslint/parser':
         specifier: 8.8.1
-        version: 8.8.1(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
+        version: 8.8.1(eslint@8.57.0)(typescript@5.5.4)
       cross-env:
         specifier: 7.0.3
         version: 7.0.3
       eslint:
-        specifier: 9.12.0
-        version: 9.12.0(jiti@2.3.3)
+        specifier: 8.57.0
+        version: 8.57.0
       eslint-config-prettier:
-        specifier: 9.1.0
-        version: 9.1.0(eslint@9.12.0(jiti@2.3.3))
+        specifier: 8.10.0
+        version: 8.10.0(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 5.2.1
-        version: 5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@9.12.0(jiti@2.3.3)))(eslint@9.12.0(jiti@2.3.3))(prettier@3.3.3)
+        version: 5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@8.10.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3)
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
+        version: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
       jest-mock-extended:
         specifier: 4.0.0-beta1
-        version: 4.0.0-beta1(@jest/globals@29.7.0)(jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 4.0.0-beta1(@jest/globals@29.7.0)(jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4)))(typescript@5.5.4)
       jwt:
         specifier: link:@types/nestjs/jwt
         version: link:@types/nestjs/jwt
@@ -361,19 +361,19 @@ importers:
         version: 7.0.0
       ts-jest:
         specifier: 29.2.5
-        version: 29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3)))(typescript@5.6.3)
+        version: 29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4)))(typescript@5.5.4)
       ts-loader:
         specifier: 9.5.1
-        version: 9.5.1(typescript@5.6.3)(webpack@5.94.0(@swc/core@1.7.26))
+        version: 9.5.1(typescript@5.5.4)(webpack@5.94.0(@swc/core@1.7.26))
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3)
+        version: 10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4)
       tsconfig-paths:
         specifier: 4.2.0
         version: 4.2.0
       typescript:
-        specifier: 5.6.3
-        version: 5.6.3
+        specifier: 5.5.4
+        version: 5.5.4
 
   packages/hoppscotch-cli:
     dependencies:
@@ -434,7 +434,7 @@ importers:
         version: 3.2.5
       tsup:
         specifier: 8.0.2
-        version: 8.0.2(@swc/core@1.4.2)(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3))(typescript@5.3.3)
+        version: 8.0.2(@swc/core@1.4.2)(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3))(typescript@5.3.3)
       typescript:
         specifier: 5.3.3
         version: 5.3.3
@@ -7805,6 +7805,12 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
+  eslint-config-prettier@8.10.0:
+    resolution: {integrity: sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
   eslint-config-prettier@8.6.0:
     resolution: {integrity: sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==}
     hasBin: true
@@ -12282,6 +12288,11 @@ packages:
 
   typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -17686,7 +17697,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -17700,7 +17711,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -17955,7 +17966,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.0': {}
 
-  '@nestjs-modules/mailer@2.0.2(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.4)(reflect-metadata@0.2.2)(rxjs@7.8.1))(nodemailer@6.9.15)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)':
+  '@nestjs-modules/mailer@2.0.2(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/core@10.4.4(@nestjs/common@10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1))(@nestjs/platform-express@10.4.4)(reflect-metadata@0.2.2)(rxjs@7.8.1))(nodemailer@6.9.15)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)':
     dependencies:
       '@css-inline/css-inline': 0.14.1
       '@nestjs/common': 10.4.4(class-transformer@0.5.1)(class-validator@0.14.1)(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -17969,7 +17980,7 @@ snapshots:
       ejs: 3.1.10
       handlebars: 4.7.8
       liquidjs: 10.17.0
-      mjml: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
       preview-email: 3.1.0
       pug: 3.0.3
     transitivePeerDependencies:
@@ -18133,14 +18144,14 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/schematics@10.1.4(chokidar@3.6.0)(typescript@5.6.3)':
+  '@nestjs/schematics@10.1.4(chokidar@3.6.0)(typescript@5.5.4)':
     dependencies:
       '@angular-devkit/core': 17.3.8(chokidar@3.6.0)
       '@angular-devkit/schematics': 17.3.8(chokidar@3.6.0)
       comment-json: 4.2.3
       jsonc-parser: 3.3.1
       pluralize: 8.0.0
-      typescript: 5.6.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - chokidar
 
@@ -19173,21 +19184,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.8.1(@typescript-eslint/parser@8.8.1(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3))(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.8.1(@typescript-eslint/parser@8.8.1(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 8.8.1(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.8.1(eslint@8.57.0)(typescript@5.5.4)
       '@typescript-eslint/scope-manager': 8.8.1
-      '@typescript-eslint/type-utils': 8.8.1(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.8.1(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/type-utils': 8.8.1(eslint@8.57.0)(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.8.1(eslint@8.57.0)(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 8.8.1
-      eslint: 9.12.0(jiti@2.3.3)
+      eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.3.0(typescript@5.5.4)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -19254,16 +19265,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.8.1(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)':
+  '@typescript-eslint/parser@8.8.1(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.8.1
       '@typescript-eslint/types': 8.8.1
-      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.5.4)
       '@typescript-eslint/visitor-keys': 8.8.1
       debug: 4.3.7(supports-color@9.4.0)
-      eslint: 9.12.0(jiti@2.3.3)
+      eslint: 8.57.0
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -19351,14 +19362,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.8.1(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)':
+  '@typescript-eslint/type-utils@8.8.1(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.8.1(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.5.4)
+      '@typescript-eslint/utils': 8.8.1(eslint@8.57.0)(typescript@5.5.4)
       debug: 4.3.7(supports-color@9.4.0)
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.3.0(typescript@5.5.4)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -19430,7 +19441,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.8.1(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@8.8.1(typescript@5.5.4)':
     dependencies:
       '@typescript-eslint/types': 8.8.1
       '@typescript-eslint/visitor-keys': 8.8.1
@@ -19439,9 +19450,9 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.3)
+      ts-api-utils: 1.3.0(typescript@5.5.4)
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - supports-color
 
@@ -19515,13 +19526,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.8.1(eslint@9.12.0(jiti@2.3.3))(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.8.1(eslint@8.57.0)(typescript@5.5.4)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.12.0(jiti@2.3.3))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@typescript-eslint/scope-manager': 8.8.1
       '@typescript-eslint/types': 8.8.1
-      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.6.3)
-      eslint: 9.12.0(jiti@2.3.3)
+      '@typescript-eslint/typescript-estree': 8.8.1(typescript@5.5.4)
+      eslint: 8.57.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -21518,14 +21529,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.3.3
 
-  cosmiconfig@9.0.0(typescript@5.6.3):
+  cosmiconfig@9.0.0(typescript@5.5.4):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.5.4
     optional: true
 
   create-jest@29.7.0(@types/node@17.0.45):
@@ -21543,13 +21554,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3)):
+  create-jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -22461,6 +22472,10 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
+  eslint-config-prettier@8.10.0(eslint@8.57.0):
+    dependencies:
+      eslint: 8.57.0
+
   eslint-config-prettier@8.6.0(eslint@8.19.0):
     dependencies:
       eslint: 8.19.0
@@ -22469,10 +22484,6 @@ snapshots:
     dependencies:
       eslint: 8.57.0
     optional: true
-
-  eslint-config-prettier@9.1.0(eslint@9.12.0(jiti@2.3.3)):
-    dependencies:
-      eslint: 9.12.0(jiti@2.3.3)
 
   eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.6.0(eslint@8.19.0))(eslint@8.19.0)(prettier@2.8.4):
     dependencies:
@@ -22507,15 +22518,15 @@ snapshots:
       '@types/eslint': 8.56.10
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
 
-  eslint-plugin-prettier@5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@9.12.0(jiti@2.3.3)))(eslint@9.12.0(jiti@2.3.3))(prettier@3.3.3):
+  eslint-plugin-prettier@5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@8.10.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3):
     dependencies:
-      eslint: 9.12.0(jiti@2.3.3)
+      eslint: 8.57.0
       prettier: 3.3.3
       prettier-linter-helpers: 1.0.0
       synckit: 0.9.2
     optionalDependencies:
       '@types/eslint': 8.56.10
-      eslint-config-prettier: 9.1.0(eslint@9.12.0(jiti@2.3.3))
+      eslint-config-prettier: 8.10.0(eslint@8.57.0)
 
   eslint-plugin-vue@9.17.0(eslint@8.47.0):
     dependencies:
@@ -23797,9 +23808,9 @@ snapshots:
       selderee: 0.11.0
     optional: true
 
-  htmlnano@2.1.1(cssnano@7.0.6(postcss@8.4.47))(postcss@8.4.47)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  htmlnano@2.1.1(cssnano@7.0.6(postcss@8.4.47))(postcss@8.4.47)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.6.3)
+      cosmiconfig: 9.0.0(typescript@5.5.4)
       posthtml: 0.16.6
       timsort: 0.3.0
     optionalDependencies:
@@ -24391,7 +24402,7 @@ snapshots:
 
   jest-cli@29.7.0(@types/node@17.0.45):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
@@ -24408,16 +24419,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3)):
+  jest-cli@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
+      create-jest: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
+      jest-config: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -24457,7 +24468,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3)):
+  jest-config@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.25.7
       '@jest/test-sequencer': 29.7.0
@@ -24483,7 +24494,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.7.5
-      ts-node: 10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3)
+      ts-node: 10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -24602,12 +24613,12 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-mock-extended@4.0.0-beta1(@jest/globals@29.7.0)(jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3)))(typescript@5.6.3):
+  jest-mock-extended@4.0.0-beta1(@jest/globals@29.7.0)(jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4)))(typescript@5.5.4):
     dependencies:
       '@jest/globals': 29.7.0
-      jest: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
-      ts-essentials: 10.0.2(typescript@5.6.3)
-      typescript: 5.6.3
+      jest: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
+      ts-essentials: 10.0.2(typescript@5.5.4)
+      typescript: 5.5.4
 
   jest-mock@29.7.0:
     dependencies:
@@ -24780,7 +24791,7 @@ snapshots:
 
   jest@29.7.0(@types/node@17.0.45):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@17.0.45)
@@ -24790,12 +24801,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3)):
+  jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
+      jest-cli: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -25402,11 +25413,11 @@ snapshots:
       minipass: 3.3.6
       yallist: 4.0.0
 
-  mjml-accordion@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-accordion@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25418,11 +25429,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-body@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-body@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25434,11 +25445,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-button@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-button@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25450,11 +25461,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-carousel@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-carousel@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25466,14 +25477,14 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-cli@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-cli@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       chokidar: 3.6.0
       glob: 10.3.10
       lodash: 4.17.21
       minimatch: 9.0.5
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
       mjml-parser-xml: 5.0.0-alpha.4
       mjml-validator: 5.0.0-alpha.4
       yargs: 17.7.2
@@ -25488,11 +25499,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-column@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-column@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25504,13 +25515,13 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-core@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-core@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       cheerio: 1.0.0-rc.12
       cssnano: 7.0.6(postcss@8.4.47)
       detect-node: 2.1.0
-      htmlnano: 2.1.1(cssnano@7.0.6(postcss@8.4.47))(postcss@8.4.47)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      htmlnano: 2.1.1(cssnano@7.0.6(postcss@8.4.47))(postcss@8.4.47)(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
       juice: 10.0.1
       lodash: 4.17.21
       mjml-parser-xml: 5.0.0-alpha.4
@@ -25528,11 +25539,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-divider@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-divider@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25544,11 +25555,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-group@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-group@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25560,11 +25571,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-head-attributes@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-head-attributes@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25576,11 +25587,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-head-breakpoint@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-head-breakpoint@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25592,11 +25603,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-head-font@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-head-font@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25608,11 +25619,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-head-html-attributes@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-head-html-attributes@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25624,11 +25635,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-head-preview@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-head-preview@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25640,11 +25651,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-head-style@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-head-style@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25656,11 +25667,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-head-title@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-head-title@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25672,11 +25683,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-head@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-head@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25688,11 +25699,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-hero@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-hero@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25704,11 +25715,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-image@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-image@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25720,11 +25731,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-navbar@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-navbar@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25744,34 +25755,34 @@ snapshots:
       lodash: 4.17.21
     optional: true
 
-  mjml-preset-core@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-preset-core@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
-      mjml-accordion: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-body: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-button: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-carousel: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-column: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-divider: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-group: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-head: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-head-attributes: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-head-breakpoint: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-head-font: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-head-html-attributes: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-head-preview: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-head-style: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-head-title: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-hero: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-image: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-navbar: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-raw: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-section: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-social: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-spacer: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-table: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-text: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-wrapper: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-accordion: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-body: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-button: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-carousel: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-column: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-divider: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-group: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-head: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-head-attributes: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-head-breakpoint: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-head-font: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-head-html-attributes: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-head-preview: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-head-style: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-head-title: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-hero: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-image: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-navbar: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-raw: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-section: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-social: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-spacer: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-table: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-text: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-wrapper: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25783,11 +25794,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-raw@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-raw@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25799,11 +25810,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-section@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-section@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25815,11 +25826,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-social@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-social@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25831,11 +25842,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-spacer@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-spacer@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25847,11 +25858,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-table@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-table@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25863,11 +25874,11 @@ snapshots:
       - uncss
     optional: true
 
-  mjml-text@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-text@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25884,12 +25895,12 @@ snapshots:
       '@babel/runtime': 7.25.7
     optional: true
 
-  mjml-wrapper@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml-wrapper@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
       lodash: 4.17.21
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-section: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-section: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - encoding
       - purgecss
@@ -25901,12 +25912,12 @@ snapshots:
       - uncss
     optional: true
 
-  mjml@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3):
+  mjml@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
       '@babel/runtime': 7.25.7
-      mjml-cli: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
-      mjml-preset-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.6.3)
+      mjml-cli: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
+      mjml-preset-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
       mjml-validator: 5.0.0-alpha.4
     transitivePeerDependencies:
       - encoding
@@ -26553,13 +26564,13 @@ snapshots:
       postcss: 8.4.47
       ts-node: 10.9.1(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@4.9.3)
 
-  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3)):
+  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.2
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3)
+      ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3)
 
   postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@18.18.8)(typescript@4.9.5)):
     dependencies:
@@ -28228,18 +28239,18 @@ snapshots:
     dependencies:
       typescript: 5.3.2
 
-  ts-api-utils@1.3.0(typescript@5.6.3):
+  ts-api-utils@1.3.0(typescript@5.5.4):
     dependencies:
-      typescript: 5.6.3
+      typescript: 5.5.4
 
   ts-clone-node@3.0.0(typescript@5.2.2):
     dependencies:
       compatfactory: 3.0.0(typescript@5.2.2)
       typescript: 5.2.2
 
-  ts-essentials@10.0.2(typescript@5.6.3):
+  ts-essentials@10.0.2(typescript@5.5.4):
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.5.4
 
   ts-interface-checker@0.1.13: {}
 
@@ -28259,18 +28270,18 @@ snapshots:
       '@babel/core': 7.25.7
       '@types/jest': 27.5.2
 
-  ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3)))(typescript@5.6.3):
+  ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4)))(typescript@5.5.4):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3))
+      jest: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.3
-      typescript: 5.6.3
+      typescript: 5.5.4
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.25.7
@@ -28278,14 +28289,14 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.25.7)
 
-  ts-loader@9.5.1(typescript@5.6.3)(webpack@5.94.0(@swc/core@1.7.26)):
+  ts-loader@9.5.1(typescript@5.5.4)(webpack@5.94.0(@swc/core@1.7.26)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.17.1
       micromatch: 4.0.8
       semver: 7.6.3
       source-map: 0.7.4
-      typescript: 5.6.3
+      typescript: 5.5.4
       webpack: 5.94.0(@swc/core@1.7.26)
 
   ts-log@2.2.5: {}
@@ -28328,14 +28339,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.7.26
 
-  ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3):
+  ts-node@10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.7.5
+      '@types/node': 17.0.27
       acorn: 8.12.1
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -28431,6 +28442,26 @@ snapshots:
       '@swc/core': 1.7.26
     optional: true
 
+  ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.7.5
+      acorn: 8.12.1
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.5.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.7.26
+
   ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -28450,6 +28481,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.7.26
+    optional: true
 
   ts-toolbelt@6.15.5: {}
 
@@ -28484,7 +28516,7 @@ snapshots:
 
   tslib@2.7.0: {}
 
-  tsup@8.0.2(@swc/core@1.4.2)(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3))(typescript@5.3.3):
+  tsup@8.0.2(@swc/core@1.4.2)(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3))(typescript@5.3.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.19.12)
       cac: 6.7.14
@@ -28494,7 +28526,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3))
       resolve-from: 5.0.0
       rollup: 4.24.0
       source-map: 0.8.0-beta.0
@@ -28585,6 +28617,8 @@ snapshots:
   typescript@5.3.2: {}
 
   typescript@5.3.3: {}
+
+  typescript@5.5.4: {}
 
   typescript@5.6.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,11 +336,11 @@ importers:
         specifier: 8.57.0
         version: 8.57.0
       eslint-config-prettier:
-        specifier: 8.10.0
-        version: 8.10.0(eslint@8.57.0)
+        specifier: 9.1.0
+        version: 9.1.0(eslint@8.57.0)
       eslint-plugin-prettier:
         specifier: 5.2.1
-        version: 5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@8.10.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3)
+        version: 5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3)
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@5.5.4))
@@ -434,7 +434,7 @@ importers:
         version: 3.2.5
       tsup:
         specifier: 8.0.2
-        version: 8.0.2(@swc/core@1.4.2)(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3))(typescript@5.3.3)
+        version: 8.0.2(@swc/core@1.4.2)(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3))(typescript@5.3.3)
       typescript:
         specifier: 5.3.3
         version: 5.3.3
@@ -7804,12 +7804,6 @@ packages:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
     hasBin: true
-
-  eslint-config-prettier@8.10.0:
-    resolution: {integrity: sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==}
-    hasBin: true
-    peerDependencies:
-      eslint: '>=7.0.0'
 
   eslint-config-prettier@8.6.0:
     resolution: {integrity: sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==}
@@ -22472,10 +22466,6 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-prettier@8.10.0(eslint@8.57.0):
-    dependencies:
-      eslint: 8.57.0
-
   eslint-config-prettier@8.6.0(eslint@8.19.0):
     dependencies:
       eslint: 8.19.0
@@ -22483,7 +22473,6 @@ snapshots:
   eslint-config-prettier@9.1.0(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
-    optional: true
 
   eslint-plugin-prettier@4.2.1(eslint-config-prettier@8.6.0(eslint@8.19.0))(eslint@8.19.0)(prettier@2.8.4):
     dependencies:
@@ -22518,7 +22507,7 @@ snapshots:
       '@types/eslint': 8.56.10
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
 
-  eslint-plugin-prettier@5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@8.10.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3):
+  eslint-plugin-prettier@5.2.1(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@8.57.0)(prettier@3.3.3):
     dependencies:
       eslint: 8.57.0
       prettier: 3.3.3
@@ -22526,7 +22515,7 @@ snapshots:
       synckit: 0.9.2
     optionalDependencies:
       '@types/eslint': 8.56.10
-      eslint-config-prettier: 8.10.0(eslint@8.57.0)
+      eslint-config-prettier: 9.1.0(eslint@8.57.0)
 
   eslint-plugin-vue@9.17.0(eslint@8.47.0):
     dependencies:
@@ -26564,13 +26553,13 @@ snapshots:
       postcss: 8.4.47
       ts-node: 10.9.1(@swc/core@1.7.26)(@types/node@22.7.5)(typescript@4.9.3)
 
-  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3)):
+  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.4.2
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3)
+      ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3)
 
   postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.7.26)(@types/node@18.18.8)(typescript@4.9.5)):
     dependencies:
@@ -28339,14 +28328,14 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.7.26
 
-  ts-node@10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3):
+  ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 17.0.27
+      '@types/node': 22.7.5
       acorn: 8.12.1
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -28516,7 +28505,7 @@ snapshots:
 
   tslib@2.7.0: {}
 
-  tsup@8.0.2(@swc/core@1.4.2)(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3))(typescript@5.3.3):
+  tsup@8.0.2(@swc/core@1.4.2)(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3))(typescript@5.3.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.19.12)
       cac: 6.7.14
@@ -28526,7 +28515,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@17.0.27)(typescript@5.3.3))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3))
       resolve-from: 5.0.0
       rollup: 4.24.0
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HSB-494

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
This PR downgraded Eslint related npm packages  to `v8` version in `hoppscotch-backend` which ware previously upgraded to `v9` which introduces braking changes.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Nil