### PR TITLE
HSB-495 feat: user workspace stats api added

### DIFF
--- a/packages/hoppscotch-backend/src/infra-token/request-response.dto.ts
+++ b/packages/hoppscotch-backend/src/infra-token/request-response.dto.ts
@@ -142,7 +142,7 @@ export class GetUserWorkspacesResponse {
 
   @ApiProperty({ enum: TeamMemberRole })
   @Expose()
-  my_role: string;
+  role: string;
 
   @ApiProperty()
   @Expose()

--- a/packages/hoppscotch-backend/src/infra-token/request-response.dto.ts
+++ b/packages/hoppscotch-backend/src/infra-token/request-response.dto.ts
@@ -10,6 +10,7 @@ import {
   IsString,
   MinLength,
 } from 'class-validator';
+import { TeamMemberRole } from 'src/team/team.model';
 import { OffsetPaginationArgs } from 'src/types/input-types.args';
 
 // POST v1/infra/user-invitations
@@ -127,4 +128,31 @@ export class DeleteUserResponse {
   @ApiProperty()
   @Expose()
   message: string;
+}
+
+// GET v1/infra/users/:uid/workspaces
+export class GetUserWorkspacesResponse {
+  @ApiProperty()
+  @Expose()
+  name: string;
+
+  @ApiProperty({ enum: TeamMemberRole })
+  @Expose()
+  my_role: string;
+
+  @ApiProperty()
+  @Expose()
+  owner_count: number;
+
+  @ApiProperty()
+  @Expose()
+  editor_count: number;
+
+  @ApiProperty()
+  @Expose()
+  viewer_count: number;
+
+  @ApiProperty()
+  @Expose()
+  member_count: number;
 }

--- a/packages/hoppscotch-backend/src/infra-token/request-response.dto.ts
+++ b/packages/hoppscotch-backend/src/infra-token/request-response.dto.ts
@@ -134,6 +134,10 @@ export class DeleteUserResponse {
 export class GetUserWorkspacesResponse {
   @ApiProperty()
   @Expose()
+  id: string;
+
+  @ApiProperty()
+  @Expose()
   name: string;
 
   @ApiProperty({ enum: TeamMemberRole })

--- a/packages/hoppscotch-backend/src/user/user.service.ts
+++ b/packages/hoppscotch-backend/src/user/user.service.ts
@@ -20,6 +20,8 @@ import { encrypt, stringToJson, taskEitherValidateArraySeq } from 'src/utils';
 import { UserDataHandler } from './user.data.handler';
 import { User as DbUser } from '@prisma/client';
 import { OffsetPaginationArgs } from 'src/types/input-types.args';
+import { GetUserWorkspacesResponse } from 'src/infra-token/request-response.dto';
+import { TeamMemberRole } from 'src/team/team.model';
 
 @Injectable()
 export class UserService {
@@ -597,5 +599,52 @@ export class UserService {
     }
 
     return E.right(true);
+  }
+
+  async fetchUserWorkspaces(userUid: string) {
+    const user = await this.prisma.user.findUnique({ where: { uid: userUid } });
+    if (!user) return E.left(USER_NOT_FOUND);
+
+    const team = await this.prisma.team.findMany({
+      where: {
+        members: {
+          some: {
+            userUid,
+          },
+        },
+      },
+      include: {
+        members: {
+          select: {
+            userUid: true,
+            role: true,
+          },
+        },
+      },
+    });
+
+    const workspaces: GetUserWorkspacesResponse[] = [];
+    team.forEach((t) => {
+      const ownerCount = t.members.filter(
+        (m) => m.role === TeamMemberRole.OWNER,
+      ).length;
+      const editorCount = t.members.filter(
+        (m) => m.role === TeamMemberRole.EDITOR,
+      ).length;
+      const viewerCount = t.members.filter(
+        (m) => m.role === TeamMemberRole.VIEWER,
+      ).length;
+      const memberCount = t.members.length;
+
+      workspaces.push({
+        name: t.name,
+        my_role: t.members.find((m) => m.userUid === userUid)?.role,
+        owner_count: ownerCount,
+        editor_count: editorCount,
+        viewer_count: viewerCount,
+        member_count: memberCount,
+      });
+    });
+    return E.right(workspaces);
   }
 }

--- a/packages/hoppscotch-backend/src/user/user.service.ts
+++ b/packages/hoppscotch-backend/src/user/user.service.ts
@@ -637,6 +637,7 @@ export class UserService {
       const memberCount = t.members.length;
 
       workspaces.push({
+        id: t.id,
         name: t.name,
         my_role: t.members.find((m) => m.userUid === userUid)?.role,
         owner_count: ownerCount,

--- a/packages/hoppscotch-backend/src/user/user.service.ts
+++ b/packages/hoppscotch-backend/src/user/user.service.ts
@@ -639,7 +639,7 @@ export class UserService {
       workspaces.push({
         id: t.id,
         name: t.name,
-        my_role: t.members.find((m) => m.userUid === userUid)?.role,
+        role: t.members.find((m) => m.userUid === userUid)?.role,
         owner_count: ownerCount,
         editor_count: editorCount,
         viewer_count: viewerCount,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HSB-495

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
This PR introduces an API to fetch a user's involvement in workspaces in `User management API` section

```
GET http://localhost:3170/v1/infra/users/{USER_UID}/workspaces
HEADER: infra-token

RESPONSE BODY
[
  {
    "id": "team_ID"
    "name": "Team A",
    "my_role": "OWNER",
    "owner_count": 1,
    "editor_count": 0,
    "viewer_count": 0,
    "member_count": 1
  }
]
```

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Nil