### PR TITLE
chore: add VITE_PROXYSCOTCH_ACCESS_TOKEN to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,5 +86,8 @@ VITE_BACKEND_API_URL=http://localhost:3170/v1
 VITE_APP_TOS_LINK=https://docs.hoppscotch.io/support/terms
 VITE_APP_PRIVACY_POLICY_LINK=https://docs.hoppscotch.io/support/privacy
 
+# Set default to null as https://proxy.hoppscotch.io/ doesn't require an access token
+VITE_PROXYSCOTCH_ACCESS_TOKEN=
+
 # Set to `true` for subpath based access
 ENABLE_SUBPATH_BASED_ACCESS=false


### PR DESCRIPTION
Adding this to example will support selfhost proxy to use VITE_PROXYSCOTCH_ACCESS_TOKEN correctly.

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->
https://github.com/hoppscotch/hoppscotch/issues/3557
<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
In vite.config.ts: envPrefix: process.env.HOPP_ALLOW_RUNTIME_ENV ? "VITE_BUILDTIME_" : "VITE_"
And in prod.Dockerfile: ENV HOPP_ALLOW_RUNTIME_ENV=true

If VITE_PROXYSCOTCH_ACCESS_TOKEN is not available on .env.example then VITE_PROXYSCOTCH_ACCESS_TOKEN is never read.


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
