### PR TITLE
hotfix: graphql connection error handler

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -452,6 +452,7 @@
   },
   "graphql": {
     "connection_switch_confirm": "Do you want to connect with the latest GraphQL endpoint?",
+    "connection_error_http": "HTTP Error",
     "connection_switch_new_url": "Switching to a tab will disconnected you from the active GraphQL connection. New connection URL is",
     "connection_switch_url": "You're connected to a GraphQL endpoint the connection URL is",
     "mutations": "Mutations",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -452,7 +452,7 @@
   },
   "graphql": {
     "connection_switch_confirm": "Do you want to connect with the latest GraphQL endpoint?",
-    "connection_error_http": "HTTP Error",
+    "connection_error_http": "Failed to fetch GraphQL Schema due to network error.",
     "connection_switch_new_url": "Switching to a tab will disconnected you from the active GraphQL connection. New connection URL is",
     "connection_switch_url": "You're connected to a GraphQL endpoint the connection URL is",
     "mutations": "Mutations",

--- a/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/graphql/RequestOptions.vue
@@ -224,7 +224,10 @@ watch(
 watch(
   () => connection,
   (newVal) => {
-    if (newVal.error && newVal.state === "DISCONNECTED") {
+    if (
+      newVal.error &&
+      (newVal.state === "DISCONNECTED" || newVal.state === "ERROR")
+    ) {
       const response = [
         {
           type: "error",

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -187,7 +187,7 @@ export const connect = async (
       }, GQL_SCHEMA_POLL_INTERVAL)
     } catch (error) {
       // Show an error toast if the introspection attempt failed and not while sending a request
-      if (connection.error && !isRunGQLOperation) {
+      if (!isRunGQLOperation) {
         toast.error(t("graphql.connection_error_http"))
       }
 

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -186,6 +186,8 @@ export const connect = async (
         poll()
       }, GQL_SCHEMA_POLL_INTERVAL)
     } catch (error) {
+      connection.state = "ERROR"
+
       // Show an error toast if the introspection attempt failed and not while sending a request
       if (!isRunGQLOperation) {
         toast.error(t("graphql.connection_error_http"))

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -227,6 +227,8 @@ const getSchema = async (url: string, headers: GQLHeader[]) => {
     const res = await interceptorService.runRequest(reqOptions).response
 
     if (E.isLeft(res)) {
+      connection.state = "ERROR"
+
       if (
         res.left !== "cancellation" &&
         res.left.error === "NO_PW_EXT_HOOK" &&

--- a/packages/hoppscotch-common/src/pages/graphql.vue
+++ b/packages/hoppscotch-common/src/pages/graphql.vue
@@ -87,7 +87,8 @@
 import { usePageHead } from "@composables/head"
 import { useI18n } from "@composables/i18n"
 import { useService } from "dioc/vue"
-import { computed, onBeforeUnmount, ref } from "vue"
+import { computed, onBeforeUnmount, ref, watch } from "vue"
+import { useToast } from "~/composables/toast"
 import { defineActionHandler } from "~/helpers/actions"
 import { connection, disconnect } from "~/helpers/graphql/connection"
 import { getDefaultGQLRequest } from "~/helpers/graphql/default"
@@ -97,6 +98,7 @@ import { HoppTab } from "~/services/tab"
 import { GQLTabService } from "~/services/tab/graphql"
 
 const t = useI18n()
+const toast = useToast()
 const tabs = useService(GQLTabService)
 
 const currentTabID = computed(() => tabs.currentTabID.value)
@@ -175,6 +177,12 @@ const onResolveConfirmCloseAllTabs = () => {
 const onTabUpdate = (tab: HoppTab<HoppGQLDocument>) => {
   tabs.updateTab(tab)
 }
+
+const connectionError = computed(() => connection.error)
+
+watch(connectionError, (error) => {
+  if (error) toast.error(error.message(t))
+})
 
 onBeforeUnmount(() => {
   if (connection.state === "CONNECTED") {

--- a/packages/hoppscotch-common/src/pages/graphql.vue
+++ b/packages/hoppscotch-common/src/pages/graphql.vue
@@ -178,12 +178,6 @@ const onTabUpdate = (tab: HoppTab<HoppGQLDocument>) => {
   tabs.updateTab(tab)
 }
 
-const connectionError = computed(() => connection.error)
-
-watch(connectionError, (error) => {
-  if (error) toast.error(error.message(t))
-})
-
 onBeforeUnmount(() => {
   if (connection.state === "CONNECTED") {
     disconnect()


### PR DESCRIPTION
This pull request fixes the error handling for GraphQL connections. It adds a new error message for HTTP errors and updates the connection state to "ERROR" when an HTTP error occurs.