### PR TITLE
chore(agent): major version dependency bump

### DIFF
--- a/packages/hoppscotch-agent/devenv.nix
+++ b/packages/hoppscotch-agent/devenv.nix
@@ -21,6 +21,8 @@
     nodePackages_latest.vls
     nodePackages_latest.prisma
     prisma-engines
+    # Cargo
+    cargo-edit
   ];
 
   # https://devenv.sh/basics/

--- a/packages/hoppscotch-agent/package.json
+++ b/packages/hoppscotch-agent/package.json
@@ -11,24 +11,24 @@
   },
   "dependencies": {
     "@hoppscotch/ui": "^0.2.1",
-    "@tauri-apps/api": ">=2.0.0-rc.0",
-    "@tauri-apps/plugin-shell": ">=2.0.0-rc.0",
+    "@tauri-apps/api": "^2.0.2",
+    "@tauri-apps/plugin-shell": "^2.0.0",
     "@vueuse/core": "^11.1.0",
     "axios": "^1.7.7",
     "fp-ts": "^2.16.9",
-    "vue": "^3.3.4"
+    "vue": "3.3.9"
   },
   "devDependencies": {
-    "@iconify-json/lucide": "^1.2.6",
-    "@tauri-apps/cli": ">=2.0.0-rc.0",
-    "@types/node": "^22.7.0",
+    "@iconify-json/lucide": "^1.2.8",
+    "@tauri-apps/cli": "^2.0.3",
+    "@types/node": "^22.7.5",
     "@vitejs/plugin-vue": "^5.1.4",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
-    "typescript": "^5.2.2",
+    "typescript": "^5.6.3",
     "unplugin-icons": "^0.19.3",
-    "vite": "^5.4.7",
-    "vue-tsc": "^2.0.22"
+    "vite": "^5.4.8",
+    "vue-tsc": "^2.1.6"
   }
 }

--- a/packages/hoppscotch-agent/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.lock
@@ -4,18 +4,12 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -163,18 +157,22 @@ dependencies = [
 
 [[package]]
 name = "ashpd"
-version = "0.8.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093"
+checksum = "4d43c03d9e36dd40cab48435be0b09646da362c278223ca535493877b2c1dee9"
 dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
  "rand 0.8.5",
+ "raw-window-handle",
  "serde",
  "serde_repr",
  "tokio",
  "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "zbus",
 ]
 
@@ -269,7 +267,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -304,7 +302,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -349,15 +347,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f43644eed690f5374f1af436ecd6aea01cd201f6fbdf0178adaf6907afb2cec"
+checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -381,7 +379,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
  "tokio",
- "tower 0.5.1",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -389,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6b8ba012a258d63c9adfa28b9ddcf66149da6f986c5b5452e629d5ee64bf00"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
 dependencies = [
  "async-trait",
  "bytes",
@@ -425,7 +423,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "serde",
- "tower 0.5.1",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -440,7 +438,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
@@ -639,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.21"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b1695e2c7e8fc85310cde85aeaab7e3097f593c91d209d3f9df76c928100f0"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "shlex",
 ]
@@ -889,7 +887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -899,7 +897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -913,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.46"
+version = "0.4.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
+checksum = "d9fb4d13a1be2b58f14d60adba57c9834b78c62fd86c3e76a148f732686e9265"
 dependencies = [
  "curl-sys",
  "libc",
@@ -928,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.76+curl-8.10.1"
+version = "0.4.77+curl-8.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00462dbe9cbb9344e1b2be34d9094d74e3b8aac59a883495b335eafd02e25120"
+checksum = "f469e8a5991f277a208224f6c7ad72ecb5f986e36d09ae1f2c1bb9259478a480"
 dependencies = [
  "cc",
  "libc",
@@ -964,7 +962,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -988,7 +986,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -999,7 +997,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1046,7 +1044,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1059,7 +1057,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1127,7 +1125,16 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+dependencies = [
+ "libloading 0.8.5",
 ]
 
 [[package]]
@@ -1150,8 +1157,14 @@ checksum = "f2b99bf03862d7f545ebc28ddd33a665b50865f4dfd84031a393823879bd4c54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -1191,9 +1204,9 @@ checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "embed-resource"
-version = "2.4.3"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4edcacde9351c33139a41e3c97eb2334351a81a2791bebb0b243df837128f602"
+checksum = "f4e24052d7be71f0efb50c201557f6fe7d237cfd5a64fd5bcd7fd8fe32dbbffa"
 dependencies = [
  "cc",
  "memchr",
@@ -1242,7 +1255,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1323,9 +1336,9 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+checksum = "d8090f921a24b04994d9929e204f50b498a33ea6ba559ffaa05e04f7ee7fb5ab"
 dependencies = [
  "simd-adler32",
 ]
@@ -1360,12 +1373,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1410,7 +1423,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1446,24 +1459,24 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1472,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -1491,32 +1504,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1638,19 +1651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustversion",
- "windows 0.48.0",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,9 +1694,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gio"
@@ -1764,7 +1764,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1843,7 +1843,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1858,7 +1858,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1876,6 +1876,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "headers"
@@ -2018,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -2075,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2088,7 +2094,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -2167,12 +2172,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -2205,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is-docker"
@@ -2373,15 +2378,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libloading"
@@ -2391,6 +2396,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2439,21 +2454,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "loom"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "serde",
- "serde_json",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2480,15 +2480,6 @@ dependencies = [
  "string_cache",
  "string_cache_codegen",
  "tendril",
-]
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2532,21 +2523,12 @@ checksum = "a05b5d0594e0cb1ad8cee3373018d2b84e25905dc75b2468114cc9a8e86cfc20"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
- "simd-adler32",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2587,16 +2569,17 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8ac4080fb1e097c2c22acae467e46e4da72d941f02e82b67a87a2a89fa38b1"
+checksum = "b8123dfd4996055ac9b15a60ad263b44b01e539007523ad7a4a533a3d93b0591"
 dependencies = [
- "cocoa",
  "crossbeam-channel",
  "dpi",
  "gtk",
  "keyboard-types",
- "objc",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "once_cell",
  "png",
  "serde",
@@ -2659,16 +2642,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,7 +2674,7 @@ dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2711,18 +2684,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
-]
-
-[[package]]
-name = "objc-foundation"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
-dependencies = [
- "block",
- "objc",
- "objc_id",
 ]
 
 [[package]]
@@ -2730,6 +2691,9 @@ name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "objc2"
@@ -2758,6 +2722,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-data"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2782,6 +2770,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-contacts",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,8 +2795,21 @@ checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.6.0",
  "block2",
+ "dispatch",
  "libc",
  "objc2",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -2825,37 +2838,87 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc_exception"
-version = "0.1.2"
+name = "objc2-symbols"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "cc",
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
-name = "objc_id"
-version = "0.1.1"
+name = "objc2-ui-kit"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "objc",
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-web-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68bc69301064cebefc6c4c90ce9cba69225239e4b8ff99d445a2b5563797da65"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"
@@ -2876,9 +2939,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -2897,7 +2960,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -2917,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -2953,12 +3016,6 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pango"
@@ -3130,7 +3187,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3158,26 +3215,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]
 
 [[package]]
@@ -3216,23 +3253,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.5.0",
- "quick-xml",
+ "indexmap 2.6.0",
+ "quick-xml 0.32.0",
  "serde",
  "time",
 ]
 
 [[package]]
 name = "png"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+checksum = "52f9d46a34a05a6a57566bc2bfae066ef07585a6e3fa30fbbdff5936380623f0"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3335,9 +3372,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
@@ -3347,6 +3384,15 @@ name = "quick-xml"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
 ]
@@ -3497,9 +3543,9 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -3517,53 +3563,38 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3605,21 +3636,20 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a73a7337fc24366edfca76ec521f51877b114e42dab584008209cca6719251"
+checksum = "8af382a047821a08aa6bfc09ab0d80ff48d45d8726f7cd8e44891f7cb4a4278e"
 dependencies = [
  "ashpd",
- "block",
- "dispatch",
+ "block2",
  "glib-sys",
  "gobject-sys",
  "gtk-sys",
  "js-sys",
  "log",
- "objc",
- "objc-foundation",
- "objc_id",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3678,9 +3708,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
  "once_cell",
  "ring",
@@ -3739,9 +3769,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -3758,6 +3788,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3769,7 +3800,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3841,7 +3872,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3852,7 +3883,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3885,14 +3916,14 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
@@ -3911,15 +3942,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3929,14 +3960,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.9.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -3991,15 +4022,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
-]
-
-[[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]
@@ -4131,15 +4153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "state"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
-dependencies = [
- "loom",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4207,9 +4220,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4246,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.30.2"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e48d7c56b3f7425d061886e8ce3b6acfab1993682ed70bef50fd133d721ee6"
+checksum = "a0dbbebe82d02044dfa481adca1550d6dd7bd16e086bc34fa0fbecceb5a63751"
 dependencies = [
  "bitflags 2.6.0",
  "cocoa",
@@ -4277,7 +4290,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.58.0",
+ "windows",
  "windows-core 0.58.0",
  "windows-version",
  "x11-dl",
@@ -4291,7 +4304,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4313,9 +4326,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.0.0-rc.15"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3c3b1c7ac5b72d59da307b84af900a0098c74c9d7369f65018cd8ec0eb50fb"
+checksum = "44438500b50708bfc1e6083844e135d1b516325aae58710dcd8fb67e050ae87c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4345,7 +4358,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serialize-to-javascript",
- "state",
  "swift-rs",
  "tauri-build",
  "tauri-macros",
@@ -4360,14 +4372,14 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows 0.58.0",
+ "windows",
 ]
 
 [[package]]
 name = "tauri-build"
-version = "2.0.0-rc.12"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5713e81e02e0b99f5219b275abbd7d2c0cc0f30180e25b1b650e08feeac63"
+checksum = "935f9b3c49b22b3e2e485a57f46d61cd1ae07b1cbb2ba87387a387caf2d8c4e7"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -4387,9 +4399,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.0.0-rc.12"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5370f2591dcc93d4ff08d9dd168f5097f79b34e859883586a409c627544190e3"
+checksum = "95d7443dd4f0b597704b6a14b964ee2ed16e99928d8e6292ae9825f09fbcd30e"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -4403,7 +4415,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.77",
+ "syn 2.0.79",
  "tauri-utils",
  "thiserror",
  "time",
@@ -4414,23 +4426,23 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.0.0-rc.11"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19442dc8ee002ab1926586f6aecb90114f3a1226766008b0c9ac2d9fec9eeb7e"
+checksum = "4d2c0963ccfc3f5194415f2cce7acc975942a8797fbabfb0aa1ed6f59326ae7f"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "tauri-codegen",
  "tauri-utils",
 ]
 
 [[package]]
 name = "tauri-plugin"
-version = "2.0.0-rc.12"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e3368e91a98aa55ea4e3e8ccff516bc1ed2f85872c335ec35e9b345469032e0"
+checksum = "b2e6660a409963e4d57b9bfab4addd141eeff41bd3a7fb14e13004a832cf7ef6"
 dependencies = [
  "anyhow",
  "glob",
@@ -4445,9 +4457,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-autostart"
-version = "2.0.0-rc.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992fef0cc6ef3637a8b336c9bf9758b8e718db934afd744846422c1da877dac0"
+checksum = "bba6bb936e0fd0a58ed958b49e2e423dd40949c9d9425cc991be996959e3838e"
 dependencies = [
  "auto-launch",
  "log",
@@ -4460,9 +4472,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-dialog"
-version = "2.0.0-rc.7"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785722c81beb4a6b729ae55d06aeb68d47166c933e64b727e33254dcb5d4d82d"
+checksum = "ddb2fe88b602461c118722c574e2775ab26a4e68886680583874b2f6520608b7"
 dependencies = [
  "log",
  "raw-window-handle",
@@ -4478,9 +4490,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.0.0-rc.5"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cb1dfbbea322afbc9dec49351bc29edf4e85e74d37d9a3fcc72d67ed55ffdbd"
+checksum = "ab300488ebec3487ca5f56289692e7e45feb07eea8d5e1dba497f7dc9dd9c407"
 dependencies = [
  "anyhow",
  "dunce",
@@ -4499,9 +4511,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-shell"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83800ddf78b820172efb5ed7310344e8e4f97fd30cd8237a3f20c12a79eb136"
+checksum = "371fb9aca2823990a2d0db7970573be5fdf07881fcaa2b835b29631feb84aec1"
 dependencies = [
  "encoding_rs",
  "log",
@@ -4520,9 +4532,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-store"
-version = "2.0.0-rc.3"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54ba1a0c0c60a6a08e711e184239f8a50354988b6fe1af8b5ce2215b2e79a2"
+checksum = "5058f179f7215390fc5a68eeffcb805b7e2681d6e817a5d08094fae7ab649e68"
 dependencies = [
  "dunce",
  "log",
@@ -4531,13 +4543,14 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
 name = "tauri-plugin-updater"
-version = "2.0.0-rc.3"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391ebb8ae8cd6aec44b5d96d3005659d88cde69c57326f639bbc660116a30d63"
+checksum = "1dd3d2fe0f02bf52eebb5a9d23b987fffac6684646ab6fd683d706dafb18da87"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -4546,6 +4559,7 @@ dependencies = [
  "http",
  "infer",
  "minisign-verify",
+ "percent-encoding",
  "reqwest",
  "semver",
  "serde",
@@ -4564,9 +4578,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.0.0-rc.12"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f38d8aaa1e81d20e8e208e3e317f81b59fb75c530fbae8a90e72d02001d687"
+checksum = "c8f437293d6f5e5dce829250f4dbdce4e0b52905e297a6689cc2963eb53ac728"
 dependencies = [
  "dpi",
  "gtk",
@@ -4578,14 +4592,14 @@ dependencies = [
  "tauri-utils",
  "thiserror",
  "url",
- "windows 0.58.0",
+ "windows",
 ]
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.0.0-rc.13"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1ef5171e14c8fe3b5a63e75004c20d057747bc3e7fdc5f8ded625f0b29f5c7"
+checksum = "1431602bcc71f2f840ad623915c9842ecc32999b867c4a787d975a17a9625cc6"
 dependencies = [
  "gtk",
  "http",
@@ -4603,15 +4617,15 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.58.0",
+ "windows",
  "wry",
 ]
 
 [[package]]
 name = "tauri-utils"
-version = "2.0.0-rc.12"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31fe4c9148e1b35225e1c00753f24b517ce00041d02eb4b4d6fd10613a47736c"
+checksum = "c38b0230d6880cf6dd07b6d7dd7789a0869f98ac12146e0d18d1c1049215a045"
 dependencies = [
  "brotli",
  "cargo_metadata",
@@ -4639,6 +4653,7 @@ dependencies = [
  "toml 0.8.2",
  "url",
  "urlpattern",
+ "uuid",
  "walkdir",
 ]
 
@@ -4699,17 +4714,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-dependencies = [
- "cfg-if",
- "once_cell",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4785,7 +4790,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4851,7 +4856,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4864,26 +4869,11 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -4948,7 +4938,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4958,43 +4948,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
-dependencies = [
- "matchers",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
 name = "tray-icon"
-version = "0.17.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044d7738b3d50f288ddef035b793228740ad4d927f5466b0af55dc15e7e03cfe"
+checksum = "7c92af36a182b46206723bdf8a7942e20838cde1cf062e5b97854d57eb01763b"
 dependencies = [
  "core-graphics",
  "crossbeam-channel",
@@ -5083,9 +5043,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -5171,19 +5131,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
  "rand 0.8.5",
+ "serde",
 ]
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -5276,7 +5231,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -5310,7 +5265,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5323,15 +5278,75 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
 dependencies = [
  "futures-util",
  "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3f45d1222915ef1fd2057220c1d9d9624b7654443ea35c3877f7a52bd0a5a2d"
+dependencies = [
+ "bitflags 2.6.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b5755d77ae9040bb872a25026555ce4cb0ae75fd923e90d25fba07d81057de0"
+dependencies = [
+ "bitflags 2.6.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.36.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5405,7 +5420,7 @@ checksum = "6f61ff3d9d0ee4efcb461b14eb3acfda2702d10dc329f339303fc3e57215ae2c"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.58.0",
+ "windows",
  "windows-core 0.58.0",
  "windows-implement",
  "windows-interface",
@@ -5419,7 +5434,7 @@ checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5429,7 +5444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3a3e2eeb58f82361c93f9777014668eb3d07e7d174ee4c819575a9208011886"
 dependencies = [
  "thiserror",
- "windows 0.58.0",
+ "windows",
  "windows-core 0.58.0",
 ]
 
@@ -5480,15 +5495,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -5527,7 +5533,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5538,7 +5544,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5824,14 +5830,12 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.43.1"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d715cf5fe88e9647f3d17b207b6d060d4a88e7171d4ccb2d2c657dd1d44728"
+checksum = "6fa1c8c760041c64ce6be99f83d6cb55fe3fcd85a1ad46d32895f6e65cee87ba"
 dependencies = [
  "base64 0.22.1",
- "block",
- "cocoa",
- "core-graphics",
+ "block2",
  "crossbeam-channel",
  "dpi",
  "dunce",
@@ -5844,8 +5848,11 @@ dependencies = [
  "kuchikiki",
  "libc",
  "ndk",
- "objc",
- "objc_id",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "objc2-web-kit",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -5856,7 +5863,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.58.0",
+ "windows",
  "windows-core 0.58.0",
  "windows-version",
  "x11-dl",
@@ -5993,7 +6000,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6013,7 +6020,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6026,7 +6033,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "memchr",
  "thiserror",
 ]

--- a/packages/hoppscotch-agent/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.toml
@@ -12,36 +12,36 @@ name = "hoppscotch_agent_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2.0.0-rc", features = [] }
+tauri-build = { version = "2.0.1", features = [] }
 
 [dependencies]
-tauri = { version = "2.0.0-rc.0", features = ["tray-icon", "image-png"] }
-tauri-plugin-shell = "2.0.0-rc"
-tauri-plugin-autostart = "2.0.0-rc"
+tauri = { version = "2.0.4", features = ["tray-icon", "image-png"] }
+tauri-plugin-shell = "2.0.1"
+tauri-plugin-autostart = "2.0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1.40.0", features = ["full"] }
 dashmap = { version = "6.1.0", features = ["serde"] }
-axum = { version = "0.7.6" }
+axum = { version = "0.7.7" }
 axum-extra = { version = "0.9.4", features = ["typed-header"] }
 tower-http = { version = "0.6.1", features = ["cors"] }
 tokio-util = "0.7.12"
-uuid = { version = "1.10.0", features = [ "v4", "fast-rng" ] }
+uuid = { version = "1.11.0", features = [ "v4", "fast-rng" ] }
 chrono = { version = "0.4", features = ["serde"] }
 rand = "0.8.5"
 log = "0.4.22"
 env_logger = "0.11.5"
-curl = { version = "0.4.46", features = ["ntlm", "static-curl", "static-ssl"] }
-openssl = { version = "0.10.66", features = ["vendored"] }
-openssl-sys = { version = "0.9.103", features = ["vendored"] }
+curl = { version = "0.4.47", features = ["ntlm", "static-curl", "static-ssl"] }
+openssl = { version = "0.10.68", features = ["vendored"] }
+openssl-sys = { version = "0.9.104", features = ["vendored"] }
 url-escape = "0.1.1"
 thiserror = "1.0.64"
-tauri-plugin-store = "2.0.0-rc.3"
+tauri-plugin-store = "2.0.1"
 x25519-dalek = { version = "2.0.1", features = ["getrandom"] }
 base16 = "0.2.1"
 aes-gcm = { version = "0.10.3", features = ["aes"] }
-tauri-plugin-updater = "2.0.0-rc.3"
-tauri-plugin-dialog = "2.0.0-rc.7"
+tauri-plugin-updater = "2.0.2"
+tauri-plugin-dialog = "2.0.1"
 http = "1.1.0"
 lazy_static = "1.5.0"
 

--- a/packages/hoppscotch-agent/src-tauri/src/error.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/error.rs
@@ -40,6 +40,8 @@ pub enum AppError {
     RegistrationInsertError,
     #[error("Failed to save registrations to store")]
     RegistrationSaveError,
+    #[error("Store error: {0}")]
+    TauriPluginStore(#[from] tauri_plugin_store::Error),
 }
 
 impl IntoResponse for AppError {

--- a/packages/hoppscotch-agent/src-tauri/src/state.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/state.rs
@@ -4,20 +4,20 @@ use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tauri_plugin_store::StoreBuilder;
-use tokio_util::sync::CancellationToken;
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 
 use crate::error::AppError;
 
 /// Describes one registered app instance
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Registration {
-  pub registered_at: DateTime<Utc>,
+    pub registered_at: DateTime<Utc>,
 
-  /// base16 (lowercase) encoded shared secret that the client
-  /// and agent established during registration that is used
-  /// to encrypt traffic between them
-  pub shared_secret_b16: String
+    /// base16 (lowercase) encoded shared secret that the client
+    /// and agent established during registration that is used
+    /// to encrypt traffic between them
+    pub shared_secret_b16: String,
 }
 
 #[derive(Default)]
@@ -30,28 +30,26 @@ pub struct AppState {
 
     /// Registrations against the agent, the key is the auth
     /// token associated to the registration
-    registrations: DashMap<String, Registration>
+    registrations: DashMap<String, Registration>,
 }
 
 impl AppState {
-
     pub fn new(app_handle: tauri::AppHandle) -> Self {
-        let mut store = StoreBuilder::new("app_data.bin")
-            .build(app_handle);
+        let store = StoreBuilder::new(&app_handle, "app_data.bin").build();
 
         let _ = store.load();
 
         // Try loading and parsing registrations from the store, if that failed,
         // load the default list
-        let registrations = store.get("registrations")
-          .and_then(|val| serde_json::from_value(val.clone()).ok())
-          .unwrap_or_else(|| DashMap::new());
-
+        let registrations = store
+            .get("registrations")
+            .and_then(|val| serde_json::from_value(val.clone()).ok())
+            .unwrap_or_else(|| DashMap::new());
 
         Self {
             active_registration_code: RwLock::new(None),
             cancellation_tokens: DashMap::new(),
-            registrations
+            registrations,
         }
     }
 
@@ -60,39 +58,41 @@ impl AppState {
     /// reference, you shouldn't do it for registrations as `update_registrations`
     /// performs save operation that needs to be done and should be used instead
     pub fn get_registrations(&self) -> &DashMap<String, Registration> {
-      &self.registrations
+        &self.registrations
     }
 
     /// Provides you an opportunity to update the registrations list
     /// and also persists the data to the disk
-        pub fn update_registrations(
+    pub fn update_registrations(
         &self,
         app_handle: tauri::AppHandle,
-        update_func: impl FnOnce(&DashMap<String, Registration>)
+        update_func: impl FnOnce(&DashMap<String, Registration>),
     ) -> Result<(), AppError> {
         update_func(&self.registrations);
 
-        let mut store = StoreBuilder::new("app_data.bin")
-            .build(app_handle);
+        let store = StoreBuilder::new(&app_handle, "app_data.bin").build();
 
-        let _ = store.load();
+        let _ = store.load()?;
 
-        store.delete("registrations")
-            .map_err(|_| AppError::RegistrationClearError)?;
+        let _ = store
+            .delete("registrations")
+            .then_some(())
+            .ok_or(AppError::RegistrationClearError)?;
 
-        store.insert("registrations".into(), serde_json::to_value(self.registrations.clone()).unwrap())
-            .map_err(|_| AppError::RegistrationInsertError)?;
+        let _ = store.set(
+            "registrations",
+            serde_json::to_value(self.registrations.clone()).unwrap(),
+        );
 
-        store.save()
-            .map_err(|_| AppError::RegistrationSaveError)?;
+        store.save().map_err(|_| AppError::RegistrationSaveError)?;
 
         Ok(())
     }
 
     pub async fn validate_registration(&self, registration: &str) -> bool {
         match *self.active_registration_code.read().await {
-          Some(ref code) => code == registration,
-          None => false
+            Some(ref code) => code == registration,
+            None => false,
         }
     }
 
@@ -105,50 +105,40 @@ impl AppState {
     }
 
     pub fn validate_access(&self, auth_key: &str) -> bool {
-      self.registrations.get(auth_key).is_some()
+        self.registrations.get(auth_key).is_some()
     }
 
     pub fn validate_access_and_get_data<T>(
-      &self,
-      auth_key: &str,
-      nonce: &str,
-      data: &Bytes
+        &self,
+        auth_key: &str,
+        nonce: &str,
+        data: &Bytes,
     ) -> Option<T>
     where
-      T : DeserializeOwned
+        T: DeserializeOwned,
     {
-      if let Some(registration) = self.registrations.get(auth_key) {
-        let key: [u8; 32] = base16::decode(&registration.shared_secret_b16)
-              .ok()?
-              [0..32]
-              .try_into()
-              .ok()?;
+        if let Some(registration) = self.registrations.get(auth_key) {
+            let key: [u8; 32] = base16::decode(&registration.shared_secret_b16).ok()?[0..32]
+                .try_into()
+                .ok()?;
 
-        let nonce: [u8; 12] = base16::decode(nonce)
-            .ok()?
-            [0..12]
-            .try_into()
-            .ok()?;
+            let nonce: [u8; 12] = base16::decode(nonce).ok()?[0..12].try_into().ok()?;
 
-        let cipher = Aes256Gcm::new(&key.into());
+            let cipher = Aes256Gcm::new(&key.into());
 
-        let data = data
-            .iter()
-            .cloned()
-            .collect::<Vec<u8>>();
+            let data = data.iter().cloned().collect::<Vec<u8>>();
 
-        let plain_data = cipher.decrypt(&nonce.into(), data.as_slice())
-          .ok()?;
+            let plain_data = cipher.decrypt(&nonce.into(), data.as_slice()).ok()?;
 
-        serde_json::from_reader(plain_data.as_slice())
-          .ok()
-      } else {
-        None
-      }
+            serde_json::from_reader(plain_data.as_slice()).ok()
+        } else {
+            None
+        }
     }
 
     pub fn get_registration_info(&self, auth_key: &str) -> Option<Registration> {
-      self.registrations.get(auth_key)
-        .map(|reference| reference.value().clone())
+        self.registrations
+            .get(auth_key)
+            .map(|reference| reference.value().clone())
     }
 }

--- a/packages/hoppscotch-agent/src-tauri/src/updater.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/updater.rs
@@ -1,34 +1,39 @@
 #[cfg(desktop)]
-pub async fn check_and_install_updates(app: tauri::AppHandle, updater: tauri_plugin_updater::Updater) {
-  use tauri::Manager;
-  use tauri_plugin_dialog::MessageDialogKind;
-  use tauri_plugin_dialog::DialogExt;
+pub async fn check_and_install_updates(
+    app: tauri::AppHandle,
+    updater: tauri_plugin_updater::Updater,
+) {
+    use tauri::Manager;
+    use tauri_plugin_dialog::DialogExt;
+    use tauri_plugin_dialog::MessageDialogButtons;
+    use tauri_plugin_dialog::MessageDialogKind;
 
+    let update = updater.check().await;
 
-  let update = updater.check().await;
+    if let Ok(Some(update)) = update {
+        let do_update = app
+            .dialog()
+            .message(format!(
+                "Update to {} is available!{}",
+                update.version,
+                update
+                    .body
+                    .clone()
+                    .map(|body| format!("\n\nRelease Notes: {}", body))
+                    .unwrap_or("".into())
+            ))
+            .title("Update Available")
+            .kind(MessageDialogKind::Info)
+            .buttons(MessageDialogButtons::OkCancelCustom(
+                "Update".to_string(),
+                "Cancel".to_string(),
+            ))
+            .blocking_show();
 
-  if let Ok(Some(update)) = update {
-      let do_update = app.dialog()
-        .message(
-          format!(
-              "Update to {} is available!{}",
-              update.version,
-              update.body
-                .clone()
-                .map(|body| format!("\n\nRelease Notes: {}", body))
-                .unwrap_or("".into())
-          )
-        )
-        .title("Update Available")
-        .kind(MessageDialogKind::Info)
-        .ok_button_label("Update")
-        .cancel_button_label("Cancel")
-        .blocking_show();
+        if do_update {
+            let _ = update.download_and_install(|_, _| {}, || {}).await;
 
-      if do_update {
-          let _ = update.download_and_install(|_, _| {}, || {}).await;
-
-          tauri::process::restart(&app.env());
-      }
-  }
+            tauri::process::restart(&app.env());
+        }
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,12 +83,12 @@ importers:
     dependencies:
       '@hoppscotch/ui':
         specifier: ^0.2.1
-        version: 0.2.1(eslint@9.13.0(jiti@2.3.3))(terser@5.36.0)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.6.3))
+        version: 0.2.1(eslint@9.13.0(jiti@2.3.3))(terser@5.36.0)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.6.3))
       '@tauri-apps/api':
-        specifier: '>=2.0.0-rc.0'
+        specifier: ^2.0.2
         version: 2.0.2
       '@tauri-apps/plugin-shell':
-        specifier: '>=2.0.0-rc.0'
+        specifier: ^2.0.0
         version: 2.0.0
       '@vueuse/core':
         specifier: ^11.1.0
@@ -104,17 +104,17 @@ importers:
         version: 3.3.9(typescript@5.6.3)
     devDependencies:
       '@iconify-json/lucide':
-        specifier: ^1.2.6
-        version: 1.2.8
+        specifier: ^1.2.8
+        version: 1.2.10
       '@tauri-apps/cli':
-        specifier: '>=2.0.0-rc.0'
+        specifier: ^2.0.3
         version: 2.0.3
       '@types/node':
-        specifier: ^22.7.0
-        version: 22.7.5
+        specifier: ^22.7.5
+        version: 22.7.6
       '@vitejs/plugin-vue':
         specifier: ^5.1.4
-        version: 5.1.4(vite@5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.6.3))
+        version: 5.1.4(vite@5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.6.3))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.47)
@@ -123,18 +123,18 @@ importers:
         version: 8.4.47
       tailwindcss:
         specifier: ^3.4.13
-        version: 3.4.13(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.6.3))
+        version: 3.4.13(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.6)(typescript@5.6.3))
       typescript:
-        specifier: ^5.2.2
+        specifier: ^5.6.3
         version: 5.6.3
       unplugin-icons:
         specifier: ^0.19.3
         version: 0.19.3(@vue/compiler-sfc@3.5.12)(vue-template-compiler@2.7.16)(webpack-sources@3.2.3)
       vite:
-        specifier: ^5.4.7
-        version: 5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+        specifier: ^5.4.8
+        version: 5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0)
       vue-tsc:
-        specifier: ^2.0.22
+        specifier: ^2.1.6
         version: 2.1.6(typescript@5.6.3)
 
   packages/hoppscotch-backend:
@@ -497,7 +497,7 @@ importers:
         version: link:../hoppscotch-js-sandbox
       '@hoppscotch/ui':
         specifier: 0.2.0
-        version: 0.2.0(eslint@8.57.0)(terser@5.36.0)(typescript@5.3.2)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))
+        version: 0.2.0(eslint@8.57.0)(terser@5.36.0)(typescript@5.3.2)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))
       '@hoppscotch/vue-toasted':
         specifier: 0.1.0
         version: 0.1.0(vue@3.3.9(typescript@5.3.2))
@@ -530,7 +530,7 @@ importers:
         version: 6.4.0(graphql@16.8.1)
       '@vitejs/plugin-legacy':
         specifier: 4.1.1
-        version: 4.1.1(terser@5.36.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))
+        version: 4.1.1(terser@5.36.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))
       '@vueuse/core':
         specifier: 10.7.0
         version: 10.7.0(vue@3.3.9(typescript@5.3.2))
@@ -569,7 +569,7 @@ importers:
         version: 16.8.1
       graphql-language-service-interface:
         specifier: 2.10.2
-        version: 2.10.2(@types/node@22.7.5)(graphql@16.8.1)
+        version: 2.10.2(@types/node@22.7.7)(graphql@16.8.1)
       graphql-tag:
         specifier: 2.12.6
         version: 2.12.6(graphql@16.8.1)
@@ -714,7 +714,7 @@ importers:
         version: 5.0.0(graphql@16.8.1)
       '@graphql-codegen/cli':
         specifier: 5.0.0
-        version: 5.0.0(@parcel/watcher@2.4.1)(@types/node@22.7.5)(graphql@16.8.1)(typescript@5.3.2)
+        version: 5.0.0(@parcel/watcher@2.4.1)(@types/node@22.7.7)(graphql@16.8.1)(typescript@5.3.2)
       '@graphql-codegen/typed-document-node':
         specifier: 5.0.1
         version: 5.0.1(graphql@16.8.1)
@@ -738,7 +738,7 @@ importers:
         version: 1.1.144
       '@intlify/vite-plugin-vue-i18n':
         specifier: 7.0.0
-        version: 7.0.0(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(vue-i18n@9.8.0(vue@3.3.9(typescript@5.3.2)))
+        version: 7.0.0(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(vue-i18n@9.8.0(vue@3.3.9(typescript@5.3.2)))
       '@relmify/jest-fp-ts':
         specifier: 2.1.1
         version: 2.1.1(fp-ts@2.16.1)(io-ts@2.2.20(fp-ts@2.16.1))
@@ -786,7 +786,7 @@ importers:
         version: 7.3.1(eslint@8.57.0)(typescript@5.3.2)
       '@vitejs/plugin-vue':
         specifier: 4.5.1
-        version: 4.5.1(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))
+        version: 4.5.1(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))
       '@vue/compiler-sfc':
         specifier: 3.3.10
         version: 3.3.10
@@ -840,13 +840,13 @@ importers:
         version: 1.69.5
       tailwindcss:
         specifier: 3.3.5
-        version: 3.3.5(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.2))
+        version: 3.3.5(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.7)(typescript@5.3.2))
       typescript:
         specifier: 5.3.2
         version: 5.3.2
       unplugin-fonts:
         specifier: 1.1.1
-        version: 1.1.1(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(webpack-sources@3.2.3)
+        version: 1.1.1(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(webpack-sources@3.2.3)
       unplugin-icons:
         specifier: 0.17.4
         version: 0.17.4(@vue/compiler-sfc@3.3.10)(vue-template-compiler@2.7.16)(webpack-sources@3.2.3)
@@ -855,31 +855,31 @@ importers:
         version: 0.25.2(@babel/parser@7.25.8)(rollup@4.24.0)(vue@3.3.9(typescript@5.3.2))(webpack-sources@3.2.3)
       vite:
         specifier: 4.5.0
-        version: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+        version: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
       vite-plugin-checker:
         specifier: 0.6.2
-        version: 0.6.2(eslint@8.57.0)(meow@13.2.0)(optionator@0.9.4)(typescript@5.3.2)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(vue-tsc@1.8.24(typescript@5.3.2))
+        version: 0.6.2(eslint@8.57.0)(optionator@0.9.4)(typescript@5.3.2)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(vue-tsc@1.8.24(typescript@5.3.2))
       vite-plugin-fonts:
         specifier: 0.7.0
-        version: 0.7.0(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))
+        version: 0.7.0(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))
       vite-plugin-html-config:
         specifier: 1.0.11
-        version: 1.0.11(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))
+        version: 1.0.11(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))
       vite-plugin-inspect:
         specifier: 0.7.42
-        version: 0.7.42(rollup@4.24.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))
+        version: 0.7.42(rollup@4.24.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))
       vite-plugin-pages:
         specifier: 0.31.0
-        version: 0.31.0(@vue/compiler-sfc@3.3.10)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))
+        version: 0.31.0(@vue/compiler-sfc@3.3.10)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))
       vite-plugin-pages-sitemap:
         specifier: 1.6.1
         version: 1.6.1
       vite-plugin-pwa:
         specifier: 0.17.3
-        version: 0.17.3(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.0.0)
+        version: 0.17.3(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.0.0)
       vite-plugin-vue-layouts:
         specifier: 0.8.0
-        version: 0.8.0(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(vue-router@4.2.5(vue@3.3.9(typescript@5.3.2)))(vue@3.3.9(typescript@5.3.2))
+        version: 0.8.0(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(vue-router@4.2.5(vue@3.3.9(typescript@5.3.2)))(vue@3.3.9(typescript@5.3.2))
       vitest:
         specifier: 0.34.6
         version: 0.34.6(jsdom@25.0.1(canvas@2.11.2))(sass@1.69.5)(terser@5.36.0)
@@ -916,7 +916,7 @@ importers:
         version: 5.2.2
       vite:
         specifier: 4.5.0
-        version: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+        version: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
 
   packages/hoppscotch-js-sandbox:
     dependencies:
@@ -977,7 +977,7 @@ importers:
         version: 2.8.4
       ts-jest:
         specifier: 27.1.5
-        version: 27.1.5(@babel/core@7.25.8)(@types/jest@27.5.2)(babel-jest@29.7.0(@babel/core@7.25.8))(jest@29.7.0(@types/node@17.0.45))(typescript@4.9.5)
+        version: 27.1.5(@babel/core@7.25.8)(@types/jest@27.5.2)(jest@29.7.0(@types/node@17.0.45))(typescript@4.9.5)
       typescript:
         specifier: 4.9.5
         version: 4.9.5
@@ -1161,7 +1161,7 @@ importers:
         version: 0.14.9(@vue/compiler-sfc@3.5.12)(vue-template-compiler@2.7.16)
       unplugin-vue-components:
         specifier: 0.21.0
-        version: 0.21.0(@babel/parser@7.25.8)(esbuild@0.24.0)(rollup@3.29.4)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@4.9.5))(webpack@5.95.0(@swc/core@1.4.2)(esbuild@0.24.0))
+        version: 0.21.0(@babel/parser@7.25.8)(esbuild@0.24.0)(rollup@2.79.2)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@4.9.5))(webpack@5.95.0(@swc/core@1.4.2)(esbuild@0.24.0))
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0)
@@ -1170,7 +1170,7 @@ importers:
         version: 1.0.11(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))
       vite-plugin-inspect:
         specifier: 0.7.38
-        version: 0.7.38(rollup@3.29.4)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))
+        version: 0.7.38(rollup@2.79.2)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))
       vite-plugin-pages:
         specifier: 0.26.0
         version: 0.26.0(@vue/compiler-sfc@3.5.12)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))
@@ -1209,10 +1209,10 @@ importers:
         version: link:../hoppscotch-data
       '@hoppscotch/ui':
         specifier: 0.1.0
-        version: 0.1.0(eslint@8.55.0)(terser@5.36.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))
+        version: 0.1.0(eslint@8.55.0)(terser@5.36.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))
       '@import-meta-env/unplugin':
         specifier: 0.4.10
-        version: 0.4.10(@import-meta-env/cli@0.7.0)(dotenv@16.4.5)(webpack-sources@3.2.3)
+        version: 0.4.10(dotenv@16.4.5)(webpack-sources@3.2.3)
       axios:
         specifier: 1.7.5
         version: 1.7.5
@@ -1252,7 +1252,7 @@ importers:
         version: 5.0.0(graphql@16.9.0)
       '@graphql-codegen/cli':
         specifier: 5.0.0
-        version: 5.0.0(@parcel/watcher@2.4.1)(@types/node@22.7.5)(graphql@16.9.0)(typescript@5.3.2)
+        version: 5.0.0(@parcel/watcher@2.4.1)(@types/node@22.7.7)(graphql@16.9.0)(typescript@5.3.2)
       '@graphql-codegen/typed-document-node':
         specifier: 5.0.1
         version: 5.0.1(graphql@16.9.0)
@@ -1276,7 +1276,7 @@ importers:
         version: 1.1.144
       '@intlify/vite-plugin-vue-i18n':
         specifier: 7.0.0
-        version: 7.0.0(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue-i18n@10.0.4(vue@3.3.9(typescript@5.3.2)))
+        version: 7.0.0(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(vue-i18n@10.0.4(vue@3.3.9(typescript@5.3.2)))
       '@rushstack/eslint-patch':
         specifier: 1.6.0
         version: 1.6.0
@@ -1288,10 +1288,10 @@ importers:
         version: 6.13.2(eslint@8.55.0)(typescript@5.3.2)
       '@vitejs/plugin-legacy':
         specifier: 4.1.1
-        version: 4.1.1(terser@5.36.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))
+        version: 4.1.1(terser@5.36.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))
       '@vitejs/plugin-vue':
         specifier: 4.5.1
-        version: 4.5.1(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))
+        version: 4.5.1(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))
       '@vue/eslint-config-typescript':
         specifier: 12.0.0
         version: 12.0.0(eslint-plugin-vue@9.19.2(eslint@8.55.0))(eslint@8.55.0)(typescript@5.3.2)
@@ -1321,46 +1321,46 @@ importers:
         version: 0.5.7(prettier@3.3.3)
       tailwindcss:
         specifier: 3.3.5
-        version: 3.3.5(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.2))
+        version: 3.3.5(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.7)(typescript@5.3.2))
       typescript:
         specifier: 5.3.2
         version: 5.3.2
       unplugin-fonts:
         specifier: 1.1.1
-        version: 1.1.1(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(webpack-sources@3.2.3)
+        version: 1.1.1(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(webpack-sources@3.2.3)
       unplugin-icons:
         specifier: 0.17.4
         version: 0.17.4(@vue/compiler-sfc@3.5.12)(vue-template-compiler@2.7.16)(webpack-sources@3.2.3)
       unplugin-vue-components:
         specifier: 0.25.2
-        version: 0.25.2(@babel/parser@7.25.8)(rollup@3.29.4)(vue@3.3.9(typescript@5.3.2))(webpack-sources@3.2.3)
+        version: 0.25.2(@babel/parser@7.25.8)(rollup@4.24.0)(vue@3.3.9(typescript@5.3.2))(webpack-sources@3.2.3)
       vite:
         specifier: 4.5.0
-        version: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+        version: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
       vite-plugin-fonts:
         specifier: 0.7.0
-        version: 0.7.0(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))
+        version: 0.7.0(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))
       vite-plugin-html-config:
         specifier: 1.0.11
-        version: 1.0.11(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))
+        version: 1.0.11(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))
       vite-plugin-inspect:
         specifier: 0.7.42
-        version: 0.7.42(rollup@3.29.4)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))
+        version: 0.7.42(rollup@4.24.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))
       vite-plugin-pages:
         specifier: 0.31.0
-        version: 0.31.0(@vue/compiler-sfc@3.5.12)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))
+        version: 0.31.0(@vue/compiler-sfc@3.5.12)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))
       vite-plugin-pages-sitemap:
         specifier: 1.6.1
         version: 1.6.1
       vite-plugin-pwa:
         specifier: 0.17.3
-        version: 0.17.3(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.0.0)
+        version: 0.17.3(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.0.0)
       vite-plugin-static-copy:
         specifier: 0.17.1
-        version: 0.17.1(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))
+        version: 0.17.1(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))
       vite-plugin-vue-layouts:
         specifier: 0.8.0
-        version: 0.8.0(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue-router@4.4.5(vue@3.3.9(typescript@5.3.2)))(vue@3.3.9(typescript@5.3.2))
+        version: 0.8.0(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(vue-router@4.4.5(vue@3.3.9(typescript@5.3.2)))(vue@3.3.9(typescript@5.3.2))
       vue-tsc:
         specifier: 1.8.24
         version: 1.8.24(typescript@5.3.2)
@@ -1387,7 +1387,7 @@ importers:
         version: 0.1.0(vue@3.3.9(typescript@5.6.3))
       '@intlify/unplugin-vue-i18n':
         specifier: 5.2.0
-        version: 5.2.0(@vue/compiler-dom@3.5.12)(eslint@9.13.0(jiti@2.3.3))(rollup@3.29.4)(typescript@5.6.3)(vue-i18n@10.0.4(vue@3.3.9(typescript@5.6.3)))(vue@3.3.9(typescript@5.6.3))(webpack-sources@3.2.3)
+        version: 5.2.0(@vue/compiler-dom@3.5.12)(eslint@9.13.0(jiti@2.3.3))(rollup@4.24.0)(typescript@5.6.3)(vue-i18n@10.0.4(vue@3.3.9(typescript@5.6.3)))(vue@3.3.9(typescript@5.6.3))(webpack-sources@3.2.3)
       '@types/cors':
         specifier: 2.8.17
         version: 2.8.17
@@ -1444,7 +1444,7 @@ importers:
         version: 0.19.3(@vue/compiler-sfc@3.5.12)(vue-template-compiler@2.7.16)(webpack-sources@3.2.3)
       unplugin-vue-components:
         specifier: 0.27.4
-        version: 0.27.4(@babel/parser@7.25.8)(rollup@3.29.4)(vue@3.3.9(typescript@5.6.3))(webpack-sources@3.2.3)
+        version: 0.27.4(@babel/parser@7.25.8)(rollup@4.24.0)(vue@3.3.9(typescript@5.6.3))(webpack-sources@3.2.3)
       vue:
         specifier: 3.3.9
         version: 3.3.9(typescript@5.6.3)
@@ -3393,8 +3393,8 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
-  '@graphql-tools/executor-http@1.1.6':
-    resolution: {integrity: sha512-wGKjJzbi6em8cWI3sry6T7kAgoxMXYNM+KlbsWczPvIsHvv1cqXlrP1lwC6f7Ja1FfWdU1ZIEgOv93ext7IDyQ==}
+  '@graphql-tools/executor-http@1.0.9':
+    resolution: {integrity: sha512-+NXaZd2MWbbrWHqU4EhXcrDbogeiCDmEbrAN+rMn4Nu2okDjn2MTFDbTIab87oEubQCH4Te1wDkWPKrzXup7+Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -3664,9 +3664,6 @@ packages:
 
   '@iconify-json/lucide@1.2.10':
     resolution: {integrity: sha512-cR1xpRJ4dnoXlC0ShDjzbrZyu+ICH4OUaYl7S51MhZUO1H040s7asVqv0LsDbofSLDuzWkHCLsBabTTRL0mCUg==}
-
-  '@iconify-json/lucide@1.2.8':
-    resolution: {integrity: sha512-knmDUXky8AAQ0rnGdnBjS1mBr6c0tT7aVbBd7AJcDTcJYvx9XEeyHlabFKG03DaLbOkCy0QHwCYoeZHRDEzOFA==}
 
   '@iconify/types@1.1.0':
     resolution: {integrity: sha512-Jh0llaK2LRXQoYsorIH8maClebsnzTcve+7U3rQUSnC11X4jtPnFuyatqFLvMxZ8MLG8dB4zfHsbPfuvxluONw==}
@@ -5051,6 +5048,9 @@ packages:
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
+  '@types/node@22.7.6':
+    resolution: {integrity: sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==}
+
   '@types/node@22.7.7':
     resolution: {integrity: sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==}
 
@@ -5548,13 +5548,6 @@ packages:
 
   '@vitejs/plugin-legacy@2.3.0':
     resolution: {integrity: sha512-Bh62i0gzQvvT8AeAAb78nOnqSYXypkRmQmOTImdPZ39meHR9e2une3AIFmVo4s1SDmcmJ6qj18Sa/lRc/14KaA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      terser: ^5.4.0
-      vite: ^3.0.0
-
-  '@vitejs/plugin-legacy@2.3.1':
-    resolution: {integrity: sha512-J5KaGBlSt2tEYPVjM/C8dA6DkRzkFkbPe+Xb4IX5G+XOV5OGbVAfkMjKywdrkO3gGynO8S98i71Lmsff4cWkCQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       terser: ^5.4.0
@@ -8079,6 +8072,16 @@ packages:
       cosmiconfig-toml-loader:
         optional: true
 
+  graphql-config@5.0.3:
+    resolution: {integrity: sha512-BNGZaoxIBkv9yy6Y7omvsaBUHOzfFcII3UN++tpH8MGOKFPFkCPZuwx09ggANMt8FgyWP1Od8SWPmrUEZca4NQ==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      cosmiconfig-toml-loader: ^1.0.0
+      graphql: ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    peerDependenciesMeta:
+      cosmiconfig-toml-loader:
+        optional: true
+
   graphql-config@5.1.3:
     resolution: {integrity: sha512-RBhejsPjrNSuwtckRlilWzLVt2j8itl74W9Gke1KejDTz7oaA5kVd6wRn9zK9TS5mcmIYGxf7zN7a1ORMdxp1Q==}
     engines: {node: '>= 16.0.0'}
@@ -9349,10 +9352,6 @@ packages:
 
   mensch@0.3.4:
     resolution: {integrity: sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g==}
-
-  meow@13.2.0:
-    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
-    engines: {node: '>=18'}
 
   meow@8.1.2:
     resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==}
@@ -14273,10 +14272,10 @@ snapshots:
       '@commitlint/execute-rule': 16.2.1
       '@commitlint/resolve-extends': 16.2.1
       '@commitlint/types': 16.2.1
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       chalk: 4.1.2
       cosmiconfig: 7.1.0
-      cosmiconfig-typescript-loader: 2.0.2(@swc/core@1.4.2)(@types/node@22.7.5)(cosmiconfig@7.1.0)(typescript@4.9.5)
+      cosmiconfig-typescript-loader: 2.0.2(@swc/core@1.4.2)(@types/node@22.7.6)(cosmiconfig@7.1.0)(typescript@4.9.5)
       lodash: 4.17.21
       resolve-from: 5.0.0
       typescript: 4.9.5
@@ -14815,7 +14814,7 @@ snapshots:
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 16.9.0
-      graphql-config: 5.1.3(@types/node@18.18.8)(graphql@16.9.0)(typescript@4.9.5)
+      graphql-config: 5.0.3(@types/node@18.18.8)(graphql@16.9.0)(typescript@4.9.5)
       inquirer: 8.2.6
       is-glob: 4.0.3
       jiti: 1.21.6
@@ -14841,7 +14840,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@graphql-codegen/cli@5.0.0(@parcel/watcher@2.4.1)(@types/node@22.7.5)(graphql@16.8.1)(typescript@5.3.2)':
+  '@graphql-codegen/cli@5.0.0(@parcel/watcher@2.4.1)(@types/node@22.7.7)(graphql@16.8.1)(typescript@5.3.2)':
     dependencies:
       '@babel/generator': 7.25.7
       '@babel/template': 7.25.7
@@ -14851,12 +14850,12 @@ snapshots:
       '@graphql-tools/apollo-engine-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/code-file-loader': 8.1.3(graphql@16.8.1)
       '@graphql-tools/git-loader': 8.0.7(graphql@16.8.1)
-      '@graphql-tools/github-loader': 8.0.1(@types/node@22.7.5)(graphql@16.8.1)
+      '@graphql-tools/github-loader': 8.0.1(@types/node@22.7.7)(graphql@16.8.1)
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/load': 8.0.2(graphql@16.8.1)
-      '@graphql-tools/prisma-loader': 8.0.4(@types/node@22.7.5)(graphql@16.8.1)
-      '@graphql-tools/url-loader': 8.0.2(@types/node@22.7.5)(graphql@16.8.1)
+      '@graphql-tools/prisma-loader': 8.0.4(@types/node@22.7.7)(graphql@16.8.1)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@22.7.7)(graphql@16.8.1)
       '@graphql-tools/utils': 10.5.4(graphql@16.8.1)
       '@whatwg-node/fetch': 0.8.8
       chalk: 4.1.2
@@ -14864,7 +14863,7 @@ snapshots:
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 16.8.1
-      graphql-config: 5.1.3(@types/node@22.7.5)(graphql@16.8.1)(typescript@5.3.2)
+      graphql-config: 5.0.3(@types/node@22.7.7)(graphql@16.8.1)(typescript@5.3.2)
       inquirer: 8.2.6
       is-glob: 4.0.3
       jiti: 1.21.6
@@ -14890,7 +14889,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@graphql-codegen/cli@5.0.0(@parcel/watcher@2.4.1)(@types/node@22.7.5)(graphql@16.9.0)(typescript@5.3.2)':
+  '@graphql-codegen/cli@5.0.0(@parcel/watcher@2.4.1)(@types/node@22.7.7)(graphql@16.9.0)(typescript@5.3.2)':
     dependencies:
       '@babel/generator': 7.25.7
       '@babel/template': 7.25.7
@@ -14900,12 +14899,12 @@ snapshots:
       '@graphql-tools/apollo-engine-loader': 8.0.1(graphql@16.9.0)
       '@graphql-tools/code-file-loader': 8.1.3(graphql@16.9.0)
       '@graphql-tools/git-loader': 8.0.7(graphql@16.9.0)
-      '@graphql-tools/github-loader': 8.0.1(@types/node@22.7.5)(graphql@16.9.0)
+      '@graphql-tools/github-loader': 8.0.1(@types/node@22.7.7)(graphql@16.9.0)
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.9.0)
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.9.0)
       '@graphql-tools/load': 8.0.2(graphql@16.9.0)
-      '@graphql-tools/prisma-loader': 8.0.4(@types/node@22.7.5)(graphql@16.9.0)
-      '@graphql-tools/url-loader': 8.0.2(@types/node@22.7.5)(graphql@16.9.0)
+      '@graphql-tools/prisma-loader': 8.0.4(@types/node@22.7.7)(graphql@16.9.0)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@22.7.7)(graphql@16.9.0)
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@whatwg-node/fetch': 0.8.8
       chalk: 4.1.2
@@ -14913,7 +14912,7 @@ snapshots:
       debounce: 1.2.1
       detect-indent: 6.1.0
       graphql: 16.9.0
-      graphql-config: 5.1.3(@types/node@22.7.5)(graphql@16.9.0)(typescript@5.3.2)
+      graphql-config: 5.0.3(@types/node@22.7.7)(graphql@16.9.0)(typescript@5.3.2)
       inquirer: 8.2.6
       is-glob: 4.0.3
       jiti: 1.21.6
@@ -15562,7 +15561,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@graphql-tools/executor-http@0.1.10(@types/node@22.7.5)(graphql@16.8.1)':
+  '@graphql-tools/executor-http@0.1.10(@types/node@22.7.7)(graphql@16.8.1)':
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@16.8.1)
       '@repeaterjs/repeater': 3.0.6
@@ -15570,13 +15569,13 @@ snapshots:
       dset: 3.1.4
       extract-files: 11.0.0
       graphql: 16.8.1
-      meros: 1.3.0(@types/node@22.7.5)
-      tslib: 2.7.0
+      meros: 1.3.0(@types/node@22.7.7)
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
 
-  '@graphql-tools/executor-http@1.1.6(@types/node@18.18.8)(graphql@16.9.0)':
+  '@graphql-tools/executor-http@1.0.9(@types/node@18.18.8)(graphql@16.9.0)':
     dependencies:
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@repeaterjs/repeater': 3.0.6
@@ -15589,33 +15588,20 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@graphql-tools/executor-http@1.1.6(@types/node@22.7.5)(graphql@16.8.1)':
+  '@graphql-tools/executor-http@1.0.9(@types/node@22.7.7)(graphql@16.8.1)':
     dependencies:
       '@graphql-tools/utils': 10.5.4(graphql@16.8.1)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/fetch': 0.9.21
       extract-files: 11.0.0
       graphql: 16.8.1
-      meros: 1.3.0(@types/node@22.7.5)
+      meros: 1.3.0(@types/node@22.7.7)
       tslib: 2.7.0
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
 
-  '@graphql-tools/executor-http@1.1.6(@types/node@22.7.5)(graphql@16.9.0)':
-    dependencies:
-      '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
-      '@repeaterjs/repeater': 3.0.6
-      '@whatwg-node/fetch': 0.9.21
-      extract-files: 11.0.0
-      graphql: 16.9.0
-      meros: 1.3.0(@types/node@22.7.5)
-      tslib: 2.7.0
-      value-or-promise: 1.0.12
-    transitivePeerDependencies:
-      - '@types/node'
-
-  '@graphql-tools/executor-http@1.1.6(@types/node@22.7.7)(graphql@16.9.0)':
+  '@graphql-tools/executor-http@1.0.9(@types/node@22.7.7)(graphql@16.9.0)':
     dependencies:
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@repeaterjs/repeater': 3.0.6
@@ -15718,42 +15704,27 @@ snapshots:
   '@graphql-tools/github-loader@8.0.1(@types/node@18.18.8)(graphql@16.9.0)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/executor-http': 1.1.6(@types/node@18.18.8)(graphql@16.9.0)
+      '@graphql-tools/executor-http': 1.0.9(@types/node@18.18.8)(graphql@16.9.0)
       '@graphql-tools/graphql-tag-pluck': 8.3.2(graphql@16.9.0)
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@whatwg-node/fetch': 0.9.21
       graphql: 16.9.0
-      tslib: 2.7.0
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
       - encoding
       - supports-color
 
-  '@graphql-tools/github-loader@8.0.1(@types/node@22.7.5)(graphql@16.8.1)':
+  '@graphql-tools/github-loader@8.0.1(@types/node@22.7.7)(graphql@16.8.1)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/executor-http': 1.1.6(@types/node@22.7.5)(graphql@16.8.1)
+      '@graphql-tools/executor-http': 1.0.9(@types/node@22.7.7)(graphql@16.8.1)
       '@graphql-tools/graphql-tag-pluck': 8.3.2(graphql@16.8.1)
       '@graphql-tools/utils': 10.5.4(graphql@16.8.1)
       '@whatwg-node/fetch': 0.9.21
       graphql: 16.8.1
-      tslib: 2.7.0
-      value-or-promise: 1.0.12
-    transitivePeerDependencies:
-      - '@types/node'
-      - encoding
-      - supports-color
-
-  '@graphql-tools/github-loader@8.0.1(@types/node@22.7.5)(graphql@16.9.0)':
-    dependencies:
-      '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/executor-http': 1.1.6(@types/node@22.7.5)(graphql@16.9.0)
-      '@graphql-tools/graphql-tag-pluck': 8.3.2(graphql@16.9.0)
-      '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
-      '@whatwg-node/fetch': 0.9.21
-      graphql: 16.9.0
-      tslib: 2.7.0
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
@@ -15763,12 +15734,12 @@ snapshots:
   '@graphql-tools/github-loader@8.0.1(@types/node@22.7.7)(graphql@16.9.0)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/executor-http': 1.1.6(@types/node@22.7.7)(graphql@16.9.0)
+      '@graphql-tools/executor-http': 1.0.9(@types/node@22.7.7)(graphql@16.9.0)
       '@graphql-tools/graphql-tag-pluck': 8.3.2(graphql@16.9.0)
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@whatwg-node/fetch': 0.9.21
       graphql: 16.9.0
-      tslib: 2.7.0
+      tslib: 2.6.2
       value-or-promise: 1.0.12
     transitivePeerDependencies:
       - '@types/node'
@@ -15973,9 +15944,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@graphql-tools/prisma-loader@8.0.4(@types/node@22.7.5)(graphql@16.8.1)':
+  '@graphql-tools/prisma-loader@8.0.4(@types/node@22.7.7)(graphql@16.8.1)':
     dependencies:
-      '@graphql-tools/url-loader': 8.0.2(@types/node@22.7.5)(graphql@16.8.1)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@22.7.7)(graphql@16.8.1)
       '@graphql-tools/utils': 10.5.4(graphql@16.8.1)
       '@types/js-yaml': 4.0.9
       '@whatwg-node/fetch': 0.9.21
@@ -15984,32 +15955,6 @@ snapshots:
       dotenv: 16.4.5
       graphql: 16.8.1
       graphql-request: 6.1.0(graphql@16.8.1)
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.5
-      jose: 5.9.4
-      js-yaml: 4.1.0
-      lodash: 4.17.21
-      scuid: 1.1.0
-      tslib: 2.7.0
-      yaml-ast-parser: 0.0.43
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@graphql-tools/prisma-loader@8.0.4(@types/node@22.7.5)(graphql@16.9.0)':
-    dependencies:
-      '@graphql-tools/url-loader': 8.0.2(@types/node@22.7.5)(graphql@16.9.0)
-      '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
-      '@types/js-yaml': 4.0.9
-      '@whatwg-node/fetch': 0.9.21
-      chalk: 4.1.2
-      debug: 4.3.7(supports-color@9.4.0)
-      dotenv: 16.4.5
-      graphql: 16.9.0
-      graphql-request: 6.1.0(graphql@16.9.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5
       jose: 5.9.4
@@ -16131,12 +16076,12 @@ snapshots:
       tslib: 2.7.0
       value-or-promise: 1.0.12
 
-  '@graphql-tools/url-loader@7.17.18(@types/node@22.7.5)(graphql@16.8.1)':
+  '@graphql-tools/url-loader@7.17.18(@types/node@22.7.7)(graphql@16.8.1)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
       '@graphql-tools/delegate': 9.0.35(graphql@16.8.1)
       '@graphql-tools/executor-graphql-ws': 0.0.14(graphql@16.8.1)
-      '@graphql-tools/executor-http': 0.1.10(@types/node@22.7.5)(graphql@16.8.1)
+      '@graphql-tools/executor-http': 0.1.10(@types/node@22.7.7)(graphql@16.8.1)
       '@graphql-tools/executor-legacy-ws': 0.0.11(graphql@16.8.1)
       '@graphql-tools/utils': 9.2.1(graphql@16.8.1)
       '@graphql-tools/wrap': 9.4.2(graphql@16.8.1)
@@ -16158,7 +16103,7 @@ snapshots:
       '@ardatan/sync-fetch': 0.0.1
       '@graphql-tools/delegate': 10.0.21(graphql@16.9.0)
       '@graphql-tools/executor-graphql-ws': 1.3.0(graphql@16.9.0)
-      '@graphql-tools/executor-http': 1.1.6(@types/node@18.18.8)(graphql@16.9.0)
+      '@graphql-tools/executor-http': 1.0.9(@types/node@18.18.8)(graphql@16.9.0)
       '@graphql-tools/executor-legacy-ws': 1.1.0(graphql@16.9.0)
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@graphql-tools/wrap': 10.0.5(graphql@16.9.0)
@@ -16175,12 +16120,12 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@graphql-tools/url-loader@8.0.2(@types/node@22.7.5)(graphql@16.8.1)':
+  '@graphql-tools/url-loader@8.0.2(@types/node@22.7.7)(graphql@16.8.1)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
       '@graphql-tools/delegate': 10.0.21(graphql@16.8.1)
       '@graphql-tools/executor-graphql-ws': 1.3.0(graphql@16.8.1)
-      '@graphql-tools/executor-http': 1.1.6(@types/node@22.7.5)(graphql@16.8.1)
+      '@graphql-tools/executor-http': 1.0.9(@types/node@22.7.7)(graphql@16.8.1)
       '@graphql-tools/executor-legacy-ws': 1.1.0(graphql@16.8.1)
       '@graphql-tools/utils': 10.5.4(graphql@16.8.1)
       '@graphql-tools/wrap': 10.0.5(graphql@16.8.1)
@@ -16197,34 +16142,12 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@graphql-tools/url-loader@8.0.2(@types/node@22.7.5)(graphql@16.9.0)':
-    dependencies:
-      '@ardatan/sync-fetch': 0.0.1
-      '@graphql-tools/delegate': 10.0.21(graphql@16.9.0)
-      '@graphql-tools/executor-graphql-ws': 1.3.0(graphql@16.9.0)
-      '@graphql-tools/executor-http': 1.1.6(@types/node@22.7.5)(graphql@16.9.0)
-      '@graphql-tools/executor-legacy-ws': 1.1.0(graphql@16.9.0)
-      '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
-      '@graphql-tools/wrap': 10.0.5(graphql@16.9.0)
-      '@types/ws': 8.5.12
-      '@whatwg-node/fetch': 0.9.21
-      graphql: 16.9.0
-      isomorphic-ws: 5.0.0(ws@8.18.0)
-      tslib: 2.7.0
-      value-or-promise: 1.0.12
-      ws: 8.18.0
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - encoding
-      - utf-8-validate
-
   '@graphql-tools/url-loader@8.0.2(@types/node@22.7.7)(graphql@16.9.0)':
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
       '@graphql-tools/delegate': 10.0.21(graphql@16.9.0)
       '@graphql-tools/executor-graphql-ws': 1.3.0(graphql@16.9.0)
-      '@graphql-tools/executor-http': 1.1.6(@types/node@22.7.7)(graphql@16.9.0)
+      '@graphql-tools/executor-http': 1.0.9(@types/node@22.7.7)(graphql@16.9.0)
       '@graphql-tools/executor-legacy-ws': 1.1.0(graphql@16.9.0)
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       '@graphql-tools/wrap': 10.0.5(graphql@16.9.0)
@@ -16332,19 +16255,19 @@ snapshots:
       stringify-object: 3.3.0
       yargs: 17.7.2
 
-  '@hoppscotch/ui@0.1.0(eslint@8.55.0)(terser@5.36.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))':
+  '@hoppscotch/ui@0.1.0(eslint@8.55.0)(terser@5.36.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))':
     dependencies:
       '@boringer-avatars/vue3': 0.2.1(vue@3.3.9(typescript@5.3.2))
       '@fontsource-variable/inter': 5.1.0
       '@fontsource-variable/material-symbols-rounded': 5.0.16
       '@fontsource-variable/roboto-mono': 5.1.0
       '@hoppscotch/vue-toasted': 0.1.0(vue@3.3.9(typescript@5.3.2))
-      '@vitejs/plugin-legacy': 2.3.0(terser@5.36.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))
+      '@vitejs/plugin-legacy': 2.3.0(terser@5.36.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))
       '@vueuse/core': 8.9.4(vue@3.3.9(typescript@5.3.2))
       fp-ts: 2.16.9
       lodash-es: 4.17.21
       path: 0.12.7
-      vite-plugin-eslint: 1.8.1(eslint@8.55.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))
+      vite-plugin-eslint: 1.8.1(eslint@8.55.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))
       vue: 3.3.9(typescript@5.3.2)
       vuedraggable-es: 4.1.1(vue@3.3.9(typescript@5.3.2))
     transitivePeerDependencies:
@@ -16353,7 +16276,7 @@ snapshots:
       - terser
       - vite
 
-  '@hoppscotch/ui@0.2.0(eslint@8.57.0)(terser@5.36.0)(typescript@5.3.2)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))':
+  '@hoppscotch/ui@0.2.0(eslint@8.57.0)(terser@5.36.0)(typescript@5.3.2)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))':
     dependencies:
       '@boringer-avatars/vue3': 0.2.1(vue@3.3.9(typescript@5.3.2))
       '@fontsource-variable/inter': 5.1.0
@@ -16361,12 +16284,12 @@ snapshots:
       '@fontsource-variable/roboto-mono': 5.1.0
       '@hoppscotch/vue-sonner': 1.2.3
       '@hoppscotch/vue-toasted': 0.1.0(vue@3.3.9(typescript@5.3.2))
-      '@vitejs/plugin-legacy': 2.3.0(terser@5.36.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))
+      '@vitejs/plugin-legacy': 2.3.0(terser@5.36.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))
       '@vueuse/core': 8.9.4(vue@3.3.9(typescript@5.3.2))
       fp-ts: 2.16.9
       lodash-es: 4.17.21
       path: 0.12.7
-      vite-plugin-eslint: 1.8.1(eslint@8.57.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))
+      vite-plugin-eslint: 1.8.1(eslint@8.57.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))
       vue: 3.3.9(typescript@5.3.2)
       vue-promise-modals: 0.1.0(typescript@5.3.2)
       vue-sonner: 1.2.1
@@ -16403,7 +16326,7 @@ snapshots:
       - typescript
       - vite
 
-  '@hoppscotch/ui@0.2.1(eslint@9.13.0(jiti@2.3.3))(terser@5.36.0)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.6.3))':
+  '@hoppscotch/ui@0.2.1(eslint@9.13.0(jiti@2.3.3))(terser@5.36.0)(typescript@5.6.3)(vite@5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.6.3))':
     dependencies:
       '@boringer-avatars/vue3': 0.2.1(vue@3.3.9(typescript@5.6.3))
       '@fontsource-variable/inter': 5.1.0
@@ -16411,12 +16334,12 @@ snapshots:
       '@fontsource-variable/roboto-mono': 5.1.0
       '@hoppscotch/vue-sonner': 1.2.3
       '@hoppscotch/vue-toasted': 0.1.0(vue@3.3.9(typescript@5.6.3))
-      '@vitejs/plugin-legacy': 2.3.1(terser@5.36.0)(vite@5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))
+      '@vitejs/plugin-legacy': 2.3.0(terser@5.36.0)(vite@5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0))
       '@vueuse/core': 8.9.4(vue@3.3.9(typescript@5.6.3))
       fp-ts: 2.16.9
       lodash-es: 4.17.21
       path: 0.12.7
-      vite-plugin-eslint: 1.8.1(eslint@9.13.0(jiti@2.3.3))(vite@5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))
+      vite-plugin-eslint: 1.8.1(eslint@9.13.0(jiti@2.3.3))(vite@5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0))
       vue: 3.3.9(typescript@5.6.3)
       vue-promise-modals: 0.1.0(typescript@5.6.3)
       vuedraggable-es: 4.1.1(vue@3.3.9(typescript@5.6.3))
@@ -16435,7 +16358,7 @@ snapshots:
       '@fontsource-variable/roboto-mono': 5.1.0
       '@hoppscotch/vue-sonner': 1.2.3
       '@hoppscotch/vue-toasted': 0.1.0(vue@3.3.9(typescript@5.6.3))
-      '@vitejs/plugin-legacy': 2.3.1(terser@5.36.0)(vite@5.4.9(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))
+      '@vitejs/plugin-legacy': 2.3.0(terser@5.36.0)(vite@5.4.9(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))
       '@vueuse/core': 8.9.4(vue@3.3.9(typescript@5.6.3))
       fp-ts: 2.16.9
       lodash-es: 4.17.21
@@ -16504,10 +16427,6 @@ snapshots:
     dependencies:
       '@iconify/types': 2.0.0
 
-  '@iconify-json/lucide@1.2.8':
-    dependencies:
-      '@iconify/types': 2.0.0
-
   '@iconify/types@1.1.0': {}
 
   '@iconify/types@2.0.0': {}
@@ -16535,17 +16454,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@import-meta-env/cli@0.7.0(@import-meta-env/unplugin@0.4.10)':
-    dependencies:
-      commander: 12.1.0
-      dotenv: 16.4.5
-      glob: 11.0.0
-      picocolors: 1.0.1
-      serialize-javascript: 6.0.2
-    optionalDependencies:
-      '@import-meta-env/unplugin': 0.4.10(@import-meta-env/cli@0.7.0)(dotenv@16.4.5)(webpack-sources@3.2.3)
-    optional: true
-
   '@import-meta-env/cli@0.7.0(@import-meta-env/unplugin@0.6.0)':
     dependencies:
       commander: 12.1.0
@@ -16556,15 +16464,13 @@ snapshots:
     optionalDependencies:
       '@import-meta-env/unplugin': 0.6.0(@import-meta-env/cli@0.7.0)(webpack-sources@3.2.3)
 
-  '@import-meta-env/unplugin@0.4.10(@import-meta-env/cli@0.7.0)(dotenv@16.4.5)(webpack-sources@3.2.3)':
+  '@import-meta-env/unplugin@0.4.10(dotenv@16.4.5)(webpack-sources@3.2.3)':
     dependencies:
       dotenv: 16.4.5
       magic-string: 0.30.12
       object-hash: 3.0.0
       picocolors: 1.1.0
       unplugin: 1.14.1(webpack-sources@3.2.3)
-    optionalDependencies:
-      '@import-meta-env/cli': 0.7.0(@import-meta-env/unplugin@0.4.10)
     transitivePeerDependencies:
       - webpack-sources
 
@@ -16667,13 +16573,13 @@ snapshots:
 
   '@intlify/shared@9.8.0': {}
 
-  '@intlify/unplugin-vue-i18n@5.2.0(@vue/compiler-dom@3.5.12)(eslint@9.13.0(jiti@2.3.3))(rollup@3.29.4)(typescript@5.6.3)(vue-i18n@10.0.4(vue@3.3.9(typescript@5.6.3)))(vue@3.3.9(typescript@5.6.3))(webpack-sources@3.2.3)':
+  '@intlify/unplugin-vue-i18n@5.2.0(@vue/compiler-dom@3.5.12)(eslint@9.13.0(jiti@2.3.3))(rollup@4.24.0)(typescript@5.6.3)(vue-i18n@10.0.4(vue@3.3.9(typescript@5.6.3)))(vue@3.3.9(typescript@5.6.3))(webpack-sources@3.2.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@9.13.0(jiti@2.3.3))
       '@intlify/bundle-utils': 9.0.0-beta.0(vue-i18n@10.0.4(vue@3.3.9(typescript@5.6.3)))
       '@intlify/shared': 10.0.0
       '@intlify/vue-i18n-extensions': 7.0.0(@intlify/shared@10.0.0)(@vue/compiler-dom@3.5.12)(vue-i18n@10.0.4(vue@3.3.9(typescript@5.6.3)))(vue@3.3.9(typescript@5.6.3))
-      '@rollup/pluginutils': 5.1.2(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.2(rollup@4.24.0)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       debug: 4.3.7(supports-color@9.4.0)
@@ -16709,7 +16615,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@intlify/vite-plugin-vue-i18n@7.0.0(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(vue-i18n@9.8.0(vue@3.3.9(typescript@5.3.2)))':
+  '@intlify/vite-plugin-vue-i18n@7.0.0(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(vue-i18n@9.8.0(vue@3.3.9(typescript@5.3.2)))':
     dependencies:
       '@intlify/bundle-utils': 3.4.0(vue-i18n@9.8.0(vue@3.3.9(typescript@5.3.2)))
       '@intlify/shared': 10.0.0
@@ -16718,12 +16624,12 @@ snapshots:
       fast-glob: 3.3.2
       source-map: 0.6.1
     optionalDependencies:
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
       vue-i18n: 9.8.0(vue@3.3.9(typescript@5.3.2))
     transitivePeerDependencies:
       - supports-color
 
-  '@intlify/vite-plugin-vue-i18n@7.0.0(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue-i18n@10.0.4(vue@3.3.9(typescript@5.3.2)))':
+  '@intlify/vite-plugin-vue-i18n@7.0.0(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(vue-i18n@10.0.4(vue@3.3.9(typescript@5.3.2)))':
     dependencies:
       '@intlify/bundle-utils': 3.4.0(vue-i18n@10.0.4(vue@3.3.9(typescript@5.3.2)))
       '@intlify/shared': 10.0.0
@@ -16732,7 +16638,7 @@ snapshots:
       fast-glob: 3.3.2
       source-map: 0.6.1
     optionalDependencies:
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
       vue-i18n: 10.0.4(vue@3.3.9(typescript@5.3.2))
     transitivePeerDependencies:
       - supports-color
@@ -16771,7 +16677,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -16784,14 +16690,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.5.4))
+      jest-config: 29.7.0(@types/node@22.7.6)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.5.4))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -16816,7 +16722,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       jest-mock: 29.7.0
 
   '@jest/expect-utils@28.1.3':
@@ -16838,7 +16744,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -16860,7 +16766,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -16933,7 +16839,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       '@types/yargs': 16.0.9
       chalk: 4.1.2
 
@@ -16942,7 +16848,7 @@ snapshots:
       '@jest/schemas': 28.1.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
@@ -16951,7 +16857,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
@@ -17575,14 +17481,6 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.2
 
-  '@rollup/pluginutils@5.1.2(rollup@3.29.4)':
-    dependencies:
-      '@types/estree': 1.0.6
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    optionalDependencies:
-      rollup: 3.29.4
-
   '@rollup/pluginutils@5.1.2(rollup@4.24.0)':
     dependencies:
       '@types/estree': 1.0.6
@@ -17857,12 +17755,12 @@ snapshots:
 
   '@types/bcrypt@5.0.2':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/chai-subset@1.3.5':
     dependencies:
@@ -17872,7 +17770,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/cookie-parser@1.4.7':
     dependencies:
@@ -17884,7 +17782,7 @@ snapshots:
 
   '@types/cors@2.8.17':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/debug@4.1.12':
     dependencies:
@@ -17910,7 +17808,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.0':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       '@types/qs': 6.9.12
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -17938,7 +17836,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/har-format@1.2.15': {}
 
@@ -17972,11 +17870,11 @@ snapshots:
 
   '@types/jsonwebtoken@9.0.5':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/jsonwebtoken@9.0.6':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/lodash-es@4.17.10':
     dependencies:
@@ -18014,7 +17912,7 @@ snapshots:
 
   '@types/node-fetch@2.6.11':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       form-data: 4.0.1
 
   '@types/node@17.0.27': {}
@@ -18026,6 +17924,10 @@ snapshots:
       undici-types: 5.26.5
 
   '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
+
+  '@types/node@22.7.6':
     dependencies:
       undici-types: 6.19.8
 
@@ -18043,7 +17945,7 @@ snapshots:
 
   '@types/oauth@0.9.4':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/object-path@0.11.4': {}
 
@@ -18089,7 +17991,7 @@ snapshots:
 
   '@types/postman-collection@3.5.10':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/pug@2.0.10':
     optional: true
@@ -18109,12 +18011,12 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       '@types/send': 0.17.4
 
   '@types/splitpanes@2.2.6(typescript@5.3.2)':
@@ -18133,7 +18035,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/supertest@6.0.2':
     dependencies:
@@ -18158,7 +18060,7 @@ snapshots:
 
   '@types/ws@8.5.12':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -18770,7 +18672,7 @@ snapshots:
       terser: 5.36.0
       vite: 4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0)
 
-  '@vitejs/plugin-legacy@2.3.0(terser@5.36.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))':
+  '@vitejs/plugin-legacy@2.3.0(terser@5.36.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))':
     dependencies:
       '@babel/standalone': 7.25.8
       core-js: 3.38.1
@@ -18778,9 +18680,9 @@ snapshots:
       regenerator-runtime: 0.13.11
       systemjs: 6.15.1
       terser: 5.36.0
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
 
-  '@vitejs/plugin-legacy@2.3.0(terser@5.36.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))':
+  '@vitejs/plugin-legacy@2.3.0(terser@5.36.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))':
     dependencies:
       '@babel/standalone': 7.25.8
       core-js: 3.38.1
@@ -18788,7 +18690,17 @@ snapshots:
       regenerator-runtime: 0.13.11
       systemjs: 6.15.1
       terser: 5.36.0
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
+
+  '@vitejs/plugin-legacy@2.3.0(terser@5.36.0)(vite@5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0))':
+    dependencies:
+      '@babel/standalone': 7.25.8
+      core-js: 3.38.1
+      magic-string: 0.26.7
+      regenerator-runtime: 0.13.11
+      systemjs: 6.15.1
+      terser: 5.36.0
+      vite: 5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0)
 
   '@vitejs/plugin-legacy@2.3.0(terser@5.36.0)(vite@5.4.9(@types/node@17.0.27)(sass@1.80.3)(terser@5.36.0))':
     dependencies:
@@ -18800,17 +18712,7 @@ snapshots:
       terser: 5.36.0
       vite: 5.4.9(@types/node@17.0.27)(sass@1.80.3)(terser@5.36.0)
 
-  '@vitejs/plugin-legacy@2.3.1(terser@5.36.0)(vite@5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))':
-    dependencies:
-      '@babel/standalone': 7.25.8
-      core-js: 3.38.1
-      magic-string: 0.26.7
-      regenerator-runtime: 0.13.11
-      systemjs: 6.15.1
-      terser: 5.36.0
-      vite: 5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
-
-  '@vitejs/plugin-legacy@2.3.1(terser@5.36.0)(vite@5.4.9(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))':
+  '@vitejs/plugin-legacy@2.3.0(terser@5.36.0)(vite@5.4.9(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))':
     dependencies:
       '@babel/standalone': 7.25.8
       core-js: 3.38.1
@@ -18820,7 +18722,7 @@ snapshots:
       terser: 5.36.0
       vite: 5.4.9(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
 
-  '@vitejs/plugin-legacy@4.1.1(terser@5.36.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))':
+  '@vitejs/plugin-legacy@4.1.1(terser@5.36.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))':
     dependencies:
       '@babel/core': 7.25.8
       '@babel/preset-env': 7.25.8(@babel/core@7.25.8)
@@ -18830,11 +18732,11 @@ snapshots:
       regenerator-runtime: 0.13.11
       systemjs: 6.15.1
       terser: 5.36.0
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-legacy@4.1.1(terser@5.36.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))':
+  '@vitejs/plugin-legacy@4.1.1(terser@5.36.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))':
     dependencies:
       '@babel/core': 7.25.8
       '@babel/preset-env': 7.25.8(@babel/core@7.25.8)
@@ -18844,7 +18746,7 @@ snapshots:
       regenerator-runtime: 0.13.11
       systemjs: 6.15.1
       terser: 5.36.0
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18853,19 +18755,19 @@ snapshots:
       vite: 4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0)
       vue: 3.3.9(typescript@4.9.5)
 
-  '@vitejs/plugin-vue@4.5.1(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))':
+  '@vitejs/plugin-vue@4.5.1(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))':
     dependencies:
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
       vue: 3.3.9(typescript@5.3.2)
 
-  '@vitejs/plugin-vue@4.5.1(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))':
+  '@vitejs/plugin-vue@4.5.1(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.3.2))':
     dependencies:
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
       vue: 3.3.9(typescript@5.3.2)
 
-  '@vitejs/plugin-vue@5.1.4(vite@5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.6.3))':
+  '@vitejs/plugin-vue@5.1.4(vite@5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.6.3))':
     dependencies:
-      vite: 5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0)
       vue: 3.3.9(typescript@5.6.3)
 
   '@vitejs/plugin-vue@5.1.4(vite@5.4.9(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@5.6.3))':
@@ -20396,11 +20298,11 @@ snapshots:
 
   corser@2.0.1: {}
 
-  cosmiconfig-typescript-loader@2.0.2(@swc/core@1.4.2)(@types/node@22.7.5)(cosmiconfig@7.1.0)(typescript@4.9.5):
+  cosmiconfig-typescript-loader@2.0.2(@swc/core@1.4.2)(@types/node@22.7.6)(cosmiconfig@7.1.0)(typescript@4.9.5):
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       cosmiconfig: 7.1.0
-      ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@4.9.5)
+      ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@22.7.6)(typescript@4.9.5)
       typescript: 4.9.5
     transitivePeerDependencies:
       - '@swc/core'
@@ -22258,13 +22160,13 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-config@4.5.0(@types/node@22.7.5)(graphql@16.8.1):
+  graphql-config@4.5.0(@types/node@22.7.7)(graphql@16.8.1):
     dependencies:
       '@graphql-tools/graphql-file-loader': 7.5.17(graphql@16.8.1)
       '@graphql-tools/json-file-loader': 7.4.18(graphql@16.8.1)
       '@graphql-tools/load': 7.8.14(graphql@16.8.1)
       '@graphql-tools/merge': 8.4.2(graphql@16.8.1)
-      '@graphql-tools/url-loader': 7.17.18(@types/node@22.7.5)(graphql@16.8.1)
+      '@graphql-tools/url-loader': 7.17.18(@types/node@22.7.7)(graphql@16.8.1)
       '@graphql-tools/utils': 9.2.1(graphql@16.8.1)
       cosmiconfig: 8.0.0
       graphql: 16.8.1
@@ -22278,7 +22180,7 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  graphql-config@5.1.3(@types/node@18.18.8)(graphql@16.9.0)(typescript@4.9.5):
+  graphql-config@5.0.3(@types/node@18.18.8)(graphql@16.9.0)(typescript@4.9.5):
     dependencies:
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.9.0)
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.9.0)
@@ -22288,8 +22190,8 @@ snapshots:
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       cosmiconfig: 8.3.6(typescript@4.9.5)
       graphql: 16.9.0
-      jiti: 2.3.3
-      minimatch: 9.0.5
+      jiti: 1.21.6
+      minimatch: 4.2.3
       string-env-interpolation: 1.0.1
       tslib: 2.7.0
     transitivePeerDependencies:
@@ -22299,18 +22201,18 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  graphql-config@5.1.3(@types/node@22.7.5)(graphql@16.8.1)(typescript@5.3.2):
+  graphql-config@5.0.3(@types/node@22.7.7)(graphql@16.8.1)(typescript@5.3.2):
     dependencies:
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.8.1)
       '@graphql-tools/load': 8.0.2(graphql@16.8.1)
       '@graphql-tools/merge': 9.0.7(graphql@16.8.1)
-      '@graphql-tools/url-loader': 8.0.2(@types/node@22.7.5)(graphql@16.8.1)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@22.7.7)(graphql@16.8.1)
       '@graphql-tools/utils': 10.5.4(graphql@16.8.1)
       cosmiconfig: 8.3.6(typescript@5.3.2)
       graphql: 16.8.1
-      jiti: 2.3.3
-      minimatch: 9.0.5
+      jiti: 1.21.6
+      minimatch: 4.2.3
       string-env-interpolation: 1.0.1
       tslib: 2.7.0
     transitivePeerDependencies:
@@ -22320,18 +22222,18 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  graphql-config@5.1.3(@types/node@22.7.5)(graphql@16.9.0)(typescript@5.3.2):
+  graphql-config@5.0.3(@types/node@22.7.7)(graphql@16.9.0)(typescript@5.3.2):
     dependencies:
       '@graphql-tools/graphql-file-loader': 8.0.1(graphql@16.9.0)
       '@graphql-tools/json-file-loader': 8.0.1(graphql@16.9.0)
       '@graphql-tools/load': 8.0.2(graphql@16.9.0)
       '@graphql-tools/merge': 9.0.7(graphql@16.9.0)
-      '@graphql-tools/url-loader': 8.0.2(@types/node@22.7.5)(graphql@16.9.0)
+      '@graphql-tools/url-loader': 8.0.2(@types/node@22.7.7)(graphql@16.9.0)
       '@graphql-tools/utils': 10.5.4(graphql@16.9.0)
       cosmiconfig: 8.3.6(typescript@5.3.2)
       graphql: 16.9.0
-      jiti: 2.3.3
-      minimatch: 9.0.5
+      jiti: 1.21.6
+      minimatch: 4.2.3
       string-env-interpolation: 1.0.1
       tslib: 2.7.0
     transitivePeerDependencies:
@@ -22362,13 +22264,13 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  graphql-language-service-interface@2.10.2(@types/node@22.7.5)(graphql@16.8.1):
+  graphql-language-service-interface@2.10.2(@types/node@22.7.7)(graphql@16.8.1):
     dependencies:
       graphql: 16.8.1
-      graphql-config: 4.5.0(@types/node@22.7.5)(graphql@16.8.1)
-      graphql-language-service-parser: 1.10.4(@types/node@22.7.5)(graphql@16.8.1)
-      graphql-language-service-types: 1.8.7(@types/node@22.7.5)(graphql@16.8.1)
-      graphql-language-service-utils: 2.7.1(@types/node@22.7.5)(graphql@16.8.1)
+      graphql-config: 4.5.0(@types/node@22.7.7)(graphql@16.8.1)
+      graphql-language-service-parser: 1.10.4(@types/node@22.7.7)(graphql@16.8.1)
+      graphql-language-service-types: 1.8.7(@types/node@22.7.7)(graphql@16.8.1)
+      graphql-language-service-utils: 2.7.1(@types/node@22.7.7)(graphql@16.8.1)
       vscode-languageserver-types: 3.17.5
     transitivePeerDependencies:
       - '@types/node'
@@ -22377,10 +22279,10 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  graphql-language-service-parser@1.10.4(@types/node@22.7.5)(graphql@16.8.1):
+  graphql-language-service-parser@1.10.4(@types/node@22.7.7)(graphql@16.8.1):
     dependencies:
       graphql: 16.8.1
-      graphql-language-service-types: 1.8.7(@types/node@22.7.5)(graphql@16.8.1)
+      graphql-language-service-types: 1.8.7(@types/node@22.7.7)(graphql@16.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - bufferutil
@@ -22388,10 +22290,10 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  graphql-language-service-types@1.8.7(@types/node@22.7.5)(graphql@16.8.1):
+  graphql-language-service-types@1.8.7(@types/node@22.7.7)(graphql@16.8.1):
     dependencies:
       graphql: 16.8.1
-      graphql-config: 4.5.0(@types/node@22.7.5)(graphql@16.8.1)
+      graphql-config: 4.5.0(@types/node@22.7.7)(graphql@16.8.1)
       vscode-languageserver-types: 3.17.5
     transitivePeerDependencies:
       - '@types/node'
@@ -22400,11 +22302,11 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  graphql-language-service-utils@2.7.1(@types/node@22.7.5)(graphql@16.8.1):
+  graphql-language-service-utils@2.7.1(@types/node@22.7.7)(graphql@16.8.1):
     dependencies:
       '@types/json-schema': 7.0.9
       graphql: 16.8.1
-      graphql-language-service-types: 1.8.7(@types/node@22.7.5)(graphql@16.8.1)
+      graphql-language-service-types: 1.8.7(@types/node@22.7.7)(graphql@16.8.1)
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - '@types/node'
@@ -23083,7 +22985,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -23202,6 +23104,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@29.7.0(@types/node@22.7.6)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.5.4)):
+    dependencies:
+      '@babel/core': 7.25.8
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.25.8)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.7.6
+      ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.5.4)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-diff@27.5.1:
     dependencies:
       chalk: 4.1.2
@@ -23240,7 +23173,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -23254,7 +23187,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -23326,7 +23259,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -23361,7 +23294,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -23389,7 +23322,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       chalk: 4.1.2
       cjs-module-lexer: 1.3.1
       collect-v8-coverage: 1.0.2
@@ -23435,7 +23368,7 @@ snapshots:
   jest-util@27.5.1:
     dependencies:
       '@jest/types': 27.5.1
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -23444,7 +23377,7 @@ snapshots:
   jest-util@28.1.3:
     dependencies:
       '@jest/types': 28.1.3
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -23453,7 +23386,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -23472,7 +23405,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -23481,13 +23414,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -23991,9 +23924,6 @@ snapshots:
   mensch@0.3.4:
     optional: true
 
-  meow@13.2.0:
-    optional: true
-
   meow@8.1.2:
     dependencies:
       '@types/minimist': 1.2.5
@@ -24017,10 +23947,6 @@ snapshots:
   meros@1.3.0(@types/node@18.18.8):
     optionalDependencies:
       '@types/node': 18.18.8
-
-  meros@1.3.0(@types/node@22.7.5):
-    optionalDependencies:
-      '@types/node': 22.7.5
 
   meros@1.3.0(@types/node@22.7.7):
     optionalDependencies:
@@ -25236,14 +25162,6 @@ snapshots:
       postcss: 8.4.47
       ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@18.18.8)(typescript@4.9.5)
 
-  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.2)):
-    dependencies:
-      lilconfig: 3.1.2
-      yaml: 2.5.1
-    optionalDependencies:
-      postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.2)
-
   postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3)):
     dependencies:
       lilconfig: 3.1.2
@@ -25252,13 +25170,21 @@ snapshots:
       postcss: 8.4.47
       ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3)
 
-  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.6.3)):
+  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.6)(typescript@5.6.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.5.1
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.6.3)
+      ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@22.7.6)(typescript@5.6.3)
+
+  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.7)(typescript@5.3.2)):
+    dependencies:
+      lilconfig: 3.1.2
+      yaml: 2.5.1
+    optionalDependencies:
+      postcss: 8.4.47
+      ts-node: 10.9.2(@swc/core@1.4.2)(@types/node@22.7.7)(typescript@5.3.2)
 
   postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.7)(typescript@5.6.3)):
     dependencies:
@@ -26599,7 +26525,7 @@ snapshots:
 
   systemjs@6.15.1: {}
 
-  tailwindcss@3.3.5(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.2)):
+  tailwindcss@3.3.5(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.7)(typescript@5.3.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -26618,7 +26544,7 @@ snapshots:
       postcss: 8.4.47
       postcss-import: 15.1.0(postcss@8.4.47)
       postcss-js: 4.0.1(postcss@8.4.47)
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.2))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.7)(typescript@5.3.2))
       postcss-nested: 6.2.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -26653,7 +26579,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.6.3)):
+  tailwindcss@3.4.13(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.6)(typescript@5.6.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -26668,11 +26594,11 @@ snapshots:
       micromatch: 4.0.8
       normalize-path: 3.0.0
       object-hash: 3.0.0
-      picocolors: 1.1.0
+      picocolors: 1.1.1
       postcss: 8.4.47
       postcss-import: 15.1.0(postcss@8.4.47)
       postcss-js: 4.0.1(postcss@8.4.47)
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.6.3))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.6)(typescript@5.6.3))
       postcss-nested: 6.2.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -26913,7 +26839,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@27.1.5(@babel/core@7.25.8)(@types/jest@27.5.2)(babel-jest@29.7.0(@babel/core@7.25.8))(jest@29.7.0(@types/node@17.0.45))(typescript@4.9.5):
+  ts-jest@27.1.5(@babel/core@7.25.8)(@types/jest@27.5.2)(jest@29.7.0(@types/node@17.0.45))(typescript@4.9.5):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -26928,7 +26854,6 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.25.8
       '@types/jest': 27.5.2
-      babel-jest: 29.7.0(@babel/core@7.25.8)
 
   ts-jest@29.2.5(@babel/core@7.25.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.8))(jest@29.7.0(@types/node@22.7.5)(ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.5.4)))(typescript@5.5.4):
     dependencies:
@@ -27000,47 +26925,6 @@ snapshots:
       '@swc/core': 1.4.2
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@4.9.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.7.5
-      acorn: 8.13.0
-      acorn-walk: 8.3.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.4.2
-
-  ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.7.5
-      acorn: 8.13.0
-      acorn-walk: 8.3.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.3.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.4.2
-    optional: true
-
   ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.3.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -27082,14 +26966,34 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.4.2
 
-  ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.5)(typescript@5.6.3):
+  ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.6)(typescript@4.9.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
+      acorn: 8.13.0
+      acorn-walk: 8.3.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 4.9.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.4.2
+
+  ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.6)(typescript@5.6.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.7.6
       acorn: 8.13.0
       acorn-walk: 8.3.0
       arg: 4.1.3
@@ -27097,6 +27001,27 @@ snapshots:
       diff: 4.0.2
       make-error: 1.3.6
       typescript: 5.6.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.4.2
+    optional: true
+
+  ts-node@10.9.2(@swc/core@1.4.2)(@types/node@22.7.7)(typescript@5.3.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.7.7
+      acorn: 8.13.0
+      acorn-walk: 8.3.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.3.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -27347,19 +27272,19 @@ snapshots:
     transitivePeerDependencies:
       - webpack-sources
 
-  unplugin-fonts@1.1.1(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(webpack-sources@3.2.3):
+  unplugin-fonts@1.1.1(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(webpack-sources@3.2.3):
     dependencies:
       fast-glob: 3.3.2
       unplugin: 1.14.1(webpack-sources@3.2.3)
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
     transitivePeerDependencies:
       - webpack-sources
 
-  unplugin-fonts@1.1.1(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(webpack-sources@3.2.3):
+  unplugin-fonts@1.1.1(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(webpack-sources@3.2.3):
     dependencies:
       fast-glob: 3.3.2
       unplugin: 1.14.1(webpack-sources@3.2.3)
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
     transitivePeerDependencies:
       - webpack-sources
 
@@ -27434,7 +27359,7 @@ snapshots:
       - supports-color
       - webpack-sources
 
-  unplugin-vue-components@0.21.0(@babel/parser@7.25.8)(esbuild@0.24.0)(rollup@3.29.4)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@4.9.5))(webpack@5.95.0(@swc/core@1.4.2)(esbuild@0.24.0)):
+  unplugin-vue-components@0.21.0(@babel/parser@7.25.8)(esbuild@0.24.0)(rollup@2.79.2)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))(vue@3.3.9(typescript@4.9.5))(webpack@5.95.0(@swc/core@1.4.2)(esbuild@0.24.0)):
     dependencies:
       '@antfu/utils': 0.5.2
       '@rollup/pluginutils': 4.2.1
@@ -27445,7 +27370,7 @@ snapshots:
       magic-string: 0.26.7
       minimatch: 5.1.6
       resolve: 1.22.8
-      unplugin: 0.7.2(esbuild@0.24.0)(rollup@3.29.4)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))(webpack@5.95.0(@swc/core@1.4.2)(esbuild@0.24.0))
+      unplugin: 0.7.2(esbuild@0.24.0)(rollup@2.79.2)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))(webpack@5.95.0(@swc/core@1.4.2)(esbuild@0.24.0))
       vue: 3.3.9(typescript@4.9.5)
     optionalDependencies:
       '@babel/parser': 7.25.8
@@ -27455,26 +27380,6 @@ snapshots:
       - supports-color
       - vite
       - webpack
-
-  unplugin-vue-components@0.25.2(@babel/parser@7.25.8)(rollup@3.29.4)(vue@3.3.9(typescript@5.3.2))(webpack-sources@3.2.3):
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.2(rollup@3.29.4)
-      chokidar: 3.6.0
-      debug: 4.3.7(supports-color@9.4.0)
-      fast-glob: 3.3.2
-      local-pkg: 0.4.3
-      magic-string: 0.30.12
-      minimatch: 9.0.5
-      resolve: 1.22.8
-      unplugin: 1.14.1(webpack-sources@3.2.3)
-      vue: 3.3.9(typescript@5.3.2)
-    optionalDependencies:
-      '@babel/parser': 7.25.8
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-      - webpack-sources
 
   unplugin-vue-components@0.25.2(@babel/parser@7.25.8)(rollup@4.24.0)(vue@3.3.9(typescript@5.3.2))(webpack-sources@3.2.3):
     dependencies:
@@ -27496,10 +27401,10 @@ snapshots:
       - supports-color
       - webpack-sources
 
-  unplugin-vue-components@0.27.4(@babel/parser@7.25.8)(rollup@3.29.4)(vue@3.3.9(typescript@5.6.3))(webpack-sources@3.2.3):
+  unplugin-vue-components@0.27.4(@babel/parser@7.25.8)(rollup@4.24.0)(vue@3.3.9(typescript@5.6.3))(webpack-sources@3.2.3):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.2(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.2(rollup@4.24.0)
       chokidar: 3.6.0
       debug: 4.3.7(supports-color@9.4.0)
       fast-glob: 3.3.2
@@ -27516,7 +27421,7 @@ snapshots:
       - supports-color
       - webpack-sources
 
-  unplugin@0.7.2(esbuild@0.24.0)(rollup@3.29.4)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))(webpack@5.95.0(@swc/core@1.4.2)(esbuild@0.24.0)):
+  unplugin@0.7.2(esbuild@0.24.0)(rollup@2.79.2)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0))(webpack@5.95.0(@swc/core@1.4.2)(esbuild@0.24.0)):
     dependencies:
       acorn: 8.12.1
       chokidar: 3.6.0
@@ -27524,7 +27429,7 @@ snapshots:
       webpack-virtual-modules: 0.4.6
     optionalDependencies:
       esbuild: 0.24.0
-      rollup: 3.29.4
+      rollup: 2.79.2
       vite: 4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0)
       webpack: 5.95.0(@swc/core@1.4.2)(esbuild@0.24.0)
 
@@ -27677,7 +27582,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-checker@0.6.2(eslint@8.57.0)(meow@13.2.0)(optionator@0.9.4)(typescript@5.3.2)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(vue-tsc@1.8.24(typescript@5.3.2)):
+  vite-plugin-checker@0.6.2(eslint@8.57.0)(optionator@0.9.4)(typescript@5.3.2)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(vue-tsc@1.8.24(typescript@5.3.2)):
     dependencies:
       '@babel/code-frame': 7.25.7
       ansi-escapes: 4.3.2
@@ -27692,41 +27597,40 @@ snapshots:
       semver: 7.6.3
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.11
       vscode-uri: 3.0.8
     optionalDependencies:
       eslint: 8.57.0
-      meow: 13.2.0
       optionator: 0.9.4
       typescript: 5.3.2
       vue-tsc: 1.8.24(typescript@5.3.2)
 
-  vite-plugin-eslint@1.8.1(eslint@8.55.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)):
+  vite-plugin-eslint@1.8.1(eslint@8.55.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@types/eslint': 8.56.12
       eslint: 8.55.0
       rollup: 2.79.2
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
 
-  vite-plugin-eslint@1.8.1(eslint@8.57.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)):
+  vite-plugin-eslint@1.8.1(eslint@8.57.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@types/eslint': 8.56.12
       eslint: 8.57.0
       rollup: 2.79.2
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
 
-  vite-plugin-eslint@1.8.1(eslint@9.13.0(jiti@2.3.3))(vite@5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)):
+  vite-plugin-eslint@1.8.1(eslint@9.13.0(jiti@2.3.3))(vite@5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@types/eslint': 8.56.12
       eslint: 9.13.0(jiti@2.3.3)
       rollup: 2.79.2
-      vite: 5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0)
 
   vite-plugin-eslint@1.8.1(eslint@9.13.0(jiti@2.3.3))(vite@5.4.9(@types/node@17.0.27)(sass@1.80.3)(terser@5.36.0)):
     dependencies:
@@ -27744,32 +27648,32 @@ snapshots:
       rollup: 2.79.2
       vite: 5.4.9(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
 
-  vite-plugin-fonts@0.7.0(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)):
+  vite-plugin-fonts@0.7.0(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)):
     dependencies:
       fast-glob: 3.3.2
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
 
-  vite-plugin-fonts@0.7.0(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)):
+  vite-plugin-fonts@0.7.0(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)):
     dependencies:
       fast-glob: 3.3.2
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
 
   vite-plugin-html-config@1.0.11(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0)):
     dependencies:
       vite: 4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0)
 
-  vite-plugin-html-config@1.0.11(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)):
+  vite-plugin-html-config@1.0.11(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)):
     dependencies:
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
 
-  vite-plugin-html-config@1.0.11(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)):
+  vite-plugin-html-config@1.0.11(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)):
     dependencies:
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
 
-  vite-plugin-inspect@0.7.38(rollup@3.29.4)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0)):
+  vite-plugin-inspect@0.7.38(rollup@2.79.2)(vite@4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0)):
     dependencies:
       '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.2(rollup@3.29.4)
+      '@rollup/pluginutils': 5.1.2(rollup@2.79.2)
       debug: 4.3.7(supports-color@9.4.0)
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0
@@ -27781,22 +27685,7 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-plugin-inspect@0.7.42(rollup@3.29.4)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)):
-    dependencies:
-      '@antfu/utils': 0.7.10
-      '@rollup/pluginutils': 5.1.2(rollup@3.29.4)
-      debug: 4.3.7(supports-color@9.4.0)
-      error-stack-parser-es: 0.1.5
-      fs-extra: 11.2.0
-      open: 9.1.0
-      picocolors: 1.1.0
-      sirv: 2.0.4
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
-
-  vite-plugin-inspect@0.7.42(rollup@4.24.0)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)):
+  vite-plugin-inspect@0.7.42(rollup@4.24.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.2(rollup@4.24.0)
@@ -27806,7 +27695,22 @@ snapshots:
       open: 9.1.0
       picocolors: 1.1.0
       sirv: 2.0.4
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+
+  vite-plugin-inspect@0.7.42(rollup@4.24.0)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)):
+    dependencies:
+      '@antfu/utils': 0.7.10
+      '@rollup/pluginutils': 5.1.2(rollup@4.24.0)
+      debug: 4.3.7(supports-color@9.4.0)
+      error-stack-parser-es: 0.1.5
+      fs-extra: 11.2.0
+      open: 9.1.0
+      picocolors: 1.1.0
+      sirv: 2.0.4
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -27830,7 +27734,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-pages@0.31.0(@vue/compiler-sfc@3.3.10)(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)):
+  vite-plugin-pages@0.31.0(@vue/compiler-sfc@3.3.10)(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)):
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.3.7(supports-color@9.4.0)
@@ -27839,15 +27743,15 @@ snapshots:
       fast-glob: 3.3.2
       json5: 2.2.3
       local-pkg: 0.4.3
-      picocolors: 1.1.0
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      picocolors: 1.0.1
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
       yaml: 2.5.1
     optionalDependencies:
       '@vue/compiler-sfc': 3.3.10
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-pages@0.31.0(@vue/compiler-sfc@3.5.12)(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)):
+  vite-plugin-pages@0.31.0(@vue/compiler-sfc@3.5.12)(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)):
     dependencies:
       '@types/debug': 4.1.12
       debug: 4.3.7(supports-color@9.4.0)
@@ -27856,8 +27760,8 @@ snapshots:
       fast-glob: 3.3.2
       json5: 2.2.3
       local-pkg: 0.4.3
-      picocolors: 1.1.0
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      picocolors: 1.0.1
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
       yaml: 2.5.1
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.12
@@ -27873,7 +27777,7 @@ snapshots:
       fast-glob: 3.3.2
       json5: 2.2.3
       local-pkg: 0.5.0
-      picocolors: 1.1.0
+      picocolors: 1.1.1
       vite: 5.4.9(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
       yaml: 2.5.1
     optionalDependencies:
@@ -27894,23 +27798,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-pwa@0.17.3(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.0.0):
+  vite-plugin-pwa@0.17.3(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.0.0):
     dependencies:
       debug: 4.3.7(supports-color@9.4.0)
       fast-glob: 3.3.2
       pretty-bytes: 6.1.1
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
       workbox-build: 7.1.1(@types/babel__core@7.20.5)
       workbox-window: 7.0.0
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-pwa@0.17.3(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.0.0):
+  vite-plugin-pwa@0.17.3(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.0.0):
     dependencies:
       debug: 4.3.7(supports-color@9.4.0)
       fast-glob: 3.3.2
       pretty-bytes: 6.1.1
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
       workbox-build: 7.1.1(@types/babel__core@7.20.5)
       workbox-window: 7.0.0
     transitivePeerDependencies:
@@ -27924,13 +27828,13 @@ snapshots:
       picocolors: 1.1.0
       vite: 4.5.0(@types/node@18.18.8)(sass@1.80.3)(terser@5.36.0)
 
-  vite-plugin-static-copy@0.17.1(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)):
+  vite-plugin-static-copy@0.17.1(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)):
     dependencies:
       chokidar: 3.6.0
       fast-glob: 3.3.2
       fs-extra: 11.2.0
-      picocolors: 1.1.0
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      picocolors: 1.1.1
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
 
   vite-plugin-vue-layouts@0.11.0(vite@5.4.9(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(vue-router@4.4.5(vue@3.3.9(typescript@5.6.3)))(vue@3.3.9(typescript@5.6.3)):
     dependencies:
@@ -27953,23 +27857,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-layouts@0.8.0(vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0))(vue-router@4.2.5(vue@3.3.9(typescript@5.3.2)))(vue@3.3.9(typescript@5.3.2)):
+  vite-plugin-vue-layouts@0.8.0(vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0))(vue-router@4.2.5(vue@3.3.9(typescript@5.3.2)))(vue@3.3.9(typescript@5.3.2)):
     dependencies:
       '@vue/compiler-sfc': 3.5.12
       debug: 4.3.7(supports-color@9.4.0)
       fast-glob: 3.3.2
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0)
       vue: 3.3.9(typescript@5.3.2)
       vue-router: 4.2.5(vue@3.3.9(typescript@5.3.2))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-layouts@0.8.0(vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0))(vue-router@4.4.5(vue@3.3.9(typescript@5.3.2)))(vue@3.3.9(typescript@5.3.2)):
+  vite-plugin-vue-layouts@0.8.0(vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0))(vue-router@4.4.5(vue@3.3.9(typescript@5.3.2)))(vue@3.3.9(typescript@5.3.2)):
     dependencies:
       '@vue/compiler-sfc': 3.5.12
       debug: 4.3.7(supports-color@9.4.0)
       fast-glob: 3.3.2
-      vite: 4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0)
+      vite: 4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0)
       vue: 3.3.9(typescript@5.3.2)
       vue-router: 4.4.5(vue@3.3.9(typescript@5.3.2))
     transitivePeerDependencies:
@@ -27986,24 +27890,24 @@ snapshots:
       sass: 1.80.3
       terser: 5.36.0
 
-  vite@4.5.0(@types/node@22.7.5)(sass@1.69.5)(terser@5.36.0):
+  vite@4.5.0(@types/node@22.7.7)(sass@1.69.5)(terser@5.36.0):
     dependencies:
       esbuild: 0.18.20
       postcss: 8.4.47
       rollup: 3.29.4
     optionalDependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.7
       fsevents: 2.3.3
       sass: 1.69.5
       terser: 5.36.0
 
-  vite@4.5.0(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0):
+  vite@4.5.0(@types/node@22.7.7)(sass@1.80.3)(terser@5.36.0):
     dependencies:
       esbuild: 0.18.20
       postcss: 8.4.47
       rollup: 3.29.4
     optionalDependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.7
       fsevents: 2.3.3
       sass: 1.80.3
       terser: 5.36.0
@@ -28019,13 +27923,13 @@ snapshots:
       sass: 1.80.3
       terser: 5.36.0
 
-  vite@5.4.8(@types/node@22.7.5)(sass@1.80.3)(terser@5.36.0):
+  vite@5.4.8(@types/node@22.7.6)(sass@1.80.3)(terser@5.36.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
       rollup: 4.24.0
     optionalDependencies:
-      '@types/node': 22.7.5
+      '@types/node': 22.7.6
       fsevents: 2.3.3
       sass: 1.80.3
       terser: 5.36.0


### PR DESCRIPTION
## Summary

This PR updates several dependencies in the Hoppscotch Agent, including `tauri-plugin-store`, `tauri-plugin-dialog`, and other Rust and JavaScript packages. 

Closes HFE-628

## Breaking Changes Overview

### `tauri-plugin-store` (2.0.0-rc.3 → 2.0.1)
- Updated the store API in `state.rs` to handle store operations using new methods like `.set()` and `.delete()`, replacing `.insert()` and `.map_err()`.
- As an extension added error propagation.
- `StoreBuilder::new()` now requires a reference to `app_handle`.
  
### `tauri-plugin-dialog` (2.0.0-rc.7 → 2.0.1)
- `updater.rs` now uses `MessageDialogButtons` for dialog button customization, replacing `.ok_button_label()` and `.cancel_button_label()`.