### PR TITLE
fix: resolve typos across packages

### DIFF
--- a/packages/hoppscotch-agent/src-tauri/src/webview/mod.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/webview/mod.rs
@@ -34,7 +34,7 @@
 /// See: https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution?tabs=dotnetcsharp#detect-if-a-webview2-runtime-is-already-installed
 ///
 /// Our implementation uses Approach 1, checking both the 32-bit (WOW6432Node) and 64-bit registry locations
-/// to make sure we have critical dependencis compatibility with different system architectures.
+/// to make sure we have critical dependency compatibility with different system architectures.
 pub mod error;
 
 use std::{io, ops::Not};

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.spec.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.spec.ts
@@ -872,7 +872,7 @@ describe('deleteCollection', () => {
     // deleteCollectionData
     // deleteCollectionData --> FindMany query 1st time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
-    // deleteCollectionData --> FindMany query 2st time
+    // deleteCollectionData --> FindMany query 2nd time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
     // deleteCollectionData --> DeleteMany query
     mockPrisma.teamRequest.deleteMany.mockResolvedValueOnce({ count: 0 });
@@ -906,7 +906,7 @@ describe('deleteCollection', () => {
     // deleteCollectionData
     // deleteCollectionData --> FindMany query 1st time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
-    // deleteCollectionData --> FindMany query 2st time
+    // deleteCollectionData --> FindMany query 2nd time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
     // deleteCollectionData --> DeleteMany query
     mockPrisma.userRequest.deleteMany.mockResolvedValueOnce({ count: 0 });
@@ -929,7 +929,7 @@ describe('deleteCollection', () => {
     // deleteCollectionData
     // deleteCollectionData --> FindMany query 1st time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
-    // deleteCollectionData --> FindMany query 2st time
+    // deleteCollectionData --> FindMany query 2nd time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
     // deleteCollectionData --> DeleteMany query
     mockPrisma.userRequest.deleteMany.mockResolvedValueOnce({ count: 0 });
@@ -1563,7 +1563,7 @@ describe('replaceCollectionsWithJSON', () => {
     // deleteCollectionData
     // deleteCollectionData --> FindMany query 1st time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
-    // deleteCollectionData --> FindMany query 2st time
+    // deleteCollectionData --> FindMany query 2nd time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
     // deleteCollectionData --> DeleteMany query
     mockPrisma.teamRequest.deleteMany.mockResolvedValueOnce({ count: 0 });
@@ -1595,7 +1595,7 @@ describe('replaceCollectionsWithJSON', () => {
     // deleteCollectionData
     // deleteCollectionData --> FindMany query 1st time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
-    // deleteCollectionData --> FindMany query 2st time
+    // deleteCollectionData --> FindMany query 2nd time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
     // deleteCollectionData --> DeleteMany query
     mockPrisma.teamRequest.deleteMany.mockResolvedValueOnce({ count: 0 });
@@ -1627,7 +1627,7 @@ describe('replaceCollectionsWithJSON', () => {
     // deleteCollectionData
     // deleteCollectionData --> FindMany query 1st time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
-    // deleteCollectionData --> FindMany query 2st time
+    // deleteCollectionData --> FindMany query 2nd time
     mockPrisma.teamCollection.findMany.mockResolvedValueOnce([]);
     // deleteCollectionData --> DeleteMany query
     mockPrisma.teamRequest.deleteMany.mockResolvedValueOnce({ count: 0 });

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.spec.ts
@@ -1081,7 +1081,7 @@ describe('deleteUserCollection', () => {
     // deleteCollectionData
     // deleteCollectionData --> FindMany query 1st time
     mockPrisma.userCollection.findMany.mockResolvedValueOnce([]);
-    // deleteCollectionData --> FindMany query 2st time
+    // deleteCollectionData --> FindMany query 2nd time
     mockPrisma.userCollection.findMany.mockResolvedValueOnce([]);
     // deleteCollectionData --> DeleteMany query
     mockPrisma.userRequest.deleteMany.mockResolvedValueOnce({ count: 0 });
@@ -1128,7 +1128,7 @@ describe('deleteUserCollection', () => {
     // deleteCollectionData
     // deleteCollectionData --> FindMany query 1st time
     mockPrisma.userCollection.findMany.mockResolvedValueOnce([]);
-    // deleteCollectionData --> FindMany query 2st time
+    // deleteCollectionData --> FindMany query 2nd time
     mockPrisma.userCollection.findMany.mockResolvedValueOnce([]);
     // deleteCollectionData --> DeleteMany query
     mockPrisma.userRequest.deleteMany.mockResolvedValueOnce({ count: 0 });
@@ -1151,7 +1151,7 @@ describe('deleteUserCollection', () => {
     // deleteCollectionData
     // deleteCollectionData --> FindMany query 1st time
     mockPrisma.userCollection.findMany.mockResolvedValueOnce([]);
-    // deleteCollectionData --> FindMany query 2st time
+    // deleteCollectionData --> FindMany query 2nd time
     mockPrisma.userCollection.findMany.mockResolvedValueOnce([]);
     // deleteCollectionData --> DeleteMany query
     mockPrisma.userRequest.deleteMany.mockResolvedValueOnce({ count: 0 });

--- a/packages/hoppscotch-backend/src/user/user.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user/user.service.spec.ts
@@ -688,7 +688,7 @@ describe('UserService', () => {
       const result = service.deleteUserByUID(user)();
       return expect(result).resolves.toBeLeft();
     });
-    test('should resolve left when ther is an unsuccessful deletion of userdata from firestore', () => {
+    test('should resolve left when there is an unsuccessful deletion of userdata from firestore', () => {
       // Handlers allow deletion to proceed
       handler1.canAllowUserDeletion.mockImplementation(() => TO.none);
       handler2.canAllowUserDeletion.mockImplementation(() => TO.none);

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/multipart-form-data-coll.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/collections/multipart-form-data-coll.json
@@ -1,6 +1,6 @@
 {
   "v": 3,
-  "name": "Multpart form data content type - Collection",
+  "name": "Multipart form data content type - Collection",
   "folders": [],
   "requests": [
     {

--- a/packages/hoppscotch-cli/src/interfaces/response.ts
+++ b/packages/hoppscotch-cli/src/interfaces/response.ts
@@ -9,7 +9,7 @@ import { HoppEnvs } from "../types/request";
  * @property {string} path Path of request within collection file.
  * @property {string} endpoint Endpoint from response config.url.
  * @property {Method} method Method from response headers.
- * @property {string} statusCode Template string concating status & statusText.
+ * @property {string} statusCode Template string concatenating status & statusText.
  */
 export interface TableResponse {
   endpoint: string;

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -69,7 +69,7 @@ const processEnvs = (envs: Partial<HoppEnvs>) => {
  * Transforms given request data to request-config used by request-runner to
  * perform HTTP request.
  * @param req Effective request data with parsed ENVs.
- * @returns Request config with data realted to HTTP request.
+ * @returns Request config with data related to HTTP request.
  */
 export const createRequest = (req: EffectiveHoppRESTRequest): RequestConfig => {
   const config: RequestConfig = {

--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -580,7 +580,7 @@ details[open] summary .indicator {
 
 .env-highlight,
 .predefined-variable-highlight {
-  // forcing the text colour to be white inside a higlighted environment variable and predefined variable
+  // forcing the text colour to be white inside a highlighted environment variable and predefined variable
   @apply text-accentContrast #{!important};
   span {
     @apply text-accentContrast #{!important};

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -371,7 +371,7 @@ const currentUser = useReadonlyStream(
 )
 const myCollections = useReadonlyStream(restCollections$, [], "deep")
 
-// Draging
+// Dragging
 const draggingToRoot = ref(false)
 const collectionMoveLoading = ref<string[]>([])
 const requestMoveLoading = ref<string[]>([])
@@ -1941,7 +1941,7 @@ const selectPicked = (payload: Picked | null) => {
 
 /**
  * This function is called when the user clicks on a request
- * @param selectedRequest The request that the user clicked on emited from the collection tree
+ * @param selectedRequest The request that the user clicked on emitted from the collection tree
  */
 const selectRequest = (selectedRequest: {
   request: HoppRESTRequest

--- a/packages/hoppscotch-common/src/components/http/BodyBinary.vue
+++ b/packages/hoppscotch-common/src/components/http/BodyBinary.vue
@@ -20,7 +20,7 @@ const emit = defineEmits<{
 // need to look into this
 // eg: body: some-json-value-user-entered, contentType: "application/json" -> change content type-> body: some-json-value-user-entered, contentType: "application/octet-stream"
 // this is not caught by the type system
-// but this behavior right now gives us persistance, which will prevent unwanted data loss
+// but this behavior right now gives us persistence, which will prevent unwanted data loss
 // eg: when the user comes back to the json body, the value is still there
 // so to solve this, we need to consider this too.
 watch(

--- a/packages/hoppscotch-common/src/components/http/authorization/NTLM.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/NTLM.vue
@@ -50,7 +50,7 @@
         :on="auth.retryingRequest"
         @change="auth.retryingRequest = !auth.retryingRequest"
       >
-        Disable Retrying Requset
+        Disable Retrying Request
       </HoppSmartCheckbox>
     </div>
   </div>

--- a/packages/hoppscotch-common/src/composables/stream.ts
+++ b/packages/hoppscotch-common/src/composables/stream.ts
@@ -91,7 +91,7 @@ export function useStream<T>(
 }
 
 /** A static (doesn't cleanup on itself and does
- *  not require component instace) version of useStream
+ *  not require component instance) version of useStream
  */
 export function useStreamStatic<T>(
   stream$: Observable<T>,

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -41,7 +41,7 @@ export function resolveSaveContextOnCollectionReorder(
   if (newIndex === -1) {
     // if (newIndex === -1) remove it from the map because it will be deleted
     affectedIndexes.delete(lastIndex)
-    // when collection deleted opended requests from that collection be affected
+    // when collection deleted opened requests from that collection be affected
     if (type === "remove") {
       resetSaveContextForAffectedRequests(
         folderPath ? `${folderPath}/${lastIndex}` : lastIndex.toString()
@@ -112,7 +112,7 @@ export function updateSaveContextForAffectedRequests(
 /**
  * Used to check the new folder path is close to the save context folder path or not
  * @param folderPathCurrent The path saved as the inherited path in the inherited properties
- * @param newFolderPath The incomming path
+ * @param newFolderPath The incoming path
  * @param saveContextPath The save context of the request
  * @returns The path which is close to saveContext.folderPath
  */

--- a/packages/hoppscotch-common/src/helpers/functional/record.ts
+++ b/packages/hoppscotch-common/src/helpers/functional/record.ts
@@ -19,9 +19,9 @@ export const tupleToRecord = <
 /**
  * Converts an array of key-value tuples (for e.g ["key", "value"]), into a record.
  * (for eg. output -> { "key": ["value"] })
- * NOTE: If you do not want the array as values (because of duplicate keys) and want to instead get the last occurance, use `tupleToRecord`
+ * NOTE: If you do not want the array as values (because of duplicate keys) and want to instead get the last occurrence, use `tupleToRecord`
  * @param tuples Array of tuples ([key, value])
- * @returns A Record with values being arrays corresponding to each key occurance
+ * @returns A Record with values being arrays corresponding to each key occurrence
  */
 export const tupleWithSameKeysToRecord = <
   KeyType extends string | number | symbol,
@@ -29,7 +29,7 @@ export const tupleWithSameKeysToRecord = <
 >(
   tuples: [KeyType, ValueType][]
 ): Record<KeyType, ValueType[]> => {
-  // By the end of the function we do ensure this typing, this can't be infered now though, hence the assertion
+  // By the end of the function we do ensure this typing, this can't be inferred now though, hence the assertion
   const out = {} as Record<KeyType, ValueType[]>
 
   for (const [key, value] of tuples) {

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -336,7 +336,7 @@ const getHoppReqBody = ({
               contentType in knownContentTypes
           ),
 
-          // Back-up plan, assume language from raw language defintion
+          // Back-up plan, assume language from raw language definition
           O.alt(() =>
             pipe(
               body.options?.raw?.language,

--- a/packages/hoppscotch-common/src/helpers/types/HoppPicked.ts
+++ b/packages/hoppscotch-common/src/helpers/types/HoppPicked.ts
@@ -1,9 +1,9 @@
 /**
- * Picked is used to defrentiate
+ * Picked is used to differentiate
  * the select item in the save request dialog
  * The save request dialog can be used
- * to save a request, folder or a collection
- * seperately for my and teams for REST.
+ * to save a request, folder, or a collection
+ * separately for 'my' and 'teams' for REST.
  * also for graphQL collections
  */
 export type Picked =

--- a/packages/hoppscotch-common/src/services/__tests__/interceptor.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/interceptor.service.spec.ts
@@ -3,7 +3,7 @@ import { Interceptor, InterceptorService } from "../interceptor.service"
 import { TestContainer } from "dioc/testing"
 
 describe("InterceptorService", () => {
-  it("initally there are no interceptors defined", () => {
+  it("initaly there are no interceptors defined", () => {
     const container = new TestContainer()
 
     const service = container.bind(InterceptorService)
@@ -147,7 +147,7 @@ describe("InterceptorService", () => {
       expect(service.availableInterceptors.value).toEqual([interceptor])
     })
 
-    it("should set the current interceptor ID to non-null after the intiial registration", () => {
+    it("should set the current interceptor ID to non-null after the initial registration", () => {
       const container = new TestContainer()
 
       const service = container.bind(InterceptorService)

--- a/packages/hoppscotch-common/src/services/debug.service.ts
+++ b/packages/hoppscotch-common/src/services/debug.service.ts
@@ -1,7 +1,7 @@
 import { Service } from "dioc"
 
 /**
- * This service provice debug utilities for the application and is
+ * This service provides debug utilities for the application and is
  * supposed to be used only in development.
  *
  * This service logs events from the container and also events

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/__tests__/environment.inspector.spec.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/__tests__/environment.inspector.spec.ts
@@ -188,7 +188,7 @@ describe("EnvironmentInspectorService", () => {
       expect(result.value).toHaveLength(1)
     })
 
-    it("should not return an inspector result when the URL contains non empty value in a environemnt variable", () => {
+    it("should not return an inspector result when the URL contains non empty value in a environment variable", () => {
       const container = new TestContainer()
       const envInspector = container.bind(EnvironmentInspectorService)
 
@@ -219,7 +219,7 @@ describe("EnvironmentInspectorService", () => {
       expect(result.value).toHaveLength(1)
     })
 
-    it("should not return an inspector result when the headers contain non empty value in a environemnt variable", () => {
+    it("should not return an inspector result when the headers contain non empty value in a environment variable", () => {
       const container = new TestContainer()
       const envInspector = container.bind(EnvironmentInspectorService)
 
@@ -254,7 +254,7 @@ describe("EnvironmentInspectorService", () => {
       expect(result.value).toHaveLength(1)
     })
 
-    it("should not return an inspector result when the params contain non empty value in a environemnt variable", () => {
+    it("should not return an inspector result when the params contain non empty value in a environment variable", () => {
       const container = new TestContainer()
       const envInspector = container.bind(EnvironmentInspectorService)
 

--- a/packages/hoppscotch-common/src/services/spotlight/__tests__/index.spec.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/__tests__/index.spec.ts
@@ -475,7 +475,7 @@ describe("SpotlightService", () => {
         expect(onResultSelectFn).not.toHaveBeenCalled()
       })
 
-      it("calls the correspondig searcher's onResultSelect method", () => {
+      it("calls the corresponding searcher's onResultSelect method", () => {
         const container = new TestContainer()
 
         const spotlight = container.bind(SpotlightService)

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/settings.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/settings.searcher.ts
@@ -101,7 +101,7 @@ export class SettingsSpotlightSearcherService extends StaticSpotlightSearcherSer
     },
   })
 
-  // TODO: Constuctors are no longer recommended as of dioc > 3, move to onServiceInit
+  // TODO: Constructors are no longer recommended as of dioc > 3, move to onServiceInit
   constructor(c: Container) {
     super(c, {
       searchFields: ["text", "alternates"],

--- a/packages/hoppscotch-data/src/predefinedVariables.ts
+++ b/packages/hoppscotch-data/src/predefinedVariables.ts
@@ -61,7 +61,7 @@ export const HOPP_SUPPORTED_PREDEFINED_VARIABLES: PredefinedVariable[] = [
   // Text, numbers, and colors
   {
     key: "$randomAlphaNumeric",
-    description: "A random alpha-numeric character.",
+    description: "A random alphanumeric character.",
     getValue: () => {
       const characters =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
@@ -159,7 +159,7 @@ export const HOPP_SUPPORTED_PREDEFINED_VARIABLES: PredefinedVariable[] = [
 
   {
     key: "$randomPassword",
-    description: "A random 15-character alpha-numeric password.",
+    description: "A random 15-character alphanumeric password.",
     getValue: () => {
       const characters =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"

--- a/packages/hoppscotch-desktop/src/views/Home.vue
+++ b/packages/hoppscotch-desktop/src/views/Home.vue
@@ -187,7 +187,7 @@ const installUpdate = async () => {
   try {
     appState.value = AppState.UPDATE_IN_PROGRESS;
     await updaterService.downloadAndInstall();
-    // In a rare occurance where we reach here but automatic restart didn't happen,
+    // In a rare occurrence where we reach here but automatic restart didn't happen,
     // we'll just show a restart button instead
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : String(err);

--- a/packages/hoppscotch-sh-admin/locales/en.json
+++ b/packages/hoppscotch-sh-admin/locales/en.json
@@ -234,7 +234,7 @@
     "remove_admin_for_deletion": "Remove admin status before attempting deletion!!",
     "remove_owner_for_deletion": "One or more users are team owners. Update ownership before deletion!!",
     "remove_invitee_failure": "Removal of invitee failed!!",
-    "remove_invitee_success": "Removal of invitee is successfull!!",
+    "remove_invitee_success": "Removal of invitee is successful!!",
     "remove_member_failure": "Member couldn't be removed!!",
     "remove_member_success": "Member removed successfully!!",
     "rename_team_failure": "Failed to rename workspace!!",

--- a/packages/hoppscotch-sh-admin/src/composables/stream.ts
+++ b/packages/hoppscotch-sh-admin/src/composables/stream.ts
@@ -90,8 +90,8 @@ export function useStream<T>(
   });
 }
 
-/** A static (doesn't cleanup on itself and does
- *  not require component instace) version of useStream
+/** A static (doesn't cleanup itself and doesn't
+ *  require component instance) version of useStream
  */
 export function useStreamStatic<T>(
   stream$: Observable<T>,

--- a/packages/hoppscotch-sh-admin/src/composables/useConfigHandler.ts
+++ b/packages/hoppscotch-sh-admin/src/composables/useConfigHandler.ts
@@ -34,7 +34,7 @@ import { useToast } from './toast';
 import { useClientHandler } from './useClientHandler';
 
 /** Composable that handles all operations related to server configurations
- * @param updatedConfigs A Config Object contatining the updated configs
+ * @param updatedConfigs A Config Object containing the updated configs
  */
 export function useConfigHandler(updatedConfigs?: ServerConfigs) {
   const t = useI18n();


### PR DESCRIPTION
### What's changed

Documentation and non-user facing typo fixes

Found via `codespell -q 3 -S "./packages/hoppscotch-common/locales,./pnpm-lock.yaml" -L afterall,atleast,childrens,doesnt,inout,parms,requestd,te`

### Notes to reviewers

I made the PR against the 'patch' branch.