### PR TITLE
feat: format JSON responses having `text/plain` content type

### DIFF
--- a/packages/hoppscotch-common/src/helpers/lenses/jsonLens.ts
+++ b/packages/hoppscotch-common/src/helpers/lenses/jsonLens.ts
@@ -1,10 +1,32 @@
 import { defineAsyncComponent } from "vue"
-import { isJSONContentType } from "../utils/contenttypes"
 import { Lens } from "./lenses"
+import { isJSONContentType } from "../utils/contenttypes"
+
+/**
+ * Checks if a string can be parsed as valid JSON
+ */
+export function isValidJSON(str: string): boolean {
+  try {
+    JSON.parse(str)
+    return true
+  } catch (e) {
+    return false
+  }
+}
 
 const jsonLens: Lens = {
   lensName: "response.json",
-  isSupportedContentType: isJSONContentType,
+  isSupportedContentType: (contentType) => {
+    // Check if it's a standard JSON content type
+    if (isJSONContentType(contentType)) return true
+
+    // For text/plain, we'll need the response body to determine if it's JSON
+    if (contentType.includes("text/plain")) {
+      return true // We'll do actual JSON validation in the renderer component
+    }
+
+    return false
+  },
   renderer: "json",
   rendererImport: defineAsyncComponent(
     () => import("~/components/lenses/renderers/JSONLensRenderer.vue")

--- a/packages/hoppscotch-common/src/helpers/lenses/jsonLens.ts
+++ b/packages/hoppscotch-common/src/helpers/lenses/jsonLens.ts
@@ -3,11 +3,24 @@ import { Lens } from "./lenses"
 import { isJSONContentType } from "../utils/contenttypes"
 
 /**
- * Checks if a string can be parsed as valid JSON
+ * Checks if response body contents can be parsed as valid JSON
  */
-export function isValidJSON(str: string): boolean {
+export function isValidJSONResponse(contents: string | ArrayBuffer): boolean {
+  if (!contents) {
+    return false
+  }
+
+  const resolvedStr =
+    contents instanceof ArrayBuffer
+      ? new TextDecoder("utf-8").decode(contents)
+      : contents
+
+  if (!resolvedStr.trim()) {
+    return false
+  }
+
   try {
-    JSON.parse(str)
+    JSON.parse(resolvedStr)
     return true
   } catch (e) {
     return false
@@ -16,17 +29,7 @@ export function isValidJSON(str: string): boolean {
 
 const jsonLens: Lens = {
   lensName: "response.json",
-  isSupportedContentType: (contentType) => {
-    // Check if it's a standard JSON content type
-    if (isJSONContentType(contentType)) return true
-
-    // For text/plain, we'll need the response body to determine if it's JSON
-    if (contentType.includes("text/plain")) {
-      return true // We'll do actual JSON validation in the renderer component
-    }
-
-    return false
-  },
+  isSupportedContentType: isJSONContentType,
   renderer: "json",
   rendererImport: defineAsyncComponent(
     () => import("~/components/lenses/renderers/JSONLensRenderer.vue")

--- a/packages/hoppscotch-common/src/helpers/lenses/lenses.ts
+++ b/packages/hoppscotch-common/src/helpers/lenses/lenses.ts
@@ -1,5 +1,5 @@
 import { HoppRESTResponse } from "../types/HoppRESTResponse"
-import jsonLens, { isValidJSON } from "./jsonLens"
+import jsonLens, { isValidJSONResponse } from "./jsonLens"
 import rawLens from "./rawLens"
 import imageLens from "./imageLens"
 import htmlLens from "./htmlLens"
@@ -45,13 +45,13 @@ export function getSuitableLenses(response: HoppRESTResponse): Lens[] {
 
   if (!contentType) return [rawLens]
 
-  // Check if content is text/plain and contains valid JSON
+  // Check if the response content type includes `text/plain` and the body contains valid JSON
   if (
     contentType.value.includes("text/plain") &&
     response.type === "success" &&
-    isValidJSON(response.body)
+    isValidJSONResponse(response.body)
   ) {
-    // If it's text/plain but contains valid JSON, prioritize JSON lens first
+    // Append JSON lens to the list of lenses
     return [rawLens, jsonLens]
   }
 

--- a/packages/hoppscotch-common/src/helpers/lenses/lenses.ts
+++ b/packages/hoppscotch-common/src/helpers/lenses/lenses.ts
@@ -1,5 +1,5 @@
 import { HoppRESTResponse } from "../types/HoppRESTResponse"
-import jsonLens from "./jsonLens"
+import jsonLens, { isValidJSON } from "./jsonLens"
 import rawLens from "./rawLens"
 import imageLens from "./imageLens"
 import htmlLens from "./htmlLens"
@@ -44,6 +44,16 @@ export function getSuitableLenses(response: HoppRESTResponse): Lens[] {
   )
 
   if (!contentType) return [rawLens]
+
+  // Check if content is text/plain and contains valid JSON
+  if (
+    contentType.value.includes("text/plain") &&
+    response.type === "success" &&
+    isValidJSON(response.body)
+  ) {
+    // If it's text/plain but contains valid JSON, prioritize JSON lens first
+    return [rawLens, jsonLens]
+  }
 
   const result = []
   for (const lens of lenses) {


### PR DESCRIPTION
Closes HFE-791 #4239

This pull request introduces improvements to the JSON lens functionality in the `hoppscotch-common` package. The key changes include adding a utility function to validate JSON strings, updating the JSON lens to handle `text/plain` content types, and modifying the lens selection logic to prioritize the JSON lens for valid JSON content.

### Enhancements to JSON lens functionality:

* [`packages/hoppscotch-common/src/helpers/lenses/jsonLens.ts`](diffhunk://#diff-cbd2b0f64781739021c5b10c958805700cf8a1c12211b3c7d840e2f6570297ffL2-R29): Added a new function `isValidJSONResponse` to check if a string can be parsed as valid JSON.

* [`packages/hoppscotch-common/src/helpers/lenses/lenses.ts`](diffhunk://#diff-79bfbf40575328139052e5ff8d6c432b3345dec7dcf6f01e0f0f5db5abecaa1fL2-R2): Imported the new `isValidJSONResponse` function.

### What's changed
* [`packages/hoppscotch-common/src/helpers/lenses/lenses.ts`](diffhunk://#diff-79bfbf40575328139052e5ff8d6c432b3345dec7dcf6f01e0f0f5db5abecaa1fR48-R57): Modified the `getSuitableLenses` function to consider the JSON lens if the content type is `text/plain` and the response body contains valid JSON.

- [ ] Not Completed
- [x] Completed
