### PR TITLE
chore: show warning for interceptors not supporting binary data

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -576,7 +576,7 @@
       "extention_not_enabled": "Extension not enabled."
     },
     "requestBody": {
-      "agent_doesnt_support_binary_body": "Sending binary data via agent is not supported yet"
+      "doesnt_support_binary_body": "Sending binary data via current interceptor is not supported yet"
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -576,7 +576,7 @@
       "extention_not_enabled": "Extension not enabled."
     },
     "requestBody": {
-      "doesnt_support_binary_body": "Sending binary data via current interceptor is not supported yet"
+      "active_interceptor_doesnt_support_binary_body": "Sending binary data via the current interceptor is not supported yet."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/src/platform/std/interceptors/agent/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/interceptors/agent/index.ts
@@ -271,7 +271,9 @@ export class AgentInterceptorService extends Service implements Interceptor {
 
   public selectable = { type: "selectable" as const }
 
+  public supportsDigestAuth = true
   public supportsCookies = true
+  public supportsBinaryContentType = false
 
   private interceptorService = this.bind(InterceptorService)
   private cookieJarService = this.bind(CookieJarService)
@@ -301,8 +303,6 @@ export class AgentInterceptorService extends Service implements Interceptor {
   private registrationOTP = ref<string | null>(null)
 
   public proxyInfo = ref<RequestDef["proxy"]>(undefined)
-
-  public supportsDigestAuth = true
 
   override onServiceInit() {
     // Register the Root UI Extension

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/interceptors.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/interceptors.inspector.ts
@@ -40,10 +40,13 @@ export class InterceptorsInspectorService extends Service implements Inspector {
       const isBinaryBody =
         req.value.body.contentType === "application/octet-stream"
 
-      // TODO: define the supported capabilities in the interceptor
-      const isAgent = this.interceptors.currentInterceptorID.value === "agent"
+      const currentInterceptor = this.interceptors.currentInterceptor.value
 
-      if (isBinaryBody && isAgent) {
+      if (
+        isBinaryBody &&
+        currentInterceptor &&
+        !currentInterceptor.supportsBinaryContentType
+      ) {
         return [
           {
             isApplicable: true,
@@ -52,7 +55,7 @@ export class InterceptorsInspectorService extends Service implements Inspector {
             text: {
               type: "text",
               text: this.t(
-                "inspections.requestBody.agent_doesnt_support_binary_body"
+                "inspections.requestBody.doesnt_support_binary_body"
               ),
             },
             locations: {

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/interceptors.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/interceptors.inspector.ts
@@ -56,7 +56,7 @@ export class InterceptorsInspectorService extends Service implements Inspector {
             text: {
               type: "text",
               text: this.t(
-                "inspections.requestBody.doesnt_support_binary_body"
+                "inspections.requestBody.active_interceptor_doesnt_support_binary_body"
               ),
             },
             locations: {

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/interceptors.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/interceptors.inspector.ts
@@ -42,10 +42,11 @@ export class InterceptorsInspectorService extends Service implements Inspector {
 
       const currentInterceptor = this.interceptors.currentInterceptor.value
 
+      // TODO: Maybe move feature determination/checking related things to interceptor system.
       if (
         isBinaryBody &&
         currentInterceptor &&
-        !currentInterceptor.supportsBinaryContentType
+        currentInterceptor.supportsBinaryContentType === false
       ) {
         return [
           {

--- a/packages/hoppscotch-common/src/services/interceptor.service.ts
+++ b/packages/hoppscotch-common/src/services/interceptor.service.ts
@@ -109,6 +109,18 @@ export type Interceptor<Err extends InterceptorError = InterceptorError> = {
   supportsCookies?: boolean
 
   /**
+   * Defines whether the interceptor has support for Digest Auth.
+   * If this field is undefined, it is assumed as not supporting the Digest Auth type.
+   */
+  supportsDigestAuth?: boolean
+
+  /**
+   * Defines whether the interceptor has support for Binary (file) content type.
+   * If this field is undefined, it is assumed as not supporting the Binary content type.
+   */
+  supportsBinaryContentType?: boolean
+
+  /**
    * Defines what to render in the Interceptor section of the Settings page.
    * Use this space to define interceptor specific settings.
    * Not setting this will lead to nothing being rendered about this interceptor in the settings page.
@@ -141,12 +153,6 @@ export type Interceptor<Err extends InterceptorError = InterceptorError> = {
    * @param request The request to run the interceptor on.
    */
   runRequest: (request: AxiosRequestConfig) => RequestRunResult<Err>
-
-  /**
-   * Defines whether the interceptor has support for Digest Auth.
-   * If this field is undefined, it is assumed as not supporting the Digest Auth type.
-   */
-  supportsDigestAuth?: boolean
 }
 
 /**

--- a/packages/hoppscotch-common/src/services/interceptor.service.ts
+++ b/packages/hoppscotch-common/src/services/interceptor.service.ts
@@ -104,19 +104,19 @@ export type Interceptor<Err extends InterceptorError = InterceptorError> = {
 
   /**
    * Defines whether the interceptor has support for cookies.
-   * If this field is undefined, it is assumed as not supporting cookies.
+   * If this field is undefined, it is assumed as *not supporting* cookies.
    */
   supportsCookies?: boolean
 
   /**
    * Defines whether the interceptor has support for Digest Auth.
-   * If this field is undefined, it is assumed as not supporting the Digest Auth type.
+   * If this field is undefined, it is assumed as *not supporting* the Digest Auth type.
    */
   supportsDigestAuth?: boolean
 
   /**
    * Defines whether the interceptor has support for Binary (file) content type.
-   * If this field is undefined, it is assumed as not supporting the Binary content type.
+   * If this field is undefined, it is assumed as *supporting* the Binary content type.
    */
   supportsBinaryContentType?: boolean
 

--- a/packages/hoppscotch-selfhost-desktop/src/main.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/main.ts
@@ -53,7 +53,7 @@ const headerPaddingTop = ref("0px")
         { type: "service", service: NativeInterceptorService },
         {
           type: "standalone",
-          interceptor: { ...proxyInterceptor, supportsDigestAuth: true },
+          interceptor: { ...proxyInterceptor, supportsDigestAuth: true, supportsBinaryContentType: true },
         },
       ],
     },

--- a/packages/hoppscotch-selfhost-desktop/src/main.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/main.ts
@@ -53,7 +53,7 @@ const headerPaddingTop = ref("0px")
         { type: "service", service: NativeInterceptorService },
         {
           type: "standalone",
-          interceptor: { ...proxyInterceptor, supportsDigestAuth: true, supportsBinaryContentType: true },
+          interceptor: { ...proxyInterceptor, supportsDigestAuth: true },
         },
       ],
     },

--- a/packages/hoppscotch-selfhost-desktop/src/platform/interceptors/native/index.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/platform/interceptors/native/index.ts
@@ -260,6 +260,8 @@ export class NativeInterceptorService extends Service implements Interceptor {
   public selectable = { type: "selectable" as const }
 
   public supportsCookies = true
+  public supportsDigestAuth = true
+  public supportsBinaryContentType = false
 
   private cookieJarService = this.bind(CookieJarService)
   private persistenceService: PersistenceService = this.bind(PersistenceService)
@@ -276,8 +278,6 @@ export class NativeInterceptorService extends Service implements Interceptor {
   public clientCertificates = ref<Map<string, ClientCertificateEntry>>(new Map())
   public validateCerts = ref(true)
   public proxyInfo = ref<RequestDef["proxy"]>(undefined)
-
-  public supportsDigestAuth = true
 
   override onServiceInit() {
     // Load SSL Validation


### PR DESCRIPTION
Added inspector warnings for sending binary data via the Agent interceptor.

![2](https://github.com/user-attachments/assets/3b470bf4-7da6-4213-80c4-df5a1273eedc)
![1](https://github.com/user-attachments/assets/0ed9425e-c1fb-4ffb-8846-e295a2e20d57)
