### PR TITLE
fix(common): oauth2 password flow not respecting scopes

### DIFF
--- a/packages/hoppscotch-common/src/services/oauth/flows/password.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/password.ts
@@ -76,7 +76,7 @@ const initPasswordOauthFlow = async ({
         client_secret: clientSecret,
       }),
       ...(scopes && {
-        scopes: scopes,
+        scope: scopes,
       }),
     }),
   })


### PR DESCRIPTION
Fixes an issue where the `scope` parameter is not sent to the IDP token endpoint when using the `password` oauth2 flow.

The code today sends the scopes as `scopes` and not `scope`, which is not according to the OAuth2 specification. The scopes selected in the UI will not be respected. After this fix, the scopes will be respected as expected.

### Testing

1. Select the `Authorization` tab of a request.
2. Select `OAuth2` as the authorization type.
3. Select `Password` as the grant type.
4. Enter all endpoints and details for a password client.
5. Select a subset of scopes in the scope parameter.
6. Notice how the subset of scopes is not respected.

### Changes

#### Before

Request received in test application (formatted as JSON):

```json
{"grant_type":"password","username":"redacted","password":"redacted","client_id":"test","client_secret":"redacted","scope":null}

```

#### After

Request received in test application (formatted as JSON):

```json
{"grant_type":"password","username":"redacted","password":"redacted","client_id":"test","client_secret":"redacted","scope":"myscope"}
```
