### PR TITLE
fix(common): `PersistenceService` call site compat

### DIFF
--- a/packages/hoppscotch-common/src/services/persistence/__tests__/index.spec.ts
+++ b/packages/hoppscotch-common/src/services/persistence/__tests__/index.spec.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-restricted-globals, no-restricted-syntax */
 
+import * as E from "fp-ts/Either"
+
 import {
   translateToNewGQLCollection,
   translateToNewRESTCollection,
@@ -1868,6 +1870,60 @@ describe("PersistenceService", () => {
 
     await service.setLocalConfig(testKey, testValue)
     await service.removeLocalConfig(testKey)
+
+    expect(setItemSpy).toHaveBeenCalledWith(
+      `${STORE_NAMESPACE}:${testKey}`,
+      expect.stringContaining(testValue)
+    )
+    expect(removeItemSpy).toHaveBeenCalledWith(`${STORE_NAMESPACE}:${testKey}`)
+  })
+
+  it("`set` method sets a value in localStorage", async () => {
+    const testKey = "temp"
+    const testValue = "test-value"
+
+    const setItemSpy = spyOnSetItem()
+
+    const service = bindPersistenceService()
+
+    await service.set(testKey, testValue)
+    expect(setItemSpy).toHaveBeenCalledWith(
+      `${STORE_NAMESPACE}:${testKey}`,
+      expect.stringContaining(testValue)
+    )
+  })
+
+  it("`get` method gets a value from localStorage", async () => {
+    const testKey = "temp"
+    const testValue = "test-value"
+
+    const setItemSpy = spyOnSetItem()
+    const getItemSpy = spyOnGetItem()
+
+    const service = bindPersistenceService()
+
+    await service.set(testKey, testValue)
+    const retrievedValue = await service.get(testKey)
+
+    expect(setItemSpy).toHaveBeenCalledWith(
+      `${STORE_NAMESPACE}:${testKey}`,
+      expect.stringContaining(testValue)
+    )
+    expect(getItemSpy).toHaveBeenCalledWith(`${STORE_NAMESPACE}:${testKey}`)
+    expect(retrievedValue).toStrictEqual(E.right(testValue))
+  })
+
+  it("`remove` method clears a value in localStorage", async () => {
+    const testKey = "temp"
+    const testValue = "test-value"
+
+    const setItemSpy = spyOnSetItem()
+    const removeItemSpy = spyOnRemoveItem()
+
+    const service = bindPersistenceService()
+
+    await service.set(testKey, testValue)
+    await service.remove(testKey)
 
     expect(setItemSpy).toHaveBeenCalledWith(
       `${STORE_NAMESPACE}:${testKey}`,

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -915,7 +915,10 @@ export class PersistenceService extends Service {
   }
 
   /**
-   * Gets a value from persistence
+   * Gets a typed value from persistence, deserialization is automatic.
+   * No need to use JSON.parse on the result, it's handled internally by the store.
+   * @param key The key to retrieve
+   * @returns Either containing the typed value or an error
    */
   public async get<T>(
     key: (typeof STORE_KEYS)[keyof typeof STORE_KEYS]
@@ -924,9 +927,11 @@ export class PersistenceService extends Service {
   }
 
   /**
-   * Gets a value from persistence, discards error
-   * NOTE: Use this cautiously, try to always use `get`,
-   *       handling error at call site is better
+   * Gets a value from persistence, discards error and returns null on failure.
+   * No need to use JSON.parse on the result, it's handled internally by the store.
+   * NOTE: Use this cautiously, try to always use `get`, handling error at call site is better
+   * @param key The key to retrieve
+   * @returns The typed value or null if not found or on error
    */
   public async getNullable<T>(
     key: (typeof STORE_KEYS)[keyof typeof STORE_KEYS]
@@ -939,7 +944,11 @@ export class PersistenceService extends Service {
   }
 
   /**
-   * Gets a value from persistence
+   * Gets a value from local config
+   * @deprecated Use get<T>() instead which provides automatic deserialization and type safety.
+   * With get<T>(), there's no need to use JSON.parse on the result.
+   * @param name The name of the config to retrieve
+   * @returns The config value as string, null or undefined
    */
   public async getLocalConfig(
     name: string
@@ -952,7 +961,11 @@ export class PersistenceService extends Service {
   }
 
   /**
-   * Sets a value in persistence
+   * Sets a value in persistence with proper type safety and automatic serialization.
+   * No need to use JSON.stringify on the value, it's handled internally by the store.
+   * @param key The key to set
+   * @param value The value to set (passed directly without manual serialization)
+   * @returns Either containing void or an error
    */
   public async set<T>(
     key: (typeof STORE_KEYS)[keyof typeof STORE_KEYS],
@@ -963,6 +976,10 @@ export class PersistenceService extends Service {
 
   /**
    * Sets a value in persistence
+   * @deprecated Use set<T>() instead which provides automatic serialization and type safety.
+   * With set<T>(), there's no need to use JSON.stringify on the value before passing it.
+   * @param key The key to set
+   * @param value The value to set as string
    */
   public async setLocalConfig(key: string, value: string): Promise<void> {
     await Store.set(STORE_NAMESPACE, key, value)
@@ -970,6 +987,8 @@ export class PersistenceService extends Service {
 
   /**
    * Clear config value from persistence
+   * @param key The key to remove
+   * @returns Either containing boolean or an error
    */
   public async remove(
     key: (typeof STORE_KEYS)[keyof typeof STORE_KEYS]
@@ -979,6 +998,8 @@ export class PersistenceService extends Service {
 
   /**
    * Clear config value from persistence
+   * @deprecated Use remove() instead which provides proper error handling and type safety.
+   * @param key The key to remove
    */
   public async removeLocalConfig(key: string): Promise<void> {
     await Store.remove(STORE_NAMESPACE, key)

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -197,9 +197,8 @@ export class PersistenceService extends Service {
       STORE_NAMESPACE,
       STORE_KEYS.SCHEMA_VERSION
     )
-    const currentVersion = E.isRight(versionResult)
-      ? versionResult.right || "0"
-      : "0"
+    const perhapsVersion = E.isRight(versionResult) ? versionResult.right : "0"
+    const currentVersion = perhapsVersion ?? "0"
     const targetVersion = "1"
 
     if (currentVersion !== targetVersion) {
@@ -918,6 +917,30 @@ export class PersistenceService extends Service {
   /**
    * Gets a value from persistence
    */
+  public async get<T>(
+    key: (typeof STORE_KEYS)[keyof typeof STORE_KEYS]
+  ): Promise<E.Either<StoreError, T | undefined>> {
+    return await Store.get<T>(STORE_NAMESPACE, key)
+  }
+
+  /**
+   * Gets a value from persistence, discards error
+   * NOTE: Use this cautiously, try to always use `get`,
+   *       handling error at call site is better
+   */
+  public async getNullable<T>(
+    key: (typeof STORE_KEYS)[keyof typeof STORE_KEYS]
+  ): Promise<T | null> {
+    const r = await Store.get<T>(STORE_NAMESPACE, key)
+
+    if (E.isLeft(r)) return null
+
+    return r.right ?? null
+  }
+
+  /**
+   * Gets a value from persistence
+   */
   public async getLocalConfig(
     name: string
   ): Promise<string | null | undefined> {
@@ -931,8 +954,27 @@ export class PersistenceService extends Service {
   /**
    * Sets a value in persistence
    */
+  public async set<T>(
+    key: (typeof STORE_KEYS)[keyof typeof STORE_KEYS],
+    value: T
+  ): Promise<E.Either<StoreError, void>> {
+    return await Store.set(STORE_NAMESPACE, key, value)
+  }
+
+  /**
+   * Sets a value in persistence
+   */
   public async setLocalConfig(key: string, value: string): Promise<void> {
     await Store.set(STORE_NAMESPACE, key, value)
+  }
+
+  /**
+   * Clear config value from persistence
+   */
+  public async remove(
+    key: (typeof STORE_KEYS)[keyof typeof STORE_KEYS]
+  ): Promise<E.Either<StoreError, boolean>> {
+    return await Store.remove(STORE_NAMESPACE, key)
   }
 
   /**

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -4,7 +4,7 @@ import * as E from "fp-ts/Either"
 import { z } from "zod"
 
 import { Service } from "dioc"
-import { watchDebounced } from "@vueuse/core"
+import { StorageLike, watchDebounced } from "@vueuse/core"
 import { assign, clone, isEmpty } from "lodash-es"
 
 import {
@@ -166,6 +166,9 @@ const migrations: Migration[] = [
  */
 export class PersistenceService extends Service {
   public static readonly ID = "PERSISTENCE_SERVICE"
+
+  // TODO: Consider swapping this with platform dependent `StoreLike` impl
+  public hoppLocalConfigStorage: StorageLike = localStorage
 
   private readonly restTabService = this.bind(RESTTabService)
   private readonly gqlTabService = this.bind(GQLTabService)

--- a/packages/hoppscotch-common/src/services/tab/graphql.ts
+++ b/packages/hoppscotch-common/src/services/tab/graphql.ts
@@ -46,7 +46,9 @@ export class GQLTabService extends TabService<HoppGQLDocument> {
 
   protected async loadPersistedState(): Promise<PersistableTabState<HoppGQLDocument> | null> {
     const persistenceService = getService(PersistenceService)
-    const savedState = await persistenceService.getNullable<PersistableTabState<HoppGQLDocument>>(STORE_KEYS.GQL_TABS)
+    const savedState = await persistenceService.getNullable<
+      PersistableTabState<HoppGQLDocument>
+    >(STORE_KEYS.GQL_TABS)
     return savedState
   }
 

--- a/packages/hoppscotch-common/src/services/tab/graphql.ts
+++ b/packages/hoppscotch-common/src/services/tab/graphql.ts
@@ -5,7 +5,7 @@ import { TabService } from "./tab"
 import { computed } from "vue"
 import { Container } from "dioc"
 import { getService } from "~/modules/dioc"
-import { PersistenceService } from "../persistence"
+import { PersistenceService, STORE_KEYS } from "../persistence"
 import { PersistableTabState } from "."
 
 export class GQLTabService extends TabService<HoppGQLDocument> {
@@ -46,16 +46,8 @@ export class GQLTabService extends TabService<HoppGQLDocument> {
 
   protected async loadPersistedState(): Promise<PersistableTabState<HoppGQLDocument> | null> {
     const persistenceService = getService(PersistenceService)
-    const savedState = await persistenceService.getLocalConfig("gqlTabs")
-
-    if (savedState) {
-      try {
-        return JSON.parse(savedState) as PersistableTabState<HoppGQLDocument>
-      } catch {
-        return null
-      }
-    }
-    return null
+    const savedState = await persistenceService.getNullable<PersistableTabState<HoppGQLDocument>>(STORE_KEYS.GQL_TABS)
+    return savedState
   }
 
   public getTabRefWithSaveContext(ctx: HoppGQLSaveContext) {

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -65,7 +65,9 @@ export class RESTTabService extends TabService<HoppTabDocument> {
 
   protected async loadPersistedState(): Promise<PersistableTabState<HoppTabDocument> | null> {
     const persistenceService = getService(PersistenceService)
-    const savedState = await persistenceService.getNullable<PersistableTabState<HoppTabDocument>>(STORE_KEYS.REST_TABS)
+    const savedState = await persistenceService.getNullable<
+      PersistableTabState<HoppTabDocument>
+    >(STORE_KEYS.REST_TABS)
     return savedState
   }
 

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -4,7 +4,7 @@ import { computed } from "vue"
 import { getDefaultRESTRequest } from "~/helpers/rest/default"
 import { HoppRESTSaveContext, HoppTabDocument } from "~/helpers/rest/document"
 import { getService } from "~/modules/dioc"
-import { PersistenceService } from "../persistence"
+import { PersistenceService, STORE_KEYS } from "../persistence"
 import { TabService } from "./tab"
 import { PersistableTabState } from "."
 
@@ -65,16 +65,8 @@ export class RESTTabService extends TabService<HoppTabDocument> {
 
   protected async loadPersistedState(): Promise<PersistableTabState<HoppTabDocument> | null> {
     const persistenceService = getService(PersistenceService)
-    const savedState = await persistenceService.getLocalConfig("restTabs")
-
-    if (savedState) {
-      try {
-        return JSON.parse(savedState) as PersistableTabState<HoppTabDocument>
-      } catch {
-        return null
-      }
-    }
-    return null
+    const savedState = await persistenceService.getNullable<PersistableTabState<HoppTabDocument>>(STORE_KEYS.REST_TABS)
+    return savedState
   }
 
   public getTabRefWithSaveContext(ctx: HoppRESTSaveContext) {


### PR DESCRIPTION
This PR fixes some of the inconsistencies in calls to `PersistenceService` around double serialization/deserialization.

Legacy `PersistenceService` calls are serialized at the call site, for example:

```typescript
persistenceService.setLocalConfig("login_state", JSON.stringify(user))
```

Although `kernel`'s `Store.set` automatically serializes value for storage (and `Store.get` deserializes automatically as well):

```typescript
async set(namespace: string, key: string, value: StoredData): Promise<void> {
    const validated = StoredDataSchema.parse(value);
    // <platform specific serialization>
    this.notifyListeners(namespace, key, validated.data);
}
```

The legacy approach still works due to how platform-dependent serialization/deserialization handles `string` values specifically. When we call `JSON.stringify(data)` in legacy modules, we're converting an object to a JSON string.

When this string is passed to `persistenceService.setLocalConfig()`, it goes through the store implementation where `<platform>.<stringify>()` is used. When `<platform>.<stringify>()` receives a primitive string value (which we've already stringified), it simply treats it as a regular string value and serializes it accordingly.

During retrieval, `<platform>.<parse>()` deserializes this back into a string.

Basically, this works due to a "wrapping" pattern that the data goes through:

```
Object → JSON.stringify → string → <platform>.<stringify>() → stored string → <platform>.<parse>() → string → JSON.parse → Object
```

This is definitely not ideal:
- It's inefficient
- We lose type information
- There's a chance of forgetting `JSON.stringify` (for legacy method calls)
- Creates unnecessary storage bloat

This PR introduces new methods `set`, `get` and `remove` in order to incrementally refactor existing code to the correct usage while keeping the codebase stable for backwards compatibility.

For future changes, it's important to note that we have migrations in place for certain keys in `PersistenceService`. When possible, add variables to the migration mechanism to make sure data isn't lost midway. Not all changes necessitate migrations - for example, `login_state` can be replaced without a migration as it will simply prompt users to log back in.

However, some data is synced with the backend (either selfhosted or cloud):

```typescript
platform.sync.settings.initSettingsSync(),
platform.sync.collections.initCollectionsSync(),
platform.sync.history.initHistorySync(),
platform.sync.environments.initEnvironmentsSync(), 
```

These synchronized items definitely need migrations to ensure users don't lose their data, and we've provided those migrations in the service.

#### Note to Reviewers

There still exist sync calls to `PersistenceService` methods, especially in `std/interceptors`, `sh-desktop/platform` and similar legacy modules. Although these modules are not directly in use anymore, there may exist some static function calls that may be used by live modules indirectly, even though they don't depend on the kernel.

These modules are up for removal upon ongoing evaluation, so any `PersistenceService` in these modules can be safely ignored.
