### PR TITLE
fix: request validation issue on load persistence tab

### DIFF
--- a/packages/hoppscotch-common/src/components/http/BodyParameters.vue
+++ b/packages/hoppscotch-common/src/components/http/BodyParameters.vue
@@ -113,8 +113,9 @@
               <HoppSmartFileChip
                 v-for="(file, fileIndex) in entry.value"
                 :key="`param-${index}-file-${fileIndex}`"
-                >{{ file.name }}</HoppSmartFileChip
               >
+                {{ file.name }}
+              </HoppSmartFileChip>
             </div>
           </div>
           <span v-else class="flex flex-1">

--- a/packages/hoppscotch-data/src/rest/v/9.ts
+++ b/packages/hoppscotch-data/src/rest/v/9.ts
@@ -28,6 +28,19 @@ export const FormDataKeyValue = z
       }),
     ])
   )
+  .transform((data) => {
+    // Sample use case about restoring the `value` field in an empty state during page reload
+    // for files chosen in the previous attempt
+    if (data.isFile && Array.isArray(data.value) && data.value.length === 0) {
+      return {
+        ...data,
+        isFile: false,
+        value: "",
+      }
+    }
+
+    return data
+  })
 
 export type FormDataKeyValue = z.infer<typeof FormDataKeyValue>
 

--- a/packages/hoppscotch-data/src/rest/v/9.ts
+++ b/packages/hoppscotch-data/src/rest/v/9.ts
@@ -20,7 +20,7 @@ export const FormDataKeyValue = z
     z.union([
       z.object({
         isFile: z.literal(true),
-        value: z.array(z.instanceof(Blob).nullable()),
+        value: z.array(z.instanceof(Blob).nullable()).catch([]),
       }),
       z.object({
         isFile: z.literal(false),


### PR DESCRIPTION
Closes HFE-761 #2453 #4591

The validation schema has been updated to include error handling for the `Blob` array. The previous implementation:

```javascript
value: z.array(z.instanceof(Blob).nullable())
```

has been replaced with:

```javascript
value: z.array(z.instanceof(Blob).nullable()).catch([])
```

This change ensures that if the validation fails, the result will default to an empty array instead of throwing an error.

- [ ] Not Completed
- [x] Completed

### Notes to reviewers

I would like to highlight that I don't believe a new versioning is necessary for this change, as we have only added a `.catch([])` to handle validation errors. This modification is minor and does not significantly alter the functionality of the schema.

