### PR TITLE
test(backend): account for race conditions in `verifyMagicLinkTokens` test suite

### DIFF
--- a/packages/hoppscotch-backend/src/auth/auth.service.spec.ts
+++ b/packages/hoppscotch-backend/src/auth/auth.service.spec.ts
@@ -213,9 +213,10 @@ describe('verifyMagicLinkTokens', () => {
 
   test('Should throw MAGIC_LINK_EXPIRED if passwordless token is expired', async () => {
     // validatePasswordlessTokens
-    mockPrisma.verificationToken.findUniqueOrThrow.mockResolvedValueOnce(
-      passwordlessData,
-    );
+    mockPrisma.verificationToken.findUniqueOrThrow.mockResolvedValueOnce({
+      ...passwordlessData,
+      expiresOn: new Date('2020-01-01T00:00:00Z'),
+    });
     // findUserById
     mockUser.findUserById.mockResolvedValue(O.some(user));
     // checkIfProviderAccountExists


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes #4964 

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
This PR fixes a test case for the `verifyMagicLinkTokens` function.
The test case was related to a timestamp issue, which is difficult to reproduce unless the test runs on a very fast machine.

#### Explanatiton
Most of the time when we run the tests, `expiresOn` becomes slightly outdated by the time and the test function passes.
Whenever you use a fast machine, `expiresOn` may hold the current time, which can trigger an error in subsequent functions.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Nil


### How to Test
Just run the followed cmds
```cmd
cd packages/hoppscotch-backend
pnpm run test
```