### PR TITLE
fix(common): OpenAPI response example status code bug

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
@@ -31,7 +31,7 @@ import * as E from "fp-ts/Either"
 import { IMPORTER_INVALID_FILE_FORMAT } from "."
 import { cloneDeep } from "lodash-es"
 import { getStatusCodeReasonPhrase } from "~/helpers/utils/statusCodes"
-import { isNumber } from "~/helpers/utils/isNumber"
+import { isNumeric } from "~/helpers/utils/number"
 
 export const OPENAPI_DEREF_ERROR = "openapi/deref_error" as const
 
@@ -173,7 +173,7 @@ const parseOpenAPIV3Responses = (
 
     const name = response.description ?? key
 
-    const code = isNumber(key) ? Number(key) : 200
+    const code = isNumeric(key) ? Number(key) : 200
 
     const status = getStatusCodeReasonPhrase(code)
 
@@ -231,7 +231,7 @@ const parseOpenAPIV2Responses = (
 
     const name = response.description ?? key
 
-    const code = isNumber(Number(key)) ? Number(key) : 200
+    const code = isNumeric(Number(key)) ? Number(key) : 200
     const status = getStatusCodeReasonPhrase(code)
 
     const headers: HoppRESTHeader[] = [

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi.ts
@@ -29,8 +29,9 @@ import * as TE from "fp-ts/TaskEither"
 import * as RA from "fp-ts/ReadonlyArray"
 import * as E from "fp-ts/Either"
 import { IMPORTER_INVALID_FILE_FORMAT } from "."
-import { cloneDeep, isNumber } from "lodash-es"
+import { cloneDeep } from "lodash-es"
 import { getStatusCodeReasonPhrase } from "~/helpers/utils/statusCodes"
+import { isNumber } from "~/helpers/utils/isNumber"
 
 export const OPENAPI_DEREF_ERROR = "openapi/deref_error" as const
 

--- a/packages/hoppscotch-common/src/helpers/utils/isNumber.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/isNumber.ts
@@ -1,0 +1,13 @@
+/**
+ * Check if a value is a number
+ * @param value - The value to check
+ * @returns True if the value is a number, false otherwise
+ */
+export const isNumber = (value: unknown): boolean => {
+  if (typeof value === "number") return !Number.isNaN(value) // handle actual numbers
+  if (typeof value !== "string") return false // only process strings or numbers!
+  return (
+    value.trim() !== "" && // ensure strings of whitespace fail
+    !isNaN(Number(value)) // use type coercion to parse the entirety of the string
+  )
+}

--- a/packages/hoppscotch-common/src/helpers/utils/number.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/number.ts
@@ -1,9 +1,10 @@
 /**
- * Check if a value is a number
+ * Check if a value is numeric — either a valid number or a numeric string
+ *
  * @param value - The value to check
- * @returns True if the value is a number, false otherwise
+ * @returns True if the value is numeric, false otherwise
  */
-export const isNumber = (value: unknown): boolean => {
+export const isNumeric = (value: unknown): boolean => {
   if (typeof value === "number") return !Number.isNaN(value) // handle actual numbers
   if (typeof value !== "string") return false // only process strings or numbers!
   return (


### PR DESCRIPTION
Closes #4956 

- This pull request fixes the bug where importing an OpenAPI request the examples show wrong status codes.
- Also added a new file for the `isNumber` function .