### PR TITLE
fix(common): oauth2 basic header encoding

### DIFF
--- a/packages/hoppscotch-common/src/services/oauth/flows/clientCredentials.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/clientCredentials.ts
@@ -177,7 +177,10 @@ const getPayloadForViaBasicAuthHeader = (
 ): RelayRequest => {
   const { clientID, clientSecret, scopes, authEndpoint } = payload
 
-  const basicAuthToken = btoa(`${clientID}:${clientSecret}`)
+  // RFC 6749 Section 2.3.1 states that the client ID and secret should be URL encoded.
+  const encodedClientID = encodeBasicAuthComponent(clientID)
+  const encodedClientSecret = encodeBasicAuthComponent(clientSecret || "")
+  const basicAuthToken = btoa(`${encodedClientID}:${encodedClientSecret}`)
 
   return {
     id: Date.now(),
@@ -217,4 +220,10 @@ const getPayloadForViaBody = (
       ...(scopes && { scope: scopes }),
     }),
   }
+}
+
+const encodeBasicAuthComponent = (component: string): string => {
+  // application/x-www-form-urlencoded expects spaces to be encoded as '+', but
+  // encodeURIComponent encodes them as '%20'.
+  return encodeURIComponent(component).replace(/%20/g, "+")
 }


### PR DESCRIPTION
Fixes the basic auth header encoding in accordance with RFC 6749.

Using OAuth2 and selecting `Send credentials as Basis Auth` using any client secret with special characters such as `+`, or `§` will result in a failure to fetch the token.

According to [RFC 6749 section 2.3.1](<https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1>) (the OAuth spec) the client ID and the secret should be encoded in accordance with `application/x-www-form-urlencoded`.

I you want me to create an issue for this I can, but I had already solved it once I finished debugging.

### What's changed

Before base64 encoding the header value, a new function will properly encode the username and password parts separately before encoding it.

As a sidenote, `encodeURIComponent` encodes spaces as `%20` and not `+` as specified by `application/x-www-form-urlencoded`. There is a [note on the MDN site](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#description>) for this.

### Before

```
Auth:    "user:0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_.,;:-/(){}!+*'#%&<>|§½"
Decoded: "user:0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_.,;-/(){}! *'#%&<>|��"
```

### After

```
Auth:    "user:0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_.,;:-/(){}!+*'#%&<>|§½"
Decoded: "user:0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_.,;:-/(){}!+*'#%&<>|§½"
```