### PR TITLE
fix: cURL header imports without trailing space

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -958,6 +958,48 @@ data2: {"type":"test2","typeId":"123"}`,
       responses: {},
     }),
   },
+  {
+    command: `curl --request GET \
+    --url https://echo.hoppscotch.io/ \
+    --header 'Authorization:Basic YXNkZmdoOjEyMzQ=' \
+    --header 'User-Agent:Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0'
+    --header 'foo:bar'`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://echo.hoppscotch.io/",
+      auth: {
+        authType: "basic",
+        authActive: true,
+        username: "asdfgh",
+        password: "1234",
+      },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      params: [],
+      headers: [
+        {
+          active: true,
+          key: "User-Agent",
+          value:
+            "Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",
+          description: "",
+        },
+        {
+          active: true,
+          key: "foo",
+          value: "bar",
+          description: "",
+        },
+      ],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -11,6 +11,7 @@ import {
 import { tupleToRecord } from "~/helpers/functional/record"
 
 const getHeaderPair = flow(
+  S.replace(":", ": "),
   S.split(": "),
   // must have a key and a value
   O.fromPredicate((arr) => arr.length === 2),


### PR DESCRIPTION
Closes #4707 <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

This PR addresses the issue where cURL headers fail to import when the key-value pairs are separated by a single `":"` (without a trailing space). The fix replaces the first occurrence of `":"` (assumed to be the key-value separator) with `": "` (colon + space), ensuring proper parsing while maintaining support for values that contain colons. This does not introduce any unwanted side effects, as the parser already includes a trim step to handle trailing spaces.

### What's changed
- Updated the header parser to replace the first occurrence of `":"` with `": "` to ensure correct splitting.
- Added a test case to validate the fix.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
I tried other approaches such as using a regex or single `":"` as the separator, but these required additional steps to deal with some other edge cases which turned out to add more complexity to the flow. 