### PR TITLE
chore: introduce `supportsDigestAuth` field at the interceptor service level

### DIFF
--- a/packages/hoppscotch-common/src/platform/index.ts
+++ b/packages/hoppscotch-common/src/platform/index.ts
@@ -54,11 +54,6 @@ export type PlatformDef = {
      * Whether to show the A/B testing workspace switcher click login flow or not
      */
     workspaceSwitcherLogin?: Ref<boolean>
-
-    /**
-     * Whether to show the warning about supported interceptors while using the Digest Authorization type
-     */
-    showInterceptorWarningForDigestAuth?: boolean
   }
   limits?: LimitsPlatformDef
   infra?: InfraPlatformDef

--- a/packages/hoppscotch-common/src/platform/interceptors.ts
+++ b/packages/hoppscotch-common/src/platform/interceptors.ts
@@ -14,5 +14,4 @@ export type PlatformInterceptorDef =
 export type InterceptorsPlatformDef = {
   default: string
   interceptors: PlatformInterceptorDef[]
-  showInterceptorWarningForDigestAuth?: boolean
 }

--- a/packages/hoppscotch-common/src/platform/std/interceptors/agent/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/interceptors/agent/index.ts
@@ -302,6 +302,8 @@ export class AgentInterceptorService extends Service implements Interceptor {
 
   public proxyInfo = ref<RequestDef["proxy"]>(undefined)
 
+  public supportsDigestAuth = true
+
   override onServiceInit() {
     // Register the Root UI Extension
     this.uiExtensionService.addRootUIExtension(AgentRootUIExtension)

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/authorization.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/authorization.inspector.ts
@@ -6,8 +6,6 @@ import { Service } from "dioc"
 import { computed, markRaw, Ref } from "vue"
 
 import { getI18n } from "~/modules/i18n"
-import { platform } from "~/platform"
-import { AgentInterceptorService } from "~/platform/std/interceptors/agent"
 import { InterceptorService } from "~/services/interceptor.service"
 import { RESTTabService } from "~/services/tab/rest"
 import IconAlertTriangle from "~icons/lucide/alert-triangle"
@@ -31,7 +29,6 @@ export class AuthorizationInspectorService
 
   private readonly inspection = this.bind(InspectionService)
   private readonly interceptorService = this.bind(InterceptorService)
-  private readonly agentService = this.bind(AgentInterceptorService)
   private readonly restTabService = this.bind(RESTTabService)
 
   override onServiceInit() {
@@ -74,15 +71,12 @@ export class AuthorizationInspectorService
 
       const results: InspectorResult[] = []
 
-      // `Agent` interceptor is recommended while using Digest Auth
-      const isUnsupportedInterceptor =
-        platform.platformFeatureFlags.showInterceptorWarningForDigestAuth &&
-        this.interceptorService.currentInterceptorID.value !==
-          this.agentService.interceptorID
-
       const resolvedAuthType = this.resolveAuthType(auth)
 
-      if (resolvedAuthType === "digest" && isUnsupportedInterceptor) {
+      if (
+        resolvedAuthType === "digest" &&
+        !this.interceptorService.currentInterceptor.value?.supportsDigestAuth
+      ) {
         results.push({
           id: "url",
           icon: markRaw(IconAlertTriangle),

--- a/packages/hoppscotch-common/src/services/interceptor.service.ts
+++ b/packages/hoppscotch-common/src/services/interceptor.service.ts
@@ -141,6 +141,12 @@ export type Interceptor<Err extends InterceptorError = InterceptorError> = {
    * @param request The request to run the interceptor on.
    */
   runRequest: (request: AxiosRequestConfig) => RequestRunResult<Err>
+
+  /**
+   * Defines whether the interceptor has support for Digest Auth.
+   * If this field is undefined, it is assumed as not supporting the Digest Auth type.
+   */
+  supportsDigestAuth?: boolean
 }
 
 /**

--- a/packages/hoppscotch-selfhost-desktop/src/platform/interceptors/native/index.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/platform/interceptors/native/index.ts
@@ -277,6 +277,8 @@ export class NativeInterceptorService extends Service implements Interceptor {
   public validateCerts = ref(true)
   public proxyInfo = ref<RequestDef["proxy"]>(undefined)
 
+  public supportsDigestAuth = true
+
   override onServiceInit() {
     // Load SSL Validation
     const persistedValidateSSL: unknown = JSON.parse(

--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -42,7 +42,6 @@ createHoppApp("#app", {
   platformFeatureFlags: {
     exportAsGIST: false,
     hasTelemetry: false,
-    showInterceptorWarningForDigestAuth: true,
   },
   limits: {
     collectionImportSizeLimit: 50,


### PR DESCRIPTION
### What's changed

This PR introduces a new field `supportsDigestAuth` at the interceptor service level replacing the previous `showInterceptorWarningForDigestAuth` platform level feature flag.

The purpose of introducing the above feature flag was to convey whether to show a warning regarding supported interceptors based on the platform. Since it is specific to interceptors, the above is removed in favour of a new member at the interceptor service layer.

### Notes to reviewers
N/A
