### PR TITLE
fix: properties not inherited while importing from postman

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -200,7 +200,7 @@ const getVariableValue = (defs: VariableDefinition[], key: string) =>
 const getHoppReqAuth = (
   hoppAuth: Item["request"]["auth"] | null
 ): HoppRESTAuth => {
-  if (!hoppAuth) return { authType: "inherit", authActive: false }
+  if (!hoppAuth) return { authType: "inherit", authActive: true }
 
   const auth = hoppAuth as unknown as PMRequestAuthDef
 

--- a/packages/hoppscotch-selfhost-desktop/src/platform/collections/collections.platform.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/platform/collections/collections.platform.ts
@@ -128,13 +128,13 @@ function exportedCollectionToHoppCollection(
       restCollection.data && restCollection.data !== "null"
         ? JSON.parse(restCollection.data)
         : {
-            auth: { authType: "inherit", authActive: false },
+            auth: { authType: "inherit", authActive: true },
             headers: [],
           }
 
     return {
       id: restCollection.id,
-      v: 4,
+      v: 6,
       name: restCollection.name,
       folders: restCollection.folders.map((folder) =>
         exportedCollectionToHoppCollection(folder, collectionType)
@@ -190,13 +190,13 @@ function exportedCollectionToHoppCollection(
       gqlCollection.data && gqlCollection.data !== "null"
         ? JSON.parse(gqlCollection.data)
         : {
-            auth: { authType: "inherit", authActive: false },
+            auth: { authType: "inherit", authActive: true },
             headers: [],
           }
 
     return {
       id: gqlCollection.id,
-      v: 4,
+      v: 6,
       name: gqlCollection.name,
       folders: gqlCollection.folders.map((folder) =>
         exportedCollectionToHoppCollection(folder, collectionType)
@@ -364,7 +364,7 @@ function setupUserCollectionCreatedSubscription() {
           res.right.userCollectionCreated.data != "null"
             ? JSON.parse(res.right.userCollectionCreated.data)
             : {
-                auth: { authType: "inherit", authActive: false },
+                auth: { authType: "inherit", authActive: true },
                 headers: [],
               }
 
@@ -374,7 +374,7 @@ function setupUserCollectionCreatedSubscription() {
                 name: res.right.userCollectionCreated.title,
                 folders: [],
                 requests: [],
-                v: 4,
+                v: 6,
                 auth: data.auth,
                 headers: addDescriptionField(data.headers),
               })
@@ -382,7 +382,7 @@ function setupUserCollectionCreatedSubscription() {
                 name: res.right.userCollectionCreated.title,
                 folders: [],
                 requests: [],
-                v: 4,
+                v: 6,
                 auth: data.auth,
                 headers: addDescriptionField(data.headers),
               })
@@ -591,7 +591,7 @@ function setupUserCollectionDuplicatedSubscription() {
         data && data != "null"
           ? JSON.parse(data)
           : {
-              auth: { authType: "inherit", authActive: false },
+              auth: { authType: "inherit", authActive: true },
               headers: [],
             }
 
@@ -607,7 +607,7 @@ function setupUserCollectionDuplicatedSubscription() {
         name,
         folders,
         requests,
-        v: 4,
+        v: 6,
         auth,
         headers: addDescriptionField(headers),
       }
@@ -1026,7 +1026,7 @@ function transformDuplicatedCollections(
       const { auth, headers } =
         data && data !== "null"
           ? JSON.parse(data)
-          : { auth: { authType: "inherit", authActive: false }, headers: [] }
+          : { auth: { authType: "inherit", authActive: true }, headers: [] }
 
       const folders = transformDuplicatedCollections(childCollectionsJSONStr)
 
@@ -1037,7 +1037,7 @@ function transformDuplicatedCollections(
         name,
         folders,
         requests,
-        v: 4,
+        v: 6,
         auth,
         headers: addDescriptionField(headers),
       }

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/collections.platform.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/collections.platform.ts
@@ -132,7 +132,7 @@ function exportedCollectionToHoppCollection(
       restCollection.data && restCollection.data !== "null"
         ? JSON.parse(restCollection.data)
         : {
-            auth: { authType: "inherit", authActive: false },
+            auth: { authType: "inherit", authActive: true },
             headers: [],
             _ref_id: generateUniqueRefId("coll"),
           }
@@ -196,7 +196,7 @@ function exportedCollectionToHoppCollection(
       gqlCollection.data && gqlCollection.data !== "null"
         ? JSON.parse(gqlCollection.data)
         : {
-            auth: { authType: "inherit", authActive: false },
+            auth: { authType: "inherit", authActive: true },
             headers: [],
             _ref_id: generateUniqueRefId("coll"),
           }
@@ -372,7 +372,7 @@ function setupUserCollectionCreatedSubscription() {
           res.right.userCollectionCreated.data != "null"
             ? JSON.parse(res.right.userCollectionCreated.data)
             : {
-                auth: { authType: "inherit", authActive: false },
+                auth: { authType: "inherit", authActive: true },
                 headers: [],
                 _ref_id: generateUniqueRefId("coll"),
               }
@@ -602,7 +602,7 @@ function setupUserCollectionDuplicatedSubscription() {
         data && data != "null"
           ? JSON.parse(data)
           : {
-              auth: { authType: "inherit", authActive: false },
+              auth: { authType: "inherit", authActive: true },
               headers: [],
             }
       // Duplicated collection will have a unique ref id
@@ -1040,7 +1040,7 @@ function transformDuplicatedCollections(
       const { auth, headers } =
         data && data !== "null"
           ? JSON.parse(data)
-          : { auth: { authType: "inherit", authActive: false }, headers: [] }
+          : { auth: { authType: "inherit", authActive: true }, headers: [] }
 
       const _ref_id = generateUniqueRefId("coll")
 


### PR DESCRIPTION
Closes HFE-744

Follow up of #4686.

This pull request addresses an issue where properties are not being inherited correctly when importing collections from Postman. 

- [ ] Not Completed
- [x] Completed

Additionally, the following updates are brought to collection-level platform definitions under the `hoppscotch-selfhost-web` & `hoppscotch-selfhost-desktop` packages:
  - Ensure `authActive: true` is specified in combination with `authType: "inherit"` while computing authorization data.
  - Resolve type errors.