### PR TITLE
feat: updated the hard coded proxy url with the server fetched 

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -823,7 +823,7 @@
     "proxy_url": "Proxy URL",
     "proxy_use_toggle": "Use the proxy middleware to send requests",
     "read_the": "Read the",
-    "reset_default": "Reset to default",
+    "reset_default": "Use Default Proxy",
     "short_codes": "Short codes",
     "short_codes_description": "Short codes which were created by you.",
     "sidebar_on_left": "Sidebar on left",

--- a/packages/hoppscotch-common/src/helpers/proxyUrl.ts
+++ b/packages/hoppscotch-common/src/helpers/proxyUrl.ts
@@ -1,0 +1,22 @@
+import { platform } from "~/platform"
+import * as E from "fp-ts/Either"
+
+// Default proxy URL
+export const DEFAULT_HOPP_PROXY_URL = "https://proxy.hoppscotch.io/"
+
+// Get default proxy URL from platform or return default
+export const getDefaultProxyUrl = async () => {
+  const proxyAppUrl = platform?.infra?.getProxyAppUrl
+
+  if (proxyAppUrl) {
+    const res = await proxyAppUrl()
+
+    if (E.isRight(res)) {
+      return res.right.value
+    }
+
+    return DEFAULT_HOPP_PROXY_URL
+  }
+
+  return DEFAULT_HOPP_PROXY_URL
+}

--- a/packages/hoppscotch-common/src/helpers/strategies/AxiosStrategy.ts
+++ b/packages/hoppscotch-common/src/helpers/strategies/AxiosStrategy.ts
@@ -6,6 +6,7 @@ import { cloneDeep } from "lodash-es"
 import { NetworkResponse, NetworkStrategy } from "../network"
 import { decodeB64StringToArrayBuffer } from "../utils/b64"
 import { settingsStore } from "~/newstore/settings"
+import { getDefaultProxyUrl } from "../proxyUrl"
 
 let cancelSource = axios.CancelToken.source()
 
@@ -41,6 +42,8 @@ const getProxyPayload = (
 
   return payload
 }
+
+const defaultProxyURL = await getDefaultProxyUrl()
 
 const preProcessRequest = (req: AxiosRequestConfig): AxiosRequestConfig => {
   const reqClone = cloneDeep(req)
@@ -103,7 +106,7 @@ const axiosWithProxy: NetworkStrategy = (req) =>
       TE.tryCatch(
         () =>
           axios.post(
-            settingsStore.value.PROXY_URL || "https://proxy.hoppscotch.io",
+            settingsStore.value.PROXY_URL || defaultProxyURL,
             payload,
             {
               headers,

--- a/packages/hoppscotch-common/src/newstore/settings.ts
+++ b/packages/hoppscotch-common/src/newstore/settings.ts
@@ -3,6 +3,7 @@ import { Observable } from "rxjs"
 import { distinctUntilChanged, pluck } from "rxjs/operators"
 import type { KeysMatching } from "~/types/ts-utils"
 import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
+import { getDefaultProxyUrl } from "~/helpers/proxyUrl"
 
 export const HoppBgColors = ["system", "light", "dark", "black"] as const
 
@@ -82,6 +83,8 @@ export type SettingsDef = {
   CUSTOM_NAMING_STYLE: string
 }
 
+const defaultProxyURL = await getDefaultProxyUrl()
+
 export const getDefaultSettings = (): SettingsDef => ({
   syncCollections: true,
   syncHistory: true,
@@ -111,7 +114,7 @@ export const getDefaultSettings = (): SettingsDef => ({
   CURRENT_INTERCEPTOR_ID: "",
 
   // TODO: Interceptor related settings should move under the interceptor systems
-  PROXY_URL: "https://proxy.hoppscotch.io/",
+  PROXY_URL: defaultProxyURL,
   URL_EXCLUDES: {
     auth: true,
     httpUser: true,

--- a/packages/hoppscotch-common/src/platform/infra.ts
+++ b/packages/hoppscotch-common/src/platform/infra.ts
@@ -1,5 +1,11 @@
 import * as E from "fp-ts/Either"
 
+type ProxyAppUrl = {
+  value: string
+  name: string
+}
+
 export type InfraPlatformDef = {
   getIsSMTPEnabled?: () => Promise<E.Either<string, boolean>>
+  getProxyAppUrl?: () => Promise<E.Either<string, ProxyAppUrl>>
 }

--- a/packages/hoppscotch-common/src/platform/std/interceptors/proxy.ts
+++ b/packages/hoppscotch-common/src/platform/std/interceptors/proxy.ts
@@ -7,6 +7,7 @@ import axios from "axios"
 import { settingsStore } from "~/newstore/settings"
 import { decodeB64StringToArrayBuffer } from "~/helpers/utils/b64"
 import SettingsProxy from "~/components/settings/Proxy.vue"
+import { getDefaultProxyUrl } from "~/helpers/proxyUrl"
 
 type ProxyHeaders = {
   "multipart-part-key"?: string
@@ -36,6 +37,8 @@ const getProxyPayload = (
   return payload
 }
 
+const defaultProxyURL = await getDefaultProxyUrl()
+
 async function runRequest(
   req: AxiosRequestConfig,
   cancelToken: CancelToken
@@ -55,7 +58,7 @@ async function runRequest(
   try {
     // TODO: Validation for the proxy result
     const { data } = await axios.post(
-      settingsStore.value.PROXY_URL ?? "https://proxy.hoppscotch.io",
+      settingsStore.value.PROXY_URL ?? defaultProxyURL,
       payload,
       {
         headers,


### PR DESCRIPTION
This PR updates the hard coded proxy URL and fetch it from the server if it exist else fall back to the default one.

Dependent on [112](https://github.com/hoppscotch/selfhost-enterprise/pull/112) and [111](https://github.com/hoppscotch/selfhost-enterprise/pull/111)
