### PR TITLE
fix: typos in packages/hoppscotch-common/src/platform

### DIFF
--- a/packages/hoppscotch-common/src/platform/auth.ts
+++ b/packages/hoppscotch-common/src/platform/auth.ts
@@ -24,7 +24,7 @@ export type HoppUser = {
 
   // Regarding `provider` and `accessToken`:
   // The current implementation and use case for these 2 fields are super weird due to legacy.
-  // Currrently these fields are only basically populated for Github Auth as we need the access token issued
+  // Currently these fields are only basically populated for Github Auth as we need the access token issued
   // by it to implement Gist submission. I would really love refactor to make this thing more sane.
 
   /** Name of the provider authenticating (NOTE: See notes on `platform/auth.ts`) */

--- a/packages/hoppscotch-common/src/platform/io.ts
+++ b/packages/hoppscotch-common/src/platform/io.ts
@@ -46,7 +46,7 @@ export type SaveFileResponse =
   | {
       /**
        * The implementation was unable to determine the status of the save operation.
-       * This cannot be considered a success or a failure and should be handled as an uncertainity.
+       * This cannot be considered a success or a failure and should be handled as an uncertainty.
        * The browser standard implementation (std) returns this value as there is no way to
        * check if the user downloaded the file or not.
        */

--- a/packages/hoppscotch-common/src/platform/kernel-io.ts
+++ b/packages/hoppscotch-common/src/platform/kernel-io.ts
@@ -46,7 +46,7 @@ export type SaveFileResponse =
   | {
       /**
        * The implementation was unable to determine the status of the save operation.
-       * This cannot be considered a success or a failure and should be handled as an uncertainity.
+       * This cannot be considered a success or a failure and should be handled as an uncertainty.
        * The browser standard implementation (std) returns this value as there is no way to
        * check if the user downloaded the file or not.
        */

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
@@ -241,7 +241,7 @@ export class ProxyKernelInterceptorService
                 ? new Uint8Array(res.body.body)
                 : null
 
-            // NOTE: This will become obsolete if we use native interceptor like error propogation.
+            // NOTE: This will become obsolete if we use native interceptor like error propagation.
             const proxyResponse = proxyBody
               ? (JSON.parse(
                   new TextDecoder().decode(proxyBody)

--- a/packages/hoppscotch-common/src/platform/ui.ts
+++ b/packages/hoppscotch-common/src/platform/ui.ts
@@ -29,7 +29,7 @@ export type UIPlatformDef = {
   onCodemirrorInstanceMount?: (element: HTMLElement) => void
 
   /**
-   * Additonal menu items shown in the "Help and Feedback" menu
+   * Additional menu items shown in the "Help and Feedback" menu
    * in the app footer.
    */
   additionalFooterMenuItems?: HoppFooterMenuItem[]


### PR DESCRIPTION
### What's changed

Documentation and non-user facing typo fixes

Found via `codespell -q 3 -S "./packages/hoppscotch-common/locales,./pnpm-lock.yaml" -L afterall,atleast,childrens,doesnt,inout,parms,requestd,te`

### Notes to reviewers

n/a