### PR TITLE
chore: truncate long secret environment variables

### DIFF
--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -17,7 +17,7 @@
         v-else
         ref="editor"
         :placeholder="placeholder"
-        class="flex flex-1"
+        class="flex flex-1 max-w-[85%]"
         :class="styles"
         @click="emit('click', $event)"
         @keydown="handleKeystroke"

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -9,7 +9,7 @@
         v-model="secretText"
         name="secret"
         :placeholder="t('environment.secret_value')"
-        class="flex flex-1 bg-transparent px-4"
+        class="flex flex-1 bg-transparent pl-4"
         :class="styles"
         type="password"
       />
@@ -17,7 +17,7 @@
         v-else
         ref="editor"
         :placeholder="placeholder"
-        class="flex flex-1 max-w-[85%]"
+        class="flex flex-1 truncate"
         :class="styles"
         @click="emit('click', $event)"
         @keydown="handleKeystroke"


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

In the current version of Hoppscotch, the show/hide button for viewing a secret value in the settings dialog box is shoved out of view by the content of the secret value input box. This change enhances the experience by keeping the button in its original location, while not preventing the value from being scrollable so the entire value can be viewed as it in the current state.

### What's changed

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->
![screencapture_before](https://github.com/user-attachments/assets/5d2c33ae-d2a5-4a16-8761-11d16823e24e)
![screencapture_after](https://github.com/user-attachments/assets/147660d7-6415-4d55-ac9f-b951e6278434)

