### PR TITLE
fix(desktop): increase bundle download timeout

### DIFF
--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/api/client.rs
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/api/client.rs
@@ -58,7 +58,17 @@ impl ApiClient {
         tracing::debug!(bundle_name = name, "Downloading bundle");
         let url = self.build_url(&format!("/api/{API_VERSION}/bundle"))?;
 
-        let response = self.client.get(url).send().await.map_err(|e| {
+        let download_client = HttpClient::builder()
+            .timeout(10 * DEFAULT_TIMEOUT)
+            .user_agent(format!(
+                "{}/{}",
+                env!("CARGO_PKG_NAME"),
+                env!("CARGO_PKG_VERSION")
+            ))
+            .build()
+            .map_err(ApiError::RequestFailed)?;
+
+        let response = download_client.get(url).send().await.map_err(|e| {
             tracing::error!(bundle_name = name, error = %e, "Download request failed");
             ApiError::RequestFailed(e)
         })?;

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.lock
@@ -4972,7 +4972,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-appload"
 version = "0.1.0"
-source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload#e44d90aefb8d930044643b41fa1ce739e49d456c"
+source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload#1c2e8b19db7f1b6af6d00abb907f15cdc2017298"
 dependencies = [
  "base64 0.22.1",
  "blake3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,7 +519,7 @@ importers:
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
         specifier: github:CuriousCorrelation/tauri-plugin-appload
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e44d90aefb8d930044643b41fa1ce739e49d456c'
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/1c2e8b19db7f1b6af6d00abb907f15cdc2017298'
       '@hoppscotch/ui':
         specifier: 0.2.2
         version: 0.2.2(eslint@8.57.0)(terser@5.34.1)(typescript@5.3.3)(vite@5.4.9(@types/node@22.9.3)(sass@1.79.5)(terser@5.34.1))(vue@3.5.12(typescript@5.3.3))
@@ -977,7 +977,7 @@ importers:
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
         specifier: github:CuriousCorrelation/tauri-plugin-appload
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e44d90aefb8d930044643b41fa1ce739e49d456c'
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/1c2e8b19db7f1b6af6d00abb907f15cdc2017298'
       '@hoppscotch/ui':
         specifier: 0.2.1
         version: 0.2.1(eslint@9.12.0(jiti@2.3.3))(terser@5.34.1)(typescript@5.7.2)(vite@5.4.11(@types/node@22.9.3)(sass@1.80.3)(terser@5.34.1))(vue@3.5.12(typescript@5.7.2))
@@ -1805,8 +1805,8 @@ packages:
       graphql:
         optional: true
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e44d90aefb8d930044643b41fa1ce739e49d456c':
-    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e44d90aefb8d930044643b41fa1ce739e49d456c}
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/1c2e8b19db7f1b6af6d00abb907f15cdc2017298':
+    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/1c2e8b19db7f1b6af6d00abb907f15cdc2017298}
     version: 0.1.0
 
   '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/4b96e40170c65189144299d896b7e97803f13cca':
@@ -13232,7 +13232,7 @@ snapshots:
     optionalDependencies:
       graphql: 16.9.0
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/e44d90aefb8d930044643b41fa1ce739e49d456c':
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/1c2e8b19db7f1b6af6d00abb907f15cdc2017298':
     dependencies:
       '@tauri-apps/api': 2.1.1
 


### PR DESCRIPTION
This PR increases bundle download timeout by creating a separate client just for handling downloads.

Closes #4842

#### Note to reviewers

You can test this by using one of the deployed instances and throttling network speeds, current timeout aims for ~15MB over 5mins.