### PR TITLE
fix(common): correct coordinates calculation for selection end position

### DIFF
--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -279,7 +279,7 @@ export function useCodemirror(
       }
 
       const text = view.value?.state.doc.sliceString(from, to)
-      const coords = view.value?.coordsAtPos(from)
+      const coords = view.value?.coordsAtPos(to)
       const top = coords?.top ?? 0
       const left = coords?.left ?? 0
       if (text?.trim()) {


### PR DESCRIPTION
Closes HFE-770

This pull request addresses a bug where the selection of text in the JSON input field does not follow the mouse cursor properly when scrolling. Users may find it difficult to find context menu because of this.

### What's Changed

In the file `packages/hoppscotch-common/src/composables/codemirror.ts`, we made an update to the `handleTextSelection` method. The change involves using the 'to' position (end position) instead of the 'from' position to correctly position the context menu at the location where the drag operation ended. This adjustment ensures that the context menu appears at the appropriate spot.

- [ ] Not Completed
- [x] Completed
