### PR TITLE
fix(sh-admin): resolve record retrieval limits in pending invites section by implementing pagination

### DIFF
--- a/packages/hoppscotch-sh-admin/src/components.d.ts
+++ b/packages/hoppscotch-sh-admin/src/components.d.ts
@@ -45,6 +45,7 @@ declare module 'vue' {
     SettingsAuthProvider: typeof import('./components/settings/AuthProvider.vue')['default']
     SettingsConfigurations: typeof import('./components/settings/Configurations.vue')['default']
     SettingsDataSharing: typeof import('./components/settings/DataSharing.vue')['default']
+    SettingsHistoryConfiguration: typeof import('./components/settings/HistoryConfiguration.vue')['default']
     SettingsReset: typeof import('./components/settings/Reset.vue')['default']
     SettingsServerRestart: typeof import('./components/settings/ServerRestart.vue')['default']
     SettingsSmtpConfiguration: typeof import('./components/settings/SmtpConfiguration.vue')['default']

--- a/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/InvitedUsers.graphql
+++ b/packages/hoppscotch-sh-admin/src/helpers/backend/gql/queries/InvitedUsers.graphql
@@ -1,6 +1,6 @@
-query InvitedUsers {
+query InvitedUsers($skip: Int, $take: Int) {
   infra {
-    invitedUsers {
+    invitedUsers(skip: $skip, take: $take) {
       adminUid
       adminEmail
       inviteeEmail

--- a/packages/hoppscotch-sh-admin/src/pages/users/invited.vue
+++ b/packages/hoppscotch-sh-admin/src/pages/users/invited.vue
@@ -156,7 +156,7 @@ const router = useRouter();
 const breakpoints = useBreakpoints(breakpointsTailwind);
 const lgAndLarger = breakpoints.greater('lg');
 
-const invitesPerPage = 4;
+const invitesPerPage = 10;
 const page = ref(1);
 
 // Get Proper Date Formats
@@ -176,7 +176,7 @@ const {
   fetching,
   error,
   refetch,
-  list: invites,
+  list: invitesList,
 } = usePagedQuery(
   InvitedUsersDocument,
   (x) => x.infra.invitedUsers,
@@ -186,7 +186,7 @@ const {
 
 const pendingInvites = ref<InvitedUsersQuery['infra']['invitedUsers']>([]);
 
-const hasNextPage = computed(() => invites.value.length === invitesPerPage);
+const hasNextPage = computed(() => invitesList.value.length === invitesPerPage);
 
 // Get Next Page
 const fetchNextInvites = () => {
@@ -196,23 +196,18 @@ const fetchNextInvites = () => {
 
 // Populate pending invites
 watch(
-  invites,
-  (newList) => {
-    if (!newList) return;
+  invitesList,
+  (newInvitesList) => {
+    if (!newInvitesList) return;
 
-    if (page.value === 1) {
-      // Reset list if it's the first page
-      pendingInvites.value.splice(0, pendingInvites.value.length, ...newList);
-    } else {
-      // Filter out any items that are already in the list
-      const newItems = newList.filter(
-        (newItem) =>
-          !pendingInvites.value.some(
-            (existingItem) => existingItem.inviteeEmail === newItem.inviteeEmail
-          )
-      );
-      pendingInvites.value.push(...newItems);
-    }
+    const newInvites = newInvitesList.filter(
+      (newInvite) =>
+        !pendingInvites.value.some(
+          (existingInvite) =>
+            existingInvite.inviteeEmail === newInvite.inviteeEmail
+        )
+    );
+    pendingInvites.value.push(...newInvites);
   },
   { immediate: true, deep: true }
 );

--- a/packages/hoppscotch-sh-admin/src/pages/users/invited.vue
+++ b/packages/hoppscotch-sh-admin/src/pages/users/invited.vue
@@ -186,14 +186,6 @@ const {
 
 const pendingInvites = ref<InvitedUsersQuery['infra']['invitedUsers']>([]);
 
-const hasNextPage = computed(() => invitesList.value.length === invitesPerPage);
-
-// Get Next Page
-const fetchNextInvites = () => {
-  page.value += 1;
-  refetch({ take: invitesPerPage, skip: (page.value - 1) * invitesPerPage });
-};
-
 // Populate pending invites
 watch(
   invitesList,
@@ -211,6 +203,14 @@ watch(
   },
   { immediate: true, deep: true }
 );
+
+// Pagination
+const hasNextPage = computed(() => invitesList.value.length === invitesPerPage);
+
+const fetchNextInvites = () => {
+  page.value += 1;
+  refetch({ take: invitesPerPage, skip: (page.value - 1) * invitesPerPage });
+};
 
 // Selected Rows
 const selectedRows = ref<InvitedUsersQuery['infra']['invitedUsers']>([]);


### PR DESCRIPTION
### Ticket
- Closes HFE-694

### Description
This PR resolves an issue where the Pending Invites page under the Users section in the Admin Dashboard was only fetching 10 records. The root cause was identified in how the frontend called the relevant query, which defaults to returning a maximum of 10 records unless specified otherwise.
To address this, pagination support is added where the frontend query now explicitly requests the desired number of records and includes additional parameters to enable fetching more data when required. This ensures that the correct number of records is displayed.

### Fix Summary:
- Updated the frontend query to specify the required record count.
- Added pagination support for Pending Invites.

### Checks
<!-- Make sure your pull request passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed