### PR TITLE
fix(cli): use os-specific invalid paths for tests

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
@@ -644,7 +644,11 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
 
       const COLL_PATH = getTestJsonFilePath("passes-coll.json", "collection");
 
-      const args = `test ${COLL_PATH} --reporter-junit /non-existent-path/report.xml`;
+      const invalidPath = process.platform === 'win32'
+        ? 'Z:/non-existent-path/report.xml'
+        : '/non-existent/report.xml';
+
+      const args = `test ${COLL_PATH} --reporter-junit ${invalidPath}`;
 
       const { stdout, stderr } = await runCLI(args, {
         cwd: path.resolve("hopp-cli-test"),


### PR DESCRIPTION
## CLI test failing on trying to test for invalid paths

#### **Initial Issue:**
Test is for the CLI tool to verify how it behaves when attempting to export a report to an invalid path.
But, when running the test on **Windows**, it failed to pass the assertions in the test, even though the error output was as expected.

#### **The Test:**
```javascript
  const args = `test ${COLL_PATH} --reporter-junit /non-existent-path/report.xml`;
  ...
  ...
  const out = getErrorCode(stderr);
  expect(out).toBe<HoppErrorCode>("REPORT_EXPORT_FAILED");
});
```

#### **What Went Wrong:**
- The test passed **on most platforms**, but not on **Windows**.
- The main issue occurred because we were checking for a specific error code in the `stderr`, but Windows returned something different in `stderr` - `ENOENT`
---

### **The Solution:**
   - On **Windows**, `Z:` would be an invalid drive letter (unless the drive is manually mapped, which it usually isn't).
   - On **Linux** (or other Unix-like systems), `/` is the root path.
   - Now both systems will have root path as the base for invalid paths.
   
   ```javascript
   const invalidPath = process.platform === 'win32'
     ? 'Z:/non-existent-path/report.xml'
     : '/non-existent/report.xml';
   ```
   
   Closes HFE-647