### PR TITLE
fix(common): url and param encoding

### DIFF
--- a/packages/hoppscotch-common/src/helpers/functional/process-request.ts
+++ b/packages/hoppscotch-common/src/helpers/functional/process-request.ts
@@ -81,10 +81,10 @@ const updateUrl = (
 
 export const preProcessRelayRequest = (req: RelayRequest): RelayRequest =>
   pipe(cloneDeep(req), (req) =>
-    req.params && req.params.length > 0
+    req.params
       ? pipe(
           updateUrl(req.url, req.params),
-          E.map((url) => ({ ...req, url, params: [] })),
+          E.map((url) => ({ ...req, url, params: {} })),
           E.getOrElse(() => req)
         )
       : req

--- a/packages/hoppscotch-common/src/helpers/functional/process-request.ts
+++ b/packages/hoppscotch-common/src/helpers/functional/process-request.ts
@@ -34,11 +34,27 @@ const processParams = (params: [string, string][]): [string, string][] => {
     const isEncodingRequired =
       encodeMode === "enable" || (encodeMode === "auto" && needsEncoding(value))
 
-    const encodedKey = isEncodingRequired ? encodeParam(key) : key
     const encodedValue = isEncodingRequired ? encodeParam(value) : value
 
-    return [encodedKey, encodedValue]
+    return [key, encodedValue]
   })
+}
+
+const buildQueryString = (params: [string, string][]): string =>
+  params.map(([k, v]) => `${encodeURIComponent(k)}=${v}`).join("&")
+
+const combineWithExistingSearch = (urlObj: URL, queryString: string): URL => {
+  const existingSearch =
+    urlObj.search.length > 1 ? urlObj.search.substring(1) : ""
+
+  urlObj.search = pipe(
+    existingSearch,
+    O.fromPredicate((s) => s.length > 0),
+    O.map((s) => `${s}&${queryString}`),
+    O.getOrElse(() => queryString)
+  )
+
+  return urlObj
 }
 
 const updateUrl = (
@@ -50,18 +66,25 @@ const updateUrl = (
       () => new URL(url),
       (e) => new Error(`Invalid URL: ${e}`)
     ),
-    E.map((u) => {
-      processParams(params).forEach(([k, v]) => u.searchParams.append(k, v))
-      return decodeURIComponent(u.toString())
-    })
+    E.map((urlObj) => {
+      const processedParams = processParams(params)
+
+      if (processedParams.length > 0) {
+        const queryString = buildQueryString(processedParams)
+        return combineWithExistingSearch(urlObj, queryString)
+      }
+
+      return urlObj
+    }),
+    E.map((u) => u.toString())
   )
 
 export const preProcessRelayRequest = (req: RelayRequest): RelayRequest =>
   pipe(cloneDeep(req), (req) =>
-    req.params
+    req.params && req.params.length > 0
       ? pipe(
           updateUrl(req.url, req.params),
-          E.map((url) => ({ ...req, url, params: {} })),
+          E.map((url) => ({ ...req, url, params: [] })),
           E.getOrElse(() => req)
         )
       : req


### PR DESCRIPTION
These changes fix URL parameter encoding behavior based on how parameter values are encoded, those based on the `ENCODE_MODE` setting.

Closes HFE-833
Closes #4971

Context: We encode query parameter values according to [RFC 3986 Section 3.4](https://datatracker.ietf.org/doc/html/rfc3986#section-3.4), query components should be encoded, which is controlled by `ENCODE_MODE` setting.

When the encoding mode was set to "enable", a parameter value like `{second-testing}` would be encoded to `%257Bsecond-testing%257D` instead of `%7Bsecond-testing%7D`.

This occurred because of a combination of the custom encoding logic and the browser's native `searchParams.append()` method.

As in [RFC 3986#2.4](https://datatracker.ietf.org/doc/html/rfc3986#section-2.4), percent-encoding is non-idempotent. When processing a URL like `http://localhost:8080/%7Bfoo%7D`, the `decodeURIComponent` call applied to the URL would revert the encoded path back to `http://localhost:8080/{foo}`.

This fix addresses all issues by modifying the impl to maintain compliance with URL standards:

The `processParams` function now only encodes values:
```javascript
const encodedValue = isEncodingRequired ? encodeParam(value) : value
return [key, encodedValue]
```

The `updateUrl` function now manually constructs query parameters:
```javascript
if (processedParams.length > 0) {
  const searchParts = processedParams.map(([k, v]) => {
    return `${encodeURIComponent(k)}=${v}`
  })

  const existingSearch = u.search ? u.search.substring(1) + '&' : ''
  u.search = existingSearch + searchParts.join('&')
}
```

The URL string generation doesn't apply `decodeURIComponent` to the entire URL:
```javascript
return u.toString()
```

### Notes to reviewers

Test by making requests with special characters in parameters using different `ENCODE_MODE` settings ("enable", "disable", and "auto"), then look for URLs with already encoded segments like `%7Bfoo%7D` which should remain encoded throughout the process.

### Demo

Below are the actual logs from testing this fix with different `ENCODE_MODE` settings and URL formats:

**With unencoded URL path and ENCODE_MODE="disable"**:
```
Input Request:
{
  url: "http://localhost:8080/{foo}",
  params: [
    ["first", "firstVal"],
    ["second", "{second-val}"],
    ["{third}", "%third_val}"]
  ]
}

Output URL (Before Fix):
http://localhost:8080/{foo}?first=firstVal&second={second-val}&{third}=%third_val}

Output URL (After Fix):
http://localhost:8080/{foo}?first=firstVal&second={second-val}&%7Bthird%7D=%third_val}
```

**With unencoded URL path and ENCODE_MODE="enable"**:
```
Input Request:
{
  url: "http://localhost:8080/{foo}",
  params: [
    ["first", "firstVal"],
    ["second", "{second-val}"],
    ["{third}", "%third_val}"]
  ]
}

Output URL (Before Fix):
http://localhost:8080/{foo}?first=firstVal&second=%257Bsecond-val%257D&
%257Bthird%257D=%25third_val%257D

Output URL (After Fix):
http://localhost:8080/{foo}?first=firstVal&second=%7Bsecond-val%7D&
%7Bthird%7D=%25third_val%7D
```

**With already encoded URL path and ENCODE_MODE="enable"**:
```
Input Request:
{
  url: "http://localhost:8080/%7Bfoo%7D",
  params: [
    ["first", "firstVal"],
    ["second", "{second-val}"],
    ["{third}", "%third_val}"]
  ]
}

Output URL (Before Fix):
http://localhost:8080/{foo}?first=firstVal&second=%257Bsecond-val%257D&
%257Bthird%257D=%25third_val%257D

Output URL (After Fix):
http://localhost:8080/%7Bfoo%7D?first=firstVal&second=%7Bsecond-val%7D&
%7Bthird%7D=%25third_val%7D
```

**With already encoded URL path and ENCODE_MODE="disable"**:
```
Input Request:
{
  url: "http://localhost:8080/%7Bfoo%7D",
  params: [
    ["first", "firstVal"],
    ["second", "{second-val}"],
    ["{third}", "%third_val}"]
  ]
}

Output URL (Before Fix):
http://localhost:8080/{foo}?first=firstVal&second={second-val}&
{third}=%third_val}

Output URL (After Fix):
http://localhost:8080/%7Bfoo%7D?first=firstVal&second={second-val}&
%7Bthird%7D=%third_val}
```