### PR TITLE
fix(common): make `cursorPosition` field optional in `HoppGQLDocument` type

### DIFF
--- a/packages/hoppscotch-common/src/helpers/graphql/document.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/document.ts
@@ -56,7 +56,7 @@ export type HoppGQLDocument = {
   /**
    * The cursor position in the document
    */
-  cursorPosition: number
+  cursorPosition?: number
 
   /**
    * Info about where this request should be saved.

--- a/packages/hoppscotch-common/src/helpers/graphql/query.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/query.ts
@@ -310,7 +310,9 @@ export function useQuery() {
     if (!currentTab) return
 
     const currentQuery = currentTab.document.request.query || ""
-    const selectedOperation = getOperation(currentTab.document.cursorPosition)
+    const selectedOperation = getOperation(
+      currentTab.document.cursorPosition || 0
+    )
     const navItems = [...navStack.value, { name: item.name, def: item }]
 
     const result = processOperation(
@@ -368,7 +370,7 @@ export function useQuery() {
     isArgument = false
   ): boolean => {
     const operation = getOperation(
-      tabs.currentActiveTab.value?.document.cursorPosition
+      tabs.currentActiveTab.value?.document.cursorPosition || 0
     )
     if (!operation) return false
 


### PR DESCRIPTION
This pull request addresses an issue by modifying the HoppGQLDocument type to make the cursorPosition property optional. 