### PR TITLE
fix: gzip not been able to decode

### DIFF
--- a/packages/hoppscotch-relay/src/lib.rs
+++ b/packages/hoppscotch-relay/src/lib.rs
@@ -13,11 +13,77 @@ pub fn add(left: u64, right: u64) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use tokio_util::sync::CancellationToken;
+    use crate::interop::KeyValuePair;
     use super::*;
 
     #[test]
     fn it_works() {
         let result = add(2, 2);
         assert_eq!(result, 4);
+    }
+
+    #[test]
+    fn test_gzip_encoding() {
+        let request = RequestWithMetadata::new(
+            1,                    // Request ID
+            "GET".to_string(),    // Method
+            "https://echo.hoppscotch.io".to_string(), // Endpoint
+            vec![                 // Headers
+                                  KeyValuePair {
+                                      key: "Accept-Encoding".to_string(),
+                                      value: "gzip".to_string(),
+                                  }
+            ],
+            None,                 // Body
+            true,                 // Validate certificates
+            vec![],              // Root certificate bundles
+            None,                // Client certificate
+            None,                // Proxy configuration
+        );
+
+        // Execute the request with cancellation support
+        let cancel_token = CancellationToken::new();
+        let response = run_request_task(&request, cancel_token).unwrap();
+        let response_data = String::from_utf8_lossy(&response.data);
+
+        println!("Status: {}", response.status_text);
+        println!("Response time: {}ms", response.time_end_ms - response.time_start_ms);
+
+        println!("{}", response_data);
+
+        assert!(response_data.contains("\"accept-encoding\": \"gzip\""))
+    }
+
+    #[test]
+    fn test_deflate_encoding() {
+        let request = RequestWithMetadata::new(
+            1,                    // Request ID
+            "GET".to_string(),    // Method
+            "https://echo.hoppscotch.io".to_string(), // Endpoint
+            vec![                 // Headers
+                                  KeyValuePair {
+                                      key: "Accept-Encoding".to_string(),
+                                      value: "deflate".to_string(),
+                                  }
+            ],
+            None,                 // Body
+            true,                 // Validate certificates
+            vec![],              // Root certificate bundles
+            None,                // Client certificate
+            None,                // Proxy configuration
+        );
+
+        // Execute the request with cancellation support
+        let cancel_token = CancellationToken::new();
+        let response = run_request_task(&request, cancel_token).unwrap();
+        let response_data = String::from_utf8_lossy(&response.data);
+
+        println!("Status: {}", response.status_text);
+        println!("Response time: {}ms", response.time_end_ms - response.time_start_ms);
+
+        println!("{}", response_data);
+
+        assert!(response_data.contains("\"accept-encoding\": \"deflate\""))
     }
 }

--- a/packages/hoppscotch-relay/src/relay.rs
+++ b/packages/hoppscotch-relay/src/relay.rs
@@ -28,6 +28,20 @@ pub fn run_request_task(
 
     let mut curl_handle = Easy::new();
 
+    // Set identity for default fallback
+    match curl_handle.accept_encoding("identity") {
+        Ok(_) => log::debug!("Fallback to identity encoding"),
+        Err(err) => {
+            log::error!(
+                "Critical failure enabling fallback encoding identity: {}
+                \nError details: {:?}",
+                err,
+                err
+            );
+            return Err(RelayError::RequestRunError(err.description().to_string()));
+        }
+    }
+
     for header in &req.headers {
         if header.key.to_lowercase() == "accept-encoding" {
             let encoding = header.value.to_lowercase();

--- a/packages/hoppscotch-relay/src/relay.rs
+++ b/packages/hoppscotch-relay/src/relay.rs
@@ -28,20 +28,6 @@ pub fn run_request_task(
 
     let mut curl_handle = Easy::new();
 
-    // Set identity for default fallback
-    match curl_handle.accept_encoding("identity") {
-        Ok(_) => log::debug!("Fallback to identity encoding"),
-        Err(err) => {
-            log::error!(
-                "Critical failure enabling fallback encoding identity: {}
-                \nError details: {:?}",
-                err,
-                err
-            );
-            return Err(RelayError::RequestRunError(err.description().to_string()));
-        }
-    }
-
     for header in &req.headers {
         if header.key.to_lowercase() == "accept-encoding" {
             let encoding = header.value.to_lowercase();


### PR DESCRIPTION
Closes # https://github.com/hoppscotch/hoppscotch/issues/4387

Set option accept_encoding on curl_handler so curl can decode gzip and deflate

### What's changed
Added test_gzip_encoding
Added test_deflate_encoding
Added curl_handle.accept_encoding(enc)

### Notes to reviewers
The project didn't have any tests, so the ones I added could be improved
Also is the library currently supported encoding are identity, zlib, and gzip. 
https://docs.rs/curl/latest/curl/easy/struct.Easy2.html#method.accept_encoding
