### PR TITLE
fix(common): resolve issues around shared workspace invite validation

### DIFF
--- a/packages/hoppscotch-common/src/pages/join-team.vue
+++ b/packages/hoppscotch-common/src/pages/join-team.vue
@@ -194,6 +194,12 @@ onMounted(async () => {
 })
 
 onLoggedIn(async () => {
+  const probableUser = platform.auth.getProbableUser()
+
+  if (probableUser !== null) {
+    await platform.auth.waitProbableLoginToConfirm()
+  }
+
   if (typeof route.query.id === "string") {
     inviteDetails.execute({
       inviteID: route.query.id,


### PR DESCRIPTION
Closes #4824 

### What's changed

This PR aims to resolve issues encountered when a user attempts to join a shared workspace and is greeted with an error screen. This is observed particularly in the cloud offering. This happens when the GQL query executed while a user visits the invite link fails with the message `auth/fail` since the login state is not confirmed yet. The proposed changes ensure the relevant login state is confirmed before the network call, maintaining backwards compatibility with SH.

### Notes to reviewers
N/A