### PR TITLE
fix: prevent keypress actions in the loading state

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/Add.vue
+++ b/packages/hoppscotch-common/src/components/collections/Add.vue
@@ -69,13 +69,15 @@ watch(
 )
 
 const addNewCollection = () => {
+  if (props.loadingState) {
+    return
+  }
+
   if (!editingName.value) {
     toast.error(t("collection.invalid_name"))
     return
   }
-  if (props.loadingState) {
-    return
-  }
+
   emit("submit", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/Add.vue
+++ b/packages/hoppscotch-common/src/components/collections/Add.vue
@@ -73,7 +73,9 @@ const addNewCollection = () => {
     toast.error(t("collection.invalid_name"))
     return
   }
-
+  if (props.loadingState) {
+    return
+  }
   emit("submit", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/AddFolder.vue
+++ b/packages/hoppscotch-common/src/components/collections/AddFolder.vue
@@ -73,6 +73,9 @@ const addFolder = () => {
     toast.error(t("folder.invalid_name"))
     return
   }
+  if (props.loadingState) {
+    return
+  }
   emit("add-folder", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/AddFolder.vue
+++ b/packages/hoppscotch-common/src/components/collections/AddFolder.vue
@@ -69,13 +69,15 @@ watch(
 )
 
 const addFolder = () => {
+  if (props.loadingState) {
+    return
+  }
+
   if (editingName.value.trim() === "") {
     toast.error(t("folder.invalid_name"))
     return
   }
-  if (props.loadingState) {
-    return
-  }
+
   emit("add-folder", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/AddRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/AddRequest.vue
@@ -170,6 +170,9 @@ const addRequest = () => {
     toast.error(`${t("error.empty_req_name")}`)
     return
   }
+  if (props.loadingState) {
+    return
+  }
   emit("add-request", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/AddRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/AddRequest.vue
@@ -166,13 +166,15 @@ watch(
 )
 
 const addRequest = () => {
+  if (props.loadingState) {
+    return
+  }
+
   if (editingName.value.trim() === "") {
     toast.error(`${t("error.empty_req_name")}`)
     return
   }
-  if (props.loadingState) {
-    return
-  }
+
   emit("add-request", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/Edit.vue
+++ b/packages/hoppscotch-common/src/components/collections/Edit.vue
@@ -69,13 +69,15 @@ watch(
 )
 
 const saveCollection = () => {
+  if (props.loadingState) {
+    return
+  }
+
   if (editingName.value.trim() === "") {
     toast.error(t("collection.invalid_name"))
     return
   }
-  if (props.loadingState) {
-    return
-  }
+
   emit("submit", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/Edit.vue
+++ b/packages/hoppscotch-common/src/components/collections/Edit.vue
@@ -73,7 +73,9 @@ const saveCollection = () => {
     toast.error(t("collection.invalid_name"))
     return
   }
-
+  if (props.loadingState) {
+    return
+  }
   emit("submit", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/EditFolder.vue
+++ b/packages/hoppscotch-common/src/components/collections/EditFolder.vue
@@ -73,7 +73,9 @@ const editFolder = () => {
     toast.error(t("folder.invalid_name"))
     return
   }
-
+  if (props.loadingState) {
+    return
+  }
   emit("submit", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/EditFolder.vue
+++ b/packages/hoppscotch-common/src/components/collections/EditFolder.vue
@@ -69,13 +69,15 @@ watch(
 )
 
 const editFolder = () => {
+  if (props.loadingState) {
+    return
+  }
+
   if (editingName.value.trim() === "") {
     toast.error(t("folder.invalid_name"))
     return
   }
-  if (props.loadingState) {
-    return
-  }
+
   emit("submit", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/EditRequest.vue
@@ -154,13 +154,15 @@ const submittedFeedback = ref(false)
 const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
 
 const editRequest = () => {
+  if (props.loadingState) {
+    return
+  }
+
   if (editingName.value.trim() === "") {
     toast.error(t("request.invalid_name"))
     return
   }
-  if (props.loadingState) {
-    return
-  }
+
   emit("submit", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/collections/EditRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/EditRequest.vue
@@ -158,7 +158,9 @@ const editRequest = () => {
     toast.error(t("request.invalid_name"))
     return
   }
-
+  if (props.loadingState) {
+    return
+  }
   emit("submit", editingName.value)
 }
 

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -355,6 +355,7 @@ const saveEnvironment = async () => {
   if (isLoading.value) {
     return
   }
+
   isLoading.value = true
 
   if (!editingName.value) {

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -352,6 +352,9 @@ const removeEnvironmentVariable = (id: number) => {
 const isLoading = ref(false)
 
 const saveEnvironment = async () => {
+  if (isLoading.value) {
+    return
+  }
   isLoading.value = true
 
   if (!editingName.value) {

--- a/packages/hoppscotch-common/src/components/teams/Add.vue
+++ b/packages/hoppscotch-common/src/components/teams/Add.vue
@@ -66,6 +66,7 @@ const addNewTeam = async () => {
   if (isLoading.value) {
     return
   }
+
   isLoading.value = true
   await pipe(
     TeamNameCodec.decode(editingName.value),

--- a/packages/hoppscotch-common/src/components/teams/Add.vue
+++ b/packages/hoppscotch-common/src/components/teams/Add.vue
@@ -63,6 +63,9 @@ const isLoading = ref(false)
 const workspaceService = useService(WorkspaceService)
 
 const addNewTeam = async () => {
+  if (isLoading.value) {
+    return
+  }
   isLoading.value = true
   await pipe(
     TeamNameCodec.decode(editingName.value),


### PR DESCRIPTION
This PR adds a check condition to the multiple cases where a repeated keypress will create multiple requests while in loading state. The changes made closes the issue #4134.
### What's changed
- In collections, functions that add or edit collections now return early if the button is in loading state.
- Similarly, add or edit functions in environment and teams also return early in loading state.
