### PR TITLE
fix(common): pre-process proxy response to base type

### DIFF
--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
@@ -340,13 +340,13 @@ export class ProxyKernelInterceptorService
             // NOTE: This should be conditional but seems to be hit always,
             // see std/interceptor/proxy.ts for more info. Also see the above similar note.
             if (parsedProxyResponse.isBinary) {
-              const decodedData = decodeB64StringToArrayBuffer(
-                parsedProxyResponse.data
+              const decodedData = new Uint8Array(
+                decodeB64StringToArrayBuffer(parsedProxyResponse.data)
               )
 
               // NOTE: This is also for backwards compat,
               // better solution would be to ask for raw bytes from proxyscotch.
-              const jsonResult = parseBytesToJSON(new Uint8Array(decodedData))
+              const jsonResult = parseBytesToJSON(decodedData)
 
               if (O.isSome(jsonResult)) {
                 return E.right({
@@ -382,7 +382,7 @@ export class ProxyKernelInterceptorService
               statusText: parsedProxyResponse.statusText,
               headers: parsedProxyResponse.headers,
               body: {
-                body: parsedProxyResponse.data,
+                body: new TextEncoder().encode(parsedProxyResponse.data),
                 mediaType:
                   parsedProxyResponse.headers["content-type"] || "text/plain",
               },


### PR DESCRIPTION
This PR fixes non-json response types not being correctly decomposed to the base `Uint8Array` type for kernel processors.

Closes #4895
Closes HFE-785

#### Notes to reviewers

Try any non-json response requests API, the request will fail.

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/6db01f10-2295-4e36-b1cf-d57ee1cabc6d) | ![image](https://github.com/user-attachments/assets/b0142921-70f5-4abf-9bc5-5f9d4d12939b)  |


> [!NOTE]
> You may see incorrect interceptor embed after request failure on live version, it is fixed with https://github.com/hoppscotch/hoppscotch/pull/4887