### PR TITLE
feat(common): create new requests without siphoning data from the previous one

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/AddRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/AddRequest.vue
@@ -15,23 +15,6 @@
           input-styles="floating-input"
           @submit="addRequest"
         />
-        <HoppButtonSecondary
-          v-if="canDoRequestNameGeneration"
-          v-tippy="{ theme: 'tooltip' }"
-          :icon="IconSparkle"
-          :disabled="isGenerateRequestNamePending"
-          class="rounded-md"
-          :class="{
-            'animate-pulse': isGenerateRequestNamePending,
-          }"
-          :title="t('ai_experiments.generate_request_name')"
-          @click="
-            async () => {
-              await generateRequestName(props.requestContext)
-              submittedFeedback = false
-            }
-          "
-        />
       </div>
     </template>
     <template #footer>
@@ -50,64 +33,15 @@
             @click="hideModal"
           />
         </div>
-
-        <div
-          v-if="lastTraceID && !submittedFeedback"
-          class="flex items-center gap-2"
-        >
-          <p>{{ t("ai_experiments.feedback_cta_request_name") }}</p>
-          <template v-if="!isSubmitFeedbackPending">
-            <HoppButtonSecondary
-              :icon="IconThumbsUp"
-              outline
-              @click="
-                async () => {
-                  if (lastTraceID) {
-                    await submitFeedback('positive', lastTraceID)
-                    submittedFeedback = true
-                  }
-                }
-              "
-            />
-            <HoppButtonSecondary
-              :icon="IconThumbsDown"
-              outline
-              @click="
-                async () => {
-                  if (lastTraceID) {
-                    await submitFeedback('negative', lastTraceID)
-                    submittedFeedback = true
-                  }
-                }
-              "
-            />
-          </template>
-          <template v-else>
-            <HoppSmartSpinner />
-          </template>
-        </div>
-        <div v-if="submittedFeedback">
-          <p>{{ t("ai_experiments.feedback_thank_you") }}</p>
-        </div>
       </div>
     </template>
   </HoppSmartModal>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
-import { useService } from "dioc/vue"
-import { RESTTabService } from "~/services/tab/rest"
-import {
-  useRequestNameGeneration,
-  useSubmitFeedback,
-} from "~/composables/ai-experiments"
-import { HoppRESTRequest } from "@hoppscotch/data"
-import IconSparkle from "~icons/lucide/sparkles"
-import IconThumbsUp from "~icons/lucide/thumbs-up"
-import IconThumbsDown from "~icons/lucide/thumbs-down"
+import { ref } from "vue"
 
 const toast = useToast()
 const t = useI18n()
@@ -116,12 +50,10 @@ const props = withDefaults(
   defineProps<{
     show: boolean
     loadingState: boolean
-    requestContext: HoppRESTRequest | null
   }>(),
   {
     show: false,
     loadingState: false,
-    requestContext: null,
   }
 )
 
@@ -131,37 +63,6 @@ const emit = defineEmits<{
 }>()
 
 const editingName = ref("")
-
-const {
-  generateRequestName,
-  isGenerateRequestNamePending,
-  canDoRequestNameGeneration,
-  lastTraceID,
-} = useRequestNameGeneration(editingName)
-
-watch(
-  () => props.show,
-  (newVal) => {
-    if (!newVal) {
-      submittedFeedback.value = false
-      lastTraceID.value = null
-    }
-  }
-)
-
-const submittedFeedback = ref(false)
-const { submitFeedback, isSubmitFeedbackPending } = useSubmitFeedback()
-
-const tabs = useService(RESTTabService)
-watch(
-  () => props.show,
-  (show) => {
-    if (show) {
-      if (tabs.currentActiveTab.value.document.type === "request")
-        editingName.value = tabs.currentActiveTab.value.document.request.name
-    }
-  }
-)
 
 const addRequest = () => {
   if (props.loadingState) {

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -137,7 +137,6 @@
     <CollectionsAddRequest
       :show="showModalAddRequest"
       :loading-state="modalLoadingState"
-      :request-context="requestContext"
       @add-request="onAddRequest"
       @hide-modal="displayModalAddRequest(false)"
     />
@@ -820,24 +819,9 @@ const addRequest = (payload: {
   displayModalAddRequest(true)
 }
 
-const requestContext = computed(() => {
-  return tabs.currentActiveTab.value.document.type === "request"
-    ? tabs.currentActiveTab.value.document.request
-    : null
-})
-
 const onAddRequest = (requestName: string) => {
-  const request =
-    tabs.currentActiveTab.value.document.type === "request"
-      ? tabs.currentActiveTab.value.document.request
-      : getDefaultRESTRequest()
-
-  if (!request) return
-
   const newRequest = {
-    ...(tabs.currentActiveTab.value.document.type === "request"
-      ? cloneDeep(tabs.currentActiveTab.value.document.request)
-      : getDefaultRESTRequest()),
+    ...getDefaultRESTRequest(),
     name: requestName,
   }
 


### PR DESCRIPTION
Closes HFE-788 #4321

This pull request resolves the issue that permits the creation of new requests independently, without depending on data from previous requests. Since we already have a duplicate request option, we do not need to borrow data from the active tab to create a new request.

- [ ] Not Completed
- [x] Completed


### Notes to reviewers

We also removed AI name generation from the add request. This is because we lack context for requests when adding a new one. However, rename requests still have the AI feature.
