### PR TITLE
fix(desktop): change updater endpoint and some UX improvements

### DIFF
--- a/packages/hoppscotch-desktop/src-tauri/src/lib.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/lib.rs
@@ -31,13 +31,6 @@ pub fn run() {
         })
         .setup(|app| {
             let handle = app.handle().clone();
-            tauri::async_runtime::spawn(async move {
-                updater::check_and_install_updates(&handle).await;
-            });
-            Ok(())
-        })
-        .setup(|app| {
-            let handle = app.handle().clone();
             tracing::info!(app_name = %app.package_info().name, "Configuring deep link handler");
 
             app.deep_link().on_open_url(move |event| {
@@ -78,7 +71,8 @@ pub fn run() {
         .plugin(tauri_plugin_relay::init())
         .invoke_handler(tauri::generate_handler![
             hopp_auth_port,
-            updater::check_updates_and_wait
+            updater::check_updates_available,
+            updater::install_updates_and_restart
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/packages/hoppscotch-desktop/src-tauri/src/updater.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/updater.rs
@@ -2,19 +2,40 @@ use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_updater::UpdaterExt;
 
 #[tauri::command]
-pub async fn check_updates_and_wait(app: tauri::AppHandle) -> Result<String, String> {
-    check_and_install_updates(&app).await;
-    Ok("Update check completed".to_string())
-}
-
-pub async fn check_and_install_updates(app: &tauri::AppHandle) {
+pub async fn check_updates_available(app: tauri::AppHandle) -> Result<bool, String> {
     tracing::info!("Checking for updates...");
-
     let updater = match app.updater() {
         Ok(updater) => updater,
         Err(e) => {
             tracing::error!(error = %e, "Failed to initialize updater");
-            return;
+            return Ok(false);
+        }
+    };
+
+    match updater.check().await {
+        Ok(Some(_update)) => {
+            tracing::info!("Update available");
+            Ok(true)
+        }
+        Ok(None) => {
+            tracing::info!("No updates available");
+            Ok(false)
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to check for updates");
+            Err(format!("Failed to check for updates: {}", e))
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn install_updates_and_restart(app: tauri::AppHandle) -> Result<(), String> {
+    tracing::info!("Installing updates...");
+    let updater = match app.updater() {
+        Ok(updater) => updater,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to initialize updater");
+            return Err(format!("Failed to initialize updater: {}", e));
         }
     };
 
@@ -23,7 +44,7 @@ pub async fn check_and_install_updates(app: &tauri::AppHandle) {
             tracing::info!(
                 current_version = app.package_info().version.to_string(),
                 update_version = update.version.to_string(),
-                "Update available"
+                "Installing update"
             );
 
             let dialog = app.dialog();
@@ -40,32 +61,35 @@ pub async fn check_and_install_updates(app: &tauri::AppHandle) {
 
             if should_update {
                 tracing::info!("User agreed to update, starting download...");
-
                 match update.download_and_install(|_, _| {}, || {}).await {
                     Ok(_) => {
                         tracing::info!("Update installed successfully, restarting app");
                         app.restart();
+                        Err("Unreachable - app should have restarted".to_string())
                     }
                     Err(e) => {
                         tracing::error!(error = %e, "Failed to download or install update");
-
                         let _ = app
                             .dialog()
                             .message(format!("Failed to install update: {}", e))
                             .title("Update Error")
                             .kind(tauri_plugin_dialog::MessageDialogKind::Error)
                             .blocking_show();
+                        Err(format!("Failed to download or install update: {}", e))
                     }
                 }
             } else {
                 tracing::info!("User declined the update");
+                Ok(())
             }
         }
         Ok(None) => {
             tracing::info!("No updates available");
+            Ok(())
         }
         Err(e) => {
             tracing::error!(error = %e, "Failed to check for updates");
+            Err(format!("Failed to check for updates: {}", e))
         }
     }
 }

--- a/packages/hoppscotch-desktop/src-tauri/tauri.conf.json
+++ b/packages/hoppscotch-desktop/src-tauri/tauri.conf.json
@@ -56,7 +56,7 @@
   "plugins": {
     "updater": {
       "active": true,
-      "endpoints": ["https://releases.hoppscotch.com/hoppscotch-desktop.json"],
+      "endpoints": ["https://releases.hoppscotch.com/hoppscotch-selfhost-desktop.json"],
       "dialog": true,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDYwOURFNEY4RDRGMDQxNTgKUldSWVFmRFUrT1NkWUc1RDM0Z2ZjTHE2dG52Q3ZlYzg3ZXVpZU9KaENPWTBMd3MwY0hWa1lreDcK"
     }

--- a/packages/hoppscotch-desktop/src/App.vue
+++ b/packages/hoppscotch-desktop/src/App.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="flex h-screen overflow-hidden bg-primary text-secondary">
-    <LayoutSidebar v-model:expanded="sidebarExpanded" v-model:open="sidebarOpen" />
     <div class="flex-1 flex flex-col overflow-hidden">
       <main class="flex-1 overflow-y-auto bg-primary">
         <div class="container mx-auto flex items-center justify-center">
@@ -15,10 +14,5 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue"
 import { Toaster } from "@hoppscotch/ui"
-import LayoutSidebar from "~/components/layout/LayoutSidebar.vue"
-
-const sidebarOpen = ref(false)
-const sidebarExpanded = ref(true)
 </script>

--- a/packages/hoppscotch-desktop/src/components.d.ts
+++ b/packages/hoppscotch-desktop/src/components.d.ts
@@ -8,7 +8,7 @@ export {}
 declare module 'vue' {
   export interface GlobalComponents {
     HoppButtonPrimary: typeof import('@hoppscotch/ui')['HoppButtonPrimary']
-    HoppSmartItem: typeof import('@hoppscotch/ui')['HoppSmartItem']
+    HoppSmartSpinner: typeof import('@hoppscotch/ui')['HoppSmartSpinner']
     LayoutHeader: typeof import('./components/layout/LayoutHeader.vue')['default']
     LayoutSidebar: typeof import('./components/layout/LayoutSidebar.vue')['default']
     Tippy: typeof import('vue-tippy')['Tippy']


### PR DESCRIPTION
PR changes updater endpoint from Cloud to SelfHosted, has a few minor UX improvements around stalling updates not notifying (typically happens when network is down or endpoint is inaccessible) 