### PR TITLE
fix(common): extention interceptor response meta

### DIFF
--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/extension/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/extension/index.ts
@@ -288,6 +288,16 @@ export class ExtensionKernelInterceptorService
       const bodySize = extensionResponse.data?.byteLength || 0
       const totalSize = headersSize + bodySize
 
+      const timingMeta = extensionResponse.timeData
+        ? {
+            start: extensionResponse.timeData.startTime,
+            end: extensionResponse.timeData.endTime,
+          }
+        : {
+            start: startTime,
+            end: endTime,
+          }
+
       return E.right({
         id: request.id,
         status: extensionResponse.status,
@@ -299,10 +309,7 @@ export class ExtensionKernelInterceptorService
           extensionResponse.headers["content-type"]
         ),
         meta: {
-          timing: {
-            start: startTime,
-            end: endTime,
-          },
+          timing: timingMeta,
           size: {
             headers: headersSize,
             body: bodySize,
@@ -320,6 +327,18 @@ export class ExtensionKernelInterceptorService
           const bodySize = response.data?.byteLength || 0
           const totalSize = headersSize + bodySize
 
+          const timingMeta = response.timeData
+            ? {
+                start: response.timeData.startTime,
+                end: response.timeData.endTime,
+              }
+            : {
+                // Fallback timing - at least show it took some time,
+                // this is mainly for cross compat with other interceptor settings.
+                start: Date.now() - 1,
+                end: Date.now(),
+              }
+
           return E.right({
             id: request.id,
             status: response.status,
@@ -328,13 +347,7 @@ export class ExtensionKernelInterceptorService
             headers: response.headers,
             body: body.body(response.data, response.headers["content-type"]),
             meta: {
-              timing: {
-                // TODO: Think of better fallback
-                // Fallback timing - at least show it took some time,
-                // this is mainly for cross compat with other interceptor settings.
-                start: Date.now() - 1,
-                end: Date.now(),
-              },
+              timing: timingMeta,
               size: {
                 headers: headersSize,
                 body: bodySize,


### PR DESCRIPTION
This addresses an issue with the extension interceptor where response metadata (timing metrics and size calculations) was missing from the response object.

This change is an isolated addition since the extension interceptor has become somewhat "detached" from the kernel capabilities over time, while other interceptors were able to be evolved with architecture.

This fix helps bridge that gap without requiring substantial refactoring of the extension interceptor implementation.

Closes HFE-810

#### Notes to reviewers

The following screenshot shows `extension` interceptor in the upper section at `localhost` (patch) with correct response metadata, followed by the current deployed version with missing response meta.

![response-meta](https://github.com/user-attachments/assets/9108e51a-96c6-46ee-a91c-88c57388f2e6)


