### PR TITLE
fix: version bump regression for sh-desktop and agent

### DIFF
--- a/packages/hoppscotch-agent/package.json
+++ b/packages/hoppscotch-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hoppscotch-agent",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/hoppscotch-agent/src-tauri/tauri.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent Portable",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/packages/hoppscotch-desktop/package.json
+++ b/packages/hoppscotch-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hoppscotch-desktop",
   "private": true,
-  "version": "25.2.0-0",
+  "version": "25.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/hoppscotch-selfhost-desktop/package.json
+++ b/packages/hoppscotch-selfhost-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hoppscotch/selfhost-desktop",
   "private": true,
-  "version": "2025.2.0",
+  "version": "2025.1.1",
   "type": "module",
   "scripts": {
     "dev:vite": "vite",

--- a/packages/hoppscotch-selfhost-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-selfhost-desktop/src-tauri/Cargo.lock
@@ -1417,7 +1417,7 @@ dependencies = [
 
 [[package]]
 name = "hoppscotch-desktop"
-version = "25.2.0"
+version = "25.1.1"
 dependencies = [
  "cocoa 0.25.0",
  "dashmap",

--- a/packages/hoppscotch-selfhost-desktop/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-selfhost-desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoppscotch-desktop"
-version = "25.2.0"
+version = "25.1.1"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/packages/hoppscotch-selfhost-desktop/src-tauri/tauri.conf.json
+++ b/packages/hoppscotch-selfhost-desktop/src-tauri/tauri.conf.json
@@ -8,7 +8,7 @@
   },
   "package": {
     "productName": "Hoppscotch",
-    "version": "25.2.0"
+    "version": "25.1.1"
   },
   "tauri": {
     "allowlist": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14972,7 +14972,7 @@ snapshots:
   '@eslint/config-array@0.18.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
-      debug: 4.3.7
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -14996,7 +14996,7 @@ snapshots:
   '@eslint/eslintrc@3.1.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7
+      debug: 4.4.0
       espree: 10.2.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -18982,6 +18982,10 @@ snapshots:
     dependencies:
       acorn: 8.12.1
 
+  acorn-jsx@5.3.2(acorn@8.14.0):
+    dependencies:
+      acorn: 8.14.0
+
   acorn-loose@6.1.0:
     dependencies:
       acorn: 6.4.2
@@ -21031,7 +21035,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.3.7
+      debug: 4.4.0
       escape-string-regexp: 4.0.0
       eslint-scope: 8.1.0
       eslint-visitor-keys: 4.1.0
@@ -21058,8 +21062,8 @@ snapshots:
 
   espree@10.2.0:
     dependencies:
-      acorn: 8.12.1
-      acorn-jsx: 5.3.2(acorn@8.12.1)
+      acorn: 8.14.0
+      acorn-jsx: 5.3.2(acorn@8.14.0)
       eslint-visitor-keys: 4.1.0
 
   espree@6.2.1:


### PR DESCRIPTION
This PR fixes agent version bump regressions.