### PR TITLE
feat: ability for aio in sub-path access configurations to specify alternate ports

### DIFF
--- a/aio-multiport-setup.Caddyfile
+++ b/aio-multiport-setup.Caddyfile
@@ -18,7 +18,3 @@
 :3170 {
 	reverse_proxy localhost:8080
 }
-
-:80 {
-	respond 404
-}

--- a/aio-subpath-access.Caddyfile
+++ b/aio-subpath-access.Caddyfile
@@ -3,19 +3,7 @@
   persist_config off
 }
 
-:3000 {
-	respond 404
-}
-
-:3100 {
-	respond 404
-}
-
-:3170 {
-	reverse_proxy localhost:8080
-}
-
-:80 {
+:{$HOPP_AIO_ALTERNATE_PORT:80} {
 	# Serve the `selfhost-web` SPA by default
 	root * /site/selfhost-web
 	file_server

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -130,6 +130,8 @@ HEALTHCHECK --interval=2s CMD /bin/sh /healthcheck.sh
 WORKDIR /dist/backend
 
 CMD ["node", "/usr/src/app/aio_run.mjs"]
+
+# NOTE: Although these ports are exposed, the HOPP_ALTERNATE_AIO_PORT variable can be used to assign a user-specified port
 EXPOSE 3170
 EXPOSE 3000
 EXPOSE 3100


### PR DESCRIPTION
This PR allows for users to specify alternate ports for AIO container configurations having sub-path access (single port) configurations. The container normally binds port 80 when using single port access, but port 80 is a privileged port and certain systems (esp. rootless systems like Podman or hardened systems like OpenShift) do not provide root level privileges to allow for binding to port 80.

### What's changed
- Added new optional environment variable `HOPP_AIO_ALTERNATE_PORT` which is used by Caddy to define which port is to be bound to. No behaviour change into Windows.
- If the variable is not specified, Caddy will use the default port 80.

### Notes
@SanskritiHarmukh do remind me to update the docs to add a section for this.