### PR TITLE
fix(common): exception while clicking request history entries

### DIFF
--- a/packages/hoppscotch-common/src/components/history/Personal.vue
+++ b/packages/hoppscotch-common/src/components/history/Personal.vue
@@ -318,8 +318,10 @@ const clearHistory = () => {
 // NOTE: For GQL, the HistoryGraphqlCard component already implements useEntry
 // (That is not a really good behaviour tho ¯\_(ツ)_/¯)
 const tabs = useService(RESTTabService)
+
 const useHistory = (entry: RESTHistoryEntry) => {
   tabs.createNewTab({
+    type: "request",
     request: entry.request,
     isDirty: false,
   })


### PR DESCRIPTION
Closes #4830 

This PR fixes the issue where the tab crashes when clicking on history request because the tab type was not defined for history request.


