### PR TITLE
fix(infra): deterministic env var ordering

### DIFF
--- a/aio_run.mjs
+++ b/aio_run.mjs
@@ -36,6 +36,7 @@ function runChildProcessWithPrefix(command, args, prefix) {
 
 const envFileContent = Object.entries(process.env)
   .filter(([env]) => env.startsWith("VITE_"))
+  .sort(([envA], [envB]) => envA.localeCompare(envB))
   .map(([env, val]) => `${env}=${
     (val.startsWith("\"") && val.endsWith("\""))
       ? val

--- a/packages/hoppscotch-selfhost-web/prod_run.mjs
+++ b/packages/hoppscotch-selfhost-web/prod_run.mjs
@@ -4,6 +4,7 @@ import fs from "fs"
 
 const envFileContent = Object.entries(process.env)
   .filter(([env]) => env.startsWith("VITE_"))
+  .sort(([envA], [envB]) => envA.localeCompare(envB))
   .map(
     ([env, val]) =>
       `${env}=${val.startsWith('"') && val.endsWith('"') ? val : `"${val}"`}`

--- a/packages/hoppscotch-sh-admin/prod_run.mjs
+++ b/packages/hoppscotch-sh-admin/prod_run.mjs
@@ -34,6 +34,7 @@ function runChildProcessWithPrefix(command, args, prefix) {
 
 const envFileContent = Object.entries(process.env)
   .filter(([env]) => env.startsWith('VITE_'))
+  .sort(([envA], [envB]) => envA.localeCompare(envB))
   .map(
     ([env, val]) =>
       `${env}=${val.startsWith('"') && val.endsWith('"') ? val : `"${val}"`}`


### PR DESCRIPTION
This change sorts environment variables alphabetically before they're processed with import-meta-env that injects them into the index.html. This makes sure consistent hashes across pod restarts when there aren't any functional changes made to the `.env` file.

The issue was affecting desktop app reconnections after k8s pod restarts. The cause was non-deterministic env var ordering (a side-effect of `Map`) during the import-meta-env injection process. Even when the env vars themselves didn't change, their order in the injected JSON could change, ultimately resulting in different file hashes.

This fix ensures that regardless of the order in which env vars are provided by the runtime, they will be sorted alphabetically before being written to the build.env file.
