### PR TITLE
Remove decodeURIComponent allowing encoded chars

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
@@ -126,7 +126,7 @@ export const parseCurlCommand = (curlCommand: string) => {
     hasBodyBeenParsed = true
   }
 
-  const urlString = decodeURIComponent(concatParams(urlObject, danglingParams))
+  const urlString = concatParams(urlObject, danglingParams)
 
   let multipartUploads: Record<string, string> = pipe(
     O.of(parsedArguments),


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes https://github.com/hoppscotch/hoppscotch/issues/4769

Some apis may use encoded chars in theirs endpoints, if I'm importing a command is expected that it remain the same without any changes in the request scope


### What's changed
Removed decodeURIComponent from curlParser;

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
This PR do not fix the code generation because code generation is another repository

