### PR TITLE
chore: add inspection warning for proxy interceptor with binary data

### DIFF
--- a/packages/hoppscotch-common/src/platform/std/interceptors/proxy.ts
+++ b/packages/hoppscotch-common/src/platform/std/interceptors/proxy.ts
@@ -95,6 +95,7 @@ export const proxyInterceptor: Interceptor = {
   interceptorID: "proxy",
   name: (t) => t("settings.proxy"),
   selectable: { type: "selectable" },
+  supportsBinaryContentType: false,
   settingsPageEntry: {
     entryTitle: (t) => t("settings.proxy"),
     component: SettingsProxy,


### PR DESCRIPTION
**Description**

This PR adds binary data content type not supported warning for proxy interceptor.