### PR TITLE
feat(common): platform ui definition for team edit and invite

### DIFF
--- a/packages/hoppscotch-common/src/components/app/Header.vue
+++ b/packages/hoppscotch-common/src/components/app/Header.vue
@@ -261,28 +261,30 @@
     />
     <TeamsModal :show="showTeamsModal" @hide-modal="showTeamsModal = false" />
 
-    <component
-      v-if="
-        platform.ui?.additionalTeamInviteComponent &&
-        workspace.type === 'team' &&
-        workspace.teamID
-      "
-      :is="platform.ui.additionalTeamInviteComponent"
-      :show="showModalInvite"
-      :editing-team-i-d="editingTeamID"
-      @hide-modal="displayModalInvite(false)"
-    />
+    <template v-if="workspace.type === 'team' && workspace.teamID">
+      <component
+        :is="platform.ui.additionalTeamInviteComponent"
+        v-if="
+          platform.ui?.additionalTeamInviteComponent &&
+          workspace.type === 'team' &&
+          workspace.teamID
+        "
+        :show="showModalInvite"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalInvite(false)"
+      />
 
-    <TeamsInvite
-      v-else-if="workspace.type === 'team' && workspace.teamID"
-      :show="showModalInvite"
-      :editing-team-i-d="editingTeamID"
-      @hide-modal="displayModalInvite(false)"
-    />
+      <TeamsInvite
+        v-else
+        :show="showModalInvite"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalInvite(false)"
+      />
+    </template>
 
     <component
-      v-if="platform.ui?.additioinalTeamEditComponent"
-      :is="platform.ui.additioinalTeamEditComponent"
+      :is="platform.ui.additionalTeamEditComponent"
+      v-if="platform.ui?.additionalTeamEditComponent"
       :show="showModalEdit"
       :editing-team="editingTeamName"
       :editing-team-i-d="editingTeamID"

--- a/packages/hoppscotch-common/src/components/app/Header.vue
+++ b/packages/hoppscotch-common/src/components/app/Header.vue
@@ -260,9 +260,9 @@
       @dismiss="dismissBanner"
     />
     <TeamsModal :show="showTeamsModal" @hide-modal="showTeamsModal = false" />
-    <template v-if="platform.ui?.teamInviteComponent">
+    <template v-if="platform.ui?.additionalTeamInviteComponent">
       <component
-        :is="platform.ui.teamInviteComponent"
+        :is="platform.ui.additionalTeamInviteComponent"
         :show="showModalInvite"
         :editing-team-i-d="editingTeamID"
         @hide-modal="displayModalInvite(false)"
@@ -277,9 +277,9 @@
       />
     </template>
 
-    <template v-if="platform.ui?.teamEditComponent">
+    <template v-if="platform.ui?.additioinalTeamEditComponent">
       <component
-        :is="platform.ui.teamEditComponent"
+        :is="platform.ui.additioinalTeamEditComponent"
         :show="showModalEdit"
         :editing-team="editingTeamName"
         :editing-team-i-d="editingTeamID"

--- a/packages/hoppscotch-common/src/components/app/Header.vue
+++ b/packages/hoppscotch-common/src/components/app/Header.vue
@@ -260,20 +260,44 @@
       @dismiss="dismissBanner"
     />
     <TeamsModal :show="showTeamsModal" @hide-modal="showTeamsModal = false" />
-    <TeamsInvite
-      v-if="workspace.type === 'team' && workspace.teamID"
-      :show="showModalInvite"
-      :editing-team-i-d="editingTeamID"
-      @hide-modal="displayModalInvite(false)"
-    />
-    <TeamsEdit
-      :show="showModalEdit"
-      :editing-team="editingTeamName"
-      :editing-team-i-d="editingTeamID"
-      @hide-modal="displayModalEdit(false)"
-      @invite-team="inviteTeam(editingTeamName, editingTeamID)"
-      @refetch-teams="refetchTeams"
-    />
+    <template v-if="platform.ui?.teamInviteComponent">
+      <component
+        :is="platform.ui.teamInviteComponent"
+        :show="showModalInvite"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalInvite(false)"
+      />
+    </template>
+    <template v-else>
+      <TeamsInvite
+        v-if="workspace.type === 'team' && workspace.teamID"
+        :show="showModalInvite"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalInvite(false)"
+      />
+    </template>
+
+    <template v-if="platform.ui?.teamEditComponent">
+      <component
+        :is="platform.ui.teamEditComponent"
+        :show="showModalEdit"
+        :editing-team="editingTeamName"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalEdit(false)"
+        @invite-team="inviteTeam(editingTeamName, editingTeamID)"
+        @refetch-teams="refetchTeams"
+      />
+    </template>
+    <template v-else>
+      <TeamsEdit
+        :show="showModalEdit"
+        :editing-team="editingTeamName"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalEdit(false)"
+        @invite-team="inviteTeam(editingTeamName, editingTeamID)"
+        @refetch-teams="refetchTeams"
+      />
+    </template>
     <HoppSmartConfirmModal
       :show="confirmRemove"
       :title="t('confirm.remove_team')"

--- a/packages/hoppscotch-common/src/components/app/Header.vue
+++ b/packages/hoppscotch-common/src/components/app/Header.vue
@@ -260,44 +260,47 @@
       @dismiss="dismissBanner"
     />
     <TeamsModal :show="showTeamsModal" @hide-modal="showTeamsModal = false" />
-    <template v-if="platform.ui?.additionalTeamInviteComponent">
-      <component
-        :is="platform.ui.additionalTeamInviteComponent"
-        :show="showModalInvite"
-        :editing-team-i-d="editingTeamID"
-        @hide-modal="displayModalInvite(false)"
-      />
-    </template>
-    <template v-else>
-      <TeamsInvite
-        v-if="workspace.type === 'team' && workspace.teamID"
-        :show="showModalInvite"
-        :editing-team-i-d="editingTeamID"
-        @hide-modal="displayModalInvite(false)"
-      />
-    </template>
 
-    <template v-if="platform.ui?.additioinalTeamEditComponent">
-      <component
-        :is="platform.ui.additioinalTeamEditComponent"
-        :show="showModalEdit"
-        :editing-team="editingTeamName"
-        :editing-team-i-d="editingTeamID"
-        @hide-modal="displayModalEdit(false)"
-        @invite-team="inviteTeam(editingTeamName, editingTeamID)"
-        @refetch-teams="refetchTeams"
-      />
-    </template>
-    <template v-else>
-      <TeamsEdit
-        :show="showModalEdit"
-        :editing-team="editingTeamName"
-        :editing-team-i-d="editingTeamID"
-        @hide-modal="displayModalEdit(false)"
-        @invite-team="inviteTeam(editingTeamName, editingTeamID)"
-        @refetch-teams="refetchTeams"
-      />
-    </template>
+    <component
+      v-if="
+        platform.ui?.additionalTeamInviteComponent &&
+        workspace.type === 'team' &&
+        workspace.teamID
+      "
+      :is="platform.ui.additionalTeamInviteComponent"
+      :show="showModalInvite"
+      :editing-team-i-d="editingTeamID"
+      @hide-modal="displayModalInvite(false)"
+    />
+
+    <TeamsInvite
+      v-else-if="workspace.type === 'team' && workspace.teamID"
+      :show="showModalInvite"
+      :editing-team-i-d="editingTeamID"
+      @hide-modal="displayModalInvite(false)"
+    />
+
+    <component
+      v-if="platform.ui?.additioinalTeamEditComponent"
+      :is="platform.ui.additioinalTeamEditComponent"
+      :show="showModalEdit"
+      :editing-team="editingTeamName"
+      :editing-team-i-d="editingTeamID"
+      @hide-modal="displayModalEdit(false)"
+      @invite-team="inviteTeam(editingTeamName, editingTeamID)"
+      @refetch-teams="refetchTeams"
+    />
+
+    <TeamsEdit
+      v-else
+      :show="showModalEdit"
+      :editing-team="editingTeamName"
+      :editing-team-i-d="editingTeamID"
+      @hide-modal="displayModalEdit(false)"
+      @invite-team="inviteTeam(editingTeamName, editingTeamID)"
+      @refetch-teams="refetchTeams"
+    />
+
     <HoppSmartConfirmModal
       :show="confirmRemove"
       :title="t('confirm.remove_team')"

--- a/packages/hoppscotch-common/src/components/teams/Edit.vue
+++ b/packages/hoppscotch-common/src/components/teams/Edit.vue
@@ -101,7 +101,10 @@
                         :active="member.role === 'OWNER'"
                         @click="
                           () => {
-                            updateMemberRole(member.userID, 'OWNER')
+                            updateMemberRole(
+                              member.userID,
+                              TeamMemberRole.Owner
+                            )
                             hide()
                           }
                         "
@@ -114,7 +117,10 @@
                         :active="member.role === 'EDITOR'"
                         @click="
                           () => {
-                            updateMemberRole(member.userID, 'EDITOR')
+                            updateMemberRole(
+                              member.userID,
+                              TeamMemberRole.Editor
+                            )
                             hide()
                           }
                         "
@@ -127,7 +133,10 @@
                         :active="member.role === 'VIEWER'"
                         @click="
                           () => {
-                            updateMemberRole(member.userID, 'VIEWER')
+                            updateMemberRole(
+                              member.userID,
+                              TeamMemberRole.Viewer
+                            )
                             hide()
                           }
                         "

--- a/packages/hoppscotch-common/src/components/teams/Edit.vue
+++ b/packages/hoppscotch-common/src/components/teams/Edit.vue
@@ -252,6 +252,7 @@ const teamDetails = useGQLQuery<GetTeamQuery, GetTeamQueryVariables, "">({
     teamID: props.editingTeamID,
   },
   pollDuration: 10000,
+  pollLoadingEnabled: false,
   defer: true,
   updateSubs: computed(() => {
     if (props.editingTeamID) {

--- a/packages/hoppscotch-common/src/components/teams/Invite.vue
+++ b/packages/hoppscotch-common/src/components/teams/Invite.vue
@@ -499,6 +499,7 @@ const pendingInvites = useGQLQuery<
     teamID: props.editingTeamID,
   }),
   pollDuration: 10000,
+  pollLoadingEnabled: false,
   updateSubs: computed(() =>
     !props.editingTeamID
       ? []

--- a/packages/hoppscotch-common/src/components/teams/index.vue
+++ b/packages/hoppscotch-common/src/components/teams/index.vue
@@ -44,9 +44,9 @@
     <TeamsAdd :show="showModalAdd" @hide-modal="displayModalAdd(false)" />
     <!-- ¯\_(ツ)_/¯ -->
 
-    <template v-if="platform.ui?.teamEditComponent">
+    <template v-if="platform.ui?.additioinalTeamEditComponent">
       <component
-        :is="platform.ui.teamEditComponent"
+        :is="platform.ui.additioinalTeamEditComponent"
         :team="editingTeam"
         :show="showModalEdit"
         :editing-team="editingTeam"
@@ -69,9 +69,9 @@
       />
     </template>
 
-    <template v-if="platform.ui?.teamInviteComponent">
+    <template v-if="platform.ui?.additionalTeamInviteComponent">
       <component
-        :is="platform.ui.teamInviteComponent"
+        :is="platform.ui.additionalTeamInviteComponent"
         :team="editingTeam"
         :show="showModalInvite"
         :editing-team="editingTeam"

--- a/packages/hoppscotch-common/src/components/teams/index.vue
+++ b/packages/hoppscotch-common/src/components/teams/index.vue
@@ -44,51 +44,53 @@
     <TeamsAdd :show="showModalAdd" @hide-modal="displayModalAdd(false)" />
     <!-- ¯\_(ツ)_/¯ -->
 
-    <template v-if="platform.ui?.additioinalTeamEditComponent">
-      <component
-        :is="platform.ui.additioinalTeamEditComponent"
-        :team="editingTeam"
-        :show="showModalEdit"
-        :editing-team="editingTeam"
-        :editing-team-i-d="editingTeamID"
-        @hide-modal="displayModalEdit(false)"
-        @invite-team="inviteTeam(editingTeam, editingTeamID)"
-        @refetch-teams="refetchTeams"
-      />
-    </template>
-    <template v-else>
-      <TeamsEdit
-        v-if="!loading && myTeams.length > 0"
-        :team="myTeams[0]"
-        :show="showModalEdit"
-        :editing-team="editingTeam"
-        :editing-team-i-d="editingTeamID"
-        @hide-modal="displayModalEdit(false)"
-        @invite-team="inviteTeam(editingTeam, editingTeamID)"
-        @refetch-teams="refetchTeams"
-      />
-    </template>
+    <component
+      v-if="
+        platform.ui?.additioinalTeamEditComponent &&
+        !loading &&
+        myTeams.length > 0
+      "
+      :is="platform.ui.additioinalTeamEditComponent"
+      :team="editingTeam"
+      :show="showModalEdit"
+      :editing-team="editingTeam"
+      :editing-team-i-d="editingTeamID"
+      @hide-modal="displayModalEdit(false)"
+      @invite-team="inviteTeam(editingTeam, editingTeamID)"
+      @refetch-teams="refetchTeams"
+    />
+    <TeamsEdit
+      v-else-if="!loading && myTeams.length > 0"
+      :team="myTeams[0]"
+      :show="showModalEdit"
+      :editing-team="editingTeam"
+      :editing-team-i-d="editingTeamID"
+      @hide-modal="displayModalEdit(false)"
+      @invite-team="inviteTeam(editingTeam, editingTeamID)"
+      @refetch-teams="refetchTeams"
+    />
 
-    <template v-if="platform.ui?.additionalTeamInviteComponent">
-      <component
-        :is="platform.ui.additionalTeamInviteComponent"
-        :team="editingTeam"
-        :show="showModalInvite"
-        :editing-team="editingTeam"
-        :editing-team-i-d="editingTeamID"
-        @hide-modal="displayModalInvite(false)"
-      />
-    </template>
-    <template v-else>
-      <TeamsInvite
-        v-if="!loading && myTeams.length > 0"
-        :team="myTeams[0]"
-        :show="showModalInvite"
-        :editing-team="editingTeam"
-        :editing-team-i-d="editingTeamID"
-        @hide-modal="displayModalInvite(false)"
-      />
-    </template>
+    <component
+      v-if="
+        platform.ui?.additionalTeamInviteComponent &&
+        !loading &&
+        myTeams.length > 0
+      "
+      :is="platform.ui.additionalTeamInviteComponent"
+      :team="editingTeam"
+      :show="showModalInvite"
+      :editing-team="editingTeam"
+      :editing-team-i-d="editingTeamID"
+      @hide-modal="displayModalInvite(false)"
+    />
+    <TeamsInvite
+      v-else-if="!loading && myTeams.length > 0"
+      :team="myTeams[0]"
+      :show="showModalInvite"
+      :editing-team="editingTeam"
+      :editing-team-i-d="editingTeamID"
+      @hide-modal="displayModalInvite(false)"
+    />
   </div>
 </template>
 

--- a/packages/hoppscotch-common/src/components/teams/index.vue
+++ b/packages/hoppscotch-common/src/components/teams/index.vue
@@ -44,53 +44,48 @@
     <TeamsAdd :show="showModalAdd" @hide-modal="displayModalAdd(false)" />
     <!-- ¯\_(ツ)_/¯ -->
 
-    <component
-      v-if="
-        platform.ui?.additioinalTeamEditComponent &&
-        !loading &&
-        myTeams.length > 0
-      "
-      :is="platform.ui.additioinalTeamEditComponent"
-      :team="editingTeam"
-      :show="showModalEdit"
-      :editing-team="editingTeam"
-      :editing-team-i-d="editingTeamID"
-      @hide-modal="displayModalEdit(false)"
-      @invite-team="inviteTeam(editingTeam, editingTeamID)"
-      @refetch-teams="refetchTeams"
-    />
-    <TeamsEdit
-      v-else-if="!loading && myTeams.length > 0"
-      :team="myTeams[0]"
-      :show="showModalEdit"
-      :editing-team="editingTeam"
-      :editing-team-i-d="editingTeamID"
-      @hide-modal="displayModalEdit(false)"
-      @invite-team="inviteTeam(editingTeam, editingTeamID)"
-      @refetch-teams="refetchTeams"
-    />
+    <template v-if="!loading && myTeams.length > 0">
+      <component
+        :is="platform.ui.additionalTeamEditComponent"
+        v-if="platform.ui?.additionalTeamEditComponent"
+        :team="editingTeam"
+        :show="showModalEdit"
+        :editing-team="editingTeam"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalEdit(false)"
+        @invite-team="inviteTeam(editingTeam, editingTeamID)"
+        @refetch-teams="refetchTeams"
+      />
 
-    <component
-      v-if="
-        platform.ui?.additionalTeamInviteComponent &&
-        !loading &&
-        myTeams.length > 0
-      "
-      :is="platform.ui.additionalTeamInviteComponent"
-      :team="editingTeam"
-      :show="showModalInvite"
-      :editing-team="editingTeam"
-      :editing-team-i-d="editingTeamID"
-      @hide-modal="displayModalInvite(false)"
-    />
-    <TeamsInvite
-      v-else-if="!loading && myTeams.length > 0"
-      :team="myTeams[0]"
-      :show="showModalInvite"
-      :editing-team="editingTeam"
-      :editing-team-i-d="editingTeamID"
-      @hide-modal="displayModalInvite(false)"
-    />
+      <TeamsEdit
+        v-else
+        :team="myTeams[0]"
+        :show="showModalEdit"
+        :editing-team="editingTeam"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalEdit(false)"
+        @invite-team="inviteTeam(editingTeam, editingTeamID)"
+        @refetch-teams="refetchTeams"
+      />
+
+      <component
+        :is="platform.ui.additionalTeamInviteComponent"
+        v-if="platform.ui?.additionalTeamInviteComponent"
+        :team="editingTeam"
+        :show="showModalInvite"
+        :editing-team="editingTeam"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalInvite(false)"
+      />
+      <TeamsInvite
+        v-else
+        :team="myTeams[0]"
+        :show="showModalInvite"
+        :editing-team="editingTeam"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalInvite(false)"
+      />
+    </template>
   </div>
 </template>
 

--- a/packages/hoppscotch-common/src/components/teams/index.vue
+++ b/packages/hoppscotch-common/src/components/teams/index.vue
@@ -43,24 +43,52 @@
     </div>
     <TeamsAdd :show="showModalAdd" @hide-modal="displayModalAdd(false)" />
     <!-- ¯\_(ツ)_/¯ -->
-    <TeamsEdit
-      v-if="!loading && myTeams.length > 0"
-      :team="myTeams[0]"
-      :show="showModalEdit"
-      :editing-team="editingTeam"
-      :editing-team-i-d="editingTeamID"
-      @hide-modal="displayModalEdit(false)"
-      @invite-team="inviteTeam(editingTeam, editingTeamID)"
-      @refetch-teams="refetchTeams"
-    />
-    <TeamsInvite
-      v-if="!loading && myTeams.length > 0"
-      :team="myTeams[0]"
-      :show="showModalInvite"
-      :editing-team="editingTeam"
-      :editing-team-i-d="editingTeamID"
-      @hide-modal="displayModalInvite(false)"
-    />
+
+    <template v-if="platform.ui?.teamEditComponent">
+      <component
+        :is="platform.ui.teamEditComponent"
+        :team="editingTeam"
+        :show="showModalEdit"
+        :editing-team="editingTeam"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalEdit(false)"
+        @invite-team="inviteTeam(editingTeam, editingTeamID)"
+        @refetch-teams="refetchTeams"
+      />
+    </template>
+    <template v-else>
+      <TeamsEdit
+        v-if="!loading && myTeams.length > 0"
+        :team="myTeams[0]"
+        :show="showModalEdit"
+        :editing-team="editingTeam"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalEdit(false)"
+        @invite-team="inviteTeam(editingTeam, editingTeamID)"
+        @refetch-teams="refetchTeams"
+      />
+    </template>
+
+    <template v-if="platform.ui?.teamInviteComponent">
+      <component
+        :is="platform.ui.teamInviteComponent"
+        :team="editingTeam"
+        :show="showModalInvite"
+        :editing-team="editingTeam"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalInvite(false)"
+      />
+    </template>
+    <template v-else>
+      <TeamsInvite
+        v-if="!loading && myTeams.length > 0"
+        :team="myTeams[0]"
+        :show="showModalInvite"
+        :editing-team="editingTeam"
+        :editing-team-i-d="editingTeamID"
+        @hide-modal="displayModalInvite(false)"
+      />
+    </template>
   </div>
 </template>
 
@@ -72,6 +100,7 @@ import { useColorMode } from "@composables/theming"
 import { WorkspaceService } from "~/services/workspace.service"
 import { useService } from "dioc/vue"
 import IconPlus from "~icons/lucide/plus"
+import { platform } from "~/platform"
 
 const t = useI18n()
 

--- a/packages/hoppscotch-common/src/composables/graphql.ts
+++ b/packages/hoppscotch-common/src/composables/graphql.ts
@@ -35,6 +35,12 @@ type UseQueryOptions<T = any, V = object> = {
   updateSubs?: MaybeRef<GraphQLRequest<any, object>[]>
   defer?: boolean
   pollDuration?: number | undefined
+
+  /**
+   * Determines the behavior of the loading state during polling.
+   * If true, the loading state toggles each time the poller runs;
+   * if false, it is set to true only once when the poller starts.
+   */
   pollLoadingEnabled?: boolean
 }
 

--- a/packages/hoppscotch-common/src/platform/ui.ts
+++ b/packages/hoppscotch-common/src/platform/ui.ts
@@ -62,12 +62,12 @@ export type UIPlatformDef = {
   /**
    * Custom invite component to be shown in the team invite page
    */
-  teamInviteComponent?: Component
+  additionalTeamInviteComponent?: Component
 
   /**
    * Custom edit component to be shown in the team edit page
    */
-  teamEditComponent?: Component
+  additioinalTeamEditComponent?: Component
 
   /**
    * More info shown in the danger zone section while attempting user deletion

--- a/packages/hoppscotch-common/src/platform/ui.ts
+++ b/packages/hoppscotch-common/src/platform/ui.ts
@@ -67,7 +67,7 @@ export type UIPlatformDef = {
   /**
    * Custom edit component to be shown in the team edit page
    */
-  additioinalTeamEditComponent?: Component
+  additionalTeamEditComponent?: Component
 
   /**
    * More info shown in the danger zone section while attempting user deletion

--- a/packages/hoppscotch-common/src/platform/ui.ts
+++ b/packages/hoppscotch-common/src/platform/ui.ts
@@ -60,12 +60,12 @@ export type UIPlatformDef = {
   additionalSidebarHeaderItem?: Component
 
   /**
-   * Custom invite user group component to be shown in the invite user group page
+   * Custom invite component to be shown in the team invite page
    */
   teamInviteComponent?: Component
 
   /**
-   * Custom edit user group component to be shown in the edit user group page
+   * Custom edit component to be shown in the team edit page
    */
   teamEditComponent?: Component
 

--- a/packages/hoppscotch-common/src/platform/ui.ts
+++ b/packages/hoppscotch-common/src/platform/ui.ts
@@ -60,6 +60,16 @@ export type UIPlatformDef = {
   additionalSidebarHeaderItem?: Component
 
   /**
+   * Custom invite user group component to be shown in the invite user group page
+   */
+  teamInviteComponent?: Component
+
+  /**
+   * Custom edit user group component to be shown in the edit user group page
+   */
+  teamEditComponent?: Component
+
+  /**
    * More info shown in the danger zone section while attempting user deletion
    * Sample use case includes displaying the instance information on cloud instances
    */


### PR DESCRIPTION
This pull request introduces support for custom UI components for team invite and edit functionality, improved GraphQL query behavior. Below is a summary of the most important changes grouped by theme:

### Code Refactoring:
* Replaced hardcoded role strings (`'OWNER'`, `'EDITOR'`, `'VIEWER'`) with the `TeamMemberRole` enum for better type safety and readability. (`packages/hoppscotch-common/src/components/teams/Edit.vue`, [[1]](diffhunk://#diff-cb9c050f11dee81270e534eb989340c0a9070a070334fdebbb796fc813a8e4f5L104-R107) [[2]](diffhunk://#diff-cb9c050f11dee81270e534eb989340c0a9070a070334fdebbb796fc813a8e4f5L117-R123) [[3]](diffhunk://#diff-cb9c050f11dee81270e534eb989340c0a9070a070334fdebbb796fc813a8e4f5L130-R139)

These changes collectively enhance the flexibility, maintainability, and performance of the team management features.