### PR TITLE
fix: resolve issues around rendering HTML response previews

### DIFF
--- a/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
@@ -138,10 +138,11 @@ const { downloadIcon, downloadResponse } = useDownloadResponse(
   })
 )
 
-const defaultPreview = computedAsync(async () => {
-  const config = await persistenceService.getLocalConfig("lens_html_preview")
-  return config === "true"
-}, false)
+const defaultPreview = computedAsync(
+  async () =>
+    (await persistenceService.getLocalConfig("lens_html_preview")) === "true",
+  false
+)
 
 const { previewFrame, previewEnabled, togglePreview } = usePreview(
   defaultPreview,

--- a/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/HTMLLensRenderer.vue
@@ -98,6 +98,7 @@ import IconEyeOff from "~icons/lucide/eye-off"
 import IconWrapText from "~icons/lucide/wrap-text"
 import IconSave from "~icons/lucide/save"
 import { HoppRESTRequestResponse } from "@hoppscotch/data"
+import { computedAsync } from "@vueuse/core"
 
 const t = useI18n()
 const persistenceService = useService(PersistenceService)
@@ -136,8 +137,11 @@ const { downloadIcon, downloadResponse } = useDownloadResponse(
     request_name: responseName.value,
   })
 )
-const defaultPreview =
-  (await persistenceService.getLocalConfig("lens_html_preview")) === "true"
+
+const defaultPreview = computedAsync(async () => {
+  const config = await persistenceService.getLocalConfig("lens_html_preview")
+  return config === "true"
+}, false)
 
 const { previewFrame, previewEnabled, togglePreview } = usePreview(
   defaultPreview,

--- a/packages/hoppscotch-common/src/composables/lens-actions.ts
+++ b/packages/hoppscotch-common/src/composables/lens-actions.ts
@@ -1,7 +1,7 @@
 import { HoppRESTResponse } from "@helpers/types/HoppRESTResponse"
 import { copyToClipboard } from "@helpers/utils/clipboard"
 import { refAutoReset } from "@vueuse/core"
-import { computed, ComputedRef, onMounted, ref, Ref } from "vue"
+import { computed, ComputedRef, ref, Ref, watch } from "vue"
 
 import jsonToLanguage from "~/helpers/utils/json-to-language"
 import { platform } from "~/platform"
@@ -88,7 +88,7 @@ export function useDownloadResponse(
 }
 
 export function usePreview(
-  previewEnabledDefault: boolean,
+  previewEnabledDefault: Ref<boolean>,
   responseBodyText: Ref<string>
 ): {
   previewFrame: Ref<HTMLIFrameElement | null>
@@ -98,15 +98,6 @@ export function usePreview(
   const previewFrame: Ref<HTMLIFrameElement | null> = ref(null)
   const previewEnabled = ref(previewEnabledDefault)
   const url = ref("")
-
-  // `previewFrame` is a template ref that gets attached to the `iframe` element when the component mounts
-  // Ensures the HTML content is rendered immediately after a request, persists between tab switches, and is not limited to preview toggles
-  onMounted(() => updatePreviewFrame())
-
-  // Prevent updating the `iframe` element attributes during preview toggle actions after they are set initially
-  const shouldUpdatePreviewFrame = computed(
-    () => previewFrame.value?.getAttribute("data-previewing-url") !== url.value
-  )
 
   const updatePreviewFrame = () => {
     if (
@@ -128,6 +119,24 @@ export function usePreview(
       previewFrame.value.setAttribute("data-previewing-url", url.value)
     }
   }
+
+  // `previewFrame` is a template ref that gets attached to the `iframe` element when the component mounts
+  // Ensures the HTML content is rendered immediately after a request, persists between tab switches, and is not limited to preview toggles
+  // Also watches for changes in the `previewEnabled` state to update the `iframe` element attributes
+  watch(
+    previewEnabled,
+    () => {
+      updatePreviewFrame()
+    },
+    {
+      immediate: true,
+    }
+  )
+
+  // Prevent updating the `iframe` element attributes during preview toggle actions after they are set initially
+  const shouldUpdatePreviewFrame = computed(
+    () => previewFrame.value?.getAttribute("data-previewing-url") !== url.value
+  )
 
   const togglePreview = () => {
     previewEnabled.value = !previewEnabled.value

--- a/packages/hoppscotch-common/src/composables/lens-actions.ts
+++ b/packages/hoppscotch-common/src/composables/lens-actions.ts
@@ -117,6 +117,14 @@ export function usePreview(
       // Finally, set the iframe source to the resulting HTML.
       previewFrame.value.srcdoc = previewDocument.documentElement.outerHTML
       previewFrame.value.setAttribute("data-previewing-url", url.value)
+
+      // Enable sandboxing for the iframe but this can have security implications
+      // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox
+      // https://stackoverflow.com/a/30785417
+      // previewFrame.value.setAttribute(
+      //   "sandbox",
+      //   "allow-scripts allow-same-origin"
+      // )
     }
   }
 

--- a/packages/hoppscotch-common/src/composables/lens-actions.ts
+++ b/packages/hoppscotch-common/src/composables/lens-actions.ts
@@ -88,7 +88,7 @@ export function useDownloadResponse(
 }
 
 export function usePreview(
-  previewEnabledDefault: Ref<boolean>,
+  previewEnabled: Ref<boolean>,
   responseBodyText: Ref<string>
 ): {
   previewFrame: Ref<HTMLIFrameElement | null>
@@ -96,7 +96,6 @@ export function usePreview(
   togglePreview: () => void
 } {
   const previewFrame: Ref<HTMLIFrameElement | null> = ref(null)
-  const previewEnabled = ref(previewEnabledDefault)
   const url = ref("")
 
   const updatePreviewFrame = () => {


### PR DESCRIPTION
Closes #4862, HFE-776.

This PR fixes the issue where the html preview was not working as expected.

### What's changed
The defaultPreview has been changed to a computedAsync variable since the persistenceService.getLocalConfig is an async function. 

### Before
![image](https://github.com/user-attachments/assets/bb8dc925-8c65-4b1a-8f89-43c54ed36651)

### After
![image](https://github.com/user-attachments/assets/ce1a2e1a-5bf7-49bb-8378-1deb2e3b7c58)

### Note to reviewers
There was already a bug where the iframe sometimes didn't load due to sandbox error 
![image](https://github.com/user-attachments/assets/0a17cef7-8c1d-4282-bc4b-bcd8df123a49)

This can be fixed by allowing `allow-scripts allow-same-origin` in the sandbox attribute of the iframe but have some security issues that follows. This can be tackled separately if necessery
