### PR TITLE
feat: cli add support for  environment variables from process env

### DIFF
--- a/packages/hoppscotch-cli/src/options/test/env.ts
+++ b/packages/hoppscotch-cli/src/options/test/env.ts
@@ -83,6 +83,28 @@ export async function parseEnvsData(options: TestCmdEnvironmentOptions) {
       return variable;
     });
 
+    const hoppEnvPrefix = "HOPP_COL_ENV";
+    const hoppEnvVariables = Object.entries(process.env)
+      .filter(([key]) => key.startsWith(hoppEnvPrefix))
+      .map(([key, value]) => ({
+        key: key.replace(hoppEnvPrefix + "_", ""),
+        value: value || "",
+        secret: false,
+      }));
+
+    const finalEnvVariables = resolvedEnvVariables.map((variable) => {
+      const hoppEnvVariable = hoppEnvVariables.find(
+        (envVar) => envVar.key === variable.key
+      );
+      return hoppEnvVariable ? hoppEnvVariable : variable;
+    });
+
+    hoppEnvVariables.forEach((hoppEnvVariable) => {
+      if (!finalEnvVariables.some((envVar) => envVar.key === hoppEnvVariable.key)) {
+        finalEnvVariables.push(hoppEnvVariable);
+      }
+    });
+
     envPairs.push(...resolvedEnvVariables);
   }
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

I need a way to use environment variables from the OS context at runtime in Hoppscotch CLI. For example, I want to use a variable called "baseurl" in the collection and then dynamically replace this variable in GitLab CI/CD with the URL of the test application deployed in the pipeline by setting the environment variable HOPP_COL_ENV_baseurl

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
