### PR TITLE
HSB-497 chore: user deletetion if not solo team owner

### DIFF
--- a/packages/hoppscotch-backend/src/admin/admin.service.ts
+++ b/packages/hoppscotch-backend/src/admin/admin.service.ts
@@ -231,9 +231,8 @@ export class AdminService {
    * @returns a count of team members
    */
   async membersCountInTeam(teamID: string) {
-    const teamMembersCount = await this.teamService.getCountOfMembersInTeam(
-      teamID,
-    );
+    const teamMembersCount =
+      await this.teamService.getCountOfMembersInTeam(teamID);
     return teamMembersCount;
   }
 
@@ -276,9 +275,8 @@ export class AdminService {
    * @returns an array team invitations
    */
   async pendingInvitationCountInTeam(teamID: string) {
-    const invitations = await this.teamInvitationService.getTeamInvitations(
-      teamID,
-    );
+    const invitations =
+      await this.teamInvitationService.getTeamInvitations(teamID);
 
     return invitations;
   }
@@ -614,9 +612,8 @@ export class AdminService {
    * @returns an Either of boolean or error
    */
   async revokeTeamInviteByID(inviteID: string) {
-    const teamInvite = await this.teamInvitationService.revokeInvitation(
-      inviteID,
-    );
+    const teamInvite =
+      await this.teamInvitationService.revokeInvitation(inviteID);
 
     if (E.isLeft(teamInvite)) return E.left(teamInvite.left);
 

--- a/packages/hoppscotch-backend/src/team/team.service.ts
+++ b/packages/hoppscotch-backend/src/team/team.service.ts
@@ -409,20 +409,20 @@ export class TeamService implements UserDataHandler, OnModuleInit {
         },
       });
 
-      // Count owners in each team
-      const ownerCounts = await Promise.all(
-        userOwnedTeams.map((team) =>
-          this.prisma.teamMember.count({
-            where: {
-              teamID: team.teamID,
-              role: TeamMemberRole.OWNER,
-            },
-          }),
-        ),
-      );
+      for (const userOwnedTeam of userOwnedTeams) {
+        const ownerCount = await this.prisma.teamMember.count({
+          where: {
+            teamID: userOwnedTeam.teamID,
+            role: TeamMemberRole.OWNER,
+          },
+        });
 
-      // Check if the user is the sole owner in any team
-      return ownerCounts.some((count) => count === 1);
+        // early return true if the user is the sole owner
+        if (ownerCount === 1) return true;
+      }
+
+      // return false if the user is not the sole owner in any team
+      return false;
     };
   }
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HSB-497

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
This PR updated the user deletion. Previously if a user a team owner, that user can not be deleted.
Now, a user can be deleted if he is not solo team owner in any of teams.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
3 ways a user can be deleted.
1. User can delete himself
2. User can delete by admin
3. User can delete via API