### PR TITLE
fix: resolve issues around import via URL

### DIFF
--- a/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/UrlImport.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/UrlImport.vue
@@ -101,7 +101,8 @@ const urlFetchLogic =
     const responsePayload = parseBodyAsJSON<unknown>(res.right.body)
 
     if (O.isSome(responsePayload)) {
-      return E.right(responsePayload)
+      // stringify the response payload
+      return E.right(JSON.stringify(responsePayload.value))
     }
 
     return E.left("REQUEST_FAILED")

--- a/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/GistSource.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/GistSource.ts
@@ -48,11 +48,10 @@ export function GistSource(metadata: {
     loading: metadata.isLoading?.value,
   }))
 }
-
 const fetchGistFromUrl = async (url: string) => {
   const { response } = interceptorService.execute({
     id: Date.now(),
-    url: `https://api.github.com/gists/${url.split("/").pop()}`,
+    url: `https://api.github.com/gists/${url.split("/")[4]}`,
     method: "GET",
     version: "HTTP/1.1",
     headers: {
@@ -69,7 +68,7 @@ const fetchGistFromUrl = async (url: string) => {
   const responsePayload = parseBodyAsJSON<unknown>(res.right.body)
 
   if (O.isSome(responsePayload)) {
-    return E.right(responsePayload)
+    return E.right(responsePayload.value)
   }
 
   return E.left("REQUEST_FAILED")

--- a/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/GistSource.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/import-sources/GistSource.ts
@@ -49,9 +49,12 @@ export function GistSource(metadata: {
   }))
 }
 const fetchGistFromUrl = async (url: string) => {
+  // Extract the gist ID from the URL (eg. https://gist.github.com/username/gistID/...)
+  const gistID = url.split("/")[4]
+
   const { response } = interceptorService.execute({
     id: Date.now(),
-    url: `https://api.github.com/gists/${url.split("/")[4]}`,
+    url: `https://api.github.com/gists/${gistID}`,
     method: "GET",
     version: "HTTP/1.1",
     headers: {


### PR DESCRIPTION
Closes HFE-778

This PR addresses and resolves issues encountered when importing collections via GitHub Gist URLs and OpenAPI specifications through URLs.