### PR TITLE
fix: postman env variables are to be imported as secrets

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -36,6 +36,7 @@ import { TeamEnvironment } from "~/helpers/teams/TeamEnvironment"
 import { computed } from "vue"
 import { useReadonlyStream } from "~/composables/stream"
 import { initializeDownloadFile } from "~/helpers/import-export/export"
+import { transformEnvironmentVariables } from "~/helpers/import-export/export/environment"
 import { environmentsExporter } from "~/helpers/import-export/export/environments"
 import { gistExporter } from "~/helpers/import-export/export/gist"
 import { platform } from "~/platform"
@@ -73,10 +74,12 @@ const isTeamEnvironment = computed(() => {
 
 const environmentJson = computed(() => {
   if (isTeamEnvironment.value && props.teamEnvironments) {
-    return props.teamEnvironments.map((x) => x.environment)
+    return props.teamEnvironments.map(({ environment }) =>
+      transformEnvironmentVariables(environment)
+    )
   }
 
-  return myEnvironments.value
+  return myEnvironments.value.map(transformEnvironmentVariables)
 })
 
 const workspaceType = computed(() =>

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -352,12 +352,12 @@ watch(
           env: {
             key: e.key,
             value: e.secret
-              ? (secretEnvironmentService.getSecretEnvironmentVariable(
+              ? secretEnvironmentService.getSecretEnvironmentVariable(
                   props.editingEnvironmentIndex === "Global"
                     ? "Global"
                     : workingEnvID.value,
                   index
-                )?.value ?? "")
+                )?.value ?? e.value
               : e.value,
             secret: e.secret,
           },

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -357,7 +357,10 @@ watch(
                     ? "Global"
                     : workingEnvID.value,
                   index
-                )?.value ?? e.value
+                )?.value ??
+                // @ts-expect-error `value` field can exist for secret environment variables as inferred while importing
+                e.value ??
+                ""
               : e.value,
             secret: e.secret,
           },

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -311,10 +311,13 @@ watch(
             env: {
               key: e.key,
               value: e.secret
-                ? (secretEnvironmentService.getSecretEnvironmentVariable(
+                ? secretEnvironmentService.getSecretEnvironmentVariable(
                     editingID.value ?? "",
                     index
-                  )?.value ?? "")
+                  )?.value ??
+                  // @ts-expect-error `value` field can exist for secret environment variables as inferred while importing
+                  e.value ??
+                  ""
                 : e.value,
               secret: e.secret,
             },
@@ -352,10 +355,6 @@ const removeEnvironmentVariable = (id: number) => {
 const isLoading = ref(false)
 
 const saveEnvironment = async () => {
-  if (isLoading.value) {
-    return
-  }
-
   isLoading.value = true
 
   if (!editingName.value) {

--- a/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
@@ -19,9 +19,39 @@ const getEnvironmentJSON = (
       ? environmentIndex
       : environmentObj.id
 
+  // Eliminate `value` field from secret environment variables prior to export
+  const transformedEnvironment = transformEnvironmentVariables(newEnvironment)
+
   return environmentId !== null
-    ? JSON.stringify(newEnvironment, null, 2)
+    ? JSON.stringify(transformedEnvironment, null, 2)
     : undefined
+}
+
+// Apply necessary transformations prior to environment exports
+export const transformEnvironmentVariables = ({
+  id,
+  v,
+  name,
+  variables,
+}: Environment) => {
+  return {
+    id,
+    v,
+    name,
+    variables: variables.map((variable) => {
+      const { key, secret } = variable
+
+      // Eliminate `value` field for secret environment variables
+      if (secret) {
+        return {
+          key,
+          secret,
+        }
+      }
+
+      return variable
+    }),
+  }
 }
 
 export const exportAsJSON = async (

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
@@ -54,9 +54,10 @@ export const postmanEnvImporter = (contents: string[]) => {
       id: uniqueID(),
       v: 1,
       name,
-      variables: values.map((entires) => ({
-        ...entires,
-        secret: entires.type === "secret",
+      variables: values.map(({ key, value, type }) => ({
+        key,
+        value,
+        secret: type === "secret",
       })),
     })
   )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
@@ -13,6 +13,7 @@ const postmanEnvSchema = z.object({
     z.object({
       key: z.string(),
       value: z.string(),
+      type: z.string(),
     })
   ),
 })
@@ -34,6 +35,7 @@ export const postmanEnvImporter = (contents: string[]) => {
         values: entry.values?.map((valueEntry) => ({
           ...valueEntry,
           value: String(valueEntry.value),
+          type: String(valueEntry.type),
         })),
       }))
     }
@@ -52,7 +54,10 @@ export const postmanEnvImporter = (contents: string[]) => {
       id: uniqueID(),
       v: 1,
       name,
-      variables: values.map((entires) => ({ ...entires, secret: false })),
+      variables: values.map((entires) => ({
+        ...entires,
+        secret: entires.type === "secret",
+      })),
     })
   )
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4470 

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
This PR addresses the issue of Postman environment secrets being imported as plain text variables. The change introduces a new variable type to correctly identify and import secret variables as masked values, enhancing security.

<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
