### PR TITLE
chore(i18n): update `es` translation

### DIFF
--- a/packages/hoppscotch-common/locales/es.json
+++ b/packages/hoppscotch-common/locales/es.json
@@ -691,7 +691,11 @@
     "use_experimental_url_bar": "Utilizar la barra de URL experimental con resaltado de entorno",
     "user": "Usuario",
     "verified_email": "Correo electrónico verificado",
-    "verify_email": "Verificar correo electrónico"
+    "verify_email": "Verificar correo electrónico",
+    "general": "General",
+    "general_description": "Configuración general utilizada en la aplicación",
+    "query_parameters_encoding": "Codificación de parámetros de consulta",
+    "query_parameters_encoding_description": "Configura la codificación para los parámetros de consulta en las solicitudes"
   },
   "shared_requests": {
     "button": "Botón",

--- a/packages/hoppscotch-common/locales/es.json
+++ b/packages/hoppscotch-common/locales/es.json
@@ -663,6 +663,8 @@
     "follow": "Síguenos",
     "interceptor": "Interceptador",
     "interceptor_description": "Middleware entre la aplicación y las APIs.",
+    "kernel_interceptor": "Interceptador",
+    "kernel_interceptor_description": "Middleware entre la aplicación y las APIs.",
     "language": "Idioma",
     "light_mode": "Luz",
     "official_proxy_hosting": "El proxy oficial está alojado en Hoppscotch.",


### PR DESCRIPTION
### What's changed

- Add missing translations for the settings section
- Fix key names to ensure translations are displayed correctly.
