### PR TITLE
chore: add warning prompt for same response name 

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -736,6 +736,7 @@
     "preview_html": "Preview HTML",
     "raw": "Raw",
     "renamed": "Response renamed",
+    "same_name_inspector_warning": "Response name already exists for this request, if saved it will overwrite the existing response",
     "size": "Size",
     "status": "Status",
     "time": "Time",

--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -59,7 +59,7 @@ const showSaveResponseName = ref(false)
 
 const hasSameNameResponse = computed(() => {
   return responseName.value
-    ? !!doc.value.request.responses[responseName.value]
+    ? responseName.value in doc.value.request.responses
     : false
 })
 

--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -10,7 +10,7 @@
   </div>
   <HttpSaveResponseName
     v-model:response-name="responseName"
-    v-model:has-same-name-response="hasSameNameResponse"
+    :has-same-name-response="hasSameNameResponse"
     :show="showSaveResponseName"
     @submit="onSaveAsExample"
     @hide-modal="showSaveResponseName = false"
@@ -19,7 +19,7 @@
 
 <script setup lang="ts">
 import { useVModel } from "@vueuse/core"
-import { computed, ref, watch } from "vue"
+import { computed, ref } from "vue"
 import { HoppRequestDocument } from "~/helpers/rest/document"
 import { useResponseBody } from "@composables/lens-actions"
 import { getStatusCodeReasonPhrase } from "~/helpers/utils/statusCodes"
@@ -55,19 +55,13 @@ const hasResponse = computed(
 )
 
 const responseName = ref("")
-const hasSameNameResponse = ref(false)
 const showSaveResponseName = ref(false)
 
-watch(
-  () => responseName.value,
-  () => {
-    if (doc.value.request.responses[responseName.value]) {
-      hasSameNameResponse.value = true
-    } else {
-      hasSameNameResponse.value = false
-    }
-  }
-)
+const hasSameNameResponse = computed(() => {
+  return responseName.value
+    ? !!doc.value.request.responses[responseName.value]
+    : false
+})
 
 const loading = computed(() => doc.value.response?.type === "loading")
 

--- a/packages/hoppscotch-common/src/components/http/SaveResponseName.vue
+++ b/packages/hoppscotch-common/src/components/http/SaveResponseName.vue
@@ -45,7 +45,7 @@
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
 import { useVModel } from "@vueuse/core"
-import { computed, markRaw, Ref } from "vue"
+import { computed, ComputedRef, markRaw } from "vue"
 import { InspectorResult } from "~/services/inspection"
 import IconAlertTriangle from "~icons/lucide/alert-triangle"
 
@@ -71,34 +71,35 @@ const emit = defineEmits<{
   (e: "submit", name: string): void
   (e: "hide-modal"): void
   (e: "update:responseName", value: string): void
-  (e: "update:hasSameNameResponse", value: boolean): void
 }>()
 
 const editingName = useVModel(props, "responseName")
 
-const hasSameNameInspectionResult: Ref<InspectorResult[]> = computed(() => {
-  if (!props.hasSameNameResponse) return []
+const hasSameNameInspectionResult: ComputedRef<InspectorResult[]> = computed(
+  () => {
+    if (!props.hasSameNameResponse) return []
 
-  return [
-    {
-      id: "same-name-response",
-      severity: 2,
-      icon: markRaw(IconAlertTriangle),
-      isApplicable: true,
-      text: {
-        type: "text",
-        text: t("response.same_name_inspector_warning"),
+    return [
+      {
+        id: "same-name-response",
+        severity: 2,
+        icon: markRaw(IconAlertTriangle),
+        isApplicable: true,
+        text: {
+          type: "text",
+          text: t("response.same_name_inspector_warning"),
+        },
+        doc: {
+          text: t("action.learn_more"),
+          link: "https://docs.hoppscotch.io/documentation",
+        },
+        locations: {
+          type: "url",
+        },
       },
-      doc: {
-        text: t("action.learn_more"),
-        link: "https://docs.hoppscotch.io/documentation",
-      },
-      locations: {
-        type: "url",
-      },
-    },
-  ]
-})
+    ]
+  }
+)
 
 const editRequest = () => {
   if (editingName.value.trim() === "") {

--- a/packages/hoppscotch-common/src/components/http/SaveResponseName.vue
+++ b/packages/hoppscotch-common/src/components/http/SaveResponseName.vue
@@ -91,7 +91,7 @@ const hasSameNameInspectionResult: ComputedRef<InspectorResult[]> = computed(
         },
         doc: {
           text: t("action.learn_more"),
-          link: "https://docs.hoppscotch.io/documentation",
+          link: "https://docs.hoppscotch.io/documentation/getting-started/rest/response-handling#save-a-response-as-an-example",
         },
         locations: {
           type: "url",

--- a/packages/hoppscotch-common/src/components/http/SaveResponseName.vue
+++ b/packages/hoppscotch-common/src/components/http/SaveResponseName.vue
@@ -12,9 +12,14 @@
           class="flex-grow"
           placeholder=" "
           :label="t('action.label')"
-          input-styles="floating-input"
+          input-styles="floating-input !border-0"
+          styles="border border-divider rounded"
           @submit="editRequest"
-        />
+        >
+          <template #button>
+            <AppInspection :inspection-results="hasSameNameInspectionResult" />
+          </template>
+        </HoppSmartInput>
       </div>
     </template>
     <template #footer>
@@ -40,6 +45,9 @@
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
 import { useVModel } from "@vueuse/core"
+import { computed, markRaw, Ref } from "vue"
+import { InspectorResult } from "~/services/inspection"
+import IconAlertTriangle from "~icons/lucide/alert-triangle"
 
 const toast = useToast()
 const t = useI18n()
@@ -48,22 +56,49 @@ const props = withDefaults(
   defineProps<{
     show: boolean
     loadingState?: boolean
-    modelValue?: string
+    responseName?: string
+    hasSameNameResponse?: boolean
   }>(),
   {
     show: false,
     loadingState: false,
-    modelValue: "",
+    responseName: "",
+    hasSameNameResponse: false,
   }
 )
 
 const emit = defineEmits<{
   (e: "submit", name: string): void
   (e: "hide-modal"): void
-  (e: "update:modelValue", value: string): void
+  (e: "update:responseName", value: string): void
+  (e: "update:hasSameNameResponse", value: boolean): void
 }>()
 
-const editingName = useVModel(props, "modelValue")
+const editingName = useVModel(props, "responseName")
+
+const hasSameNameInspectionResult: Ref<InspectorResult[]> = computed(() => {
+  if (!props.hasSameNameResponse) return []
+
+  return [
+    {
+      id: "same-name-response",
+      severity: 2,
+      icon: markRaw(IconAlertTriangle),
+      isApplicable: true,
+      text: {
+        type: "text",
+        text: t("response.same_name_inspector_warning"),
+      },
+      doc: {
+        text: t("action.learn_more"),
+        link: "https://docs.hoppscotch.io/documentation",
+      },
+      locations: {
+        type: "url",
+      },
+    },
+  ]
+})
 
 const editRequest = () => {
   if (editingName.value.trim() === "") {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes HFE-717 #4652 

This PR adds a flow where, when saving a response, the name inside the modal will be prefilled with the request name. Additionally, a warning indicator has been added to the modal input, which notifies the user if they attempt to save the response with a name that already exists for the request. The user can still proceed with saving, but the response will be overwritten with the latest changes.
<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

https://github.com/user-attachments/assets/eb2d7776-5fbe-45c3-b7bb-edbedbd59124
