### PR TITLE
feat(desktop): complete lifecycle logs

### DIFF
--- a/packages/hoppscotch-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.lock
@@ -1140,7 +1140,16 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -1151,8 +1160,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2036,6 +2057,7 @@ name = "hoppscotch-desktop"
 version = "25.4.2"
 dependencies = [
  "axum",
+ "dirs 6.0.0",
  "file-rotate",
  "portpicker",
  "serde",
@@ -3922,6 +3944,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 2.0.7",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4859,7 +4892,7 @@ checksum = "e545de0a2dfe296fa67db208266cd397c5a55ae782da77973ef4c4fac90e9f2c"
 dependencies = [
  "anyhow",
  "bytes",
- "dirs",
+ "dirs 5.0.1",
  "dunce",
  "embed_plist",
  "futures-util",
@@ -4909,7 +4942,7 @@ checksum = "7bd2a4bcfaf5fb9f4be72520eefcb61ae565038f8ccba2a497d8c28f463b8c01"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 5.0.1",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -5147,7 +5180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2d39224390c41ba544f02b4f1721f42256320b3fb8c371e9425cbddeb4a68c"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 5.0.1",
  "flate2",
  "futures-util",
  "http",
@@ -5667,7 +5700,7 @@ checksum = "d48a05076dd272615d03033bf04f480199f7d1b66a8ac64d75c625fc4a70c06b"
 dependencies = [
  "core-graphics",
  "crossbeam-channel",
- "dirs",
+ "dirs 5.0.1",
  "libappindicator",
  "muda",
  "objc2",

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ portpicker = "0.1.1"
 tokio = "1.43.0"
 tauri-plugin-process = "2.2.0"
 file-rotate = "0.8.0"
+dirs = "6.0.0"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2.3.1"

--- a/packages/hoppscotch-desktop/src-tauri/src/lib.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ use tauri_plugin_appload::VendorConfigBuilder;
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_window_state::StateFlags;
 
+pub const HOPPSCOTCH_DESKTOP_IDENTIFIER: &'static str = "io.hoppscotch.desktop";
 static SERVER_PORT: OnceLock<u16> = OnceLock::new();
 
 #[tauri::command]
@@ -21,9 +22,6 @@ pub fn run() {
     tauri::Builder::default()
         .setup(|app| {
             let handle = app.handle().clone();
-
-            logger::setup(app.handle().clone())?;
-            tracing::info!("Logger setup complete");
 
             let server_port = portpicker::pick_unused_port().expect("Cannot find unused port");
             tracing::info!("Selected server port: {}", server_port);

--- a/packages/hoppscotch-desktop/src-tauri/src/main.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/main.rs
@@ -1,7 +1,48 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use hoppscotch_desktop_lib::{
+    logger::{self, LogGuard},
+    HOPPSCOTCH_DESKTOP_IDENTIFIER,
+};
+
 fn main() {
-    println!("Starting Hoppscotch Desktop application...");
+    // Follows how `tauri` does this
+    // see: https://github.com/tauri-apps/tauri/blob/dev/crates/tauri/src/path/desktop.rs
+    let path = {
+        #[cfg(target_os = "macos")]
+        let path = dirs::home_dir()
+            .map(|dir| dir.join("Library/Logs").join(HOPPSCOTCH_DESKTOP_IDENTIFIER));
+
+        #[cfg(not(target_os = "macos"))]
+        let path =
+            dirs::data_local_dir().map(|dir| dir.join(HOPPSCOTCH_DESKTOP_IDENTIFIER).join("logs"));
+
+        path
+    };
+
+    let Some(log_file_path) = path else {
+        eprint!("Failed to setup logging!");
+
+        println!("Starting Hoppscotch Desktop...");
+
+        return hoppscotch_desktop_lib::run()
+    };
+
+    let Ok(LogGuard(guard)) = logger::setup(&log_file_path) else {
+        eprint!("Failed to setup logging!");
+
+        println!("Starting Hoppscotch Desktop...");
+
+        return hoppscotch_desktop_lib::run()
+    };
+
+    // This keeps the guard alive, this is scoped to `main`
+    // so it can only drop when the entire app exits,
+    // so safe to have it like this.
+    let _guard = guard;
+
+    tracing::info!("Starting Hoppscotch Desktop...");
+
     hoppscotch_desktop_lib::run()
 }


### PR DESCRIPTION
This changes how logging is initialized and managed, fixing an issue where some logs were missing from `io.hoppscotch.log` files.

Closes HFE-838

Basically some debug log messages just weren't appearing in the logs. This was quite odd because other debug messages from the same module were appearing correctly.

In Tauri app, logging is tricky... mainly because of the application lifecycle. The application starts in `main.rs` before any Tauri-specific functionality is available. Having log sinks setup at `main` would be great, but we also need file-based logging that requires the Tauri AppHandle to determine the right log file paths.

There is a "theoretical" way to achieve this, to simply initialize logging twice:

```rust
// In main.rs - Basic console logging
tracing_subscriber::registry()
    .with(tracing_subscriber::EnvFilter::try_from_default_env()
        .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()))
    .with(tracing_subscriber::fmt::layer().without_time())
    .init();

// Later in lib.rs - File-based logging
logger::setup(app.handle().clone())?;
```

Why this doesn't work is `tracing` needs a global dispatcher

```
thread 'main' panicked at .../tracing-subscriber-0.3.19/src/util.rs:91:14:
failed to set global default subscriber: SetGlobalDefaultError("a global
default trace dispatcher has already been set")
```

This error occurs because the `tracing` ecosystem only allows setting the global default subscriber once, see:
https://docs.rs/tracing-subscriber/latest/src/tracing_subscriber/util.rs.html#63-92

The issue is that when we use `init()` to initialize the global dispatcher in `main.rs`, we can't set it again in `lib.rs`. This means any early logs in the application lifecycle before the Tauri `AppHandle` is available were getting captured by the basic console logger, but we couldn't add file-based logging later.

The missing logs showed up when running the application with only the basic console logger set in `main.rs`, but this approach lacks the file persistence based logging. Essentially we can see the disk space check and other initialization logs in the console, but they weren't being saved to the log file.

```rust
DEBUG tauri_plugin_appload::storage::manager: Checking available disk space required_space=15972964
DEBUG tauri_plugin_appload::storage::manager: Sufficient disk space available available_space=649181622
```

A classic timing issue: we need file-based logging set up before Tauri plugins begin initialization but we could only get the appropriate paths after Tauri starts.

The solution is - rather than relying on Tauri's built-in path resolution which are only available after the app is created, we implemented a similar path resolution directly in `main.rs`:

```rust
// Follows how `tauri` does this
// see: https://github.com/tauri-apps/tauri/blob/dev/crates/tauri/src/path/desktop.rs
let path = {
    #[cfg(target_os = "macos")]
    let path = dirs::home_dir()
        .map(|dir| dir.join("Library/Logs").join(HOPPSCOTCH_DESKTOP_IDENTIFIER));

    #[cfg(not(target_os = "macos"))]
    let path =
        dirs::data_local_dir().map(|dir| dir.join(HOPPSCOTCH_DESKTOP_IDENTIFIER).join("logs"));

    path
};
```

This mimics Tauri's own path resolution logic to find the log directory before the Tauri application starts.

Next, change `logger.rs` to accept a path rather than an `AppHandle`:

```rust
pub fn setup(log_dir: &PathBuf) -> Result<LogGuard, Box<dyn std::error::Error>> {
    std::fs::create_dir_all(log_dir)?;
    // ... logging setup ...
    Ok(LogGuard(guard))
}
```

So now, instead of managing the log guard within the `setup` function using `app_handle.manage()`, we return the guard to the caller, allowing it to be managed in the `main` function's scope:

```rust
let Ok(LogGuard(guard)) = logger::setup(&log_file_path) else {
    eprint!("Failed to setup logging!");
    println!("Starting Hoppscotch Desktop...");
    return hoppscotch_desktop_lib::run()
};

// This keeps the guard alive, this is scoped to `main`
// so it can only drop when the entire app exits,
// so safe to have it like this.
let _guard = guard;
```

The `_guard` is important. Underscore is just for warnings, but the variable itself keeps the guard alive for the lifetime of the `main`. Since the guard is responsible for buffered logs to get flushed to disk.
