### PR TITLE
chore: pin pnpm v9 as the package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Hoppscotch (support@hoppscotch.io)",
   "private": true,
   "license": "MIT",
+  "packageManager": "pnpm@9.15.4",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky",

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -40,7 +40,7 @@ ENV HOPP_ALLOW_RUNTIME_ENV=true
 # Required by @hoppscotch/js-sandbox to build `isolated-vm`
 RUN apk add python3 make g++ zlib-dev brotli-dev c-ares-dev nghttp2-dev openssl-dev icu-dev
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9.15.4
 COPY pnpm-lock.yaml .
 RUN pnpm fetch
 
@@ -67,7 +67,7 @@ RUN sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=10.9.2 sh
 # Install caddy
 COPY --from=caddy_builder /tmp/caddy-build/cmd/caddy/caddy /usr/bin/caddy
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9.15.4
 
 COPY --from=base_builder  /usr/src/app/packages/hoppscotch-backend/backend.Caddyfile /etc/caddy/backend.Caddyfile
 COPY --from=backend_builder /dist/backend /dist/backend
@@ -181,7 +181,7 @@ LABEL org.opencontainers.image.source="https://github.com/hoppscotch/hoppscotch"
 
 RUN apk add tini
 
-RUN npm install -g pnpm
+RUN npm install -g pnpm@9.15.4
 
 # Copy necessary files
 # Backend files


### PR DESCRIPTION
This PR intends to pin pnpm v9 (v9.15.4) as the package manager for the Hoppscotch repo.

This is intended as a temporary measure until some issues in pnpm v10 which break the build pipeline are ironed out.
(Follow: https://github.com/orgs/pnpm/discussions/3938#discussioncomment-12050478)

### What's changed
1. Added `packageManager` field pinning the package management to `pnpm@9.15.4`
2. Pin the version of `pnpm` that build dockerfile (prod.Dockerfile) downloads to 9.15.4

### Notes to reviewers
If you get an error when running `pnpm install` saying it couldn't find the given version, it is because that given version isn't installed in your system, you can do that by typing:
```
pnpm add -g pnpm@9.15.4
```
NOTE: This will still retain your existing `pnpm` version, but switch to using `9.15.4` when you are interacting with the repo (due to the `packageManager` field addition)