### PR TITLE
chore: format collections prior to export

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -2666,7 +2666,7 @@ const initializeDownloadCollection = async (
  */
 const exportData = async (collection: HoppCollection | TeamCollection) => {
   if (collectionsType.value.type === "my-collections") {
-    const collectionJSON = JSON.stringify(collection)
+    const collectionJSON = JSON.stringify(collection, null, 2)
 
     const name = (collection as HoppCollection).name
 
@@ -2685,7 +2685,7 @@ const exportData = async (collection: HoppCollection | TeamCollection) => {
         },
         async (coll) => {
           const hoppColl = teamCollToHoppRESTColl(coll)
-          const collectionJSONString = JSON.stringify(hoppColl)
+          const collectionJSONString = JSON.stringify(hoppColl, null, 2)
 
           await initializeDownloadCollection(
             collectionJSONString,

--- a/packages/hoppscotch-common/src/helpers/backend/helpers.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/helpers.ts
@@ -254,5 +254,5 @@ export const getTeamCollectionJSON = async (teamID: string) => {
   }
 
   const hoppCollections = collections.map(teamCollectionJSONToHoppRESTColl)
-  return E.right(JSON.stringify(hoppCollections))
+  return E.right(JSON.stringify(hoppCollections, null, 2))
 }


### PR DESCRIPTION
### What's changed
I noticed that indentation is used in all methods of exporting data in JSON format. However, there is no such thing when exporting command collections. Fixing it

- [ ] Not Completed
- [x] Completed

