### PR TITLE
fix: ensure correct body for application/x-www-form-urlencoded in all code exports

### DIFF
--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -468,6 +468,10 @@ export const resolvesEnvsInBody = (
   if (isJSONContentType(body.contentType))
     bodyContent = stripComments(body.body)
 
+  if (body.contentType === "application/x-www-form-urlencoded") {
+    bodyContent = body.body
+  }
+
   return {
     contentType: body.contentType,
     body: parseTemplateString(bodyContent, env.variables, false, true),


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4690

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
https://github.com/hoppscotch/hoppscotch/blob/e967b3361d0fba3d2b6648af65509bbc1f49aa69/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts#L431-L475 if `body.contentType` is `application/x-www-form-urlencoded`, the processed body is empty string, so I fixed it.
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
