### PR TITLE
fix: scrollbar appearing on digest auth input fields and other improvements

### DIFF
--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -240,7 +240,6 @@ export const processRequest =
 
       // Updating report for errors & current result
       report.errors.push(preRequestRes.left);
-      console.error(`Report result is `, report.result);
       report.result = report.result;
     } else {
       // Updating effective-request and consuming updated envs after pre-request script execution

--- a/packages/hoppscotch-common/src/components/http/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/http/Authorization.vue
@@ -272,8 +272,6 @@ const selectDigestAuthType = () => {
     algorithm = "MD5",
   } = auth.value as HoppRESTAuthDigest
 
-  console.error(`Auth is `, auth.value)
-
   auth.value = {
     ...auth.value,
     authType: "digest",

--- a/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/Digest.vue
@@ -36,8 +36,7 @@
         :auto-complete-env="true"
         :placeholder="`${t(
           'authorization.digest.realm'
-        )} (e.g. testrealm@example.com)
-        `"
+        )} (e.g. testrealm@example.com)`"
         :envs="envs"
       />
     </div>
@@ -98,8 +97,7 @@
       <SmartEnvInput
         v-model="auth.qop"
         :auto-complete-env="true"
-        :placeholder="`${t('authorization.digest.qop')} (e.g. auth-int)
-        `"
+        :placeholder="`${t('authorization.digest.qop')} (e.g. auth-int)`"
         :envs="envs"
       />
     </div>
@@ -108,8 +106,7 @@
       <SmartEnvInput
         v-model="auth.nc"
         :auto-complete-env="true"
-        :placeholder="`${t('authorization.digest.nonce_count')} (e.g. 00000001)
-        `"
+        :placeholder="`${t('authorization.digest.nonce_count')} (e.g. 00000001)`"
         :envs="envs"
       />
     </div>
@@ -118,8 +115,7 @@
       <SmartEnvInput
         v-model="auth.cnonce"
         :auto-complete-env="true"
-        :placeholder="`${t('authorization.digest.client_nonce')} (e.g. Oa4f113b)
-        `"
+        :placeholder="`${t('authorization.digest.client_nonce')} (e.g. Oa4f113b)`"
         :envs="envs"
       />
     </div>

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/authorization.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/authorization.inspector.ts
@@ -6,6 +6,7 @@ import { Service } from "dioc"
 import { computed, markRaw, Ref } from "vue"
 
 import { getI18n } from "~/modules/i18n"
+import { platform } from "~/platform"
 import { AgentInterceptorService } from "~/platform/std/interceptors/agent"
 import { InterceptorService } from "~/services/interceptor.service"
 import { RESTTabService } from "~/services/tab/rest"
@@ -74,9 +75,12 @@ export class AuthorizationInspectorService
       const results: InspectorResult[] = []
 
       // `Agent` interceptor is recommended while using Digest Auth
+      // TODO: Better check to detect the platform
+      // Interceptor check only applies to the browser platform
       const isUnsupportedInterceptor =
+        platform.interceptors.default === "browser" &&
         this.interceptorService.currentInterceptorID.value !==
-        this.agentService.interceptorID
+          this.agentService.interceptorID
 
       const resolvedAuthType = this.resolveAuthType(auth)
 


### PR DESCRIPTION
This fix resolves an issue where a scrollbar appeared on digest authentication input fields. Additionally: 

- Fixes the issue where the interceptor warning regarding supported interceptors for Digest Auth was displayed on the Desktop app.
- Stale console logs are removed.

### What's changed
The issue was caused by an extra return character in the placeholder text. This fix removes the extra return character, eliminating the scrollbar.

- [ ] Not Completed
- [x] Completed
