### PR TITLE
fix: typos in packages/hoppscotch-selfhost-desktop

### DIFF
--- a/packages/hoppscotch-selfhost-desktop/src/components/modals/NativeCACertificates.vue
+++ b/packages/hoppscotch-selfhost-desktop/src/components/modals/NativeCACertificates.vue
@@ -47,7 +47,7 @@
         <HoppButtonSecondary
           class="mx-4"
           :icon="IconPlus"
-          :label="'Add Certifcate File'"
+          :label="'Add Certificate File'"
           :loading="selectedFiles && selectedFiles!.length > 0"
           filled
           outline

--- a/packages/hoppscotch-selfhost-desktop/src/components/modals/NativeClientCertsAdd.vue
+++ b/packages/hoppscotch-selfhost-desktop/src/components/modals/NativeClientCertsAdd.vue
@@ -27,7 +27,7 @@
                   :label="
                     pemCert?.type === 'loaded'
                       ? pemCert.filename
-                      : 'Add Certifcate File'
+                      : 'Add Certificate File'
                   "
                   filled
                   outline

--- a/packages/hoppscotch-selfhost-desktop/src/main.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/main.ts
@@ -31,7 +31,7 @@ const headerPaddingTop = ref("0px")
         paddingTop: headerPaddingTop,
         onHeaderAreaClick() {
           if (platform === "Darwin") {
-            // Drag thw window when the user drags the header area
+            // Drag the window when the user drags the header area
             // TODO: Ignore click on headers and fields
             appWindow.startDragging()
           }

--- a/packages/hoppscotch-selfhost-desktop/src/platform/collections/collections.sync.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/platform/collections/collections.sync.ts
@@ -36,7 +36,7 @@ export const restCollectionsMapper = createMapper<string, string>()
 // restRequestsMapper uses the collectionPath/requestIndex as the local identifier
 export const restRequestsMapper = createMapper<string, string>()
 
-// temp implementation untill the backend implements an endpoint that accepts an entire collection
+// temp implementation until the backend implements an endpoint that accepts an entire collection
 // TODO: use importCollectionsJSON to do this
 const recursivelySyncCollections = async (
   collection: HoppCollection,

--- a/packages/hoppscotch-selfhost-desktop/src/platform/collections/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/platform/collections/gqlCollections.sync.ts
@@ -33,7 +33,7 @@ export const gqlCollectionsMapper = createMapper<string, string>()
 // gqlRequestsMapper uses the collectionPath/requestIndex as the local identifier
 export const gqlRequestsMapper = createMapper<string, string>()
 
-// temp implementation untill the backend implements an endpoint that accepts an entire collection
+// temp implementation until the backend implements an endpoint that accepts an entire collection
 // TODO: use importCollectionsJSON to do this
 const recursivelySyncCollections = async (
   collection: HoppCollection,

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/collections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/collections.sync.ts
@@ -40,7 +40,7 @@ export const restCollectionsMapper = createMapper<string, string>()
 // restRequestsMapper uses the collectionPath/requestIndex as the local identifier
 export const restRequestsMapper = createMapper<string, string>()
 
-// temp implementation untill the backend implements an endpoint that accepts an entire collection
+// temp implementation until the backend implements an endpoint that accepts an entire collection
 // TODO: use importCollectionsJSON to do this
 const recursivelySyncCollections = async (
   collection: HoppCollection,

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/gqlCollections.sync.ts
@@ -35,7 +35,7 @@ export const gqlCollectionsMapper = createMapper<string, string>()
 // gqlRequestsMapper uses the collectionPath/requestIndex as the local identifier
 export const gqlRequestsMapper = createMapper<string, string>()
 
-// temp implementation untill the backend implements an endpoint that accepts an entire collection
+// temp implementation until the backend implements an endpoint that accepts an entire collection
 // TODO: use importCollectionsJSON to do this
 const recursivelySyncCollections = async (
   collection: HoppCollection,


### PR DESCRIPTION
### What's changed

User and non-user facing typo fixes

Found via `codespell -q 3 -S "./packages/hoppscotch-common/locales,./pnpm-lock.yaml" -L afterall,atleast,childrens,doesnt,inout,parms,requestd,te`


### Notes to reviewers