### PR TITLE
feat(infra): desktop aio build workflow pipeline

### DIFF
--- a/.github/workflows/build-hoppscotch-desktop.yml
+++ b/.github/workflows/build-hoppscotch-desktop.yml
@@ -1,7 +1,5 @@
 name: Build Desktop Self Host - AIO
 on:
-  release:
-    types: [created]
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/build-hoppscotch-desktop.yml
+++ b/.github/workflows/build-hoppscotch-desktop.yml
@@ -1,0 +1,466 @@
+name: Build Desktop Self Host - AIO
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Tag of the version to build
+        required: true
+      repository:
+        description: Repository to checkout
+        required: false
+        default: "hoppscotch/hoppscotch"
+      branch:
+        description: Branch to checkout
+        required: false
+        default: "main"
+      tag:
+        description: Tag to checkout (takes precedence over branch if provided)
+        required: false
+        default: ""
+      release_notes:
+        description: Release notes for the update
+        required: false
+        default: "PLACEHOLDER RELEASE NOTES"
+      env_content:
+        description: Custom .env file content (highest prio, overrides existing .env and .env.example)
+        required: false
+        default: ""
+      disable_signing:
+        description: Disable executable signing
+        required: false
+        type: boolean
+        default: false
+env:
+  CARGO_TERM_COLOR: always
+  WORKSPACE_PATH: ${{ github.workspace }}
+  WEB_PATH: ${{ github.workspace }}/packages/hoppscotch-selfhost-web
+  DESKTOP_PATH: ${{ github.workspace }}/packages/hoppscotch-desktop
+  BUNDLER_PATH: ${{ github.workspace }}/packages/hoppscotch-desktop/crates/webapp-bundler
+jobs:
+  build-linux:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
+          token: ${{ secrets.CHECKOUT_GITHUB_TOKEN }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.2.1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Install additional tools
+        run: |
+          curl -LO "https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v2.2.0/cargo-tauri-x86_64-unknown-linux-gnu.tgz"
+          tar -xzf cargo-tauri-x86_64-unknown-linux-gnu.tgz
+          chmod +x cargo-tauri
+          sudo mv cargo-tauri /usr/local/bin/tauri
+      - name: Install system dependencies
+        run: |
+          sudo apt update;
+          sudo apt install -y \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libssl-dev \
+            libgtk-3-dev \
+            libappindicator3-dev \
+            librsvg2-dev;
+
+          sudo apt install -y \
+            libwebkit2gtk-4.1-0=2.44.0-2 \
+            libwebkit2gtk-4.1-dev=2.44.0-2 \
+            libjavascriptcoregtk-4.1-0=2.44.0-2 \
+            libjavascriptcoregtk-4.1-dev=2.44.0-2 \
+            gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
+            gir1.2-webkit2-4.1=2.44.0-2;
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install dependencies
+        run: |
+          if [ ! -z "${{ inputs.env_content }}" ]; then
+            echo "${{ inputs.env_content }}" > ${{ env.WORKSPACE_PATH }}/.env
+          elif [ ! -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
+            cp ${{ env.WORKSPACE_PATH }}/.env.example ${{ env.WORKSPACE_PATH }}/.env
+          fi
+          pnpm install --dir ${{ env.DESKTOP_PATH }}
+      - name: Build web app
+        run: |
+          pnpm install --dir ${{ env.WEB_PATH }}
+          pnpm --dir ${{ env.WEB_PATH }} generate
+      - name: Build and run webapp-bundler
+        run: |
+          cargo build --release --manifest-path ${{ env.BUNDLER_PATH }}/Cargo.toml
+          ${{ env.BUNDLER_PATH }}/target/release/webapp-bundler \
+            --input ${{ env.WEB_PATH }}/dist \
+            --output ${{ env.DESKTOP_PATH }}/bundle.zip \
+            --manifest ${{ env.DESKTOP_PATH }}/manifest.json
+      - name: Build AppImage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          RUST_LOG: debug
+        run: pnpm --dir ${{ env.DESKTOP_PATH }} tauri build --verbose -b appimage -b updater
+      - name: Build DEB
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          RUST_LOG: debug
+        run: pnpm --dir ${{ env.DESKTOP_PATH }} tauri build --verbose -b deb -b updater
+      - name: Prepare artifacts
+        run: |
+          ls -lahR ${{ env.DESKTOP_PATH }}/src-tauri/target/release/bundle/
+          mkdir -p dist
+          cp ${{ env.DESKTOP_PATH }}/src-tauri/target/release/bundle/appimage/*.AppImage dist/Hoppscotch_SelfHost_linux_x64.AppImage
+          cp ${{ env.DESKTOP_PATH }}/src-tauri/target/release/bundle/appimage/*.AppImage.sig dist/Hoppscotch_SelfHost_linux_x64.AppImage.sig
+          cp ${{ env.DESKTOP_PATH }}/src-tauri/target/release/bundle/deb/*.deb dist/Hoppscotch_SelfHost_linux_x64.deb
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux
+          path: dist/*
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
+          token: ${{ secrets.CHECKOUT_GITHUB_TOKEN }}
+      - name: Set Perl environment variables
+        shell: pwsh
+        run: |
+          echo "PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          echo "OPENSSL_SRC_PERL=$((where.exe perl)[0])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.2.1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Download trusted-signing-cli
+        if: ${{ inputs.disable_signing != true }}
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri "https://github.com/Levminer/trusted-signing-cli/releases/download/0.5.0/trusted-signing-cli.exe" -OutFile "trusted-signing-cli.exe"
+          Move-Item -Path "trusted-signing-cli.exe" -Destination "$env:GITHUB_WORKSPACE\trusted-signing-cli.exe"
+          echo "$env:GITHUB_WORKSPACE" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+      - name: Setting up Windows Signing Environment
+        if: ${{ inputs.disable_signing != true }}
+        timeout-minutes: 20
+        shell: bash
+        env:
+          WINDOWS_SIGN_COMMAND: trusted-signing-cli -e ${{ secrets.AZURE_ENDPOINT }} -a ${{ secrets.AZURE_CODE_SIGNING_NAME }} -c ${{ secrets.AZURE_CERT_PROFILE_NAME }} %1
+        run: |
+          cat "${{ env.DESKTOP_PATH }}/src-tauri/tauri.conf.json" | jq '.bundle .windows += { "signCommand": env.WINDOWS_SIGN_COMMAND}' > "${{ env.DESKTOP_PATH }}/src-tauri/temp.json" && mv "${{ env.DESKTOP_PATH }}/src-tauri/temp.json" "${{ env.DESKTOP_PATH }}/src-tauri/tauri.conf.json"
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install dependencies
+        run: |
+          if ("${{ inputs.env_content }}" -ne "") {
+            "${{ inputs.env_content }}" | Out-File -FilePath ${{ env.WORKSPACE_PATH }}\.env -Encoding utf8
+          } elseif (-not (Test-Path -Path "${{ env.WORKSPACE_PATH }}\.env")) {
+            Copy-Item ${{ env.WORKSPACE_PATH }}\.env.example ${{ env.WORKSPACE_PATH }}\.env
+          }
+          pnpm install -f --shamefully-hoist --ignore-scripts
+          pnpm --filter hoppscotch-backend exec prisma generate
+          pnpm install -f --shamefully-hoist --dir ${{ env.DESKTOP_PATH }}
+      - name: Build web app
+        shell: pwsh
+        run: |
+          pnpm install --dir ${{ env.WEB_PATH }}
+          pnpm --dir ${{ env.WEB_PATH }} generate
+      - name: Build and run webapp-bundler
+        shell: pwsh
+        run: |
+          cargo build --release --manifest-path ${{ env.BUNDLER_PATH }}\Cargo.toml
+          ${{ env.BUNDLER_PATH }}\target\release\webapp-bundler.exe `
+            --input ${{ env.WEB_PATH }}\dist `
+            --output ${{ env.DESKTOP_PATH }}\bundle.zip `
+            --manifest ${{ env.DESKTOP_PATH }}\manifest.json
+      - name: Build Tauri app with Azure signing
+        if: ${{ inputs.disable_signing != true }}
+        shell: powershell
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          RUST_LOG: debug
+        run: pnpm --dir ${{ env.DESKTOP_PATH }} tauri build --verbose -b msi -b updater
+      - name: Build Tauri app without Azure signing
+        if: ${{ inputs.disable_signing == true }}
+        shell: powershell
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          RUST_LOG: debug
+        run: pnpm --dir ${{ env.DESKTOP_PATH }} tauri build --verbose -b msi -b updater
+      - name: Prepare artifacts
+        shell: pwsh
+        run: |
+          Get-ChildItem -Recurse ${{ env.DESKTOP_PATH }}\src-tauri\target\release\bundle
+          mkdir dist
+          Copy-Item ${{ env.DESKTOP_PATH }}\src-tauri\target\release\bundle\msi\*_x64_en-US.msi dist\Hoppscotch_SelfHost_win_x64.msi
+          Copy-Item ${{ env.DESKTOP_PATH }}\src-tauri\target\release\bundle\msi\*_x64_en-US.msi.sig dist\Hoppscotch_SelfHost_win_x64.msi.sig
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows
+          path: dist/*
+  build-macos-x64:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
+          token: ${{ secrets.CHECKOUT_GITHUB_TOKEN }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.2.1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Install Rust target
+        run: rustup target add x86_64-apple-darwin
+      - name: Install additional tools
+        run: |
+          mkdir __dist/
+          cd __dist/
+          curl -LO "https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v2.2.0/cargo-tauri-x86_64-apple-darwin.zip"
+          unzip cargo-tauri-x86_64-apple-darwin.zip
+          chmod +x cargo-tauri
+          sudo mv cargo-tauri /usr/local/bin/tauri
+      - uses: apple-actions/import-codesign-certs@v3
+        if: ${{ inputs.disable_signing != true }}
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-x86_64-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install dependencies
+        run: |
+          if [ ! -z "${{ inputs.env_content }}" ]; then
+            echo "${{ inputs.env_content }}" > ${{ env.WORKSPACE_PATH }}/.env
+          elif [ ! -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
+            cp ${{ env.WORKSPACE_PATH }}/.env.example ${{ env.WORKSPACE_PATH }}/.env
+          fi
+          pnpm install --dir ${{ env.DESKTOP_PATH }}
+      - name: Build web app
+        run: |
+          pnpm install --dir ${{ env.WEB_PATH }}
+          pnpm --dir ${{ env.WEB_PATH }} generate
+      - name: Build and run webapp-bundler
+        run: |
+          cargo build --release --manifest-path ${{ env.BUNDLER_PATH }}/Cargo.toml
+          ${{ env.BUNDLER_PATH }}/target/release/webapp-bundler \
+            --input ${{ env.WEB_PATH }}/dist \
+            --output ${{ env.DESKTOP_PATH }}/bundle.zip \
+            --manifest ${{ env.DESKTOP_PATH }}/manifest.json
+      - name: Build Tauri app with Apple signing
+        if: ${{ inputs.disable_signing != true }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          RUST_LOG: debug
+        run: pnpm --dir ${{ env.DESKTOP_PATH }} tauri build --verbose --target x86_64-apple-darwin
+      - name: Build Tauri app without Apple signing
+        if: ${{ inputs.disable_signing == true }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          RUST_LOG: debug
+        run: pnpm --dir ${{ env.DESKTOP_PATH }} tauri build --verbose --target x86_64-apple-darwin
+      - name: Prepare artifacts
+        run: |
+          ls -lahR ${{ env.DESKTOP_PATH }}/src-tauri/target/x86_64-apple-darwin/release/bundle/
+          mkdir -p dist
+          cp ${{ env.DESKTOP_PATH }}/src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg dist/Hoppscotch_SelfHost_mac_x64.dmg
+          cp ${{ env.DESKTOP_PATH }}/src-tauri/target/x86_64-apple-darwin/release/bundle/macos/Hoppscotch.app.tar.gz dist/Hoppscotch_SelfHost_mac_x64.tar.gz
+          cp ${{ env.DESKTOP_PATH }}/src-tauri/target/x86_64-apple-darwin/release/bundle/macos/Hoppscotch.app.tar.gz.sig dist/Hoppscotch_SelfHost_mac_x64.tar.gz.sig
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-x64
+          path: dist/*
+  build-macos-arm64:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.tag != '' && inputs.tag || inputs.branch }}
+          token: ${{ secrets.CHECKOUT_GITHUB_TOKEN }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.2.1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Install Rust target
+        run: rustup target add aarch64-apple-darwin
+      - name: Install additional tools
+        run: |
+          mkdir __dist/
+          cd __dist/
+          curl -LO "https://github.com/tauri-apps/tauri/releases/download/tauri-cli-v2.2.0/cargo-tauri-aarch64-apple-darwin.zip"
+          unzip cargo-tauri-aarch64-apple-darwin.zip
+          chmod +x cargo-tauri
+          sudo mv cargo-tauri /usr/local/bin/tauri
+      - uses: apple-actions/import-codesign-certs@v3
+        if: ${{ inputs.disable_signing != true }}
+        with:
+          p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
+          p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-aarch64-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install dependencies
+        run: |
+          if [ ! -z "${{ inputs.env_content }}" ]; then
+            echo "${{ inputs.env_content }}" > ${{ env.WORKSPACE_PATH }}/.env
+          elif [ ! -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
+            cp ${{ env.WORKSPACE_PATH }}/.env.example ${{ env.WORKSPACE_PATH }}/.env
+          fi
+          pnpm install --dir ${{ env.DESKTOP_PATH }}
+      - name: Build web app
+        run: |
+          pnpm install --dir ${{ env.WEB_PATH }}
+          pnpm --dir ${{ env.WEB_PATH }} generate
+      - name: Build and run webapp-bundler
+        run: |
+          cargo build --release --manifest-path ${{ env.BUNDLER_PATH }}/Cargo.toml
+          ${{ env.BUNDLER_PATH }}/target/release/webapp-bundler \
+            --input ${{ env.WEB_PATH }}/dist \
+            --output ${{ env.DESKTOP_PATH }}/bundle.zip \
+            --manifest ${{ env.DESKTOP_PATH }}/manifest.json
+      - name: Build Tauri app with Apple signing
+        if: ${{ inputs.disable_signing != true }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          RUST_LOG: debug
+        run: pnpm --dir ${{ env.DESKTOP_PATH }} tauri build --verbose --target aarch64-apple-darwin
+      - name: Build Tauri app without Apple signing
+        if: ${{ inputs.disable_signing == true }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_KEY_PASSWORD }}
+          RUST_LOG: debug
+        run: pnpm --dir ${{ env.DESKTOP_PATH }} tauri build --verbose --target aarch64-apple-darwin
+      - name: Prepare artifacts
+        run: |
+          ls -lahR ${{ env.DESKTOP_PATH }}/src-tauri/target/aarch64-apple-darwin/release/bundle/
+          mkdir -p dist
+          cp ${{ env.DESKTOP_PATH }}/src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg dist/Hoppscotch_SelfHost_mac_aarch64.dmg
+          cp ${{ env.DESKTOP_PATH }}/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Hoppscotch.app.tar.gz dist/Hoppscotch_SelfHost_mac_aarch64.tar.gz
+          cp ${{ env.DESKTOP_PATH }}/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Hoppscotch.app.tar.gz.sig dist/Hoppscotch_SelfHost_mac_aarch64.tar.gz.sig
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-aarch64
+          path: dist/*
+  create-update-manifest:
+    needs: [build-linux, build-windows, build-macos-x64, build-macos-arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Create update manifest
+        run: |
+          VERSION="${{ inputs.version }}"
+          CURRENT_DATE=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
+
+          cat > artifacts/hoppscotch-selfhost-desktop.json << EOF
+          {
+            "version": "${VERSION}",
+            "notes": "${{ inputs.release_notes }}",
+            "pub_date": "${CURRENT_DATE}",
+            "platforms": {
+              "linux-x86_64": {
+                "signature": "$(cat artifacts/linux/Hoppscotch_SelfHost_linux_x64.AppImage.sig)",
+                "url": "https://github.com/hoppscotch/releases/releases/download/${VERSION}/Hoppscotch_SelfHost_linux_x64.AppImage"
+              },
+              "windows-x86_64": {
+                "signature": "$(cat artifacts/windows/Hoppscotch_SelfHost_win_x64.msi.sig)",
+                "url": "https://github.com/hoppscotch/releases/releases/download/${VERSION}/Hoppscotch_SelfHost_win_x64.msi"
+              },
+              "darwin-x86_64": {
+                "signature": "$(cat artifacts/macos-x64/Hoppscotch_SelfHost_mac_x64.tar.gz.sig)",
+                "url": "https://github.com/hoppscotch/releases/releases/download/${VERSION}/Hoppscotch_SelfHost_mac_x64.tar.gz"
+              },
+              "darwin-aarch64": {
+                "signature": "$(cat artifacts/macos-aarch64/Hoppscotch_SelfHost_mac_aarch64.tar.gz.sig)",
+                "url": "https://github.com/hoppscotch/releases/releases/download/${VERSION}/Hoppscotch_SelfHost_mac_aarch64.tar.gz"
+              }
+            }
+          }
+          EOF
+      - name: Upload manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: update-manifest
+          path: artifacts/hoppscotch-selfhost-desktop.json

--- a/.github/workflows/build-hoppscotch-desktop.yml
+++ b/.github/workflows/build-hoppscotch-desktop.yml
@@ -21,10 +21,6 @@ on:
         description: Release notes for the update
         required: false
         default: "PLACEHOLDER RELEASE NOTES"
-      env_content:
-        description: Custom .env file content (highest prio, overrides existing .env and .env.example)
-        required: false
-        default: ""
       disable_signing:
         description: Disable executable signing
         required: false
@@ -88,12 +84,16 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install dependencies
+      - name: Setup environment
         run: |
-          if [ ! -z "${{ inputs.env_content }}" ]; then
-            echo "${{ inputs.env_content }}" > ${{ env.WORKSPACE_PATH }}/.env
-          elif [ ! -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
+          if [ ! -z "${{ secrets.ENV_FILE_CONTENT }}" ]; then
+            echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ env.WORKSPACE_PATH }}/.env
+            echo "Created .env file from repository secret"
+          elif [ -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
+            echo "Using existing .env file found in repository"
+          else
             cp ${{ env.WORKSPACE_PATH }}/.env.example ${{ env.WORKSPACE_PATH }}/.env
+            echo "No .env found, copied from .env.example template"
           fi
           pnpm install --dir ${{ env.DESKTOP_PATH }}
       - name: Build web app
@@ -179,12 +179,17 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install dependencies
+      - name: Setup environment
+        shell: pwsh
         run: |
-          if ("${{ inputs.env_content }}" -ne "") {
-            "${{ inputs.env_content }}" | Out-File -FilePath ${{ env.WORKSPACE_PATH }}\.env -Encoding utf8
-          } elseif (-not (Test-Path -Path "${{ env.WORKSPACE_PATH }}\.env")) {
+          if ("${{ secrets.ENV_FILE_CONTENT }}" -ne "") {
+            "${{ secrets.ENV_FILE_CONTENT }}" | Out-File -FilePath ${{ env.WORKSPACE_PATH }}\.env -Encoding utf8
+            Write-Host "Created .env file from repository secret"
+          } elseif (Test-Path -Path "${{ env.WORKSPACE_PATH }}\.env") {
+            Write-Host "Using existing .env file found in repository"
+          } else {
             Copy-Item ${{ env.WORKSPACE_PATH }}\.env.example ${{ env.WORKSPACE_PATH }}\.env
+            Write-Host "No .env found, copied from .env.example template"
           }
           pnpm install -f --shamefully-hoist --ignore-scripts
           pnpm --filter hoppscotch-backend exec prisma generate
@@ -276,12 +281,16 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-x86_64-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install dependencies
+      - name: Setup environment
         run: |
-          if [ ! -z "${{ inputs.env_content }}" ]; then
-            echo "${{ inputs.env_content }}" > ${{ env.WORKSPACE_PATH }}/.env
-          elif [ ! -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
+          if [ ! -z "${{ secrets.ENV_FILE_CONTENT }}" ]; then
+            echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ env.WORKSPACE_PATH }}/.env
+            echo "Created .env file from repository secret"
+          elif [ -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
+            echo "Using existing .env file found in repository"
+          else
             cp ${{ env.WORKSPACE_PATH }}/.env.example ${{ env.WORKSPACE_PATH }}/.env
+            echo "No .env found, copied from .env.example template"
           fi
           pnpm install --dir ${{ env.DESKTOP_PATH }}
       - name: Build web app
@@ -368,12 +377,16 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-aarch64-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install dependencies
+      - name: Setup environment
         run: |
-          if [ ! -z "${{ inputs.env_content }}" ]; then
-            echo "${{ inputs.env_content }}" > ${{ env.WORKSPACE_PATH }}/.env
-          elif [ ! -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
+          if [ ! -z "${{ secrets.ENV_FILE_CONTENT }}" ]; then
+            echo "${{ secrets.ENV_FILE_CONTENT }}" > ${{ env.WORKSPACE_PATH }}/.env
+            echo "Created .env file from repository secret"
+          elif [ -f "${{ env.WORKSPACE_PATH }}/.env" ]; then
+            echo "Using existing .env file found in repository"
+          else
             cp ${{ env.WORKSPACE_PATH }}/.env.example ${{ env.WORKSPACE_PATH }}/.env
+            echo "No .env found, copied from .env.example template"
           fi
           pnpm install --dir ${{ env.DESKTOP_PATH }}
       - name: Build web app


### PR DESCRIPTION
This PR adds an actions workflow pipeline for building and packaging the self-hosted Hoppscotch Desktop app across different platforms.

Platform supported right now are
- Windows x86_64 (`msi`)
- MacOS x64 and ARM64 (`dmg`)
- Linux x86_64 (`.deb`, `AppImage`)

The workflow can be triggered either automatically when a new release is created or manually through workflow dispatch.

| Dispatch | Runners |
| --- | --- | 
| ![image](https://github.com/user-attachments/assets/f259f8fa-d429-48f7-b366-5c350b9b6255) | ![image](https://github.com/user-attachments/assets/7b007f6f-84f8-4773-925c-03238b8e4415) |


| Artifacts | Files |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/e3020032-db5b-4544-af70-134ac8bba274) | ![image](https://github.com/user-attachments/assets/d5e9eb56-cc96-44c0-92ed-7f014fbb77f8) |

Manual trigger has a few customizations like
- build version,
  - to support building a different version of the app from prior releases
- repository to checkout,
  - to support building from a different source
- branch or tag to build from,
  - to support building a different release
- release notes,
  - these are mainly for the updater manifest
- custom environment file content
  - from `secrets.ENV_FILE_CONTENT` (repo secrets)
  - to customize instance target
- an option to disable code signing
  - this is self explanatory
  - this doesn't disable updater signing

Closes HFE-800

### Notes to reviewers

For Linux builds, the workflow generates packages using Ubuntu 24.04, yet it still contains some specific libraries

```
libwebkit2gtk-4.1-0=2.44.0-2 \
libwebkit2gtk-4.1-dev=2.44.0-2 \
libjavascriptcoregtk-4.1-0=2.44.0-2 \
libjavascriptcoregtk-4.1-dev=2.44.0-2 \
gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
gir1.2-webkit2-4.1=2.44.0-2;
```

For more information, see https://github.com/hoppscotch/hoppscotch/issues/4880
```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```
Also see:
tauri-apps/tauri#8588
https://bugs.webkit.org/show_bug.cgi?id=180739
https://bugs.webkit.org/show_bug.cgi?id=165246
tauri-apps/tauri#8535

Also `code-signing-cli` is often installed directly from source bin, since installing it from `crates.io` sometimes breaks the CI:
```
error[E0599]: no method named `fetch_mode_no_cors` found for struct `reqwest::RequestBuilder` in the current scope
   --> C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\reqwest-middleware-0.4.1\src\client.rs:532:31
    |
532 |             inner: self.inner.fetch_mode_no_cors(),
    |                               ^^^^^^^^^^^^^^^^^^ method not found in `RequestBuilder`
```

The build dependency management is a bit complex but it should handles all necessary system dependencies and builds for the web app first before bundling it into the desktop app using `webapp-bundler`.

On Windows, the workflow uses Microsoft Azure code signing integration (when enabled).

For macOS, the workflow builds separate packages for both Intel (x64) and Apple Silicon (ARM64). It similar to Windows workflow, implements Apple's code signing and notarization (when credentials are provided).

The final step generates an update manifest that includes info about all built packages, their signatures, and download URLs. This manifest is used by the app's auto-updater.

You can checkout the latest builds with this workflow from the internal desktop ci repo. 
