### PR TITLE
fix: inherited headers and auth included in code generation

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Codegen.vue
+++ b/packages/hoppscotch-common/src/components/http/Codegen.vue
@@ -203,6 +203,7 @@ const requestCode = asyncComputed(async () => {
   let requestHeaders
   let requestAuth
 
+  // Add inherited headers and auth from the parent
   if (document.value.type === "request") {
     requestAuth =
       request.value.auth.authType === "inherit" && request.value.auth.authActive
@@ -228,7 +229,6 @@ const requestCode = asyncComputed(async () => {
     true
   )
 
-  //Generate code, adding the inheritedHeaders to the headers array
   const result = generateCode(
     lang,
     makeRESTRequest({


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes HFE-670 #4286  

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
Fixes inherited headers and auth of parent collections not being shown in codegen. 

Example before (header and auth not shown in generated code):
![image](https://github.com/user-attachments/assets/780f02c7-2516-467d-8dcf-b492f30b2541)

After (inherited header and auth shown in generated code):
![image](https://github.com/user-attachments/assets/a43819be-127e-49e8-b1ca-5c957230a4fa)


### What's changed
- Added the array of inherited headers found in the inherited properties of the current document to the generateCode() method.
- The auth is fetched from the document and populated accordingly.
