### PR TITLE
Fix schema generation issue on test runner

### DIFF
--- a/packages/hoppscotch-common/src/components/http/ResponseInterface.vue
+++ b/packages/hoppscotch-common/src/components/http/ResponseInterface.vue
@@ -185,6 +185,11 @@ const response = computed(() => {
       if (res?.type === "success" || res?.type === "fail") {
         response = getResponseBodyText(res.body)
       }
+    } else if (doc.type === "test-runner") {
+      const res = doc.request?.response
+      if (res?.type === "success" || res?.type === "fail") {
+        response = getResponseBodyText(res.body)
+      }
     } else {
       const res = doc.response.body
       response = res


### PR DESCRIPTION
Closes HFE-709

Address a schema generation issue by ensuring the response handling for test runner documents is correctly implemented.