### PR TITLE
fix(agent): propagate default values to persistent store

### DIFF
--- a/packages/hoppscotch-agent/devenv.nix
+++ b/packages/hoppscotch-agent/devenv.nix
@@ -1,20 +1,30 @@
 { pkgs, lib, config, inputs, ... }:
 
-{
+let
+  rosettaPkgs =
+    if pkgs.stdenv.isDarwin && pkgs.stdenv.isAarch64
+    then pkgs.pkgsx86_64Darwin
+    else pkgs;
+
+  darwinPackages = with pkgs; [
+    darwin.apple_sdk.frameworks.Security
+    darwin.apple_sdk.frameworks.CoreServices
+    darwin.apple_sdk.frameworks.CoreFoundation
+    darwin.apple_sdk.frameworks.Foundation
+    darwin.apple_sdk.frameworks.AppKit
+    darwin.apple_sdk.frameworks.WebKit
+  ];
+
+  linuxPackages = with pkgs; [
+    libsoup
+    webkitgtk_4_0
+  ];
+
+in {
   # https://devenv.sh/packages/
   packages = with pkgs; [
     git
-    openssl
     postgresql_16
-    jq
-    xxd
-    # BE and Tauri stuff
-    libsoup_3
-    webkitgtk_4_1
-    librsvg
-    libappindicator
-    libayatana-appindicator
-    libappindicator-gtk3
     # FE and Node stuff
     nodejs_22
     nodePackages_latest.typescript-language-server
@@ -23,31 +33,37 @@
     prisma-engines
     # Cargo
     cargo-edit
-  ];
+  ] ++ lib.optionals pkgs.stdenv.isDarwin darwinPackages
+    ++ lib.optionals pkgs.stdenv.isLinux linuxPackages;
 
   # https://devenv.sh/basics/
-  #
-  # NOTE: Setting these `PRISMA_*` environment variable fixes
-  # Error: Failed to fetch sha256 checksum at https://binaries.prisma.sh/all_commits/<hash>/linux-nixos/libquery_engine.so.node.gz.sha256 - 404 Not Found
-  # See: https://github.com/prisma/prisma/discussions/3120
   env = {
     APP_GREET = "Hoppscotch";
+  } // lib.optionalAttrs pkgs.stdenv.isLinux {
+    # NOTE: Setting these `PRISMA_*` environment variable fixes
+    # Error: Failed to fetch sha256 checksum at https://binaries.prisma.sh/all_commits/<hash>/linux-nixos/libquery_engine.so.node.gz.sha256 - 404 Not Found
+    # See: https://github.com/prisma/prisma/discussions/3120
     PRISMA_QUERY_ENGINE_LIBRARY = "${pkgs.prisma-engines}/lib/libquery_engine.node";
     PRISMA_QUERY_ENGINE_BINARY = "${pkgs.prisma-engines}/bin/query-engine";
     PRISMA_SCHEMA_ENGINE_BINARY = "${pkgs.prisma-engines}/bin/schema-engine";
-
-    LD_LIBRARY_PATH = lib.makeLibraryPath [
-      pkgs.libappindicator
-      pkgs.libayatana-appindicator
-      pkgs.libappindicator-gtk3
-    ];
+  } // lib.optionalAttrs pkgs.stdenv.isDarwin {
+    # Place to put macOS-specific environment variables
   };
 
   # https://devenv.sh/scripts/
-  scripts.hello.exec = "echo hello from $APP_GREET";
+  scripts = {
+    hello.exec = "echo hello from $APP_GREET";
+    e.exec = "emacs";
+  };
 
   enterShell = ''
     git --version
+    ${lib.optionalString pkgs.stdenv.isDarwin ''
+      # Place to put macOS-specific shell initialization
+    ''}
+    ${lib.optionalString pkgs.stdenv.isLinux ''
+      # Place to put Linux-specific shell initialization
+    ''}
   '';
 
   # https://devenv.sh/tests/
@@ -59,31 +75,27 @@
   dotenv.enable = true;
 
   # https://devenv.sh/languages/
-  languages.javascript = {
-    enable = true;
-    pnpm = {
+  languages = {
+    typescript.enable = true;
+    javascript = {
       enable = true;
+      pnpm.enable = true;
+      npm.enable = true;
     };
-    npm = {
+    rust = {
       enable = true;
+      channel = "nightly";
+      components = [
+        "rustc"
+        "cargo"
+        "clippy"
+        "rustfmt"
+        "rust-analyzer"
+        "llvm-tools-preview"
+        "rust-src"
+        "rustc-codegen-cranelift-preview"
+      ];
     };
-  };
-
-  languages.typescript.enable = true;
-
-  languages.rust = {
-    enable = true;
-    channel = "nightly";
-    components = [
-      "rustc"
-      "cargo"
-      "clippy"
-      "rustfmt"
-      "rust-analyzer"
-      "llvm-tools-preview"
-      "rust-src"
-      "rustc-codegen-cranelift-preview"
-    ];
   };
 
   # https://devenv.sh/pre-commit-hooks/

--- a/packages/hoppscotch-agent/devenv.nix
+++ b/packages/hoppscotch-agent/devenv.nix
@@ -16,8 +16,11 @@ let
   ];
 
   linuxPackages = with pkgs; [
-    libsoup
-    webkitgtk_4_0
+    libsoup_3
+    webkitgtk_4_1
+    librsvg
+    libappindicator
+    libayatana-appindicator
   ];
 
 in {
@@ -46,6 +49,11 @@ in {
     PRISMA_QUERY_ENGINE_LIBRARY = "${pkgs.prisma-engines}/lib/libquery_engine.node";
     PRISMA_QUERY_ENGINE_BINARY = "${pkgs.prisma-engines}/bin/query-engine";
     PRISMA_SCHEMA_ENGINE_BINARY = "${pkgs.prisma-engines}/bin/schema-engine";
+
+    LD_LIBRARY_PATH = lib.makeLibraryPath [
+      pkgs.libappindicator
+      pkgs.libayatana-appindicator
+    ];
   } // lib.optionalAttrs pkgs.stdenv.isDarwin {
     # Place to put macOS-specific environment variables
   };

--- a/packages/hoppscotch-agent/package.json
+++ b/packages/hoppscotch-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hoppscotch-agent",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/hoppscotch-agent/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 
 [[package]]
 name = "hoppscotch-agent"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/packages/hoppscotch-agent/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoppscotch-agent"
-version = "0.1.2"
+version = "0.1.3"
 description = "A cross-platform HTTP request agent for Hoppscotch for advanced request handling including custom headers, certificates, proxies, and local system integration."
 authors = ["AndrewBastin", "CuriousCorrelation"]
 edition = "2021"

--- a/packages/hoppscotch-agent/src-tauri/src/error.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/error.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum AppError {
+pub enum AgentError {
     #[error("Invalid Registration")]
     InvalidRegistration,
     #[error("Invalid Client Public Key")]
@@ -48,22 +48,22 @@ pub enum AppError {
     Relay(#[from] hoppscotch_relay::RelayError),
 }
 
-impl IntoResponse for AppError {
+impl IntoResponse for AgentError {
     fn into_response(self) -> Response {
         let (status, error_message) = match self {
-            AppError::InvalidRegistration => (StatusCode::BAD_REQUEST, self.to_string()),
-            AppError::InvalidClientPublicKey => (StatusCode::BAD_REQUEST, self.to_string()),
-            AppError::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
-            AppError::RequestNotFound => (StatusCode::NOT_FOUND, self.to_string()),
-            AppError::InternalServerError => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
-            AppError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
-            AppError::ClientCertError => (StatusCode::BAD_REQUEST, self.to_string()),
-            AppError::RootCertError => (StatusCode::BAD_REQUEST, self.to_string()),
-            AppError::InvalidMethod => (StatusCode::BAD_REQUEST, self.to_string()),
-            AppError::InvalidUrl => (StatusCode::BAD_REQUEST, self.to_string()),
-            AppError::InvalidHeaders => (StatusCode::BAD_REQUEST, self.to_string()),
-            AppError::RequestRunError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
-            AppError::RequestCancelled => (StatusCode::BAD_REQUEST, self.to_string()),
+            AgentError::InvalidRegistration => (StatusCode::BAD_REQUEST, self.to_string()),
+            AgentError::InvalidClientPublicKey => (StatusCode::BAD_REQUEST, self.to_string()),
+            AgentError::Unauthorized => (StatusCode::UNAUTHORIZED, self.to_string()),
+            AgentError::RequestNotFound => (StatusCode::NOT_FOUND, self.to_string()),
+            AgentError::InternalServerError => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
+            AgentError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg),
+            AgentError::ClientCertError => (StatusCode::BAD_REQUEST, self.to_string()),
+            AgentError::RootCertError => (StatusCode::BAD_REQUEST, self.to_string()),
+            AgentError::InvalidMethod => (StatusCode::BAD_REQUEST, self.to_string()),
+            AgentError::InvalidUrl => (StatusCode::BAD_REQUEST, self.to_string()),
+            AgentError::InvalidHeaders => (StatusCode::BAD_REQUEST, self.to_string()),
+            AgentError::RequestRunError(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg),
+            AgentError::RequestCancelled => (StatusCode::BAD_REQUEST, self.to_string()),
             _ => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Internal Server Error".to_string(),
@@ -78,4 +78,4 @@ impl IntoResponse for AppError {
     }
 }
 
-pub type AppResult<T> = std::result::Result<T, AppError>;
+pub type AgentResult<T> = std::result::Result<T, AgentError>;

--- a/packages/hoppscotch-agent/src-tauri/src/error.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/error.rs
@@ -40,6 +40,8 @@ pub enum AppError {
     RegistrationInsertError,
     #[error("Failed to save registrations to store")]
     RegistrationSaveError,
+    #[error("Serde error: {0}")]
+    Serde(#[from] serde_json::Error),
     #[error("Store error: {0}")]
     TauriPluginStore(#[from] tauri_plugin_store::Error),
     #[error("Relay error: {0}")]

--- a/packages/hoppscotch-agent/src-tauri/src/global.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/global.rs
@@ -1,0 +1,2 @@
+pub const AGENT_STORE: &str = "app_data.bin";
+pub const REGISTRATIONS: &str = "registrations";

--- a/packages/hoppscotch-agent/src-tauri/src/lib.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod controller;
 pub mod dialog;
 pub mod error;
+pub mod global;
 pub mod model;
 pub mod route;
 pub mod server;

--- a/packages/hoppscotch-agent/src-tauri/src/state.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/state.rs
@@ -46,6 +46,10 @@ impl AppState {
             .and_then(|val| serde_json::from_value(val.clone()).ok())
             .unwrap_or_else(|| DashMap::new());
 
+        // Try to save the latest registrations list
+        let _ = store.set("registrations", serde_json::to_value(&registrations)?);
+        let _ = store.save();
+
         Ok(Self {
             active_registration_code: RwLock::new(None),
             cancellation_tokens: DashMap::new(),

--- a/packages/hoppscotch-agent/src-tauri/src/state.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/state.rs
@@ -3,11 +3,14 @@ use axum::body::Bytes;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use tauri_plugin_store::StoreBuilder;
+use tauri_plugin_store::StoreExt;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
-use crate::error::{AppError, AppResult};
+use crate::{
+    error::{AgentError, AgentResult},
+    global::{AGENT_STORE, REGISTRATIONS},
+};
 
 /// Describes one registered app instance
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -34,20 +37,18 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(app_handle: tauri::AppHandle) -> AppResult<Self> {
-        let store = StoreBuilder::new(&app_handle, "app_data.bin").build()?;
-
-        let _ = store.reload();
+    pub fn new(app_handle: tauri::AppHandle) -> AgentResult<Self> {
+        let store = app_handle.store(AGENT_STORE)?;
 
         // Try loading and parsing registrations from the store, if that failed,
         // load the default list
         let registrations = store
-            .get("registrations")
+            .get(REGISTRATIONS)
             .and_then(|val| serde_json::from_value(val.clone()).ok())
             .unwrap_or_else(|| DashMap::new());
 
         // Try to save the latest registrations list
-        let _ = store.set("registrations", serde_json::to_value(&registrations)?);
+        let _ = store.set(REGISTRATIONS, serde_json::to_value(&registrations)?);
         let _ = store.save();
 
         Ok(Self {
@@ -66,38 +67,50 @@ impl AppState {
     }
 
     /// Provides you an opportunity to update the registrations list
-    /// and also persists the data to the disk
+    /// and also persists the data to the disk.
+    /// This function bypasses `store.reload()` to avoid issues from stale or inconsistent
+    /// data on disk. By relying solely on the in-memory `self.registrations`,
+    /// we make sure that updates are applied based on the most recent changes in memory.
     pub fn update_registrations(
         &self,
         app_handle: tauri::AppHandle,
         update_func: impl FnOnce(&DashMap<String, Registration>),
-    ) -> Result<(), AppError> {
+    ) -> Result<(), AgentError> {
         update_func(&self.registrations);
 
-        let store = StoreBuilder::new(&app_handle, "app_data.bin").build()?;
+        let store = app_handle.store(AGENT_STORE)?;
 
-        let _ = store.reload()?;
+        if store.has(REGISTRATIONS) {
+            // We've confirmed `REGISTRATIONS` exists in the store
+            store
+                .delete(REGISTRATIONS)
+                .then_some(())
+                .ok_or(AgentError::RegistrationClearError)?;
+        } else {
+            log::debug!("`REGISTRATIONS` key not found in store; continuing with update.");
+        }
 
-        let _ = store
-            .delete("registrations")
-            .then_some(())
-            .ok_or(AppError::RegistrationClearError)?;
+        // Since we've established `self.registrations` as the source of truth,
+        // we avoid reloading the store from disk and instead choose to override it.
 
-        let _ = store.set(
-            "registrations",
-            serde_json::to_value(self.registrations.clone()).unwrap(),
+        store.set(
+            REGISTRATIONS,
+            serde_json::to_value(self.registrations.clone())?,
         );
 
-        store.save().map_err(|_| AppError::RegistrationSaveError)?;
+        // Explicitly save the changes
+        store.save()?;
 
         Ok(())
     }
 
+    /// Clear all the registrations
+    pub fn clear_registrations(&self, app_handle: tauri::AppHandle) -> Result<(), AgentError> {
+        Ok(self.update_registrations(app_handle, |registrations| registrations.clear())?)
+    }
+
     pub async fn validate_registration(&self, registration: &str) -> bool {
-        match *self.active_registration_code.read().await {
-            Some(ref code) => code == registration,
-            None => false,
-        }
+        self.active_registration_code.read().await.as_deref() == Some(registration)
     }
 
     pub fn remove_cancellation_token(&self, req_id: usize) -> Option<(usize, CancellationToken)> {

--- a/packages/hoppscotch-agent/src-tauri/src/tray.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/tray.rs
@@ -57,18 +57,19 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
         .menu_on_left_click(true)
         .on_menu_event(move |app, event| match event.id.as_ref() {
             "quit" => {
+                log::info!("Exiting the agent...");
                 app.exit(-1);
             }
             "clear_registrations" => {
                 let app_state = app.state::<Arc<AppState>>();
 
                 app_state
-                    .update_registrations(app.clone(), |regs| {
-                        regs.clear();
-                    })
-                    .expect("Failed to clear registrations");
+                    .clear_registrations(app.clone())
+                    .expect("Invariant violation: Failed to clear registrations");
             }
-            _ => {}
+            _ => {
+                log::warn!("Unhandled menu event: {:?}", event.id);
+            }
         })
         .on_tray_icon_event(|tray, event| {
             if let TrayIconEvent::Click {

--- a/packages/hoppscotch-agent/src-tauri/tauri.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent Portable",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
This PR fixes an issue where sane default values set in the ephemeral store were not being propagated to the persistent store if the store was uninitialized or encountered a loading error. Now, if the persistent store is absent or fails to load, default values will be established in the ephemeral store and subsequently saved to the persistent store, syncing two both storage layers.

Closes HFE-645