### PR TITLE
chore: fix typos in `.vue` component files

### DIFF
--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -80,7 +80,7 @@ const props = defineProps({
   },
   isEmbed: {
     type: Boolean,
-    defaul: false,
+    default: false,
   },
   forceColumnLayout: {
     type: Boolean,

--- a/packages/hoppscotch-sh-admin/src/components/teams/Add.vue
+++ b/packages/hoppscotch-sh-admin/src/components/teams/Add.vue
@@ -7,7 +7,7 @@
   >
     <template #body>
       <div class="flex flex-col space-y-4 relative">
-        <div class="flex flex-col relaive">
+        <div class="flex flex-col relative">
           <label for="teamName" class="py-2"> {{ t('teams.email') }} </label>
           <HoppSmartAutoComplete
             type="email"


### PR DESCRIPTION
Found 2 source typos via `codespell -q 3 -D ../dictionary.txt -S "./packages/hoppscotch-common/locales,./pnpm-lock.yaml" -L afterall,atleast,childrens,doesnt,inout,parms,requestd,te`

### What's changed

2 typos corrected

### Notes to reviewers

