### PR TITLE
feat: visual enhancement for inactive fields

### DIFF
--- a/packages/hoppscotch-common/src/components/http/BodyParameters.vue
+++ b/packages/hoppscotch-common/src/components/http/BodyParameters.vue
@@ -93,8 +93,8 @@
             />
           </span>
           <SmartEnvInput
-            :class="{ 'opacity-50': !entry.active }"
             v-model="entry.key"
+            :class="{ 'opacity-50': !entry.active }"
             :placeholder="`${t('count.parameter', { count: index + 1 })}`"
             :auto-complete-env="true"
             :envs="envs"
@@ -119,8 +119,8 @@
           </div>
           <span v-else class="flex flex-1">
             <SmartEnvInput
-              :class="{ 'opacity-50': !entry.active }"
               v-model="entry.value"
+              :class="{ 'opacity-50': !entry.active }"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               :auto-complete-env="true"
               :envs="envs"

--- a/packages/hoppscotch-common/src/components/http/BodyParameters.vue
+++ b/packages/hoppscotch-common/src/components/http/BodyParameters.vue
@@ -93,6 +93,7 @@
             />
           </span>
           <SmartEnvInput
+            :class="{ 'opacity-50': !entry.active }"
             v-model="entry.key"
             :placeholder="`${t('count.parameter', { count: index + 1 })}`"
             :auto-complete-env="true"
@@ -118,6 +119,7 @@
           </div>
           <span v-else class="flex flex-1">
             <SmartEnvInput
+              :class="{ 'opacity-50': !entry.active }"
               v-model="entry.value"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               :auto-complete-env="true"

--- a/packages/hoppscotch-common/src/components/http/BodyParameters.vue
+++ b/packages/hoppscotch-common/src/components/http/BodyParameters.vue
@@ -144,6 +144,7 @@
               :auto-complete-env="true"
               :auto-complete-source="autoCompleteContenTypes"
               :envs="envs"
+              :class="{ 'opacity-50': !entry.active }"
               @change="
                 updateBodyParam(index, {
                   key: entry.key,

--- a/packages/hoppscotch-common/src/components/http/KeyValue.vue
+++ b/packages/hoppscotch-common/src/components/http/KeyValue.vue
@@ -19,6 +19,7 @@
       />
     </span>
     <SmartEnvInput
+      :class="{ 'opacity-50': !entityActive }"
       :model-value="name"
       :placeholder="t('count.key')"
       :auto-complete-source="keyAutoCompleteSource"
@@ -37,6 +38,7 @@
       "
     />
     <SmartEnvInput
+      :class="{ 'opacity-50': !entityActive }"
       :model-value="value"
       :placeholder="t('count.value')"
       :auto-complete-env="true"

--- a/packages/hoppscotch-common/src/components/http/KeyValue.vue
+++ b/packages/hoppscotch-common/src/components/http/KeyValue.vue
@@ -61,6 +61,7 @@
       :placeholder="t('count.description')"
       class="flex flex-1 px-4 bg-transparent"
       type="text"
+      :class="{ 'opacity-50': !entityActive }"
       @update:value="emit('update:description', $event.target.value)"
       @input="
         updateEntity(index, {

--- a/packages/hoppscotch-common/src/components/http/RequestVariables.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestVariables.vue
@@ -84,6 +84,7 @@
             <SmartEnvInput
               v-model="variable.key"
               :placeholder="`${t('count.variable', { count: index + 1 })}`"
+              :class="{ 'opacity-50': !variable.active }"
               @change="
                 updateVariable(index, {
                   id: variable.id,
@@ -96,6 +97,7 @@
             <SmartEnvInput
               v-model="variable.value"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
+              :class="{ 'opacity-50': !variable.active }"
               @change="
                 updateVariable(index, {
                   id: variable.id,

--- a/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
+++ b/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
@@ -85,6 +85,7 @@
               />
             </span>
             <SmartEnvInput
+              :class="{ 'opacity-50': !param.active }"
               v-model="param.key"
               :placeholder="`${t('count.parameter', { count: index + 1 })}`"
               :auto-complete-env="true"
@@ -99,6 +100,7 @@
               "
             />
             <SmartEnvInput
+              :class="{ 'opacity-50': !param.active }"
               v-model="param.value"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               :auto-complete-env="true"

--- a/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
+++ b/packages/hoppscotch-common/src/components/http/URLEncodedParams.vue
@@ -85,8 +85,8 @@
               />
             </span>
             <SmartEnvInput
-              :class="{ 'opacity-50': !param.active }"
               v-model="param.key"
+              :class="{ 'opacity-50': !param.active }"
               :placeholder="`${t('count.parameter', { count: index + 1 })}`"
               :auto-complete-env="true"
               :envs="envs"
@@ -100,8 +100,8 @@
               "
             />
             <SmartEnvInput
-              :class="{ 'opacity-50': !param.active }"
               v-model="param.value"
+              :class="{ 'opacity-50': !param.active }"
               :placeholder="`${t('count.value', { count: index + 1 })}`"
               :auto-complete-env="true"
               :envs="envs"


### PR DESCRIPTION
Closes #4750

This pull request addresses the visual representation of inactive entries within the `SmartEnvInput` components for the following cases:

- Query params.
- Request body with content types set to `multipart/form-data` or `application/x-www-form-urlencoded`. 
- Headers
- Request variables.