### PR TITLE
fix: do not show an empty body element when bulk editing

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -803,7 +803,7 @@
     "sync_description": "These settings are synced to cloud.",
     "sync_environments": "Environments",
     "sync_history": "History",
-    "history_disabled": "History is disabled",
+    "history_disabled": "History is disabled. Contact your organization admin to enable history",
     "system_mode": "System",
     "telemetry": "Telemetry",
     "telemetry_helps_us": "Telemetry helps us to personalize our operations and deliver the best experience to you.",

--- a/packages/hoppscotch-common/src/components/http/BodyParameters.vue
+++ b/packages/hoppscotch-common/src/components/http/BodyParameters.vue
@@ -214,7 +214,7 @@
     </div>
 
     <HoppSmartPlaceholder
-      v-if="workingParams.length === 0"
+      v-if="workingParams.length === 0 && !isBulkEditing"
       :src="`/images/states/${colorMode.value}/upload_single_file.svg`"
       :alt="`${t('empty.body')}`"
       :text="t('empty.body')"

--- a/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
+++ b/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
@@ -153,7 +153,7 @@
         </template>
       </draggable>
       <HoppSmartPlaceholder
-        v-if="workingUrlEncodedParams.length === 0"
+        v-if="workingUrlEncodedParams.length === 0 && !isBulkEditing"
         :src="`/images/states/${colorMode.value}/add_category.svg`"
         :alt="`${t('empty.body')}`"
         :text="t('empty.body')"


### PR DESCRIPTION
**Before**

The empty element for no body was visible when bulk editing also.

**After**

This PR removes the empty element for no body when bulk editing