### PR TITLE
fix(desktop): verbatim path handling in disk resolution

### DIFF
--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/Cargo.lock
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/Cargo.lock
@@ -4061,6 +4061,7 @@ dependencies = [
  "chrono",
  "cocoa",
  "dashmap",
+ "dunce",
  "ed25519-dalek",
  "flate2",
  "futures",

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/Cargo.toml
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/Cargo.toml
@@ -34,6 +34,7 @@ futures = "0.3.31"
 mime_guess = "2.0.5"
 rayon = "1.10.0"
 hex_color = "3.0.0"
+dunce = "1.0.5"
 
 [build-dependencies]
 tauri-plugin = { version = "2.0.1", features = ["build"] }

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/ui/windows/posit.rs
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/ui/windows/posit.rs
@@ -65,7 +65,7 @@ impl<R: Runtime> WindowsWindow<R> {
 
     fn set_dark_mode(&self) {
         if let Some(version) = WindowsVersion::detect() {
-            if version.major() >= 10 && version.build() >= MIN_WIN11_BUILD {
+            if version.major >= 10 && version.build >= MIN_WIN11_BUILD {
                 unsafe {
                     let use_dark_mode = BOOL::from(true);
                     let _ = DwmSetWindowAttribute(
@@ -81,7 +81,7 @@ impl<R: Runtime> WindowsWindow<R> {
 
     fn set_caption_color(&self, color: HexColor) {
         if let Some(version) = WindowsVersion::detect() {
-            if version.major() >= 10 && version.build() >= MIN_WIN11_BUILD {
+            if version.major >= 10 && version.build >= MIN_WIN11_BUILD {
                 unsafe {
                     let color_ref = self.hex_color_to_colorref(color);
                     let _ = DwmSetWindowAttribute(

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.lock
@@ -2653,9 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
@@ -2963,6 +2963,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3086,6 +3095,15 @@ dependencies = [
  "block2",
  "objc2",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -4774,13 +4792,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sys-info"
-version = "0.9.1"
+name = "sysinfo"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
 dependencies = [
- "cc",
  "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "windows 0.57.0",
 ]
 
 [[package]]
@@ -5017,13 +5038,14 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-appload"
 version = "0.1.0"
-source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload#1c2e8b19db7f1b6af6d00abb907f15cdc2017298"
+source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload#87e78a8d35c02e53366d3b56286d0350f772efb7"
 dependencies = [
  "base64 0.22.1",
  "blake3",
  "chrono",
  "cocoa",
  "dashmap",
+ "dunce",
  "ed25519-dalek",
  "flate2",
  "futures",
@@ -5040,7 +5062,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sys-info",
+ "sysinfo",
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.7",
@@ -5069,7 +5091,7 @@ dependencies = [
  "tracing",
  "url",
  "windows-registry 0.3.0",
- "windows-result",
+ "windows-result 0.2.0",
 ]
 
 [[package]]
@@ -6184,8 +6206,8 @@ dependencies = [
  "webview2-com-sys",
  "windows 0.58.0",
  "windows-core 0.58.0",
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
 ]
 
 [[package]]
@@ -6266,6 +6288,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -6285,15 +6317,38 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement 0.57.0",
+ "windows-interface 0.57.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
  "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -6301,6 +6356,17 @@ name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6324,7 +6390,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
@@ -6335,8 +6401,17 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafa604f2104cf5ae2cc2db1dee84b7e6a5d11b05f737b60def0ffdc398cbc0a"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings 0.2.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -6355,7 +6430,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,7 +522,7 @@ importers:
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
         specifier: github:CuriousCorrelation/tauri-plugin-appload
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/60adb82d0cc886004307057194cf680373e14e02'
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/87e78a8d35c02e53366d3b56286d0350f772efb7'
       '@hoppscotch/ui':
         specifier: 0.2.2
         version: 0.2.2(eslint@8.57.0)(terser@5.34.1)(typescript@5.3.3)(vite@5.4.9(@types/node@22.9.3)(sass@1.79.5)(terser@5.34.1))(vue@3.5.12(typescript@5.3.3))
@@ -986,7 +986,7 @@ importers:
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
         specifier: github:CuriousCorrelation/tauri-plugin-appload
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/60adb82d0cc886004307057194cf680373e14e02'
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/87e78a8d35c02e53366d3b56286d0350f772efb7'
       '@hoppscotch/ui':
         specifier: 0.2.1
         version: 0.2.1(eslint@9.12.0(jiti@2.3.3))(terser@5.34.1)(typescript@5.7.2)(vite@5.4.11(@types/node@22.9.3)(sass@1.80.3)(terser@5.34.1))(vue@3.5.12(typescript@5.7.2))
@@ -1814,8 +1814,8 @@ packages:
       graphql:
         optional: true
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/60adb82d0cc886004307057194cf680373e14e02':
-    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/60adb82d0cc886004307057194cf680373e14e02}
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/87e78a8d35c02e53366d3b56286d0350f772efb7':
+    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/87e78a8d35c02e53366d3b56286d0350f772efb7}
     version: 0.1.0
 
   '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/3273b9b075f1f6fa9171799a961c435454c0c9a2':
@@ -13295,7 +13295,7 @@ snapshots:
     optionalDependencies:
       graphql: 16.9.0
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/60adb82d0cc886004307057194cf680373e14e02':
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/87e78a8d35c02e53366d3b56286d0350f772efb7':
     dependencies:
       '@tauri-apps/api': 2.1.1
 


### PR DESCRIPTION
The storage init was failing on Windows when checking available disk space due to verbatim paths (also known as extended-length paths) returned by `std::fs::canonicalize()`.

Windows has two path formats: traditional paths limited to 260 characters, and extended-length paths (prefixed with `\\?\`) that support longer paths.

While Rust's `std::path` is "platform-independent", Windows-specific behavior still requires special consideration for these extended-length paths.

This fixes that.

Closes HFE-839
Closes #4859

Basically the issue occurred because `std::fs::canonicalize()` on Windows may return extended-length paths when:
1. The path exceeds 260 characters
2. The path contains certain special characters
3. The system is configured to use extended paths (fairly common on Win 10/11)

The root issue is when comparing the canonicalized storage path against disk mount points.

A verbatim path like `\\?\C:\Users\SomeUser\AppData\...` would fail to match against the disk's mount point `C:\` because the comparison was done as a path string prefix check. This isn't handled by `std::path`, see [dunce's README](https://gitlab.com/kornelski/dunce/-/blob/master/README.md?ref_type=heads&plain=1#L16-17)

This caused the disk resolution to fail with "Disk not found" errors, preventing the app from initializing the bundle, which would show a `404`.

See the docs at (https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#win32-file-namespaces).

`dunce` crate provides cross-platform path canonicalization that specifically handles Windows verbatim paths correctly. When given a verbatim path, dunce safely strips the `\\?\` prefix when possible while maintaining path validity:

```rust
let normalized_path = dunce::canonicalize(&storage_path).unwrap_or(storage_path.clone());
```

The normalization preserves the verbatim prefix only when necessary - for example with reserved filenames like `\\?\C:\COM1` or paths containing certain special characters.

On non-Windows systems, dunce **behaves identically** to `std::fs::canonicalize()`.

Testing:
- Traditional Windows paths (< 260 chars)
- Extended-length paths (> 260 chars) that get verbatim prefixes
- Paths containing special characters
- UNC paths and network shares
- All supported non-Windows platforms


### Notes to reviewers

To test this, launch the app on Windows, have the install location be ~95% full (using something like `fsutil file createnew largefile.bin <size-in-bytes>`), launch the app, you should see `404` because the app bundle wasn't loaded due to 1. incorrect space calculation or 2. disk mismatch. Now try the same thing with this patch.