### PR TITLE
fix(agent): mention name in updater dialog

### DIFF
--- a/packages/hoppscotch-agent/src-tauri/src/updater.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/updater.rs
@@ -26,7 +26,7 @@ pub async fn check_and_install_updates(
                         .map(|body| format!("\n\nRelease Notes: {}", body))
                         .unwrap_or("".into())
                 ))
-                .title("Update Available")
+                .title("Hoppscotch Agent Update Available")
                 .kind(MessageDialogKind::Info)
                 .buttons(MessageDialogButtons::OkCancelCustom(
                     "Update".to_string(),


### PR DESCRIPTION
This PR fixes agent updater dialog ambiguity as expressed in #4816 

This will also address ambiguity on some Linux setups where dialog might not appear next to Agent's tray icon.

Now the update dialog will say "Hoppscotch Agent Update Available"

Closes #4816