### PR TITLE
feat(common): enhanced cookie parsing from curl arguments

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
@@ -14,7 +14,7 @@ import * as O from "fp-ts/Option"
 import parser from "yargs-parser/browser"
 import { getAuthObject } from "./sub_helpers/auth"
 import { getHeaders, recordToHoppHeaders } from "./sub_helpers/headers"
-// import { getCookies } from "./sub_helpers/cookies"
+import { getCookies } from "./sub_helpers/cookies"
 import {
   objHasArrayProperty,
   objHasProperty,
@@ -66,7 +66,22 @@ export const parseCurlCommand = (curlCommand: string) => {
   )
 
   const method = getMethod(parsedArguments)
-  // const cookies = getCookies(parsedArguments)
+  const cookies = getCookies(parsedArguments)
+
+  // Add cookies to headers if they exist
+  if (Object.keys(cookies).length > 0) {
+    const cookieString = Object.entries(cookies)
+      .map(([key, value]) => `${key}=${value}`)
+      .join("; ")
+
+    hoppHeaders.push({
+      key: "Cookie",
+      value: cookieString,
+      active: true,
+      description: "",
+    })
+  }
+
   const urlObject = getURLObject(parsedArguments)
   const auth = getAuthObject(parsedArguments, headers, urlObject)
 

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/cookies.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/cookies.ts
@@ -1,27 +1,64 @@
-import parser from "yargs-parser"
-import * as cookie from "cookie"
+import { pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
-import { pipe, flow } from "fp-ts/function"
-import { objHasProperty } from "~/helpers/functional/object"
+import {
+  objHasArrayProperty,
+  objHasProperty,
+} from "~/helpers/functional/object"
 
-export function getCookies(parsedArguments: parser.Arguments) {
+/**
+ * Parses cookies from curl arguments
+ * Handles both -b flag and --cookie parameter
+ */
+export const getCookies = (parsedArguments: any): Record<string, string> => {
+  // Handle -b or --cookie flags
   return pipe(
     parsedArguments,
-    O.fromPredicate(objHasProperty("cookie", "string")),
-
-    O.map((args) => args.cookie),
-
-    O.alt(() =>
+    O.fromPredicate(objHasArrayProperty("b", "string")),
+    O.map((args) => parseCookieStrings(args.b)),
+    O.altW(() =>
       pipe(
         parsedArguments,
         O.fromPredicate(objHasProperty("b", "string")),
-        O.map((args) => args.b)
+        O.map((args) => parseCookieString(args.b))
       )
     ),
-
-    O.map(flow(S.replace(/^cookie: /i, ""), cookie.parse)),
-
-    O.getOrElse(() => ({}))
+    O.altW(() =>
+      pipe(
+        parsedArguments,
+        O.fromPredicate(objHasArrayProperty("cookie", "string")),
+        O.map((args) => parseCookieStrings(args.cookie))
+      )
+    ),
+    O.altW(() =>
+      pipe(
+        parsedArguments,
+        O.fromPredicate(objHasProperty("cookie", "string")),
+        O.map((args) => parseCookieString(args.cookie))
+      )
+    ),
+    O.getOrElseW(() => ({}))
   )
+}
+
+/**
+ * Parse multiple cookie strings and combine them
+ */
+const parseCookieStrings = (cookies: string[]): Record<string, string> => {
+  return cookies.reduce((acc, cookie) => {
+    return { ...acc, ...parseCookieString(cookie) }
+  }, {})
+}
+
+/**
+ * Parse a single cookie string into a record
+ */
+const parseCookieString = (cookieString: string): Record<string, string> => {
+  return cookieString
+    .split(";")
+    .map((pair) => pair.trim())
+    .filter(Boolean)
+    .reduce((acc, pair) => {
+      const [key, value] = pair.split("=", 2)
+      return { ...acc, [key]: value || "" }
+    }, {})
 }


### PR DESCRIPTION
Closes HFE-805 #4961

### What's changed

This pull request addresses an issue with the handling of cookies in cURL requests. The current behavior fails when cookies are set using the `-b` option without the appropriate `-H` header. This fix ensures that cookies are correctly processed.

- [ ] Not Completed
- [x] Completed