### PR TITLE
fix: i18n strings not falling back correctly

### DIFF
--- a/packages/hoppscotch-common/src/modules/i18n.ts
+++ b/packages/hoppscotch-common/src/modules/i18n.ts
@@ -11,6 +11,8 @@ import { throwError } from "~/helpers/functional/error"
 import { PersistenceService } from "~/services/persistence"
 import { getService } from "./dioc"
 
+import FALLBACK_LANG_MESSAGES from "../../locales/en.json"
+
 /*
   In context of this file, we have 2 main kinds of things.
   1. Locale -> A locale is termed as the i18n entries present in the /locales folder
@@ -143,6 +145,12 @@ export default <HoppModule>{
     app.use(i18n)
 
     i18nInstance = i18n
+
+    // Load in fallback lang messages
+    i18nInstance.global.setLocaleMessage(
+      FALLBACK_LANG_CODE,
+      FALLBACK_LANG_MESSAGES
+    )
 
     // TODO: Global loading state to hide the resolved lang loading
     const currentLocale = resolveCurrentLocale()


### PR DESCRIPTION
This PR intends to fix an issue with the i18n system not falling back correctly to the fallback language (English) translations.
This results in the value printed out being the actual raw i18n tags. This is not visible when the language is changed from English, but once we are in a non-English language and we do a reload, the `en` language messages are not present and this causes the fields to be present there.

Current State (on reload when German is set as the language):
![image](https://github.com/user-attachments/assets/abc17c39-88b2-401e-ac24-5b86842be273)

Notice the `count.key` field.

### What's changed
- Add code to load in fallback langauge regardless of set locale.
