### PR TITLE
fix: preserve hierarchy during personal collection imports

### DIFF
--- a/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/gqlCollections.sync.ts
@@ -115,6 +115,7 @@ const recursivelySyncCollections = async (
       collection.id = childCollectionId
       collection.auth = returnedData.auth
       collection.headers = returnedData.headers
+      parentCollectionID = childCollectionId
 
       removeDuplicateGraphqlCollectionOrFolder(
         childCollectionId,

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/sync.ts
@@ -120,6 +120,7 @@ const recursivelySyncCollections = async (
       collection._ref_id = returnedData._ref_id ?? generateUniqueRefId("coll")
       collection.auth = returnedData.auth
       collection.headers = returnedData.headers
+      parentCollectionID = childCollectionId
 
       removeDuplicateRESTCollectionOrFolder(
         childCollectionId,

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/gqlCollections.sync.ts
@@ -115,6 +115,7 @@ const recursivelySyncCollections = async (
       collection.id = childCollectionId
       collection.auth = returnedData.auth
       collection.headers = returnedData.headers
+      parentCollectionID = childCollectionId
 
       removeDuplicateGraphqlCollectionOrFolder(
         childCollectionId,

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/sync.ts
@@ -120,6 +120,7 @@ const recursivelySyncCollections = async (
       collection._ref_id = returnedData._ref_id ?? generateUniqueRefId("coll")
       collection.auth = returnedData.auth
       collection.headers = returnedData.headers
+      parentCollectionID = childCollectionId
 
       removeDuplicateRESTCollectionOrFolder(
         childCollectionId,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4171, HFE-361.

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
The proposed changes ensure that (REST/GQL) child collections/requests are associated with the respective parent level collections instead of the root collection during imports to the personal workspace.

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
Updating the parent collection ID when creating a new parent during each recursive call.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

