### PR TITLE
chore: bump vulnerable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
       "micromatch@<4.0.8": "4.0.8",
       "dset@3.1.3": "3.1.4",
       "nanoid@3.3.7": "3.3.8",
-      "execa@0.10.0": "2.0.0"
+      "execa@0.10.0": "2.0.0",
+      "@babel/runtime@<7.26.10": "7.26.10"
     },
     "packageExtensions": {
       "@hoppscotch/httpsnippet": {

--- a/packages/hoppscotch-agent/package.json
+++ b/packages/hoppscotch-agent/package.json
@@ -14,7 +14,7 @@
     "@tauri-apps/api": "^2.0.2",
     "@tauri-apps/plugin-shell": "^2.0.0",
     "@vueuse/core": "^11.1.0",
-    "axios": "^1.7.7",
+    "axios": "1.8.2",
     "fp-ts": "^2.16.9",
     "lodash-es": "4.17.21",
     "vue": "3.3.9"

--- a/packages/hoppscotch-cli/package.json
+++ b/packages/hoppscotch-cli/package.json
@@ -42,7 +42,7 @@
   "private": false,
   "dependencies": {
     "aws4fetch": "1.0.20",
-    "axios": "1.7.7",
+    "axios": "1.8.2",
     "chalk": "5.3.0",
     "commander": "12.1.0",
     "isolated-vm": "5.0.1",

--- a/packages/hoppscotch-common/package.json
+++ b/packages/hoppscotch-common/package.json
@@ -55,7 +55,7 @@
     "@vueuse/core": "11.1.0",
     "acorn-walk": "8.3.4",
     "aws4fetch": "1.0.20",
-    "axios": "1.7.7",
+    "axios": "1.8.2",
     "buffer": "6.0.3",
     "cookie-es": "1.2.2",
     "dioc": "3.0.2",

--- a/packages/hoppscotch-kernel/package.json
+++ b/packages/hoppscotch-kernel/package.json
@@ -48,7 +48,7 @@
     }
   },
   "dependencies": {
-    "axios": "1.6.2",
+    "axios": "1.8.2",
     "fp-ts": "2.16.9",
     "aws4fetch": "1.0.20",
     "zod": "3.22.4",

--- a/packages/hoppscotch-selfhost-desktop/package.json
+++ b/packages/hoppscotch-selfhost-desktop/package.json
@@ -22,7 +22,7 @@
     "@tauri-apps/api": "1.5.1",
     "@tauri-apps/cli": "1.5.6",
     "@vueuse/core": "10.5.0",
-    "axios": "1.7.5",
+    "axios": "1.8.2",
     "buffer": "6.0.3",
     "dioc": "3.0.2",
     "environments.api": "link:@platform/environments/environments.api",

--- a/packages/hoppscotch-selfhost-web/package.json
+++ b/packages/hoppscotch-selfhost-web/package.json
@@ -36,7 +36,7 @@
     "@tauri-apps/plugin-fs": "2.0.2",
     "@tauri-apps/plugin-shell": "2.0.1",
     "@vueuse/core": "10.5.0",
-    "axios": "1.7.7",
+    "axios": "1.8.2",
     "buffer": "6.0.3",
     "dioc": "3.0.2",
     "fp-ts": "2.16.9",

--- a/packages/hoppscotch-sh-admin/package.json
+++ b/packages/hoppscotch-sh-admin/package.json
@@ -24,7 +24,7 @@
     "@urql/exchange-auth": "2.2.0",
     "@urql/vue": "1.4.0",
     "@vueuse/core": "11.1.0",
-    "axios": "1.7.7",
+    "axios": "1.8.2",
     "cors": "2.8.5",
     "date-fns": "4.1.0",
     "fp-ts": "2.16.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   dset@3.1.3: 3.1.4
   nanoid@3.3.7: 3.3.8
   execa@0.10.0: 2.0.0
+  '@babel/runtime@<7.26.10': 7.26.10
 
 packageExtensionsChecksum: sha256-Qhsch/G1LLagBL1kRb8nf11C5HcyCWi8Px3h3uWxYUw=
 
@@ -95,8 +96,8 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0(vue@3.5.12(typescript@5.6.3))
       axios:
-        specifier: ^1.7.7
-        version: 1.7.7
+        specifier: 1.8.2
+        version: 1.8.2
       fp-ts:
         specifier: ^2.16.9
         version: 2.16.9
@@ -391,8 +392,8 @@ importers:
         specifier: 1.0.20
         version: 1.0.20
       axios:
-        specifier: 1.7.7
-        version: 1.7.7
+        specifier: 1.8.2
+        version: 1.8.2
       chalk:
         specifier: 5.3.0
         version: 5.3.0
@@ -566,8 +567,8 @@ importers:
         specifier: 1.0.20
         version: 1.0.20
       axios:
-        specifier: 1.7.7
-        version: 1.7.7
+        specifier: 1.8.2
+        version: 1.8.2
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -1200,8 +1201,8 @@ importers:
         specifier: 1.0.20
         version: 1.0.20
       axios:
-        specifier: 1.6.2
-        version: 1.6.2
+        specifier: 1.8.2
+        version: 1.8.2
       fp-ts:
         specifier: 2.16.9
         version: 2.16.9
@@ -1252,8 +1253,8 @@ importers:
         specifier: 10.5.0
         version: 10.5.0(vue@3.5.12(typescript@4.9.5))
       axios:
-        specifier: 1.7.5
-        version: 1.7.5
+        specifier: 1.8.2
+        version: 1.8.2
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -1466,8 +1467,8 @@ importers:
         specifier: 10.5.0
         version: 10.5.0(vue@3.5.12(typescript@5.3.3))
       axios:
-        specifier: 1.7.7
-        version: 1.7.7
+        specifier: 1.8.2
+        version: 1.8.2
       buffer:
         specifier: 6.0.3
         version: 6.0.3
@@ -1659,8 +1660,8 @@ importers:
         specifier: 11.1.0
         version: 11.1.0(vue@3.5.12(typescript@5.6.3))
       axios:
-        specifier: 1.7.7
-        version: 1.7.7
+        specifier: 1.8.2
+        version: 1.8.2
       cors:
         specifier: 2.8.5
         version: 2.8.5
@@ -2604,8 +2605,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
 
-  '@babel/runtime@7.25.7':
-    resolution: {integrity: sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==}
+  '@babel/runtime@7.26.10':
+    resolution: {integrity: sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/standalone@7.24.5':
@@ -6439,14 +6440,8 @@ packages:
   aws4fetch@1.0.20:
     resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
 
-  axios@1.6.2:
-    resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
-
-  axios@1.7.5:
-    resolution: {integrity: sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==}
-
-  axios@1.7.7:
-    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
+  axios@1.8.2:
+    resolution: {integrity: sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -13440,7 +13435,7 @@ snapshots:
       '@babel/core': 7.25.7
       '@babel/generator': 7.25.7
       '@babel/parser': 7.25.7
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       '@babel/traverse': 7.25.7
       '@babel/types': 7.25.7
       babel-preset-fbjs: 3.4.0(@babel/core@7.25.7)
@@ -14269,7 +14264,7 @@ snapshots:
       '@babel/types': 7.25.7
       esutils: 2.0.3
 
-  '@babel/runtime@7.25.7':
+  '@babel/runtime@7.26.10':
     dependencies:
       regenerator-runtime: 0.14.1
 
@@ -19293,26 +19288,10 @@ snapshots:
 
   aws4fetch@1.0.20: {}
 
-  axios@1.6.2:
+  axios@1.8.2:
     dependencies:
       follow-redirects: 1.15.6
       form-data: 4.0.1
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.7.5:
-    dependencies:
-      follow-redirects: 1.15.6
-      form-data: 4.0.1
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.7.7:
-    dependencies:
-      follow-redirects: 1.15.6
-      form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -23494,7 +23473,7 @@ snapshots:
 
   mjml-accordion@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23510,7 +23489,7 @@ snapshots:
 
   mjml-body@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23526,7 +23505,7 @@ snapshots:
 
   mjml-button@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23542,7 +23521,7 @@ snapshots:
 
   mjml-carousel@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23558,7 +23537,7 @@ snapshots:
 
   mjml-cli@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       chokidar: 3.6.0
       glob: 10.4.2
       lodash: 4.17.21
@@ -23580,7 +23559,7 @@ snapshots:
 
   mjml-column@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23596,7 +23575,7 @@ snapshots:
 
   mjml-core@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       cheerio: 1.0.0-rc.12
       cssnano: 7.0.6(postcss@8.4.49)
       detect-node: 2.1.0
@@ -23620,7 +23599,7 @@ snapshots:
 
   mjml-divider@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23636,7 +23615,7 @@ snapshots:
 
   mjml-group@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23652,7 +23631,7 @@ snapshots:
 
   mjml-head-attributes@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23668,7 +23647,7 @@ snapshots:
 
   mjml-head-breakpoint@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23684,7 +23663,7 @@ snapshots:
 
   mjml-head-font@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23700,7 +23679,7 @@ snapshots:
 
   mjml-head-html-attributes@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23716,7 +23695,7 @@ snapshots:
 
   mjml-head-preview@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23732,7 +23711,7 @@ snapshots:
 
   mjml-head-style@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23748,7 +23727,7 @@ snapshots:
 
   mjml-head-title@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23764,7 +23743,7 @@ snapshots:
 
   mjml-head@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23780,7 +23759,7 @@ snapshots:
 
   mjml-hero@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23796,7 +23775,7 @@ snapshots:
 
   mjml-image@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23812,7 +23791,7 @@ snapshots:
 
   mjml-navbar@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23828,7 +23807,7 @@ snapshots:
 
   mjml-parser-xml@5.0.0-alpha.4:
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       detect-node: 2.1.0
       htmlparser2: 9.1.0
       lodash: 4.17.21
@@ -23836,7 +23815,7 @@ snapshots:
 
   mjml-preset-core@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       mjml-accordion: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
       mjml-body: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
       mjml-button: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
@@ -23875,7 +23854,7 @@ snapshots:
 
   mjml-raw@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23891,7 +23870,7 @@ snapshots:
 
   mjml-section@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23907,7 +23886,7 @@ snapshots:
 
   mjml-social@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23923,7 +23902,7 @@ snapshots:
 
   mjml-spacer@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23939,7 +23918,7 @@ snapshots:
 
   mjml-table@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23955,7 +23934,7 @@ snapshots:
 
   mjml-text@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
     transitivePeerDependencies:
@@ -23971,12 +23950,12 @@ snapshots:
 
   mjml-validator@5.0.0-alpha.4:
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
     optional: true
 
   mjml-wrapper@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       lodash: 4.17.21
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
       mjml-section: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
@@ -23993,7 +23972,7 @@ snapshots:
 
   mjml@5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4):
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       mjml-cli: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
       mjml-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
       mjml-preset-core: 5.0.0-alpha.4(relateurl@0.2.7)(svgo@3.3.2)(terser@5.34.1)(typescript@5.5.4)
@@ -24905,7 +24884,7 @@ snapshots:
 
   posthog-node@4.2.0:
     dependencies:
-      axios: 1.7.7
+      axios: 1.8.2
       rusha: 0.8.14
     transitivePeerDependencies:
       - debug
@@ -25249,7 +25228,7 @@ snapshots:
 
   regenerator-transform@0.15.2:
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
 
   regexp.prototype.flags@1.5.2:
     dependencies:
@@ -25285,7 +25264,7 @@ snapshots:
 
   relay-runtime@12.0.0:
     dependencies:
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       fbjs: 3.0.5
       invariant: 2.2.4
     transitivePeerDependencies:
@@ -28078,7 +28057,7 @@ snapshots:
       '@apideck/better-ajv-errors': 0.3.6(ajv@8.17.1)
       '@babel/core': 7.25.7
       '@babel/preset-env': 7.25.7(@babel/core@7.25.7)
-      '@babel/runtime': 7.25.7
+      '@babel/runtime': 7.26.10
       '@rollup/plugin-babel': 5.3.1(@babel/core@7.25.7)(@types/babel__core@7.20.5)(rollup@2.79.2)
       '@rollup/plugin-node-resolve': 15.3.0(rollup@2.79.2)
       '@rollup/plugin-replace': 2.4.2(rollup@2.79.2)

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,6 +1,6 @@
 # This step is used to build a custom build of Caddy to prevent
 # vulnerable packages on the dependency chain
-FROM alpine:3.21.2 AS caddy_builder
+FROM alpine:3.21.3 AS caddy_builder
 RUN apk add curl go
 
 RUN mkdir -p /tmp/caddy-build
@@ -23,6 +23,9 @@ RUN go get github.com/golang/glog@v1.2.4
 RUN go get github.com/go-jose/go-jose/v3@v3.0.4
 # Patch to resolve CVE-2025-22869 on crypto
 RUN go get golang.org/x/crypto@v0.35.0
+# Patch to resolve CVE-2025-22870 on net
+RUN go get golang.org/x/net@v0.37.0
+
 RUN go mod vendor
 
 WORKDIR /tmp/caddy-build/cmd/caddy


### PR DESCRIPTION
This PR intends to update some of the dependencies in the Hoppscotch dependency chain that have published CVEs.

### What's changed
1. Bump and unify axios versions to 1.8.2 across all workspace packages.
2. Bump @babel/runtime to 7.26.10
3. Bump Caddy's build dependency (`golang.org/x/net`)