### PR TITLE
HSB-500 fix: returning introspection complexity to 0

### DIFF
--- a/packages/hoppscotch-backend/src/plugins/GQLComplexityPlugin.ts
+++ b/packages/hoppscotch-backend/src/plugins/GQLComplexityPlugin.ts
@@ -7,6 +7,7 @@ import {
 import { Plugin } from '@nestjs/apollo';
 import { GraphQLError } from 'graphql';
 import {
+  ComplexityEstimatorArgs,
   fieldExtensionsEstimator,
   getComplexity,
   simpleEstimator,
@@ -29,6 +30,14 @@ export class GQLComplexityPlugin implements ApolloServerPlugin {
           query: document,
           variables: request.variables,
           estimators: [
+            // Custom estimator for introspection fields
+            (args: ComplexityEstimatorArgs) => {
+              const fieldName = args.field.name;
+              if (fieldName.startsWith('__')) {
+                return 0; // Return 0 complexity for introspection fields
+              }
+              return;
+            },
             fieldExtensionsEstimator(),
             simpleEstimator({ defaultComplexity: 1 }),
           ],

--- a/packages/hoppscotch-backend/src/plugins/GQLComplexityPlugin.ts
+++ b/packages/hoppscotch-backend/src/plugins/GQLComplexityPlugin.ts
@@ -24,17 +24,20 @@ export class GQLComplexityPlugin implements ApolloServerPlugin {
 
     return {
       async didResolveOperation({ request, document }) {
-        const isIntrospectionQuery =
-          request.operationName === 'IntrospectionQuery';
-
         const complexity = getComplexity({
           schema,
           operationName: request.operationName,
           query: document,
           variables: request.variables,
           estimators: [
-            // Custom estimator for introspection queries
-            (info) => (isIntrospectionQuery ? 0 : undefined),
+            // Custom estimator for introspection fields
+            (args: ComplexityEstimatorArgs) => {
+              const fieldName = args.field.name;
+              if (fieldName.startsWith('__')) {
+                return 0; // Return 0 complexity for introspection fields
+              }
+              return;
+            },
             fieldExtensionsEstimator(),
             simpleEstimator({ defaultComplexity: 1 }),
           ],

--- a/packages/hoppscotch-backend/src/plugins/GQLComplexityPlugin.ts
+++ b/packages/hoppscotch-backend/src/plugins/GQLComplexityPlugin.ts
@@ -24,20 +24,17 @@ export class GQLComplexityPlugin implements ApolloServerPlugin {
 
     return {
       async didResolveOperation({ request, document }) {
+        const isIntrospectionQuery =
+          request.operationName === 'IntrospectionQuery';
+
         const complexity = getComplexity({
           schema,
           operationName: request.operationName,
           query: document,
           variables: request.variables,
           estimators: [
-            // Custom estimator for introspection fields
-            (args: ComplexityEstimatorArgs) => {
-              const fieldName = args.field.name;
-              if (fieldName.startsWith('__')) {
-                return 0; // Return 0 complexity for introspection fields
-              }
-              return;
-            },
+            // Custom estimator for introspection queries
+            (info) => (isIntrospectionQuery ? 0 : undefined),
             fieldExtensionsEstimator(),
             simpleEstimator({ defaultComplexity: 1 }),
           ],


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HSB-500

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
This fix PR handles the breaking changes of [graphql-query-complexity](https://github.com/slicknode/graphql-query-complexity/releases/tag/v1.0.0).

For the introspection query, now returning 0 value as mentioned in the release note.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Nil