### PR TITLE
HSB-515 fix: read data from DB for latest value

### DIFF
--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -371,10 +371,10 @@ export class InfraConfigService implements OnModuleInit {
    * @returns Either true or an error
    */
   async enableAndDisableSSO(providerInfo: EnableAndDisableSSOArgs[]) {
-    const allowedAuthProviders = this.configService
-      .get<string>('INFRA.VITE_ALLOWED_AUTH_PROVIDERS')
-      .split(',');
+    const infra = await this.get(InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS);
+    if (E.isLeft(infra)) return E.left(infra.left);
 
+    const allowedAuthProviders = infra.right.value.split(',');
     let updatedAuthProviders = allowedAuthProviders;
 
     const infraConfigMap = await this.getInfraConfigsMap();


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HSB-515

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
Currently, data is read from the `ConfigService` to avoid DB calls. But an issue arises, that function is called by different caller functions, where Config Service returns the same data instead of the latest.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Disable SMTP auth and save. Then try to toggle any other SSO and save. If the SSO changes persists then good to go.