### PR TITLE
fix(desktop): enable cookie support for sh-desktop

### DIFF
--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -90,6 +90,8 @@ async function initApp() {
     platformFeatureFlags: {
       exportAsGIST: false,
       hasTelemetry: false,
+      cookiesEnabled: kernelMode === "desktop",
+      promptAsUsingCookies: false,
     },
     limits: {
       collectionImportSizeLimit: 50,


### PR DESCRIPTION
This PR enables cookie support for the SH Desktop App.

| Before | After |
| ---       | ---    |
| ![Before 1](https://github.com/user-attachments/assets/a02ee9de-e8bd-40fc-afa9-627a1e2577ed) | ![After 1](https://github.com/user-attachments/assets/bafd9d19-47de-43c0-b27a-8535730c7349) | 
| Notice the missing `Cookie` button at the footer | Button is now present |

![After 2](https://github.com/user-attachments/assets/ab384246-2439-4518-8190-0cc2bec4e030)
![After 3](https://github.com/user-attachments/assets/3bcf9b8a-6a9f-4b46-b454-d53029a25984) 



Closes HFE-796
Closes  #4918

#### Notes for reviewers

This feature is already present and enabled on the Cloud Desktop App, see the corresponding file in the relevant repo.

For testing this out quickly without setting up AIO container, you can:
```
❯ cd packages/hoppscotch-selfhost-web
❯ pnpm generate && cd webapp-server && RUST_LOG=debug cargo run
```
This will start a temporary bundle server. 
After it's up and running, use `localhost:3200` as the instance URL in the "Add a new Instance" section. This will work with the currently released desktop app as well, no need to re-build it from source.