### PR TITLE
fix: close context menu while scrolling

### DIFF
--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -358,8 +358,8 @@ export function useCodemirror(
           view.requestMeasure()
 
           if (event.target && options.contextMenuEnabled) {
-            // Debounce to make the performance better
-            debouncedTextSelection(30)()
+            // close the context menu when the editor is scrolled
+            closeContextMenu()
           }
         },
       }),


### PR DESCRIPTION
Closes HFE-759 #4754 

This PR fixes the issue where the context menu was attached to the selected text, now the context menu closes while scrolling.

### What's changed

https://github.com/user-attachments/assets/05cfd5a8-d715-4e39-91bb-c61904968b61


