### PR TITLE
fix: update embed redirect URL

### DIFF
--- a/packages/hoppscotch-common/src/components/embeds/index.vue
+++ b/packages/hoppscotch-common/src/components/embeds/index.vue
@@ -52,7 +52,7 @@ const shortcodeBaseURL = computed(
 )
 
 const sharedRequestURL = computed(() => {
-  return `${shortcodeBaseURL.value}/e/${props.sharedRequestID}`
+  return `${shortcodeBaseURL.value}/r/${props.sharedRequestID}`
 })
 
 const tabRequestVariables = computed(() => {


### PR DESCRIPTION
This PR fixes the embeds redirect URL which will redirect the embed to hoppscotch app
