### PR TITLE
fix(selfhost-desktop): specify `Digest Auth` support for `Proxy` interceptor

### DIFF
--- a/packages/hoppscotch-selfhost-desktop/src/main.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/main.ts
@@ -46,14 +46,15 @@ const headerPaddingTop = ref("0px")
       settings: settingsDef,
       history: historyDef,
     },
-    addedHoppModules: [
-      interopModule
-    ],
+    addedHoppModules: [interopModule],
     interceptors: {
       default: "native",
       interceptors: [
         { type: "service", service: NativeInterceptorService },
-        { type: "standalone", interceptor: proxyInterceptor },
+        {
+          type: "standalone",
+          interceptor: { ...proxyInterceptor, supportsDigestAuth: true },
+        },
       ],
     },
     platformFeatureFlags: {


### PR DESCRIPTION
Previously, with the active interceptor being `Proxy` and Authorization set to `Digest Auth`, the warning regarding supported interceptors would appear in the Desktop App. This PR includes a fix for the same.

Related to HFE-642.

### What's changed

Specify `supportsDigestAuth` at the `selfhost-desktop` platform level `Proxy` interceptor config.