### PR TITLE
fix: update the newline key in codemirror

### DIFF
--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -402,7 +402,8 @@ export function useCodemirror(
       Prec.highest(
         keymap.of([
           {
-            key: "Cmd-Enter" /* macOS */ || "Ctrl-Enter" /* Windows */,
+            key: "Ctrl-Enter" /* Windows */,
+            mac: "Cmd-Enter" /* Mac */,
             preventDefault: true,
             run: () => true,
           },


### PR DESCRIPTION
Closes #4574 

This PR fixes the issue in windows where when pressing "Ctrl-Enter" sends the request also added a new line when the focus was on a codemirror instance
