### PR TITLE
fix: kernel-io calls via `openExternalLink`

### DIFF
--- a/packages/hoppscotch-common/src/components/app/WhatsNewDialog.vue
+++ b/packages/hoppscotch-common/src/components/app/WhatsNewDialog.vue
@@ -48,7 +48,8 @@ defineEmits<{
 }>()
 
 const openWhatsNew = () => {
-  if (props.notesUrl) platform.kernelIO.openExternalLink({ url: props.notesUrl})
+  if (props.notesUrl)
+    platform.kernelIO.openExternalLink({ url: props.notesUrl })
 }
 </script>
 

--- a/packages/hoppscotch-common/src/components/app/WhatsNewDialog.vue
+++ b/packages/hoppscotch-common/src/components/app/WhatsNewDialog.vue
@@ -48,7 +48,7 @@ defineEmits<{
 }>()
 
 const openWhatsNew = () => {
-  if (props.notesUrl) platform.kernelIO.openExternalLink(props.notesUrl)
+  if (props.notesUrl) platform.kernelIO.openExternalLink({ url: props.notesUrl})
 }
 </script>
 

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -625,7 +625,7 @@ const HoppGistCollectionsExporter: ImporterOrExporter = {
         platform: "rest",
       })
 
-      platform.kernelIO.openExternalLink(res.right)
+      platform.kernelIO.openExternalLink({ url: res.right })
     } else {
       toast.error(collectionJSON.left)
     }

--- a/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
@@ -208,7 +208,7 @@ const GqlCollectionsGistExporter: ImporterOrExporter = {
         exporter: "gist",
       })
 
-      platform.kernelIO.openExternalLink(res.right)
+      platform.kernelIO.openExternalLink({ url: res.right })
     }
 
     isGqlCollectionGistExportInProgress.value = false

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -328,7 +328,7 @@ const HoppEnvironmentsGistExporter: ImporterOrExporter = {
         platform: "rest",
       })
 
-      platform.kernelIO.openExternalLink(res.right)
+      platform.kernelIO.openExternalLink({ url: res.right })
     }
 
     isEnvironmentGistExportInProgress.value = false

--- a/packages/hoppscotch-common/src/platform/kernel-io.ts
+++ b/packages/hoppscotch-common/src/platform/kernel-io.ts
@@ -42,11 +42,24 @@ export type SaveFileWithDialogOptions = {
   }>
 }
 
+/**
+ * Options for opening an external link.
+ */
+export type OpenExternalLinkOptions = {
+  /**
+   * The URL to open.
+   */
+  url: string
+}
+
+/**
+ * Response from a file save operation.
+ */
 export type SaveFileResponse =
   | {
       /**
        * The implementation was unable to determine the status of the save operation.
-       * This cannot be considered a success or a failure and should be handled as an uncertainity.
+       * This cannot be considered a success or a failure and should be handled as an uncertainty.
        * The browser standard implementation (std) returns this value as there is no way to
        * check if the user downloaded the file or not.
        */
@@ -71,6 +84,29 @@ export type SaveFileResponse =
     }
 
 /**
+ * Response from an external link operation.
+ */
+export type OpenExternalLinkResponse =
+  | {
+      /**
+       * The implementation was unable to determine the status of the open operation.
+       */
+      type: "unknown"
+    }
+  | {
+      /**
+       * The result is known and the user cancelled the open action.
+       */
+      type: "cancelled"
+    }
+  | {
+      /**
+       * The result is known and the link was opened successfully.
+       */
+      type: "opened"
+    }
+
+/**
  * Platform definitions for how to handle IO operations.
  */
 export type KernelIO = {
@@ -85,7 +121,8 @@ export type KernelIO = {
   /**
    * Opens a link in the user's browser.
    * The expected behaviour is for the browser to open a new tab/window (for example in desktop app) with the given URL.
-   * @param url The URL to open
    */
-  openExternalLink: (url: string) => Promise<void>
+  openExternalLink: (
+    opts: OpenExternalLinkOptions
+  ) => Promise<OpenExternalLinkResponse>
 }

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/extension/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/extension/index.ts
@@ -1,4 +1,4 @@
-import { computed, markRaw, ref } from "vue"
+import { computed, markRaw } from "vue"
 import { Service } from "dioc"
 import type { RelayRequest, RelayResponse } from "@hoppscotch/kernel"
 import { body } from "@hoppscotch/kernel"
@@ -147,10 +147,7 @@ export class ExtensionKernelInterceptorService
             status: response.status,
             statusText: response.statusText,
             headers: response.headers,
-            body: body.body(
-              response.data,
-              response.headers["content-type"]
-            ),
+            body: body.body(response.data, response.headers["content-type"]),
           })
         }
       }

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/extension/store.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/extension/store.ts
@@ -119,9 +119,8 @@ export class KernelInterceptorExtensionStore extends Service {
       })
 
       window.__HOPP_EXTENSION_STATUS_PROXY__ = statusProxy
-      statusProxy.subscribe(
-        "status",
-        (status: ExtensionStatus) => this.updateSettings({ status })
+      statusProxy.subscribe("status", (status: ExtensionStatus) =>
+        this.updateSettings({ status })
       )
 
       /**

--- a/packages/hoppscotch-common/src/platform/std/kernel-io.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-io.ts
@@ -5,7 +5,7 @@ export const kernelIO: KernelIO = {
   saveFileWithDialog(opts) {
     return Io.saveFileWithDialog(opts)
   },
-  openExternalLink(url) {
-    return Io.openExternalLink(url)
+  openExternalLink(opts) {
+    return Io.openExternalLink(opts)
   },
 }

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/general.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/general.searcher.ts
@@ -118,7 +118,7 @@ export class GeneralSpotlightSearcherService extends StaticSpotlightSearcherServ
   }
 
   private openURL(url: string) {
-    platform.kernelIO.openExternalLink(url)
+    platform.kernelIO.openExternalLink({ url })
   }
 
   public onDocSelected(id: string): void {


### PR DESCRIPTION
This PR fixes some of the remaining calls to `openExternalLink` that's now routed through `kernel-io`.