### PR TITLE
fix: import bug with extension and agent interceptors

### DIFF
--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/extension/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/extension/index.ts
@@ -276,7 +276,7 @@ export class ExtensionKernelInterceptorService
         await window.__POSTWOMAN_EXTENSION_HOOK__.sendRequest({
           url: request.url,
           method: request.method,
-          headers: request.headers,
+          headers: request.headers ?? {},
           data: requestData,
           wantsBinary: true,
         })


### PR DESCRIPTION
Closes HFE-789

This PR fixes the issue where the OpenAPI URL and Gist import failed when using extension and Agent as interceptors.

### Todo
- [x] OpenAPI spec via URL with the interceptor set to Browser extension
- [ ] GitHub Gist with the interceptor set to Agent  
