### PR TITLE
build: enable the use of external DB for internal test deployments

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -26,7 +26,9 @@ services:
       context: .
       target: aio
     environment:
-      # - DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch
+      # DATABASE_URL is read from the .env file to allow the backend to connect with an external database.
+      # This allows the backend to retain existing data and prevents database resets during deployments.
+      # DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch
       - ENABLE_SUBPATH_BASED_ACCESS=true
     env_file:
       - ./.env

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -26,7 +26,7 @@ services:
       context: .
       target: aio
     environment:
-      - DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch
+      # - DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch
       - ENABLE_SUBPATH_BASED_ACCESS=true
     env_file:
       - ./.env


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HSB-516

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

The `DATABASE_URL` in the `docker-compose.deploy.yaml` file is commented out. Instead, this environment variable will be read from the `.env` file, allowing us to use a separate database that will not reset on every deployment.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Nil