### PR TITLE
fix: resolve empty state image correctly in profile page

### DIFF
--- a/packages/hoppscotch-common/src/components/accessTokens/List.vue
+++ b/packages/hoppscotch-common/src/components/accessTokens/List.vue
@@ -13,7 +13,7 @@
 
   <HoppSmartPlaceholder
     v-else-if="accessTokens.length === 0"
-    :src="`/images/states/${colorMode}/pack.svg`"
+    :src="`/images/states/${colorMode.value}/pack.svg`"
     :alt="`${t('empty.access_tokens')}`"
     :text="t('empty.access_tokens')"
     @drop.stop


### PR DESCRIPTION
### Description

This PR aims to fix a broken reference to an image as part of the `Personal Access Tokens` view empty state on the profile page. Follow up of #4304.

Closes HFE-629.

### What's changed

`colorMode` as consumed from the `useColorMode()` composable is a `reactive` object, hence, inferring the current `Background` selection via the `value` field.

https://github.com/hoppscotch/hoppscotch/blob/9da5f63e701ba072ea393e68847d7f8e395d4c4a/packages/hoppscotch-common/src/modules/theming.ts#L54-L60

https://github.com/hoppscotch/hoppscotch/blob/9da5f63e701ba072ea393e68847d7f8e395d4c4a/packages/hoppscotch-common/src/composables/theming.ts#L1-L4

### Preview

#### Before

![image](https://github.com/user-attachments/assets/15105c43-1aa7-4f68-92ca-cebf70a8719e)

#### After

![image](https://github.com/user-attachments/assets/ed41d30d-a8d8-4ba3-9d1a-7c994b87dcfc)
