### PR TITLE
Added versioned entities for Settings and History (REST/GraphQL)

### DIFF
--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -4,6 +4,9 @@ import {
   Environment,
   GlobalEnvironment,
   GlobalEnvironmentVariable,
+  HoppRESTHistory,
+  HoppGQLHistory,
+  Settings,
   translateToNewGQLCollection,
   translateToNewRESTCollection,
 } from "@hoppscotch/data"
@@ -246,7 +249,7 @@ export class PersistenceService extends Service {
 
   private setupSettingsPersistence() {
     const settingsKey = "settings"
-    let settingsData = JSON.parse(
+    let settingsData: Settings = JSON.parse(
       window.localStorage.getItem(settingsKey) ?? "null"
     )
 
@@ -255,9 +258,9 @@ export class PersistenceService extends Service {
     }
 
     // Validate data read from localStorage
-    const result = SETTINGS_SCHEMA.safeParse(settingsData)
-    if (result.success) {
-      settingsData = result.data
+    const result = Settings.safeParse(settingsData)
+    if (result.type === "ok") {
+      settingsData = result.value
     } else {
       this.showErrorToast(settingsKey)
       window.localStorage.setItem(
@@ -281,22 +284,22 @@ export class PersistenceService extends Service {
 
   private setupHistoryPersistence() {
     const restHistoryKey = "history"
-    let restHistoryData = JSON.parse(
+    let restHistoryData: HoppRESTHistory = JSON.parse(
       window.localStorage.getItem(restHistoryKey) || "[]"
     )
 
     const graphqlHistoryKey = "graphqlHistory"
-    let graphqlHistoryData = JSON.parse(
+    let graphqlHistoryData: HoppGQLHistory = JSON.parse(
       window.localStorage.getItem(graphqlHistoryKey) || "[]"
     )
 
     // Validate data read from localStorage
     const restHistorySchemaParsedresult = z
-      .array(REST_HISTORY_ENTRY_SCHEMA)
+      .array(HoppRESTHistory)
       .safeParse(restHistoryData)
 
-    if (restHistorySchemaParsedresult.success) {
-      restHistoryData = restHistorySchemaParsedresult.data
+    if (restHistorySchemaParsedresult.type === "ok") {
+      restHistoryData = restHistorySchemaParsedresult.value
     } else {
       this.showErrorToast(restHistoryKey)
       window.localStorage.setItem(
@@ -306,11 +309,11 @@ export class PersistenceService extends Service {
     }
 
     const gqlHistorySchemaParsedresult = z
-      .array(GQL_HISTORY_ENTRY_SCHEMA)
+      .array(HoppGQLHistory)
       .safeParse(graphqlHistoryData)
 
-    if (gqlHistorySchemaParsedresult.success) {
-      graphqlHistoryData = gqlHistorySchemaParsedresult.data
+    if (gqlHistorySchemaParsedresult === "ok") {
+      graphqlHistoryData = gqlHistorySchemaParsedresult.value
     } else {
       this.showErrorToast(graphqlHistoryKey)
       window.localStorage.setItem(

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -74,6 +74,8 @@ const SettingsDefSchema = z.object({
 
   HAS_OPENED_SPOTLIGHT: z.optional(z.boolean()),
   ENABLE_AI_EXPERIMENTS: z.optional(z.boolean()),
+  EXTENSIONS_ENABLED: z.optional(z.booolean()),
+  PROXY_ENABLED: z.optional(z.boolean()),
 })
 
 const HoppRESTRequestSchema = entityReference(HoppRESTRequest)
@@ -109,10 +111,7 @@ export const LOCAL_STATE_SCHEMA = z.union([
     .strict(),
 ])
 
-export const SETTINGS_SCHEMA = SettingsDefSchema.extend({
-  EXTENSIONS_ENABLED: z.optional(z.boolean()),
-  PROXY_ENABLED: z.optional(z.boolean()),
-})
+export const SETTINGS_SCHEMA = SettingsDefSchema
 
 export const REST_HISTORY_ENTRY_SCHEMA = z
   .object({

--- a/packages/hoppscotch-data/src/history/graphql/index.ts
+++ b/packages/hoppscotch-data/src/history/graphql/index.ts
@@ -1,0 +1,21 @@
+import { InferredEntity, createVersionedEntity } from "verzod"
+import { z } from "zod"
+import V1_VERSION from "./v/1"
+
+const versionedObject = z.object({
+    v: z.number(),
+})
+  
+export const HoppGQLHistory = createVersionedEntity({
+    latestVersion: 1,
+    versionMap: {
+      1: V1_VERSION,
+    },
+    getVersion(data) {
+      const versionCheck = versionedObject.safeParse(data)
+  
+      if (versionCheck.success) return versionCheck.data.v
+    },
+})
+  
+export type HoppGQLHistory = InferredEntity<typeof HoppGQLHistory>

--- a/packages/hoppscotch-data/src/history/graphql/v/1.ts
+++ b/packages/hoppscotch-data/src/history/graphql/v/1.ts
@@ -1,0 +1,21 @@
+import { z } from "zod"
+import { defineVersion, entityReference } from "verzod"
+import { HoppGQLRequest } from "../../../graphql"
+
+const HoppGQLRequestSchema = entityReference(HoppGQLRequest)
+
+export const V1_SCHEMA = z
+    .object({
+        v: z.literal(1),
+        request: HoppGQLRequestSchema,
+        response: z.string(),
+        star: z.boolean(),
+        id: z.optional(z.string()),
+        updatedOn: z.optional(z.union([z.date(), z.string()])),
+      })
+      .strict()
+
+export default defineVersion({
+    initial: true,
+    schema: V1_SCHEMA,
+})

--- a/packages/hoppscotch-data/src/history/rest/index.ts
+++ b/packages/hoppscotch-data/src/history/rest/index.ts
@@ -1,0 +1,21 @@
+import { InferredEntity, createVersionedEntity } from "verzod"
+import { z } from "zod"
+import V1_VERSION from "./v/1"
+
+const versionedObject = z.object({
+  v: z.number(),
+})
+  
+export const HoppRESTHistory = createVersionedEntity({
+  latestVersion: 1,
+  versionMap: {
+    1: V1_VERSION,
+  },
+  getVersion(data) {
+    const versionCheck = versionedObject.safeParse(data)
+  
+    if (versionCheck.success) return versionCheck.data.v
+  },
+})
+  
+export type HoppRESTHistory = InferredEntity<typeof HoppRESTHistory>

--- a/packages/hoppscotch-data/src/history/rest/v/1.ts
+++ b/packages/hoppscotch-data/src/history/rest/v/1.ts
@@ -1,0 +1,26 @@
+import { z } from "zod"
+import { defineVersion, entityReference } from "verzod"
+import { HoppRESTRequest } from "../../../rest"
+
+const HoppRESTRequestSchema = entityReference(HoppRESTRequest)
+
+export const V1_SCHEMA = z
+  .object({
+    v: z.literal(1),
+    request: HoppRESTRequestSchema,
+    responseMeta: z
+      .object({
+        duration: z.nullable(z.number()),
+        statusCode: z.nullable(z.number()),
+      })
+      .strict(),
+    star: z.boolean(),
+    id: z.optional(z.string()),
+    updatedOn: z.optional(z.union([z.date(), z.string()])),
+  })
+  .strict()
+
+export default defineVersion({
+  initial: true,
+  schema: V1_SCHEMA,
+})

--- a/packages/hoppscotch-data/src/settings/index.ts
+++ b/packages/hoppscotch-data/src/settings/index.ts
@@ -1,0 +1,25 @@
+import { InferredEntity, createVersionedEntity } from "verzod"
+import { z } from "zod"
+import V0_VERSION from "./v/0"
+
+const versionedObject = z.object({
+  v: z.number(),
+})
+
+export const Settings = createVersionedEntity({
+  latestVersion: 0,
+  versionMap: {
+    0: V0_VERSION,
+  },
+  getVersion(data) {
+    const versionCheck = versionedObject.safeParse(data)
+
+    if (versionCheck.success) return versionCheck.data.v
+
+    // For V0 we have to check the schema
+    const result = V0_VERSION.schema.safeParse(data)
+    return result.success ? 0 : null
+  },
+})
+
+export type Settings = InferredEntity<typeof Settings>

--- a/packages/hoppscotch-data/src/settings/v/0.ts
+++ b/packages/hoppscotch-data/src/settings/v/0.ts
@@ -1,0 +1,73 @@
+import { z } from "zod"
+import { defineVersion } from "verzod"
+
+const ThemeColorSchema = z.enum([
+  "green",
+  "teal",
+  "blue",
+  "indigo",
+  "purple",
+  "yellow",
+  "orange",
+  "red",
+  "pink",
+])
+
+const BgColorSchema = z.enum(["system", "light", "dark", "black"])
+
+const EncodeMode = z.enum(["enable", "disable", "auto"])
+
+export const V0_SCHEMA = z.object({
+  v: z.literal(0),
+  syncCollections: z.boolean(),
+  syncHistory: z.boolean(),
+  syncEnvironments: z.boolean(),
+  PROXY_URL: z.string(),
+  CURRENT_INTERCEPTOR_ID: z.string(),
+  URL_EXCLUDES: z.object({
+    auth: z.boolean(),
+    httpUser: z.boolean(),
+    httpPassword: z.boolean(),
+    bearerToken: z.boolean(),
+    oauth2Token: z.optional(z.boolean()),
+  }),
+  THEME_COLOR: ThemeColorSchema,
+  BG_COLOR: BgColorSchema,
+  ENCODE_MODE: EncodeMode.catch("enable"),
+  TELEMETRY_ENABLED: z.boolean(),
+  EXPAND_NAVIGATION: z.boolean(),
+  SIDEBAR: z.boolean(),
+  SIDEBAR_ON_LEFT: z.boolean(),
+  COLUMN_LAYOUT: z.boolean(),
+
+  WRAP_LINES: z.optional(
+    z.object({
+      httpRequestBody: z.boolean().catch(true),
+      httpResponseBody: z.boolean().catch(true),
+      httpHeaders: z.boolean().catch(true),
+      httpParams: z.boolean().catch(true),
+      httpUrlEncoded: z.boolean().catch(true),
+      httpPreRequest: z.boolean().catch(true),
+      httpTest: z.boolean().catch(true),
+      httpRequestVariables: z.boolean().catch(true),
+      graphqlQuery: z.boolean().catch(true),
+      graphqlResponseBody: z.boolean().catch(true),
+      graphqlHeaders: z.boolean().catch(false),
+      graphqlVariables: z.boolean().catch(false),
+      graphqlSchema: z.boolean().catch(true),
+      importCurl: z.boolean().catch(true),
+      codeGen: z.boolean().catch(true),
+      cookie: z.boolean().catch(true),
+    })
+  ),
+
+  HAS_OPENED_SPOTLIGHT: z.optional(z.boolean()),
+  ENABLE_AI_EXPERIMENTS: z.optional(z.boolean()),
+  EXTENSIONS_ENABLED: z.optional(z.booolean()),
+  PROXY_ENABLED: z.optional(z.boolean()),
+})
+
+export default defineVersion({
+  initial: true,
+  schema: V0_SCHEMA,
+})


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Addresses #[4160](https://github.com/hoppscotch/hoppscotch/issues/4160)

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This PR adds versioned entities for Settings and History (REST/GraphQL)

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

- Added directories and implemented schemas for the Settings and History versioned entities.

- Updated the implementation to utilize the versioned entity, ensuring the necessary migration is performed to handle the latest version.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

<!-- Any information you feel the reviewer should know about when reviewing your PR -->
