### PR TITLE
fix(desktop): cache size for larger bundles, dev server, lints

### DIFF
--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/cache/mod.rs
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/cache/mod.rs
@@ -8,5 +8,5 @@ pub use manager::CacheManager;
 pub use policy::CachePolicy;
 pub use store::FileStore;
 
-pub const DEFAULT_CACHE_SIZE: usize = 100 * 1024 * 1024; // 100MB
+pub const DEFAULT_CACHE_SIZE: usize = 1000 * 1024 * 1024; // 1000MB
 pub const DEFAULT_FILE_TTL: u64 = 3600; // 1 hour

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.lock
@@ -4970,7 +4970,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-appload"
 version = "0.1.0"
-source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload#2faadf6528d175f0fe3a0861bcda2025030b856b"
+source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload#e44d90aefb8d930044643b41fa1ce739e49d456c"
 dependencies = [
  "base64 0.22.1",
  "blake3",

--- a/packages/hoppscotch-desktop/src-tauri/tauri.conf.json
+++ b/packages/hoppscotch-desktop/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "io.hoppscotch.desktop",
   "build": {
     "beforeDevCommand": "pnpm dev",
-    "devUrl": "http://localhost:1420",
+    "devUrl": "http://127.0.0.1:1420",
     "beforeBuildCommand": "pnpm build",
     "frontendDist": "../dist"
   },

--- a/packages/hoppscotch-desktop/vite.config.ts
+++ b/packages/hoppscotch-desktop/vite.config.ts
@@ -65,7 +65,7 @@ export default defineConfig(async () => ({
   server: {
     port: 1420,
     strictPort: true,
-    host: host || false,
+    host: '127.0.0.1',
     hmr: host
       ? {
         protocol: "ws",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -516,7 +516,7 @@ importers:
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
         specifier: github:CuriousCorrelation/tauri-plugin-appload
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/2faadf6528d175f0fe3a0861bcda2025030b856b'
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e44d90aefb8d930044643b41fa1ce739e49d456c'
       '@hoppscotch/ui':
         specifier: 0.2.2
         version: 0.2.2(eslint@8.57.0)(terser@5.34.1)(typescript@5.3.3)(vite@5.4.9(@types/node@22.9.3)(sass@1.79.5)(terser@5.34.1))(vue@3.5.12(typescript@5.3.3))
@@ -974,7 +974,7 @@ importers:
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
         specifier: github:CuriousCorrelation/tauri-plugin-appload
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/2faadf6528d175f0fe3a0861bcda2025030b856b'
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e44d90aefb8d930044643b41fa1ce739e49d456c'
       '@hoppscotch/ui':
         specifier: 0.2.1
         version: 0.2.1(eslint@9.12.0(jiti@2.3.3))(terser@5.34.1)(typescript@5.7.2)(vite@5.4.11(@types/node@22.9.3)(sass@1.80.3)(terser@5.34.1))(vue@3.5.12(typescript@5.7.2))
@@ -1796,8 +1796,8 @@ packages:
       graphql:
         optional: true
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/2faadf6528d175f0fe3a0861bcda2025030b856b':
-    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/2faadf6528d175f0fe3a0861bcda2025030b856b}
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e44d90aefb8d930044643b41fa1ce739e49d456c':
+    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e44d90aefb8d930044643b41fa1ce739e49d456c}
     version: 0.1.0
 
   '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/bbf25139962fd59b6e0c09f2a8034df29ac10bdf':
@@ -13151,7 +13151,7 @@ snapshots:
     optionalDependencies:
       graphql: 16.9.0
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/2faadf6528d175f0fe3a0861bcda2025030b856b':
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e44d90aefb8d930044643b41fa1ce739e49d456c':
     dependencies:
       '@tauri-apps/api': 2.1.1
 


### PR DESCRIPTION
This PR changes how dev server is setup to fix local DNS resolution issue on MacOS after the recent update, increases cache size for LRU hot-cache since the expected bundle size has grown since the latest merge which triggers cache eviction that degrades performance, eviction was purely meant as a fail safe so it being triggered often is not ideal. Also fixes HoppSpinner being missing on launch.