### PR TITLE
fix: ensure duplicated headers are mapped to response

### DIFF
--- a/packages/hoppscotch-common/src/helpers/network.ts
+++ b/packages/hoppscotch-common/src/helpers/network.ts
@@ -33,10 +33,13 @@ function processResponse(
     // If multi headers are present, then we can just use that, else fallback to Axios type
     headers:
       res.additional?.multiHeaders ??
-      Object.keys(res.headers).map((x) => ({
-        key: x,
-        value: res.headers[x],
-      })),
+      Object.keys(res.headers).flatMap((key) => {
+        const headerValues = res.headers[key]
+        if (Array.isArray(headerValues)) {
+          return headerValues.map((value) => ({ key, value }))
+        }
+        return { key, value: headerValues }
+      }),
     meta: {
       responseSize: contentLength,
       responseDuration: backupTimeEnd - backupTimeStart,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Related to https://github.com/hoppscotch/hoppscotch/issues/3532#issuecomment-1983491480

When a NetworkResponse has multiple headers with the same key, the old code only retrieved the first header with that key. This is a classic scenario for the set-cookie header, where multiple cookies are often sent.
<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

- Handle NetworkResponse.headers values as possible string[]

