### PR TITLE
fix(relay): better matching for `content-type` detection

### DIFF
--- a/packages/hoppscotch-agent/package.json
+++ b/packages/hoppscotch-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hoppscotch-agent",
   "private": true,
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/hoppscotch-agent/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.lock
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "hoppscotch-agent"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/packages/hoppscotch-agent/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.lock
@@ -4098,7 +4098,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "relay"
 version = "0.1.1"
-source = "git+https://github.com/CuriousCorrelation/relay.git#cac0d123d0f7ff6971edacf5809c120d5378c25e"
+source = "git+https://github.com/CuriousCorrelation/relay.git#dfa662f2e8a2731cd21c59b2a10bfc6e2ef70ca3"
 dependencies = [
  "bytes",
  "curl",

--- a/packages/hoppscotch-agent/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoppscotch-agent"
-version = "0.1.9"
+version = "0.1.10"
 description = "A cross-platform HTTP request agent for Hoppscotch for advanced request handling including custom headers, certificates, proxies, and local system integration."
 authors = ["AndrewBastin", "CuriousCorrelation"]
 edition = "2021"

--- a/packages/hoppscotch-agent/src-tauri/tauri.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent Portable",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/Cargo.lock
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/Cargo.lock
@@ -2888,7 +2888,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "relay"
 version = "0.1.1"
-source = "git+https://github.com/CuriousCorrelation/relay.git#cac0d123d0f7ff6971edacf5809c120d5378c25e"
+source = "git+https://github.com/CuriousCorrelation/relay.git#dfa662f2e8a2731cd21c59b2a10bfc6e2ef70ca3"
 dependencies = [
  "bytes",
  "curl",

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.lock
@@ -3968,7 +3968,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "relay"
 version = "0.1.1"
-source = "git+https://github.com/CuriousCorrelation/relay.git#d258a2c1557b9da0715681a1f267a686eb4920bb"
+source = "git+https://github.com/CuriousCorrelation/relay.git#dfa662f2e8a2731cd21c59b2a10bfc6e2ef70ca3"
 dependencies = [
  "bytes",
  "curl",
@@ -5093,7 +5093,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-relay"
 version = "0.1.0"
-source = "git+https://github.com/CuriousCorrelation/tauri-plugin-relay#4b96e40170c65189144299d896b7e97803f13cca"
+source = "git+https://github.com/CuriousCorrelation/tauri-plugin-relay#3273b9b075f1f6fa9171799a961c435454c0c9a2"
 dependencies = [
  "relay",
  "serde",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1181,7 +1181,7 @@ importers:
     dependencies:
       '@hoppscotch/plugin-relay':
         specifier: github:CuriousCorrelation/tauri-plugin-relay
-        version: '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/68d6b2532c900b4be24a038c49eec4794e990a3d'
+        version: '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/3273b9b075f1f6fa9171799a961c435454c0c9a2'
       '@tauri-apps/api':
         specifier: 2.1.1
         version: 2.1.1
@@ -1810,8 +1810,8 @@ packages:
     resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/60adb82d0cc886004307057194cf680373e14e02}
     version: 0.1.0
 
-  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/68d6b2532c900b4be24a038c49eec4794e990a3d':
-    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/68d6b2532c900b4be24a038c49eec4794e990a3d}
+  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/3273b9b075f1f6fa9171799a961c435454c0c9a2':
+    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/3273b9b075f1f6fa9171799a961c435454c0c9a2}
     version: 0.1.0
 
   '@alloc/quick-lru@5.2.0':
@@ -13208,7 +13208,7 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.1.1
 
-  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/68d6b2532c900b4be24a038c49eec4794e990a3d':
+  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/3273b9b075f1f6fa9171799a961c435454c0c9a2':
     dependencies:
       '@tauri-apps/api': 2.1.1
 


### PR DESCRIPTION
This PR addresses an issue where headers with different capitalizations were not being matched during `Content-Type` detection due to HTTP/2.0 middlewares (like Istio's) normalizing headers to lowercase according to RFC 7540.

Closes HFE-832

#### Notes to reviewers

The new method iterates over all headers with `headers.iter()` and then converts header keys to lowercase before comparison. Also fixes log guard ordering, to capture plugin init logs and prevent server from dropping early.