### PR TITLE
fix: resolve GraphQL collection tree and tab dissociation issues

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/graphql/AddRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/AddRequest.vue
@@ -96,7 +96,7 @@
 <script setup lang="ts">
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
-import { HoppRESTRequest } from "@hoppscotch/data"
+import { HoppGQLRequest } from "@hoppscotch/data"
 import { useService } from "dioc/vue"
 import { ref, watch } from "vue"
 
@@ -106,8 +106,8 @@ import {
 } from "~/composables/ai-experiments"
 import { GQLTabService } from "~/services/tab/graphql"
 import IconSparkle from "~icons/lucide/sparkles"
-import IconThumbsUp from "~icons/lucide/thumbs-up"
 import IconThumbsDown from "~icons/lucide/thumbs-down"
+import IconThumbsUp from "~icons/lucide/thumbs-up"
 
 const toast = useToast()
 const t = useI18n()
@@ -117,7 +117,7 @@ const tabs = useService(GQLTabService)
 const props = defineProps<{
   show: boolean
   folderPath?: string
-  requestContext: HoppRESTRequest | null
+  requestContext: HoppGQLRequest | null
 }>()
 
 const emit = defineEmits<{

--- a/packages/hoppscotch-common/src/components/collections/graphql/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/index.vue
@@ -400,21 +400,13 @@ const duplicateCollection = ({
   collectionSyncID?: string
 }) => duplicateGraphQLCollection(path, collectionSyncID)
 
-const onAddRequest = ({
-  name,
-  path,
-  index,
-}: {
-  name: string
-  path: string
-  index: number
-}) => {
+const onAddRequest = ({ name, path }: { name: string; path: string }) => {
   const newRequest = {
     ...tabs.currentActiveTab.value.document.request,
     name,
   }
 
-  saveGraphqlRequestAs(path, newRequest)
+  const insertionIndex = saveGraphqlRequestAs(path, newRequest)
 
   const { auth, headers } = cascadeParentCollectionForHeaderAuth(
     path,
@@ -425,7 +417,7 @@ const onAddRequest = ({
     saveContext: {
       originLocation: "user-collection",
       folderPath: path,
-      requestIndex: index,
+      requestIndex: insertionIndex,
     },
     request: newRequest,
     isDirty: false,

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -1508,6 +1508,14 @@ export function editGraphqlRequest(
 }
 
 export function saveGraphqlRequestAs(path: string, request: HoppGQLRequest) {
+  // For calculating the insertion request index
+  const targetLocation = navigateToFolderWithIndexPath(
+    graphqlCollectionStore.value.state,
+    path.split("/").map((x) => parseInt(x))
+  )
+
+  const insertionIndex = targetLocation!.requests.length
+
   graphqlCollectionStore.dispatch({
     dispatcher: "saveRequestAs",
     payload: {
@@ -1515,6 +1523,8 @@ export function saveGraphqlRequestAs(path: string, request: HoppGQLRequest) {
       request,
     },
   })
+
+  return insertionIndex
 }
 
 export function removeGraphqlRequest(

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -279,8 +279,7 @@ const HoppGQLSaveContextSchema = z.nullable(
       .object({
         originLocation: z.literal("user-collection"),
         folderPath: z.string(),
-        // TODO: Investigate why this field is not populated at times
-        requestIndex: z.optional(z.number()),
+        requestIndex: z.number(),
       })
       .strict(),
     z


### PR DESCRIPTION
This PR aims to resolve the issues with the GraphQL workspace, where requests from the collection tree and the ones open under tabs get dissociated following certain actions.

> Dissociation due to request move and overwrite via spotlight `Save as new request` actions are beyond the scope.

Closes HFE-546 #4500.

### What's changed

- The `saveGraphqlRequestAs` function exposed from the store premises, invoking the underlying dispatcher now returns the insertion index for the request being added.
- Updates the places of consumption of the above to leverage the insertion index and resolve issues with the pre-existing implementation where the request index came up as `undefined` resulting in dissociation with the tab.
- Updates signature for the `OnAddRequest` method in the `CollectionGraphql` component removing `index` (resolved as `undefined`) from the incoming data and leveraging the request index instead.
- Resolve type errors in the `CollectionsGraphqlAddRequest` component.
- Updates the GQL tab request save context schema enabling requirement for the `requestIndex` field existence as a follow up of #4211.

### Notes to reviewers

Please ensure to verify actions except for moves and overwrites via the `Save as new request` from the spotlight with requests from the collection tree and that the association is kept with the tabs in which they're open:

- Adding request under a root/child level collection.
- Saving the request open in the current tab under a collection. It should open the above request in a new tab.
- Editing a request.
- The above actions within the `Save as` modal.