### PR TITLE
fix authorization hierarchy in postman import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -198,7 +198,7 @@ const getVariableValue = (defs: VariableDefinition[], key: string) =>
   defs.find((param) => param.key === key)?.value as string | undefined
 
 const getHoppReqAuth = (hoppAuth: Item["request"]["auth"]): HoppRESTAuth => {
-  if (!hoppAuth) return { authType: "none", authActive: true }
+  if (!hoppAuth) return { authType: "inherit", authActive: true }
 
   // Cast to the type for more stricter checking down the line
   const auth = hoppAuth as unknown as PMRequestAuthDef
@@ -269,7 +269,7 @@ const getHoppReqAuth = (hoppAuth: Item["request"]["auth"]): HoppRESTAuth => {
     }
   }
 
-  return { authType: "none", authActive: true }
+  return { authType: "inherit", authActive: true }
 }
 
 const getHoppReqBody = ({

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -409,8 +409,8 @@ const getHoppRequest = (item: Item): HoppRESTRequest => {
   })
 }
 
-const getHoppFolder = (ig: ItemGroup<Item>): HoppCollection => {
-  return makeCollection({
+const getHoppFolder = (ig: ItemGroup<Item>): HoppCollection =>
+  makeCollection({
     name: ig.name,
     folders: pipe(
       ig.items.all(),
@@ -421,10 +421,9 @@ const getHoppFolder = (ig: ItemGroup<Item>): HoppCollection => {
     auth: getHoppReqAuth(ig.auth),
     headers: [],
   })
-}
 
 export const getHoppCollections = (collections: PMCollection[]) => {
-  return collections.map((coll) => getHoppFolder(coll))
+  return collections.map(getHoppFolder)
 }
 
 export const hoppPostmanImporter = (fileContents: string[]) =>


### PR DESCRIPTION
Closes HFE-718 #4649 

### Overview

This PR addresses an issue where the authorization hierarchy is not correctly transferred when importing collections from Postman. The fix ensures that the proper authorization settings are maintained.

- [ ] Not Completed
- [x] Completed

