### PR TITLE
feat: add support to export http postman graphql request

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -4,6 +4,7 @@
     modal-title="modal.collections"
     :importer-modules="importerModules"
     :exporter-modules="exporterModules"
+    :has-team-write-access="hasTeamWriteAccess"
     @hide-modal="emit('hide-modal')"
   />
 </template>
@@ -696,7 +697,8 @@ const importerModules = computed(() => {
     }
 
     return isTeams
-      ? importer.metadata.applicableTo.includes("team-workspace")
+      ? importer.metadata.applicableTo.includes("team-workspace") &&
+          hasTeamWriteAccess.value
       : importer.metadata.applicableTo.includes("personal-workspace")
   })
 })

--- a/packages/hoppscotch-common/src/components/importExport/Base.vue
+++ b/packages/hoppscotch-common/src/components/importExport/Base.vue
@@ -50,6 +50,10 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  hasTeamWriteAccess: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const {
@@ -87,6 +91,7 @@ const chooseImporterOrExporter = defineStep(
       disabled: exporter.metadata.disabled,
       loading: exporter.metadata.isLoading?.value ?? false,
     })),
+    hasTeamWriteAccess: props.hasTeamWriteAccess,
     "onImporter-selected": (id: string) => {
       selectedImporterID.value = id
 

--- a/packages/hoppscotch-common/src/components/importExport/ImportExportList.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportList.vue
@@ -9,7 +9,7 @@
         @click="emit('importer-selected', importer.id)"
       />
     </div>
-    <hr />
+    <hr v-if="hasTeamWriteAccess" />
     <div class="flex flex-col space-y-2">
       <template v-for="exporter in exporters" :key="exporter.id">
         <!-- adding the title to a span if the item is visible, otherwise the title won't be shown -->
@@ -64,6 +64,7 @@ type ImportExportEntryMeta = {
 defineProps<{
   importers: ImportExportEntryMeta[]
   exporters: ImportExportEntryMeta[]
+  hasTeamWriteAccess: boolean
 }>()
 
 const emit = defineEmits<{

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -371,10 +371,27 @@ const getHoppReqBody = ({
           }
       )
     )
+  } else if (body.mode === "graphql") {
+    const formatedQuery = {
+      // @ts-expect-error - this is a valid option, but seems like the types are not updated
+      query: body.graphql?.query,
+      // @ts-expect-error - this is a valid option, but seems like the types are not updated
+      variables: body.graphql?.variables
+        ? // @ts-expect-error - this is a valid option, but seems like the types are not updated
+          JSON.parse(body.graphql?.variables)
+        : undefined,
+    }
+
+    return {
+      contentType: "application/json",
+      body: pipe(
+        JSON.stringify(formatedQuery, null, 2),
+        replacePMVarTemplating
+      ),
+    }
   }
 
   // TODO: File
-  // TODO: GraphQL ?
 
   return { contentType: null, body: null }
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -372,7 +372,7 @@ const getHoppReqBody = ({
       )
     )
   } else if (body.mode === "graphql") {
-    const formatedQuery = {
+    const formattedQuery = {
       // @ts-expect-error - this is a valid option, but seems like the types are not updated
       query: body.graphql?.query,
       // @ts-expect-error - this is a valid option, but seems like the types are not updated
@@ -385,7 +385,7 @@ const getHoppReqBody = ({
     return {
       contentType: "application/json",
       body: pipe(
-        JSON.stringify(formatedQuery, null, 2),
+        JSON.stringify(formattedQuery, null, 2),
         replacePMVarTemplating
       ),
     }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -375,11 +375,12 @@ const getHoppReqBody = ({
     const formattedQuery = {
       // @ts-expect-error - this is a valid option, but seems like the types are not updated
       query: body.graphql?.query,
-      // @ts-expect-error - this is a valid option, but seems like the types are not updated
-      variables: body.graphql?.variables
-        ? // @ts-expect-error - this is a valid option, but seems like the types are not updated
-          JSON.parse(body.graphql?.variables)
-        : undefined,
+      variables: pipe(
+        // @ts-expect-error - this is a valid option, but seems like the types are not updated
+        body.graphql?.variables,
+        safeParseJSON,
+        O.getOrElse(() => undefined)
+      ),
     }
 
     return {


### PR DESCRIPTION
Closes HFE-730

![image](https://github.com/user-attachments/assets/66144b1b-82db-4cdf-a38e-349405bff75c)


- This PR adds support for handling http GraphQL requests by formatting the query and variables properly.
- Also disables imports for users having no write access in a teams