### PR TITLE
feat: alphabetical sorting for collection folder requests

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -65,7 +65,8 @@
     "verify": "Verify",
     "yes": "Yes",
     "enable": "Enable",
-    "disable": "Disable"
+    "disable": "Disable",
+    "alphabetical-sort": "Alphabetical Sort"
   },
   "activity_logs": {
     "ACTIVITY_LOG_DELETE": "Activity log has been deleted",

--- a/packages/hoppscotch-common/src/components/collections/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/Collection.vue
@@ -106,6 +106,7 @@
                   @keyup.x="exportAction?.$el.click()"
                   @keyup.p="propertiesAction?.$el.click()"
                   @keyup.t="runCollectionAction?.$el.click()"
+                  @keyup.a="propertiesReorder?.$el.click()"
                   @keyup.escape="hide()"
                 >
                   <HoppSmartItem
@@ -206,6 +207,18 @@
                       }
                     "
                   />
+                  <HoppSmartItem
+                    ref="propertiesReorder"
+                    :icon="IconSort"
+                    :label="t('action.alphabetical-sort')"
+                    :shortcut="['A']"
+                    @click="
+                      () => {
+                        emit('alphabetic-sort')
+                        hide()
+                      }
+                    "
+                  />
                 </div>
               </template>
             </tippy>
@@ -253,6 +266,7 @@ import IconMoreVertical from "~icons/lucide/more-vertical"
 import IconPlaySquare from "~icons/lucide/play-square"
 import IconSettings2 from "~icons/lucide/settings-2"
 import IconTrash2 from "~icons/lucide/trash-2"
+import IconSort from "~icons/lucide/sort-asc"
 
 type CollectionType = "my-collections" | "team-collections"
 type FolderType = "collection" | "folder"
@@ -301,6 +315,7 @@ const emit = defineEmits<{
   (event: "edit-properties"): void
   (event: "duplicate-collection"): void
   (event: "export-data"): void
+  (event: "alphabetic-sort"): void
   (event: "remove-collection"): void
   (event: "drop-event", payload: DataTransfer): void
   (event: "drag-event", payload: DataTransfer): void
@@ -320,6 +335,7 @@ const exportAction = ref<HTMLButtonElement | null>(null)
 const options = ref<TippyComponent | null>(null)
 const propertiesAction = ref<HTMLButtonElement | null>(null)
 const runCollectionAction = ref<HTMLButtonElement | null>(null)
+const propertiesReorder = ref<HTMLButtonElement | null>(null)
 
 const dragging = ref(false)
 const ordering = ref(false)

--- a/packages/hoppscotch-common/src/components/collections/MyCollections.vue
+++ b/packages/hoppscotch-common/src/components/collections/MyCollections.vue
@@ -95,6 +95,11 @@
               node.data.type === 'collections' &&
                 emit('export-data', node.data.data.data)
             "
+            @alphabetic-sort="
+              emit('alphabetic-sort', {
+                collectionIndex: node.id,
+              })
+            "
             @remove-collection="emit('remove-collection', node.id)"
             @drop-event="dropEvent($event, node.id)"
             @drag-event="dragEvent($event, node.id)"
@@ -179,6 +184,11 @@
                   collectionIndex: node.id,
                   collection: node.data.data.data,
                 })
+            "
+            @alphabetic-sort="
+              emit('alphabetic-sort', {
+                collectionIndex: node.id,
+              })
             "
             @export-data="
               node.data.type === 'folders' &&
@@ -558,6 +568,7 @@ const emit = defineEmits<{
   ): void
   (event: "duplicate-response", payload: ResponsePayload): void
   (event: "export-data", payload: HoppCollection): void
+  (event: "alphabetic-sort", payload: { collectionIndex: string }): void
   (event: "remove-collection", payload: string): void
   (event: "remove-folder", payload: string): void
   (

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -55,6 +55,7 @@
       @duplicate-response="duplicateResponse"
       @edit-properties="editProperties"
       @export-data="exportData"
+      @alphabetic-sort="alphabeticSort"
       @remove-collection="removeCollection"
       @remove-folder="removeFolder"
       @remove-request="removeRequest"
@@ -274,6 +275,7 @@ import {
   addRESTCollection,
   addRESTFolder,
   cascadeParentCollectionForHeaderAuth,
+  changeRequestsOrder,
   duplicateRESTCollection,
   editRESTCollection,
   editRESTFolder,
@@ -2696,6 +2698,35 @@ const exportData = async (collection: HoppCollection | TeamCollection) => {
       )
     )()
   }
+}
+
+const alphabeticSort = async (payload: { collectionIndex: string }) => {
+  const collection = navigateToFolderWithIndexPath(
+    myCollections.value,
+    payload.collectionIndex.split("/").map((i) => parseInt(i))
+  )
+  if (!collection) return
+  const requests = JSON.parse(JSON.stringify(collection.requests))
+
+  for (let i = 0; i < requests.length; i++) {
+    requests[i] = {
+      ...requests[i],
+      id: i,
+    }
+  }
+
+  const sortedOrder = Array(requests.length)
+  const sortedRequests = requests.sort(
+    (a: HoppRESTRequest, b: HoppRESTRequest) => {
+      return a.name.localeCompare(b.name)
+    }
+  )
+  for (let i = 0; i < sortedRequests.length; i++) {
+    sortedOrder[sortedRequests[i].id] = i
+  }
+
+  changeRequestsOrder(sortedOrder, payload.collectionIndex)
+  toast.success(`${t("request.order_changed")}`)
 }
 
 const shareRequest = ({ request }: { request: HoppRESTRequest }) => {

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -807,6 +807,40 @@ const restCollectionDispatchers = defineDispatchers({
       state: after,
     }
   },
+
+  updateRequestsSequentialOrder(
+    { state }: RESTCollectionStoreType,
+    {
+      requestIndices,
+      collectionPath,
+    }: {
+      collectionPath: string
+      requestIndices: number[]
+    }
+  ) {
+    const newState = state
+    const indexPaths = collectionPath.split("/").map((x) => parseInt(x))
+
+    if (indexPaths.length === 0) {
+      return {}
+    }
+
+    const targetLocation = navigateToFolderWithIndexPath(newState, indexPaths)
+
+    if (targetLocation === null) {
+      return {}
+    }
+
+    const sortedRequests = requestIndices.map(
+      (index) => targetLocation.requests[index]
+    )
+
+    targetLocation.requests = sortedRequests
+
+    return {
+      state: newState,
+    }
+  },
 })
 
 const gqlCollectionDispatchers = defineDispatchers({
@@ -1471,6 +1505,19 @@ export function updateRESTRequestOrder(
       requestIndex,
       destinationRequestIndex,
       destinationCollectionPath,
+    },
+  })
+}
+
+export function changeRequestsOrder(
+  sortedOrder: number[],
+  collectionPath: string
+) {
+  restCollectionStore.dispatch({
+    dispatcher: "updateRequestsSequentialOrder",
+    payload: {
+      collectionPath,
+      requestIndices: sortedOrder,
     },
   })
 }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4353<!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
Adds the functionality to sort the requests in a particular folder alphabetically. Each collection or folder has a Alphabetical Sort Option, which will sort all the request inside this folder alphabetically.

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
* Added new emit `alphabetic-sort` to Collections. 
* Added a function `alphabeticSort` to sort the requests

![{E611FAF6-0123-4E32-A1F2-EA627E36242E}](https://github.com/user-attachments/assets/d2af0850-6664-4bab-a582-28ec52a381f0)


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
