### PR TITLE
feat: allow multiple params with same key to process get request queryparams

### DIFF
--- a/packages/hoppscotch-common/src/helpers/functional/filter-active.ts
+++ b/packages/hoppscotch-common/src/helpers/functional/filter-active.ts
@@ -11,3 +11,10 @@ export const filterActiveToRecord = (
     A.map((header): [string, string] => [header.key, header.value]),
     (entries) => Object.fromEntries(entries)
   )
+
+export const filterParamsActiveToRecord = (params: HoppRESTRequestVariables) =>
+  pipe(
+    params,
+    A.filter((param) => param.active),
+    A.map((param): [string, string] => [param.key, param.value])
+  )

--- a/packages/hoppscotch-common/src/helpers/functional/preprocess.ts
+++ b/packages/hoppscotch-common/src/helpers/functional/preprocess.ts
@@ -1,10 +1,9 @@
+import type { RelayRequest } from "@hoppscotch/kernel"
+import * as E from "fp-ts/Either"
 import { pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import * as E from "fp-ts/Either"
-import * as R from "fp-ts/Record"
 import { cloneDeep } from "lodash-es"
 import { useSetting } from "~/composables/settings"
-import type { RelayRequest } from "@hoppscotch/kernel"
 
 const isEncoded = (value: string): boolean =>
   pipe(
@@ -23,26 +22,25 @@ const encodeParam = (value: string): string =>
     O.getOrElse(() => value)
   )
 
-const processParams = (
-  params: Record<string, string>
-): Record<string, string> => {
+const processParams = (params: [string, string][]): [string, string][] => {
   const encodeMode = useSetting("ENCODE_MODE").value
   const needsEncoding = (v: string) =>
     /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]+/.test(v)
 
-  return pipe(
-    params,
-    R.map((value) =>
-      encodeMode === "enable" || (encodeMode === "auto" && needsEncoding(value))
+  return params.map(([key, value]) => {
+    const encodedKey = encodeMode === "enable" ? encodeParam(key) : key
+    const encodedValue =
+      encodeMode === "enable" && needsEncoding(value)
         ? encodeParam(value)
         : value
-    )
-  )
+
+    return [encodedKey, encodedValue]
+  })
 }
 
 const updateUrl = (
   url: string,
-  params: Record<string, string>
+  params: [string, string][]
 ): E.Either<Error, string> =>
   pipe(
     E.tryCatch(
@@ -50,9 +48,10 @@ const updateUrl = (
       (e) => new Error(`Invalid URL: ${e}`)
     ),
     E.map((u) => {
-      Object.entries(processParams(params)).forEach(([k, v]) =>
-        u.searchParams.append(k, v)
-      )
+      processParams(params).forEach(([k, v]) => {
+        console.log("adding param", k, v)
+        return u.searchParams.append(k, v)
+      })
       return decodeURIComponent(u.toString())
     })
   )

--- a/packages/hoppscotch-common/src/helpers/kernel/rest/request.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/rest/request.ts
@@ -8,7 +8,10 @@ import { EffectiveHoppRESTRequest } from "~/helpers/utils/EffectiveURL"
 
 import { transformAuth, transformContent } from "~/helpers/kernel/common"
 import { defaultAuth } from "~/helpers/kernel/common/auth"
-import { filterActiveToRecord } from "~/helpers/functional/filter-active"
+import {
+  filterActiveToRecord,
+  filterParamsActiveToRecord,
+} from "~/helpers/functional/filter-active"
 
 export const RESTRequest = {
   async toRequest(request: EffectiveHoppRESTRequest): Promise<RelayRequest> {
@@ -24,7 +27,7 @@ export const RESTRequest = {
     )()
 
     const headers = filterActiveToRecord(request.effectiveFinalHeaders)
-    const params = filterActiveToRecord(request.effectiveFinalParams)
+    const params = filterParamsActiveToRecord(request.effectiveFinalParams)
 
     return {
       id: Date.now(),


### PR DESCRIPTION
Closes #4941


### What's changed

This PR addresses the issue where the query parameter array does not function as expected. The current implementation only considers the last value of a parameter when multiple values are provided. This fix aims to ensure that all values in the array are recognized and processed correctly.

- [ ] Not Completed
- [x] Completed
