### PR TITLE
fix: account for `templates` directory in ARM images

### DIFF
--- a/packages/hoppscotch-backend/package.json
+++ b/packages/hoppscotch-backend/package.json
@@ -7,11 +7,13 @@
   "license": "UNLICENSED",
   "files": [
     "prisma",
-    "dist"
+    "dist",
+    "src/mailer/templates"
   ],
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
+    "postbuild": "mkdir -p dist/mailer && cp -r src/mailer/templates dist/mailer/templates",
     "generate-gql-sdl": "cross-env GQL_SCHEMA_EMIT_LOCATION='../../../gql-gen/backend-schema.gql' GENERATE_GQL_SCHEMA=true WHITELISTED_ORIGINS='' nest start",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",


### PR DESCRIPTION
**What's changed**
Fixed an issue where the templates folder wasn't being copied to the /dist/backend directory during ARM builds in GitHub Actions. Added the necessary configuration in package.json to ensure the templates are included in the deployment.

**Notes to reviewers**
Nil

**How to test**
1. Run the GitHub Actions workflow for ARM build
2. Verify the templates folder is present in the /dist/backend directory
