### PR TITLE
refactor: rename enum `TeamMemberRole` to `TeamAccessRole`

### DIFF
--- a/packages/hoppscotch-backend/prisma/migrations/20230406064219_init/migration.sql
+++ b/packages/hoppscotch-backend/prisma/migrations/20230406064219_init/migration.sql
@@ -2,7 +2,7 @@
 CREATE TYPE "ReqType" AS ENUM ('REST', 'GQL');
 
 -- CreateEnum
-CREATE TYPE "TeamMemberRole" AS ENUM ('OWNER', 'VIEWER', 'EDITOR');
+CREATE TYPE "TeamAccessRole" AS ENUM ('OWNER', 'VIEWER', 'EDITOR');
 
 -- CreateTable
 CREATE TABLE "Team" (
@@ -15,7 +15,7 @@ CREATE TABLE "Team" (
 -- CreateTable
 CREATE TABLE "TeamMember" (
     "id" TEXT NOT NULL,
-    "role" "TeamMemberRole" NOT NULL,
+    "role" "TeamAccessRole" NOT NULL,
     "userUid" TEXT NOT NULL,
     "teamID" TEXT NOT NULL,
 
@@ -28,7 +28,7 @@ CREATE TABLE "TeamInvitation" (
     "teamID" TEXT NOT NULL,
     "creatorUid" TEXT NOT NULL,
     "inviteeEmail" TEXT NOT NULL,
-    "inviteeRole" "TeamMemberRole" NOT NULL,
+    "inviteeRole" "TeamAccessRole" NOT NULL,
 
     CONSTRAINT "TeamInvitation_pkey" PRIMARY KEY ("id")
 );

--- a/packages/hoppscotch-backend/prisma/migrations/20230406064219_init/migration.sql
+++ b/packages/hoppscotch-backend/prisma/migrations/20230406064219_init/migration.sql
@@ -2,7 +2,7 @@
 CREATE TYPE "ReqType" AS ENUM ('REST', 'GQL');
 
 -- CreateEnum
-CREATE TYPE "TeamAccessRole" AS ENUM ('OWNER', 'VIEWER', 'EDITOR');
+CREATE TYPE "TeamMemberRole" AS ENUM ('OWNER', 'VIEWER', 'EDITOR');
 
 -- CreateTable
 CREATE TABLE "Team" (
@@ -15,7 +15,7 @@ CREATE TABLE "Team" (
 -- CreateTable
 CREATE TABLE "TeamMember" (
     "id" TEXT NOT NULL,
-    "role" "TeamAccessRole" NOT NULL,
+    "role" "TeamMemberRole" NOT NULL,
     "userUid" TEXT NOT NULL,
     "teamID" TEXT NOT NULL,
 
@@ -28,7 +28,7 @@ CREATE TABLE "TeamInvitation" (
     "teamID" TEXT NOT NULL,
     "creatorUid" TEXT NOT NULL,
     "inviteeEmail" TEXT NOT NULL,
-    "inviteeRole" "TeamAccessRole" NOT NULL,
+    "inviteeRole" "TeamMemberRole" NOT NULL,
 
     CONSTRAINT "TeamInvitation_pkey" PRIMARY KEY ("id")
 );

--- a/packages/hoppscotch-backend/prisma/migrations/20250306054346_team_access_role_enum/migration.sql
+++ b/packages/hoppscotch-backend/prisma/migrations/20250306054346_team_access_role_enum/migration.sql
@@ -1,0 +1,2 @@
+-- Alter the enum type "TeamMemberRole" to "TeamAccessRole"
+ALTER TYPE "TeamMemberRole" RENAME TO "TeamAccessRole";

--- a/packages/hoppscotch-backend/prisma/schema.prisma
+++ b/packages/hoppscotch-backend/prisma/schema.prisma
@@ -20,7 +20,7 @@ model Team {
 
 model TeamMember {
   id      String         @id @default(uuid()) // Membership ID
-  role    TeamMemberRole
+  role    TeamAccessRole
   userUid String
   teamID  String
   team    Team           @relation(fields: [teamID], references: [id], onDelete: Cascade)
@@ -34,7 +34,7 @@ model TeamInvitation {
   team         Team           @relation(fields: [teamID], references: [id], onDelete: Cascade)
   creatorUid   String
   inviteeEmail String
-  inviteeRole  TeamMemberRole
+  inviteeRole  TeamAccessRole
 
   @@unique([teamID, inviteeEmail])
   @@index([teamID])
@@ -207,7 +207,7 @@ model UserCollection {
   updatedOn  DateTime         @updatedAt @db.Timestamp(3)
 }
 
-enum TeamMemberRole {
+enum TeamAccessRole {
   OWNER
   VIEWER
   EDITOR

--- a/packages/hoppscotch-backend/src/admin/admin.service.ts
+++ b/packages/hoppscotch-backend/src/admin/admin.service.ts
@@ -26,7 +26,7 @@ import { TeamCollectionService } from '../team-collection/team-collection.servic
 import { TeamRequestService } from '../team-request/team-request.service';
 import { TeamEnvironmentsService } from '../team-environments/team-environments.service';
 import { TeamInvitationService } from '../team-invitation/team-invitation.service';
-import { TeamMemberRole } from '../team/team.model';
+import { TeamAccessRole } from '../team/team.model';
 import { ShortcodeService } from 'src/shortcode/shortcode.service';
 import { ConfigService } from '@nestjs/config';
 import { OffsetPaginationArgs } from 'src/types/input-types.args';
@@ -292,9 +292,9 @@ export class AdminService {
   async changeRoleOfUserTeam(
     userUid: string,
     teamID: string,
-    newRole: TeamMemberRole,
+    newRole: TeamAccessRole,
   ) {
-    const updatedTeamMember = await this.teamService.updateTeamMemberRole(
+    const updatedTeamMember = await this.teamService.updateTeamAccessRole(
       teamID,
       userUid,
       newRole,
@@ -325,7 +325,7 @@ export class AdminService {
    * @param role team member role for the user
    * @returns an Either of boolean or error
    */
-  async addUserToTeam(teamID: string, userEmail: string, role: TeamMemberRole) {
+  async addUserToTeam(teamID: string, userEmail: string, role: TeamAccessRole) {
     if (!validateEmail(userEmail)) return E.left(INVALID_EMAIL);
 
     const user = await this.userService.findUserByEmail(userEmail);

--- a/packages/hoppscotch-backend/src/admin/input-types.args.ts
+++ b/packages/hoppscotch-backend/src/admin/input-types.args.ts
@@ -1,5 +1,5 @@
 import { Field, ID, ArgsType } from '@nestjs/graphql';
-import { TeamMemberRole } from '../team/team.model';
+import { TeamAccessRole } from '../team/team.model';
 
 @ArgsType()
 export class ChangeUserRoleInTeamArgs {
@@ -14,11 +14,11 @@ export class ChangeUserRoleInTeamArgs {
   })
   teamID: string;
 
-  @Field(() => TeamMemberRole, {
+  @Field(() => TeamAccessRole, {
     name: 'newRole',
     description: 'updated team role',
   })
-  newRole: TeamMemberRole;
+  newRole: TeamAccessRole;
 }
 
 @ArgsType()
@@ -29,11 +29,11 @@ export class AddUserToTeamArgs {
   })
   teamID: string;
 
-  @Field(() => TeamMemberRole, {
+  @Field(() => TeamAccessRole, {
     name: 'role',
     description: 'The role of the user to add in the team',
   })
-  role: TeamMemberRole;
+  role: TeamAccessRole;
 
   @Field({
     name: 'userEmail',

--- a/packages/hoppscotch-backend/src/infra-token/request-response.dto.ts
+++ b/packages/hoppscotch-backend/src/infra-token/request-response.dto.ts
@@ -10,7 +10,7 @@ import {
   IsString,
   MinLength,
 } from 'class-validator';
-import { TeamMemberRole } from 'src/team/team.model';
+import { TeamAccessRole } from 'src/team/team.model';
 import { OffsetPaginationArgs } from 'src/types/input-types.args';
 
 // POST v1/infra/user-invitations
@@ -140,7 +140,7 @@ export class GetUserWorkspacesResponse {
   @Expose()
   name: string;
 
-  @ApiProperty({ enum: TeamMemberRole })
+  @ApiProperty({ enum: TeamAccessRole })
   @Expose()
   role: string;
 

--- a/packages/hoppscotch-backend/src/team-collection/guards/gql-collection-team-member.guard.ts
+++ b/packages/hoppscotch-backend/src/team-collection/guards/gql-collection-team-member.guard.ts
@@ -3,7 +3,7 @@ import { Reflector } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { TeamCollectionService } from '../team-collection.service';
 import { TeamService } from '../../team/team.service';
-import { TeamMemberRole } from '../../team/team.model';
+import { TeamAccessRole } from '../../team/team.model';
 import {
   BUG_TEAM_NO_REQUIRE_TEAM_ROLE,
   BUG_AUTH_NO_USER_CTX,
@@ -22,7 +22,7 @@ export class GqlCollectionTeamMemberGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const requireRoles = this.reflector.get<TeamMemberRole[]>(
+    const requireRoles = this.reflector.get<TeamAccessRole[]>(
       'requiresTeamRole',
       context.getHandler(),
     );

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.controller.ts
@@ -11,7 +11,7 @@ import * as E from 'fp-ts/Either';
 import { ThrottlerBehindProxyGuard } from 'src/guards/throttler-behind-proxy.guard';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RequiresTeamRole } from 'src/team/decorators/requires-team-role.decorator';
-import { TeamMemberRole } from '@prisma/client';
+import { TeamAccessRole } from '@prisma/client';
 import { RESTTeamMemberGuard } from 'src/team/guards/rest-team-member.guard';
 import { throwHTTPErr } from 'src/utils';
 import { RESTError } from 'src/types/RESTError';
@@ -24,9 +24,9 @@ export class TeamCollectionController {
 
   @Get('search/:teamID')
   @RequiresTeamRole(
-    TeamMemberRole.VIEWER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
+    TeamAccessRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
   )
   @UseGuards(JwtAuthGuard, RESTTeamMemberGuard)
   async searchByTitle(

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.resolver.ts
@@ -9,7 +9,7 @@ import {
   ID,
 } from '@nestjs/graphql';
 import { CollectionReorderData, TeamCollection } from './team-collection.model';
-import { Team, TeamMemberRole } from '../team/team.model';
+import { Team, TeamAccessRole } from '../team/team.model';
 import { TeamCollectionService } from './team-collection.service';
 import { GqlAuthGuard } from '../guards/gql-auth.guard';
 import { GqlTeamMemberGuard } from '../team/guards/gql-team-member.guard';
@@ -86,9 +86,9 @@ export class TeamCollectionResolver {
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.VIEWER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
+    TeamAccessRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
   )
   async exportCollectionsToJSON(
     @Args({ name: 'teamID', description: 'ID of the team', type: () => ID })
@@ -108,9 +108,9 @@ export class TeamCollectionResolver {
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.VIEWER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
+    TeamAccessRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
   )
   async exportCollectionToJSON(
     @Args({ name: 'teamID', description: 'ID of the team', type: () => ID })
@@ -137,9 +137,9 @@ export class TeamCollectionResolver {
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.VIEWER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
+    TeamAccessRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
   )
   async rootCollectionsOfTeam(@Args() args: GetRootTeamCollectionsArgs) {
     return this.teamCollectionService.getTeamRootCollections(
@@ -155,9 +155,9 @@ export class TeamCollectionResolver {
   })
   @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.VIEWER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
+    TeamAccessRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
   )
   async collection(
     @Args({
@@ -188,7 +188,7 @@ export class TeamCollectionResolver {
       'Creates a collection at the root of the team hierarchy (no parent collection)',
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async createRootCollection(@Args() args: CreateRootTeamCollectionArgs) {
     const teamCollection = await this.teamCollectionService.createCollection(
       args.teamID,
@@ -205,7 +205,7 @@ export class TeamCollectionResolver {
     description: 'Import collections from JSON string to the specified Team',
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async importCollectionsFromJSON(
     @Args({
       name: 'teamID',
@@ -242,7 +242,7 @@ export class TeamCollectionResolver {
       'Replace existing collections of a specific team with collections in JSON string',
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async replaceCollectionsWithJSON(@Args() args: ReplaceTeamCollectionArgs) {
     const teamCollection =
       await this.teamCollectionService.replaceCollectionsWithJSON(
@@ -259,7 +259,7 @@ export class TeamCollectionResolver {
     description: 'Create a collection that has a parent collection',
   })
   @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async createChildCollection(@Args() args: CreateChildTeamCollectionArgs) {
     const team = await this.teamCollectionService.getTeamOfCollection(
       args.collectionID,
@@ -282,7 +282,7 @@ export class TeamCollectionResolver {
     deprecationReason: 'Switch to updateTeamCollection mutation instead',
   })
   @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async renameCollection(@Args() args: RenameTeamCollectionArgs) {
     const updatedTeamCollection =
       await this.teamCollectionService.renameCollection(
@@ -298,7 +298,7 @@ export class TeamCollectionResolver {
     description: 'Delete a collection',
   })
   @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async deleteCollection(
     @Args({
       name: 'collectionID',
@@ -320,7 +320,7 @@ export class TeamCollectionResolver {
       'Move a collection into a new parent collection or the root of the team',
   })
   @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async moveCollection(@Args() args: MoveTeamCollectionArgs) {
     const res = await this.teamCollectionService.moveCollection(
       args.collectionID,
@@ -334,7 +334,7 @@ export class TeamCollectionResolver {
     description: 'Update the order of collections',
   })
   @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async updateCollectionOrder(@Args() args: UpdateTeamCollectionOrderArgs) {
     const request = await this.teamCollectionService.updateCollectionOrder(
       args.collectionID,
@@ -348,7 +348,7 @@ export class TeamCollectionResolver {
     description: 'Update Team Collection details',
   })
   @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async updateTeamCollection(@Args() args: UpdateTeamCollectionArgs) {
     const updatedTeamCollection =
       await this.teamCollectionService.updateTeamCollection(
@@ -365,7 +365,7 @@ export class TeamCollectionResolver {
     description: 'Duplicate a Team Collection',
   })
   @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async duplicateTeamCollection(
     @Args({
       name: 'collectionID',
@@ -389,9 +389,9 @@ export class TeamCollectionResolver {
     resolve: (value) => value,
   })
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
@@ -411,9 +411,9 @@ export class TeamCollectionResolver {
     resolve: (value) => value,
   })
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
@@ -433,9 +433,9 @@ export class TeamCollectionResolver {
     resolve: (value) => value,
   })
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
@@ -455,9 +455,9 @@ export class TeamCollectionResolver {
     resolve: (value) => value,
   })
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
@@ -477,9 +477,9 @@ export class TeamCollectionResolver {
     resolve: (value) => value,
   })
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.spec.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.spec.ts
@@ -1778,7 +1778,7 @@ describe('getCollectionForCLI', () => {
   //   mockTeamService.getTeamMember.mockResolvedValue({
   //     membershipID: 'sdc3sfdv',
   //     userUid: user.uid,
-  //     role: TeamMemberRole.OWNER,
+  //     role: TeamAccessRole.OWNER,
   //   });
 
   //   const result = await teamCollectionService.getCollectionForCLI(

--- a/packages/hoppscotch-backend/src/team-environments/gql-team-env-team.guard.ts
+++ b/packages/hoppscotch-backend/src/team-environments/gql-team-env-team.guard.ts
@@ -11,7 +11,7 @@ import {
 import { TeamService } from 'src/team/team.service';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import * as E from 'fp-ts/Either';
-import { TeamMemberRole } from '@prisma/client';
+import { TeamAccessRole } from '@prisma/client';
 import { throwErr } from 'src/utils';
 
 /**
@@ -28,7 +28,7 @@ export class GqlTeamEnvTeamGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const requireRoles = this.reflector.get<TeamMemberRole[]>(
+    const requireRoles = this.reflector.get<TeamAccessRole[]>(
       'requiresTeamRole',
       context.getHandler(),
     );

--- a/packages/hoppscotch-backend/src/team-environments/team-environments.resolver.ts
+++ b/packages/hoppscotch-backend/src/team-environments/team-environments.resolver.ts
@@ -8,7 +8,7 @@ import { GqlThrottlerGuard } from 'src/guards/gql-throttler.guard';
 import { PubSubService } from 'src/pubsub/pubsub.service';
 import { RequiresTeamRole } from 'src/team/decorators/requires-team-role.decorator';
 import { GqlTeamMemberGuard } from 'src/team/guards/gql-team-member.guard';
-import { TeamMemberRole } from 'src/team/team.model';
+import { TeamAccessRole } from 'src/team/team.model';
 import { throwErr } from 'src/utils';
 import { GqlTeamEnvTeamGuard } from './gql-team-env-team.guard';
 import { TeamEnvironment } from './team-environments.model';
@@ -33,7 +33,7 @@ export class TeamEnvironmentsResolver {
     description: 'Create a new Team Environment for given Team ID',
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async createTeamEnvironment(
     @Args() args: CreateTeamEnvironmentArgs,
   ): Promise<TeamEnvironment> {
@@ -52,7 +52,7 @@ export class TeamEnvironmentsResolver {
     description: 'Delete a Team Environment for given Team ID',
   })
   @UseGuards(GqlAuthGuard, GqlTeamEnvTeamGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async deleteTeamEnvironment(
     @Args({
       name: 'id',
@@ -74,7 +74,7 @@ export class TeamEnvironmentsResolver {
       'Add/Edit a single environment variable or variables to a Team Environment',
   })
   @UseGuards(GqlAuthGuard, GqlTeamEnvTeamGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async updateTeamEnvironment(
     @Args()
     args: UpdateTeamEnvironmentArgs,
@@ -94,7 +94,7 @@ export class TeamEnvironmentsResolver {
     description: 'Delete all variables from a Team Environment',
   })
   @UseGuards(GqlAuthGuard, GqlTeamEnvTeamGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async deleteAllVariablesFromTeamEnvironment(
     @Args({
       name: 'id',
@@ -116,7 +116,7 @@ export class TeamEnvironmentsResolver {
     description: 'Create a duplicate of an existing environment',
   })
   @UseGuards(GqlAuthGuard, GqlTeamEnvTeamGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER, TeamMemberRole.EDITOR)
+  @RequiresTeamRole(TeamAccessRole.OWNER, TeamAccessRole.EDITOR)
   async createDuplicateEnvironment(
     @Args({
       name: 'id',
@@ -142,9 +142,9 @@ export class TeamEnvironmentsResolver {
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   teamEnvironmentUpdated(
     @Args({
@@ -164,9 +164,9 @@ export class TeamEnvironmentsResolver {
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   teamEnvironmentCreated(
     @Args({
@@ -186,9 +186,9 @@ export class TeamEnvironmentsResolver {
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   teamEnvironmentDeleted(
     @Args({

--- a/packages/hoppscotch-backend/src/team-environments/team-environments.service.spec.ts
+++ b/packages/hoppscotch-backend/src/team-environments/team-environments.service.spec.ts
@@ -9,7 +9,7 @@ import {
   TEAM_MEMBER_NOT_FOUND,
 } from 'src/errors';
 import { TeamService } from 'src/team/team.service';
-import { TeamMemberRole } from 'src/team/team.model';
+import { TeamAccessRole } from 'src/team/team.model';
 
 const mockPrisma = mockDeep<PrismaService>();
 
@@ -394,7 +394,7 @@ describe('TeamEnvironmentsService', () => {
       mockTeamService.getTeamMember.mockResolvedValue({
         membershipID: 'sdc3sfdv',
         userUid: '123454',
-        role: TeamMemberRole.OWNER,
+        role: TeamAccessRole.OWNER,
       });
 
       const result = await teamEnvironmentsService.getTeamEnvironmentForCLI(

--- a/packages/hoppscotch-backend/src/team-invitation/input-type.args.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/input-type.args.ts
@@ -1,5 +1,5 @@
 import { ArgsType, Field, ID } from '@nestjs/graphql';
-import { TeamMemberRole } from 'src/team/team.model';
+import { TeamAccessRole } from 'src/team/team.model';
 
 @ArgsType()
 export class CreateTeamInvitationArgs {
@@ -12,9 +12,9 @@ export class CreateTeamInvitationArgs {
   @Field({ name: 'inviteeEmail', description: 'Email of the user to invite' })
   inviteeEmail: string;
 
-  @Field(() => TeamMemberRole, {
+  @Field(() => TeamAccessRole, {
     name: 'inviteeRole',
     description: 'Role to be given to the user',
   })
-  inviteeRole: TeamMemberRole;
+  inviteeRole: TeamAccessRole;
 }

--- a/packages/hoppscotch-backend/src/team-invitation/team-invitation.model.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invitation.model.ts
@@ -1,5 +1,5 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql';
-import { TeamMemberRole } from '../team/team.model';
+import { TeamAccessRole } from '../team/team.model';
 
 @ObjectType()
 export class TeamInvitation {
@@ -23,8 +23,8 @@ export class TeamInvitation {
   })
   inviteeEmail: string;
 
-  @Field(() => TeamMemberRole, {
+  @Field(() => TeamAccessRole, {
     description: 'The role that will be given to the invitee',
   })
-  inviteeRole: TeamMemberRole;
+  inviteeRole: TeamAccessRole;
 }

--- a/packages/hoppscotch-backend/src/team-invitation/team-invitation.resolver.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invitation.resolver.ts
@@ -14,7 +14,7 @@ import { pipe } from 'fp-ts/function';
 import * as TE from 'fp-ts/TaskEither';
 import * as E from 'fp-ts/Either';
 import * as O from 'fp-ts/Option';
-import { Team, TeamMember, TeamMemberRole } from 'src/team/team.model';
+import { Team, TeamMember, TeamAccessRole } from 'src/team/team.model';
 import { TEAM_INVITE_NO_INVITE_FOUND, USER_NOT_FOUND } from 'src/errors';
 import { GqlUser } from 'src/decorators/gql-user.decorator';
 import { User } from 'src/user/user.model';
@@ -96,7 +96,7 @@ export class TeamInvitationResolver {
     description: 'Creates a Team Invitation',
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER)
+  @RequiresTeamRole(TeamAccessRole.OWNER)
   async createTeamInvitation(
     @GqlUser() user: AuthUser,
     @Args() args: CreateTeamInvitationArgs,
@@ -116,7 +116,7 @@ export class TeamInvitationResolver {
     description: 'Revokes an invitation and deletes it',
   })
   @UseGuards(GqlAuthGuard, TeamInviteTeamOwnerGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER)
+  @RequiresTeamRole(TeamAccessRole.OWNER)
   async revokeTeamInvitation(
     @Args({
       name: 'inviteID',
@@ -161,9 +161,9 @@ export class TeamInvitationResolver {
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   teamInvitationAdded(
     @Args({
@@ -183,9 +183,9 @@ export class TeamInvitationResolver {
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   teamInvitationRemoved(
     @Args({

--- a/packages/hoppscotch-backend/src/team-invitation/team-invitation.service.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invitation.service.ts
@@ -3,7 +3,7 @@ import * as O from 'fp-ts/Option';
 import * as E from 'fp-ts/Either';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { TeamInvitation as DBTeamInvitation } from '@prisma/client';
-import { TeamMember, TeamMemberRole } from 'src/team/team.model';
+import { TeamMember, TeamAccessRole } from 'src/team/team.model';
 import { TeamService } from 'src/team/team.service';
 import {
   INVALID_EMAIL,
@@ -41,7 +41,7 @@ export class TeamInvitationService {
   cast(dbTeamInvitation: DBTeamInvitation): TeamInvitation {
     return {
       ...dbTeamInvitation,
-      inviteeRole: TeamMemberRole[dbTeamInvitation.inviteeRole],
+      inviteeRole: TeamAccessRole[dbTeamInvitation.inviteeRole],
     };
   }
 
@@ -103,7 +103,7 @@ export class TeamInvitationService {
     creator: AuthUser,
     teamID: string,
     inviteeEmail: string,
-    inviteeRole: TeamMemberRole,
+    inviteeRole: TeamAccessRole,
   ) {
     // validate email
     const isEmailValid = validateEmail(inviteeEmail);

--- a/packages/hoppscotch-backend/src/team-invitation/team-invite-team-owner.guard.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invite-team-owner.guard.ts
@@ -11,7 +11,7 @@ import {
   TEAM_NOT_REQUIRED_ROLE,
 } from 'src/errors';
 import { throwErr } from 'src/utils';
-import { TeamMemberRole } from 'src/team/team.model';
+import { TeamAccessRole } from 'src/team/team.model';
 
 /**
  * This guard only allows team owner to execute the resolver
@@ -45,7 +45,7 @@ export class TeamInviteTeamOwnerGuard implements CanActivate {
     );
 
     if (!teamMember) throwErr(TEAM_MEMBER_NOT_FOUND);
-    if (teamMember.role !== TeamMemberRole.OWNER)
+    if (teamMember.role !== TeamAccessRole.OWNER)
       throwErr(TEAM_NOT_REQUIRED_ROLE);
 
     return true;

--- a/packages/hoppscotch-backend/src/team-request/guards/gql-request-team-member.guard.ts
+++ b/packages/hoppscotch-backend/src/team-request/guards/gql-request-team-member.guard.ts
@@ -3,7 +3,7 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 import { TeamRequestService } from '../team-request.service';
 import { TeamService } from '../../team/team.service';
 import { Reflector } from '@nestjs/core';
-import { TeamMemberRole } from '../../team/team.model';
+import { TeamAccessRole } from '../../team/team.model';
 import {
   BUG_AUTH_NO_USER_CTX,
   BUG_TEAM_REQ_NO_REQ_ID,
@@ -23,7 +23,7 @@ export class GqlRequestTeamMemberGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const requireRoles = this.reflector.get<TeamMemberRole[]>(
+    const requireRoles = this.reflector.get<TeamAccessRole[]>(
       'requiresTeamRole',
       context.getHandler(),
     );

--- a/packages/hoppscotch-backend/src/team-request/team-request.resolver.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.resolver.ts
@@ -17,7 +17,7 @@ import {
   MoveTeamRequestArgs,
   UpdateLookUpRequestOrderArgs,
 } from './input-type.args';
-import { Team, TeamMemberRole } from '../team/team.model';
+import { Team, TeamAccessRole } from '../team/team.model';
 import { TeamRequestService } from './team-request.service';
 import { TeamCollection } from '../team-collection/team-collection.model';
 import { UseGuards } from '@nestjs/common';
@@ -70,9 +70,9 @@ export class TeamRequestResolver {
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.VIEWER,
   )
   async searchForRequest(@Args() args: SearchTeamRequestArgs) {
     return this.teamRequestService.searchRequest(
@@ -89,9 +89,9 @@ export class TeamRequestResolver {
   })
   @UseGuards(GqlAuthGuard, GqlRequestTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.VIEWER,
   )
   async request(
     @Args({
@@ -111,9 +111,9 @@ export class TeamRequestResolver {
   })
   @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.VIEWER,
   )
   async requestsInCollection(@Args() input: GetTeamRequestInCollectionArgs) {
     return this.teamRequestService.getRequestsInCollection(
@@ -128,7 +128,7 @@ export class TeamRequestResolver {
     description: 'Create a team request in the given collection.',
   })
   @UseGuards(GqlAuthGuard, GqlCollectionTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.EDITOR, TeamMemberRole.OWNER)
+  @RequiresTeamRole(TeamAccessRole.EDITOR, TeamAccessRole.OWNER)
   async createRequestInCollection(
     @Args({
       name: 'collectionID',
@@ -158,7 +158,7 @@ export class TeamRequestResolver {
     description: 'Update a request with the given ID',
   })
   @UseGuards(GqlAuthGuard, GqlRequestTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.EDITOR, TeamMemberRole.OWNER)
+  @RequiresTeamRole(TeamAccessRole.EDITOR, TeamAccessRole.OWNER)
   async updateRequest(
     @Args({
       name: 'requestID',
@@ -187,7 +187,7 @@ export class TeamRequestResolver {
     description: 'Delete a request with the given ID',
   })
   @UseGuards(GqlAuthGuard, GqlRequestTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.EDITOR, TeamMemberRole.OWNER)
+  @RequiresTeamRole(TeamAccessRole.EDITOR, TeamAccessRole.OWNER)
   async deleteRequest(
     @Args({
       name: 'requestID',
@@ -207,7 +207,7 @@ export class TeamRequestResolver {
     description: 'Update the order of requests in the lookup table',
   })
   @UseGuards(GqlAuthGuard, GqlRequestTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.EDITOR, TeamMemberRole.OWNER)
+  @RequiresTeamRole(TeamAccessRole.EDITOR, TeamAccessRole.OWNER)
   async updateLookUpRequestOrder(
     @Args()
     args: UpdateLookUpRequestOrderArgs,
@@ -227,7 +227,7 @@ export class TeamRequestResolver {
     description: 'Move a request to the given collection',
   })
   @UseGuards(GqlAuthGuard, GqlRequestTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.EDITOR, TeamMemberRole.OWNER)
+  @RequiresTeamRole(TeamAccessRole.EDITOR, TeamAccessRole.OWNER)
   async moveRequest(@Args() args: MoveTeamRequestArgs) {
     const teamRequest = await this.teamRequestService.moveRequest(
       args.srcCollID,
@@ -248,9 +248,9 @@ export class TeamRequestResolver {
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.VIEWER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
+    TeamAccessRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
   )
   teamRequestAdded(
     @Args({
@@ -270,9 +270,9 @@ export class TeamRequestResolver {
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.VIEWER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
+    TeamAccessRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
   )
   teamRequestUpdated(
     @Args({
@@ -293,9 +293,9 @@ export class TeamRequestResolver {
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.VIEWER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
+    TeamAccessRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
   )
   teamRequestDeleted(
     @Args({
@@ -316,9 +316,9 @@ export class TeamRequestResolver {
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.VIEWER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
+    TeamAccessRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
   )
   requestOrderUpdated(
     @Args({
@@ -339,9 +339,9 @@ export class TeamRequestResolver {
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.VIEWER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
+    TeamAccessRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
   )
   requestMoved(
     @Args({

--- a/packages/hoppscotch-backend/src/team/decorators/requires-team-role.decorator.ts
+++ b/packages/hoppscotch-backend/src/team/decorators/requires-team-role.decorator.ts
@@ -1,5 +1,5 @@
-import { TeamMemberRole } from '@prisma/client';
+import { TeamAccessRole } from '@prisma/client';
 import { SetMetadata } from '@nestjs/common';
 
-export const RequiresTeamRole = (...roles: TeamMemberRole[]) =>
+export const RequiresTeamRole = (...roles: TeamAccessRole[]) =>
   SetMetadata('requiresTeamRole', roles);

--- a/packages/hoppscotch-backend/src/team/guards/gql-team-member.guard.ts
+++ b/packages/hoppscotch-backend/src/team/guards/gql-team-member.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { TeamService } from '../team.service';
-import { TeamMemberRole } from '../team.model';
+import { TeamAccessRole } from '../team.model';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import {
   TEAM_NOT_REQUIRED_ROLE,
@@ -19,7 +19,7 @@ export class GqlTeamMemberGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const requireRoles = this.reflector.get<TeamMemberRole[]>(
+    const requireRoles = this.reflector.get<TeamAccessRole[]>(
       'requiresTeamRole',
       context.getHandler(),
     );

--- a/packages/hoppscotch-backend/src/team/guards/rest-team-member.guard.ts
+++ b/packages/hoppscotch-backend/src/team/guards/rest-team-member.guard.ts
@@ -1,7 +1,7 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { TeamService } from '../../team/team.service';
-import { TeamMemberRole } from '../../team/team.model';
+import { TeamAccessRole } from '../../team/team.model';
 import {
   BUG_TEAM_NO_REQUIRE_TEAM_ROLE,
   BUG_AUTH_NO_USER_CTX,
@@ -19,7 +19,7 @@ export class RESTTeamMemberGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const requireRoles = this.reflector.get<TeamMemberRole[]>(
+    const requireRoles = this.reflector.get<TeamAccessRole[]>(
       'requiresTeamRole',
       context.getHandler(),
     );

--- a/packages/hoppscotch-backend/src/team/team.model.ts
+++ b/packages/hoppscotch-backend/src/team/team.model.ts
@@ -22,18 +22,18 @@ export class TeamMember {
 
   userUid: string;
 
-  @Field(() => TeamMemberRole, {
+  @Field(() => TeamAccessRole, {
     description: 'Role of the given team member in the given team',
   })
-  role: TeamMemberRole;
+  role: TeamAccessRole;
 }
 
-export enum TeamMemberRole {
+export enum TeamAccessRole {
   OWNER = 'OWNER',
   VIEWER = 'VIEWER',
   EDITOR = 'EDITOR',
 }
 
-registerEnumType(TeamMemberRole, {
-  name: 'TeamMemberRole',
+registerEnumType(TeamAccessRole, {
+  name: 'TeamAccessRole',
 });

--- a/packages/hoppscotch-backend/src/team/team.resolver.ts
+++ b/packages/hoppscotch-backend/src/team/team.resolver.ts
@@ -1,4 +1,4 @@
-import { Team, TeamMember, TeamMemberRole } from './team.model';
+import { Team, TeamMember, TeamAccessRole } from './team.model';
 import {
   Resolver,
   ResolveField,
@@ -59,7 +59,7 @@ export class TeamResolver {
     return this.teamService.getTeamMembers(team.id);
   }
 
-  @ResolveField(() => TeamMemberRole, {
+  @ResolveField(() => TeamAccessRole, {
     description: 'The role of the current user in the team',
     nullable: true,
   })
@@ -67,7 +67,7 @@ export class TeamResolver {
   myRole(
     @Parent() team: Team,
     @GqlUser() user: AuthUser,
-  ): Promise<TeamMemberRole | null> {
+  ): Promise<TeamAccessRole | null> {
     return this.teamService.getRoleOfUserInTeam(team.id, user.uid);
   }
 
@@ -77,7 +77,7 @@ export class TeamResolver {
   ownersCount(@Parent() team: Team): Promise<number> {
     return this.teamService.getCountOfUsersWithRoleInTeam(
       team.id,
-      TeamMemberRole.OWNER,
+      TeamAccessRole.OWNER,
     );
   }
 
@@ -87,7 +87,7 @@ export class TeamResolver {
   editorsCount(@Parent() team: Team): Promise<number> {
     return this.teamService.getCountOfUsersWithRoleInTeam(
       team.id,
-      TeamMemberRole.EDITOR,
+      TeamAccessRole.EDITOR,
     );
   }
 
@@ -97,7 +97,7 @@ export class TeamResolver {
   viewersCount(@Parent() team: Team): Promise<number> {
     return this.teamService.getCountOfUsersWithRoleInTeam(
       team.id,
-      TeamMemberRole.VIEWER,
+      TeamAccessRole.VIEWER,
     );
   }
 
@@ -126,9 +126,9 @@ export class TeamResolver {
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
   @RequiresTeamRole(
-    TeamMemberRole.VIEWER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.OWNER,
+    TeamAccessRole.VIEWER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.OWNER,
   )
   team(
     @Args({
@@ -178,7 +178,7 @@ export class TeamResolver {
     description: 'Removes the team member from the team',
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER)
+  @RequiresTeamRole(TeamAccessRole.OWNER)
   async removeTeamMember(
     @GqlUser() _user: AuthUser,
     @Args({
@@ -203,7 +203,7 @@ export class TeamResolver {
     description: 'Renames a team',
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER)
+  @RequiresTeamRole(TeamAccessRole.OWNER)
   async renameTeam(
     @Args({ name: 'teamID', description: 'ID of the team', type: () => ID })
     teamID: string,
@@ -219,7 +219,7 @@ export class TeamResolver {
     description: 'Deletes the team',
   })
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
-  @RequiresTeamRole(TeamMemberRole.OWNER)
+  @RequiresTeamRole(TeamAccessRole.OWNER)
   async deleteTeam(
     @Args({ name: 'teamID', description: 'ID of the team', type: () => ID })
     teamID: string,
@@ -232,9 +232,9 @@ export class TeamResolver {
   @Mutation(() => TeamMember, {
     description: 'Update role of a team member the executing user owns',
   })
-  @RequiresTeamRole(TeamMemberRole.OWNER)
+  @RequiresTeamRole(TeamAccessRole.OWNER)
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
-  async updateTeamMemberRole(
+  async updateTeamAccessRole(
     @Args({
       name: 'teamID',
       description: 'ID of the affected team',
@@ -250,11 +250,11 @@ export class TeamResolver {
     @Args({
       name: 'newRole',
       description: 'Updated role value',
-      type: () => TeamMemberRole,
+      type: () => TeamAccessRole,
     })
-    newRole: TeamMemberRole,
+    newRole: TeamAccessRole,
   ): Promise<TeamMember> {
-    const teamMember = await this.teamService.updateTeamMemberRole(
+    const teamMember = await this.teamService.updateTeamAccessRole(
       teamID,
       userUid,
       newRole,
@@ -270,9 +270,9 @@ export class TeamResolver {
     resolve: (value) => value,
   })
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
@@ -293,9 +293,9 @@ export class TeamResolver {
     resolve: (value) => value,
   })
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)
@@ -316,9 +316,9 @@ export class TeamResolver {
     resolve: (value) => value,
   })
   @RequiresTeamRole(
-    TeamMemberRole.OWNER,
-    TeamMemberRole.EDITOR,
-    TeamMemberRole.VIEWER,
+    TeamAccessRole.OWNER,
+    TeamAccessRole.EDITOR,
+    TeamAccessRole.VIEWER,
   )
   @SkipThrottle()
   @UseGuards(GqlAuthGuard, GqlTeamMemberGuard)

--- a/packages/hoppscotch-backend/src/team/team.service.spec.ts
+++ b/packages/hoppscotch-backend/src/team/team.service.spec.ts
@@ -1,6 +1,6 @@
 import { TeamService } from './team.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { Team, TeamMember, TeamMemberRole } from './team.model';
+import { Team, TeamMember, TeamAccessRole } from './team.model';
 import { TeamMember as DbTeamMember } from '@prisma/client';
 import {
   USER_NOT_FOUND,
@@ -51,13 +51,13 @@ const teams: Team[] = [
 ];
 const dbTeamMember: DbTeamMember = {
   id: 'teamMemberID',
-  role: TeamMemberRole.VIEWER,
+  role: TeamAccessRole.VIEWER,
   userUid: 'userUid',
   teamID: team.id,
 };
 const teamMember: TeamMember = {
   membershipID: dbTeamMember.id,
-  role: TeamMemberRole[dbTeamMember.role],
+  role: TeamAccessRole[dbTeamMember.role],
   userUid: dbTeamMember.userUid,
 };
 
@@ -70,14 +70,14 @@ describe('getCountOfUsersWithRoleInTeam', () => {
     await expect(
       teamService.getCountOfUsersWithRoleInTeam(
         dbTeamMember.teamID,
-        TeamMemberRole.OWNER,
+        TeamAccessRole.OWNER,
       ),
     ).resolves.toEqual(2);
 
     expect(mockPrisma.teamMember.count).toHaveBeenCalledWith({
       where: {
         teamID: dbTeamMember.teamID,
-        role: TeamMemberRole.OWNER,
+        role: TeamAccessRole.OWNER,
       },
     });
   });
@@ -88,14 +88,14 @@ describe('getCountOfUsersWithRoleInTeam', () => {
     await expect(
       teamService.getCountOfUsersWithRoleInTeam(
         dbTeamMember.teamID,
-        TeamMemberRole.VIEWER,
+        TeamAccessRole.VIEWER,
       ),
     ).resolves.toEqual(2);
 
     expect(mockPrisma.teamMember.count).toHaveBeenCalledWith({
       where: {
         teamID: dbTeamMember.teamID,
-        role: TeamMemberRole.VIEWER,
+        role: TeamAccessRole.VIEWER,
       },
     });
   });
@@ -106,14 +106,14 @@ describe('getCountOfUsersWithRoleInTeam', () => {
     await expect(
       teamService.getCountOfUsersWithRoleInTeam(
         dbTeamMember.teamID,
-        TeamMemberRole.EDITOR,
+        TeamAccessRole.EDITOR,
       ),
     ).resolves.toEqual(2);
 
     expect(mockPrisma.teamMember.count).toHaveBeenCalledWith({
       where: {
         teamID: dbTeamMember.teamID,
-        role: TeamMemberRole.EDITOR,
+        role: TeamAccessRole.EDITOR,
       },
     });
   });
@@ -127,7 +127,7 @@ describe('addMemberToTeam', () => {
       teamService.addMemberToTeam(
         dbTeamMember.teamID,
         dbTeamMember.userUid,
-        TeamMemberRole[dbTeamMember.role],
+        TeamAccessRole[dbTeamMember.role],
       ),
     ).resolves.toEqual(expect.objectContaining(teamMember));
   });
@@ -138,7 +138,7 @@ describe('addMemberToTeam', () => {
     await teamService.addMemberToTeam(
       dbTeamMember.teamID,
       dbTeamMember.userUid,
-      TeamMemberRole[dbTeamMember.role],
+      TeamAccessRole[dbTeamMember.role],
     );
 
     expect(mockPrisma.teamMember.create).toHaveBeenCalledWith({
@@ -149,7 +149,7 @@ describe('addMemberToTeam', () => {
             id: dbTeamMember.teamID,
           },
         },
-        role: TeamMemberRole[dbTeamMember.role],
+        role: TeamAccessRole[dbTeamMember.role],
       },
     });
   });
@@ -160,7 +160,7 @@ describe('addMemberToTeam', () => {
     const member = await teamService.addMemberToTeam(
       dbTeamMember.teamID,
       dbTeamMember.userUid,
-      TeamMemberRole[dbTeamMember.role],
+      TeamAccessRole[dbTeamMember.role],
     );
 
     expect(mockPubSub.publish).toHaveBeenCalledWith(
@@ -188,7 +188,7 @@ describe('addMemberToTeamWithEmail', () => {
     const result = teamService.addMemberToTeamWithEmail(
       dbTeamMember.teamID,
       'test@hoppscotch.io',
-      TeamMemberRole[dbTeamMember.role],
+      TeamAccessRole[dbTeamMember.role],
     );
     return expect(result).resolves.toBeDefined();
   });
@@ -199,7 +199,7 @@ describe('addMemberToTeamWithEmail', () => {
     const result = teamService.addMemberToTeamWithEmail(
       dbTeamMember.teamID,
       'test@hoppscotch.io',
-      TeamMemberRole[dbTeamMember.role],
+      TeamAccessRole[dbTeamMember.role],
     );
     return expect(result).resolves.toEqualLeft(USER_NOT_FOUND);
   });
@@ -215,7 +215,7 @@ describe('addMemberToTeamWithEmail', () => {
     await teamService.addMemberToTeamWithEmail(
       dbTeamMember.teamID,
       'test@hoppscotch.io',
-      TeamMemberRole[dbTeamMember.role],
+      TeamAccessRole[dbTeamMember.role],
     );
 
     expect(mockPrisma.teamMember.create).toHaveBeenCalledWith({
@@ -226,7 +226,7 @@ describe('addMemberToTeamWithEmail', () => {
             id: dbTeamMember.teamID,
           },
         },
-        role: TeamMemberRole[dbTeamMember.role],
+        role: TeamAccessRole[dbTeamMember.role],
       },
     });
   });
@@ -242,7 +242,7 @@ describe('addMemberToTeamWithEmail', () => {
     await teamService.addMemberToTeamWithEmail(
       dbTeamMember.teamID,
       'test@hoppscotch.io',
-      TeamMemberRole[dbTeamMember.role],
+      TeamAccessRole[dbTeamMember.role],
     );
 
     expect(mockPubSub.publish).toHaveBeenCalledWith(
@@ -376,7 +376,7 @@ describe('renameTeam', () => {
   });
 });
 
-describe('updateTeamMemberRole', () => {
+describe('updateTeamAccessRole', () => {
   /**
    * Test Scenario:
    * 3 users (testuid1 thru 3) having each of the roles
@@ -385,19 +385,19 @@ describe('updateTeamMemberRole', () => {
    */
 
   test('updates the role', async () => {
-    const newRole = TeamMemberRole.EDITOR;
+    const newRole = TeamAccessRole.EDITOR;
 
     mockPrisma.teamMember.count.mockResolvedValue(1);
     mockPrisma.teamMember.findUnique.mockResolvedValue({
       ...dbTeamMember,
-      role: TeamMemberRole[dbTeamMember.role],
+      role: TeamAccessRole[dbTeamMember.role],
     });
     mockPrisma.teamMember.update.mockResolvedValue({
       ...dbTeamMember,
       role: newRole,
     });
 
-    await teamService.updateTeamMemberRole(
+    await teamService.updateTeamAccessRole(
       dbTeamMember.teamID,
       dbTeamMember.userUid,
       newRole,
@@ -417,7 +417,7 @@ describe('updateTeamMemberRole', () => {
   });
 
   test('returns the updated details', () => {
-    const newRole = TeamMemberRole.EDITOR;
+    const newRole = TeamAccessRole.EDITOR;
 
     mockPrisma.teamMember.count.mockResolvedValue(1);
     mockPrisma.teamMember.findUnique.mockResolvedValue(dbTeamMember);
@@ -427,7 +427,7 @@ describe('updateTeamMemberRole', () => {
     });
 
     return expect(
-      teamService.updateTeamMemberRole(
+      teamService.updateTeamAccessRole(
         dbTeamMember.teamID,
         dbTeamMember.userUid,
         newRole,
@@ -439,17 +439,17 @@ describe('updateTeamMemberRole', () => {
     mockPrisma.teamMember.count.mockResolvedValue(1);
     mockPrisma.teamMember.findUnique.mockResolvedValue({
       ...dbTeamMember,
-      role: TeamMemberRole.OWNER,
+      role: TeamAccessRole.OWNER,
     });
 
     // Prisma doesn't care if it goes through
     mockPrisma.teamMember.update.mockResolvedValue(dbTeamMember);
 
     return expect(
-      teamService.updateTeamMemberRole(
+      teamService.updateTeamAccessRole(
         dbTeamMember.teamID,
         dbTeamMember.userUid,
-        TeamMemberRole[dbTeamMember.role],
+        TeamAccessRole[dbTeamMember.role],
       ),
     ).resolves.toEqualLeft(TEAM_ONLY_ONE_OWNER);
   });
@@ -458,18 +458,18 @@ describe('updateTeamMemberRole', () => {
     mockPrisma.teamMember.count.mockResolvedValue(1);
     mockPrisma.teamMember.findUnique.mockResolvedValue({
       ...dbTeamMember,
-      role: TeamMemberRole.OWNER,
+      role: TeamAccessRole.OWNER,
     });
     mockPrisma.teamMember.update.mockResolvedValue({
       ...dbTeamMember,
-      role: TeamMemberRole.OWNER,
+      role: TeamAccessRole.OWNER,
     });
 
     return expect(
-      teamService.updateTeamMemberRole(
+      teamService.updateTeamAccessRole(
         dbTeamMember.teamID,
         dbTeamMember.userUid,
-        TeamMemberRole[TeamMemberRole.OWNER],
+        TeamAccessRole[TeamAccessRole.OWNER],
       ),
     ).resolves.toBeDefined();
   });
@@ -478,28 +478,28 @@ describe('updateTeamMemberRole', () => {
     mockPrisma.teamMember.count.mockResolvedValue(2);
     mockPrisma.teamMember.findUnique.mockResolvedValue({
       ...dbTeamMember,
-      role: TeamMemberRole.OWNER,
+      role: TeamAccessRole.OWNER,
     });
     mockPrisma.teamMember.update.mockResolvedValue(dbTeamMember);
 
     // Set another user as the owner
-    await teamService.updateTeamMemberRole(
+    await teamService.updateTeamAccessRole(
       dbTeamMember.teamID,
       'testuid2',
-      TeamMemberRole.OWNER,
+      TeamAccessRole.OWNER,
     );
 
     await expect(
-      teamService.updateTeamMemberRole(
+      teamService.updateTeamAccessRole(
         dbTeamMember.teamID,
         dbTeamMember.userUid,
-        TeamMemberRole[dbTeamMember.role],
+        TeamAccessRole[dbTeamMember.role],
       ),
     ).resolves.toBeDefined();
   });
 
   test('fires "team/<team_id>/member_updated" pubsub message with correct payload', async () => {
-    const newRole = TeamMemberRole.EDITOR;
+    const newRole = TeamAccessRole.EDITOR;
 
     mockPrisma.teamMember.count.mockResolvedValue(2);
     mockPrisma.teamMember.findUnique.mockResolvedValue(dbTeamMember);
@@ -508,7 +508,7 @@ describe('updateTeamMemberRole', () => {
       role: newRole,
     });
 
-    await teamService.updateTeamMemberRole(
+    await teamService.updateTeamAccessRole(
       dbTeamMember.teamID,
       dbTeamMember.userUid,
       newRole,
@@ -582,13 +582,13 @@ describe('leaveTeam', () => {
     mockPrisma.teamMember.count.mockResolvedValue(1);
     mockPrisma.teamMember.findUnique.mockResolvedValue({
       ...dbTeamMember,
-      role: TeamMemberRole.OWNER,
+      role: TeamAccessRole.OWNER,
     });
 
     // Prisma does not care
     mockPrisma.teamMember.delete.mockResolvedValue({
       ...dbTeamMember,
-      role: TeamMemberRole.OWNER,
+      role: TeamAccessRole.OWNER,
     });
 
     return expect(
@@ -600,11 +600,11 @@ describe('leaveTeam', () => {
     mockPrisma.teamMember.count.mockResolvedValue(2);
     mockPrisma.teamMember.findUnique.mockResolvedValue({
       ...dbTeamMember,
-      role: TeamMemberRole.OWNER,
+      role: TeamAccessRole.OWNER,
     });
     mockPrisma.teamMember.delete.mockResolvedValue({
       ...dbTeamMember,
-      role: TeamMemberRole.OWNER,
+      role: TeamAccessRole.OWNER,
     });
 
     await expect(
@@ -652,7 +652,7 @@ describe('createTeam', () => {
           members: {
             create: {
               userUid: dbTeamMember.userUid,
-              role: TeamMemberRole.OWNER,
+              role: TeamAccessRole.OWNER,
             },
           },
         }),
@@ -905,7 +905,7 @@ describe('deleteUserFromAllTeams', () => {
     mockPrisma.teamMember.count.mockResolvedValue(1);
     mockPrisma.teamMember.findUnique.mockResolvedValue({
       ...dbTeamMember,
-      role: TeamMemberRole.OWNER,
+      role: TeamAccessRole.OWNER,
     });
 
     const result = teamService.deleteUserFromAllTeams(dbTeamMember.userUid)();
@@ -922,7 +922,7 @@ describe('deleteUserFromAllTeams', () => {
     mockPrisma.teamMember.findMany.mockResolvedValue([
       {
         ...dbTeamMember,
-        role: TeamMemberRole.OWNER,
+        role: TeamAccessRole.OWNER,
       },
     ]);
     mockPrisma.teamMember.count.mockResolvedValue(2);

--- a/packages/hoppscotch-backend/src/user/user.service.ts
+++ b/packages/hoppscotch-backend/src/user/user.service.ts
@@ -21,7 +21,7 @@ import { UserDataHandler } from './user.data.handler';
 import { User as DbUser } from '@prisma/client';
 import { OffsetPaginationArgs } from 'src/types/input-types.args';
 import { GetUserWorkspacesResponse } from 'src/infra-token/request-response.dto';
-import { TeamMemberRole } from 'src/team/team.model';
+import { TeamAccessRole } from 'src/team/team.model';
 
 @Injectable()
 export class UserService {
@@ -626,13 +626,13 @@ export class UserService {
     const workspaces: GetUserWorkspacesResponse[] = [];
     team.forEach((t) => {
       const ownerCount = t.members.filter(
-        (m) => m.role === TeamMemberRole.OWNER,
+        (m) => m.role === TeamAccessRole.OWNER,
       ).length;
       const editorCount = t.members.filter(
-        (m) => m.role === TeamMemberRole.EDITOR,
+        (m) => m.role === TeamAccessRole.EDITOR,
       ).length;
       const viewerCount = t.members.filter(
-        (m) => m.role === TeamMemberRole.VIEWER,
+        (m) => m.role === TeamAccessRole.VIEWER,
       ).length;
       const memberCount = t.members.length;
 

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -16,7 +16,7 @@ import {
   ENV_NOT_SUPPORT_AUTH_PROVIDERS,
   JSON_INVALID,
 } from './errors';
-import { TeamMemberRole } from './team/team.model';
+import { TeamAccessRole } from './team/team.model';
 import { RESTError } from './types/RESTError';
 import * as crypto from 'crypto';
 
@@ -76,7 +76,7 @@ export const getAnnotatedRequiredRoles = (
   context: ExecutionContext,
 ) =>
   pipe(
-    reflector.get<TeamMemberRole[]>('requiresTeamRole', context.getHandler()),
+    reflector.get<TeamAccessRole[]>('requiresTeamRole', context.getHandler()),
     O.fromNullable,
   );
 

--- a/packages/hoppscotch-common/src/components/app/Header.vue
+++ b/packages/hoppscotch-common/src/components/app/Header.vue
@@ -325,7 +325,7 @@ import * as TE from "fp-ts/TaskEither"
 import { pipe } from "fp-ts/function"
 import { computed, onMounted, reactive, ref, watch } from "vue"
 import { useToast } from "~/composables/toast"
-import { GetMyTeamsQuery, TeamMemberRole } from "~/helpers/backend/graphql"
+import { GetMyTeamsQuery, TeamAccessRole } from "~/helpers/backend/graphql"
 import { deleteTeam as backendDeleteTeam } from "~/helpers/backend/mutations/Team"
 import { platform } from "~/platform"
 import {
@@ -600,7 +600,7 @@ defineActionHandler(
 )
 
 defineActionHandler("modals.team.delete", ({ teamId }) => {
-  if (selectedTeam.value?.myRole !== TeamMemberRole.Owner) return noPermission()
+  if (selectedTeam.value?.myRole !== TeamAccessRole.Owner) return noPermission()
   teamID.value = teamId
   confirmRemove.value = true
 })

--- a/packages/hoppscotch-common/src/components/teams/Edit.vue
+++ b/packages/hoppscotch-common/src/components/teams/Edit.vue
@@ -196,13 +196,13 @@ import {
   GetTeamQueryVariables,
   TeamMemberAddedDocument,
   TeamMemberRemovedDocument,
-  TeamMemberRole,
+  TeamAccessRole,
   TeamMemberUpdatedDocument,
 } from "~/helpers/backend/graphql"
 import {
   removeTeamMember,
   renameTeam,
-  updateTeamMemberRole,
+  updateTeamAccessRole,
 } from "~/helpers/backend/mutations/Team"
 import { TeamNameCodec } from "~/helpers/backend/types/TeamName"
 
@@ -307,7 +307,7 @@ watch(
 const roleUpdates = ref<
   {
     userID: string
-    role: TeamMemberRole
+    role: TeamAccessRole
   }[]
 >([])
 
@@ -330,7 +330,7 @@ watch(
   }
 )
 
-const updateMemberRole = (userID: string, role: TeamMemberRole) => {
+const updateMemberRole = (userID: string, role: TeamAccessRole) => {
   const updateIndex = roleUpdates.value.findIndex(
     (item) => item.userID === userID
   )
@@ -404,7 +404,7 @@ const saveTeam = async () => {
         toast.error(`${t("error.something_went_wrong")}`)
       } else {
         roleUpdates.value.forEach(async (update) => {
-          const updateMemberRoleResult = await updateTeamMemberRole(
+          const updateMemberRoleResult = await updateTeamAccessRole(
             update.userID,
             props.editingTeamID,
             update.role

--- a/packages/hoppscotch-common/src/components/teams/Edit.vue
+++ b/packages/hoppscotch-common/src/components/teams/Edit.vue
@@ -101,9 +101,9 @@
                         :active="member.role === 'OWNER'"
                         @click="
                           () => {
-                            updateMemberRole(
+                            updateAccessRole(
                               member.userID,
-                              TeamMemberRole.Owner
+                              TeamAccessRole.Owner
                             )
                             hide()
                           }
@@ -117,9 +117,9 @@
                         :active="member.role === 'EDITOR'"
                         @click="
                           () => {
-                            updateMemberRole(
+                            updateAccessRole(
                               member.userID,
-                              TeamMemberRole.Editor
+                              TeamAccessRole.Editor
                             )
                             hide()
                           }
@@ -133,9 +133,9 @@
                         :active="member.role === 'VIEWER'"
                         @click="
                           () => {
-                            updateMemberRole(
+                            updateAccessRole(
                               member.userID,
-                              TeamMemberRole.Viewer
+                              TeamAccessRole.Viewer
                             )
                             hide()
                           }
@@ -330,7 +330,7 @@ watch(
   }
 )
 
-const updateMemberRole = (userID: string, role: TeamAccessRole) => {
+const updateAccessRole = (userID: string, role: TeamAccessRole) => {
   const updateIndex = roleUpdates.value.findIndex(
     (item) => item.userID === userID
   )
@@ -404,14 +404,14 @@ const saveTeam = async () => {
         toast.error(`${t("error.something_went_wrong")}`)
       } else {
         roleUpdates.value.forEach(async (update) => {
-          const updateMemberRoleResult = await updateTeamAccessRole(
+          const updateAccessRoleResult = await updateTeamAccessRole(
             update.userID,
             props.editingTeamID,
             update.role
           )()
-          if (E.isLeft(updateMemberRoleResult)) {
+          if (E.isLeft(updateAccessRoleResult)) {
             toast.error(`${t("error.something_went_wrong")}`)
-            console.error(updateMemberRoleResult.left.error)
+            console.error(updateAccessRoleResult.left.error)
           }
         })
       }

--- a/packages/hoppscotch-common/src/components/teams/Invite.vue
+++ b/packages/hoppscotch-common/src/components/teams/Invite.vue
@@ -232,7 +232,7 @@
                       :active="invitee.value === 'OWNER'"
                       @click="
                         () => {
-                          updateNewInviteeRole(index, TeamMemberRole.Owner)
+                          updateNewInviteeRole(index, TeamAccessRole.Owner)
                           hide()
                         }
                       "
@@ -245,7 +245,7 @@
                       :active="invitee.value === 'EDITOR'"
                       @click="
                         () => {
-                          updateNewInviteeRole(index, TeamMemberRole.Editor)
+                          updateNewInviteeRole(index, TeamAccessRole.Editor)
                           hide()
                         }
                       "
@@ -258,7 +258,7 @@
                       :active="invitee.value === 'VIEWER'"
                       @click="
                         () => {
-                          updateNewInviteeRole(index, TeamMemberRole.Viewer)
+                          updateNewInviteeRole(index, TeamAccessRole.Viewer)
                           hide()
                         }
                       "
@@ -360,7 +360,7 @@
               newInvites = [
                 {
                   key: '',
-                  value: TeamMemberRole.Viewer,
+                  value: TeamAccessRole.Viewer,
                 },
               ]
             }
@@ -404,7 +404,7 @@ import {
   GetPendingInvitesQueryVariables,
   TeamInvitationAddedDocument,
   TeamInvitationRemovedDocument,
-  TeamMemberRole,
+  TeamAccessRole,
 } from "../../helpers/backend/graphql"
 import {
   createTeamInvitation,
@@ -558,21 +558,21 @@ const removeInvitee = async (id: string, index: number) => {
   isLoadingIndex.value = null
 }
 
-const newInvites = ref<Array<{ key: string; value: TeamMemberRole }>>([
+const newInvites = ref<Array<{ key: string; value: TeamAccessRole }>>([
   {
     key: "",
-    value: TeamMemberRole.Viewer,
+    value: TeamAccessRole.Viewer,
   },
 ])
 
 const addNewInvitee = () => {
   newInvites.value.push({
     key: "",
-    value: TeamMemberRole.Viewer,
+    value: TeamAccessRole.Viewer,
   })
 }
 
-const updateNewInviteeRole = (index: number, role: TeamMemberRole) => {
+const updateNewInviteeRole = (index: number, role: TeamAccessRole) => {
   newInvites.value[index].value = role
 }
 
@@ -623,7 +623,7 @@ const sendInvites = async () => {
   const validationResult = pipe(
     newInvites.value,
     O.fromPredicate(
-      (invites): invites is Array<{ key: Email; value: TeamMemberRole }> =>
+      (invites): invites is Array<{ key: Email; value: TeamAccessRole }> =>
         pipe(
           invites,
           A.every((invitee) => EmailCodec.is(invitee.key))
@@ -697,7 +697,7 @@ const hideModal = () => {
   newInvites.value = [
     {
       key: "",
-      value: TeamMemberRole.Viewer,
+      value: TeamAccessRole.Viewer,
     },
   ]
   emit("hide-modal")

--- a/packages/hoppscotch-common/src/helpers/backend/gql/mutations/CreateTeamInvitation.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/mutations/CreateTeamInvitation.graphql
@@ -1,4 +1,4 @@
-mutation CreateTeamInvitation($inviteeEmail: String!, $inviteeRole: TeamMemberRole!, $teamID: ID!) {
+mutation CreateTeamInvitation($inviteeEmail: String!, $inviteeRole: TeamAccessRole!, $teamID: ID!) {
   createTeamInvitation(inviteeRole: $inviteeRole, inviteeEmail: $inviteeEmail, teamID: $teamID) {
     id
     teamID

--- a/packages/hoppscotch-common/src/helpers/backend/gql/mutations/UpdateTeamMemberRole.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/mutations/UpdateTeamMemberRole.graphql
@@ -1,9 +1,9 @@
-mutation UpdateTeamMemberRole(
-  $newRole: TeamMemberRole!,
+mutation UpdateTeamAccessRole(
+  $newRole: TeamAccessRole!,
   $userUid: ID!,
   $teamID: ID!
 ) {
-  updateTeamMemberRole(
+  updateTeamAccessRole(
     newRole: $newRole
     userUid: $userUid
     teamID: $teamID

--- a/packages/hoppscotch-common/src/helpers/backend/mutations/Team.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/mutations/Team.ts
@@ -15,10 +15,10 @@ import {
   RenameTeamDocument,
   RenameTeamMutation,
   RenameTeamMutationVariables,
-  TeamMemberRole,
-  UpdateTeamMemberRoleDocument,
-  UpdateTeamMemberRoleMutation,
-  UpdateTeamMemberRoleMutationVariables,
+  TeamAccessRole,
+  UpdateTeamAccessRoleDocument,
+  UpdateTeamAccessRoleMutation,
+  UpdateTeamAccessRoleMutationVariables,
 } from "../graphql"
 import { platform } from "~/platform"
 
@@ -40,7 +40,7 @@ type RenameTeamErrors =
   | "team/invalid_id"
   | "team/not_required_role"
 
-type UpdateTeamMemberRoleErrors =
+type UpdateTeamAccessRoleErrors =
   | "ea/not_invite_or_admin"
   | "team/invalid_id"
   | "team/not_required_role"
@@ -96,22 +96,22 @@ export const renameTeam = (teamID: string, newName: TeamName) =>
     TE.map(({ renameTeam }) => renameTeam)
   )
 
-export const updateTeamMemberRole = (
+export const updateTeamAccessRole = (
   userUid: string,
   teamID: string,
-  newRole: TeamMemberRole
+  newRole: TeamAccessRole
 ) =>
   pipe(
     runMutation<
-      UpdateTeamMemberRoleMutation,
-      UpdateTeamMemberRoleMutationVariables,
-      UpdateTeamMemberRoleErrors
-    >(UpdateTeamMemberRoleDocument, {
+      UpdateTeamAccessRoleMutation,
+      UpdateTeamAccessRoleMutationVariables,
+      UpdateTeamAccessRoleErrors
+    >(UpdateTeamAccessRoleDocument, {
       newRole,
       userUid,
       teamID,
     }),
-    TE.map(({ updateTeamMemberRole }) => updateTeamMemberRole)
+    TE.map(({ updateTeamAccessRole }) => updateTeamAccessRole)
   )
 
 export const removeTeamMember = (userUid: string, teamID: string) =>

--- a/packages/hoppscotch-common/src/helpers/backend/mutations/TeamInvitation.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/mutations/TeamInvitation.ts
@@ -6,7 +6,7 @@ import {
   RevokeTeamInvitationDocument,
   RevokeTeamInvitationMutation,
   RevokeTeamInvitationMutationVariables,
-  TeamMemberRole,
+  TeamAccessRole,
 } from "../graphql"
 import { Email } from "../types/Email"
 
@@ -29,7 +29,7 @@ type AcceptTeamInvitationErrors =
 
 export const createTeamInvitation = (
   inviteeEmail: Email,
-  inviteeRole: TeamMemberRole,
+  inviteeRole: TeamAccessRole,
   teamID: string
 ) => {
   return pipe(

--- a/packages/hoppscotch-common/src/platform/backend.ts
+++ b/packages/hoppscotch-common/src/platform/backend.ts
@@ -9,7 +9,7 @@ import {
   GetInviteDetailsQueryVariables,
   GetMyTeamsQuery,
   GetUserShortcodesQuery,
-  TeamMemberRole,
+  TeamAccessRole,
 } from "~/helpers/backend/graphql"
 
 import { useGQLQuery } from "~/composables/graphql"
@@ -51,7 +51,7 @@ export type BackendPlatformDef = {
 
   createTeamInvitation: <CreateTeamInvitationErrors extends string>(
     inviteeEmail: Email,
-    inviteeRole: TeamMemberRole,
+    inviteeRole: TeamAccessRole,
     teamID: string
   ) => TE.TaskEither<
     GQLError<CreateTeamInvitationErrors>,

--- a/packages/hoppscotch-common/src/platform/std/backend.ts
+++ b/packages/hoppscotch-common/src/platform/std/backend.ts
@@ -28,7 +28,7 @@ import {
   GetUserShortcodesDocument,
   GetUserShortcodesQuery,
   GetUserShortcodesQueryVariables,
-  TeamMemberRole,
+  TeamAccessRole,
 } from "../../helpers/backend/graphql"
 
 const getInviteDetails = <GetInviteDetailsError extends string>(
@@ -81,7 +81,7 @@ export const createTeam = <CreateTeamErrors extends string>(name: TeamName) => {
 
 export const createTeamInvitation = <CreateTeamInvitationErrors extends string>(
   inviteeEmail: Email,
-  inviteeRole: TeamMemberRole,
+  inviteeRole: TeamAccessRole,
   teamID: string
 ) => {
   return runMutation<

--- a/packages/hoppscotch-common/src/services/workspace.service.ts
+++ b/packages/hoppscotch-common/src/services/workspace.service.ts
@@ -5,7 +5,7 @@ import { useStreamStatic } from "~/composables/stream"
 import TeamListAdapter from "~/helpers/teams/TeamListAdapter"
 import { platform } from "~/platform"
 import { min } from "lodash-es"
-import { TeamMemberRole } from "~/helpers/backend/graphql"
+import { TeamAccessRole } from "~/helpers/backend/graphql"
 
 /**
  * Defines a workspace and its information
@@ -19,7 +19,7 @@ export type TeamWorkspace = {
   type: "team"
   teamID: string
   teamName: string
-  role: TeamMemberRole | null | undefined
+  role: TeamAccessRole | null | undefined
 }
 
 export type Workspace = PersonalWorkspace | TeamWorkspace

--- a/packages/hoppscotch-sh-admin/src/components/teams/Invite.vue
+++ b/packages/hoppscotch-sh-admin/src/components/teams/Invite.vue
@@ -72,7 +72,7 @@
                       :active="member.value === 'OWNER'"
                       @click="
                         () => {
-                          updateNewMemberRole(index, TeamMemberRole.Owner);
+                          updateNewMemberRole(index, TeamAccessRole.Owner);
                           hide();
                         }
                       "
@@ -85,7 +85,7 @@
                       :active="member.value === 'EDITOR'"
                       @click="
                         () => {
-                          updateNewMemberRole(index, TeamMemberRole.Editor);
+                          updateNewMemberRole(index, TeamAccessRole.Editor);
                           hide();
                         }
                       "
@@ -98,7 +98,7 @@
                       :active="member.value === 'VIEWER'"
                       @click="
                         () => {
-                          updateNewMemberRole(index, TeamMemberRole.Viewer);
+                          updateNewMemberRole(index, TeamAccessRole.Viewer);
                           hide();
                         }
                       "
@@ -222,7 +222,7 @@ import IconTrash from '~icons/lucide/trash';
 import {
   AddUserToTeamByAdminDocument,
   MetricsDocument,
-  TeamMemberRole,
+  TeamAccessRole,
   UsersListDocument,
 } from '../../helpers/backend/graphql';
 
@@ -258,21 +258,21 @@ const { list: usersList } = usePagedQuery(
 
 const allUsersEmail = computed(() => usersList.value.map((user) => user.email));
 
-const newMembersList = ref<Array<{ key: string; value: TeamMemberRole }>>([
+const newMembersList = ref<Array<{ key: string; value: TeamAccessRole }>>([
   {
     key: '',
-    value: TeamMemberRole.Viewer,
+    value: TeamAccessRole.Viewer,
   },
 ]);
 
 const addNewMember = () => {
   newMembersList.value.push({
     key: '',
-    value: TeamMemberRole.Viewer,
+    value: TeamAccessRole.Viewer,
   });
 };
 
-const updateNewMemberRole = (index: number, role: TeamMemberRole) => {
+const updateNewMemberRole = (index: number, role: TeamAccessRole) => {
   newMembersList.value[index].value = role;
 };
 
@@ -291,7 +291,7 @@ const addUserasTeamMember = async () => {
     O.fromPredicate(
       (
         memberInvites
-      ): memberInvites is Array<{ key: Email; value: TeamMemberRole }> =>
+      ): memberInvites is Array<{ key: Email; value: TeamAccessRole }> =>
         pipe(
           memberInvites,
           A.every((member) => EmailCodec.is(member.key))
@@ -319,7 +319,7 @@ const hideModal = () => {
   newMembersList.value = [
     {
       key: '',
-      value: TeamMemberRole.Viewer,
+      value: TeamAccessRole.Viewer,
     },
   ];
   emit('hide-modal');
@@ -328,7 +328,7 @@ const hideModal = () => {
 const addUserToTeamMutation = useMutation(AddUserToTeamByAdminDocument);
 const addUserToTeam = async (
   email: string,
-  userRole: TeamMemberRole,
+  userRole: TeamAccessRole,
   teamID: string
 ) => {
   const variables = { userEmail: email, role: userRole, teamID: teamID };

--- a/packages/hoppscotch-sh-admin/src/components/teams/Invite.vue
+++ b/packages/hoppscotch-sh-admin/src/components/teams/Invite.vue
@@ -72,7 +72,7 @@
                       :active="member.value === 'OWNER'"
                       @click="
                         () => {
-                          updateNewMemberRole(index, TeamAccessRole.Owner);
+                          updateNewAccessRole(index, TeamAccessRole.Owner);
                           hide();
                         }
                       "
@@ -85,7 +85,7 @@
                       :active="member.value === 'EDITOR'"
                       @click="
                         () => {
-                          updateNewMemberRole(index, TeamAccessRole.Editor);
+                          updateNewAccessRole(index, TeamAccessRole.Editor);
                           hide();
                         }
                       "
@@ -98,7 +98,7 @@
                       :active="member.value === 'VIEWER'"
                       @click="
                         () => {
-                          updateNewMemberRole(index, TeamAccessRole.Viewer);
+                          updateNewAccessRole(index, TeamAccessRole.Viewer);
                           hide();
                         }
                       "
@@ -272,7 +272,7 @@ const addNewMember = () => {
   });
 };
 
-const updateNewMemberRole = (index: number, role: TeamAccessRole) => {
+const updateNewAccessRole = (index: number, role: TeamAccessRole) => {
   newMembersList.value[index].value = role;
 };
 

--- a/packages/hoppscotch-sh-admin/src/components/teams/Members.vue
+++ b/packages/hoppscotch-sh-admin/src/components/teams/Members.vue
@@ -76,7 +76,7 @@
                       :active="member.role === 'OWNER'"
                       @click="
                         () => {
-                          updateMemberRole(member.userID, TeamAccessRole.Owner);
+                          updateAccessRole(member.userID, TeamAccessRole.Owner);
                           hide();
                         }
                       "
@@ -89,7 +89,7 @@
                       :active="member.role === 'EDITOR'"
                       @click="
                         () => {
-                          updateMemberRole(
+                          updateAccessRole(
                             member.userID,
                             TeamAccessRole.Editor
                           );
@@ -105,7 +105,7 @@
                       :active="member.role === 'VIEWER'"
                       @click="
                         () => {
-                          updateMemberRole(
+                          updateAccessRole(
                             member.userID,
                             TeamAccessRole.Viewer
                           );
@@ -223,7 +223,7 @@ const updateMembers = async () => {
 const tippyActions = ref<any | null>(null);
 
 // Roles of the members in the team
-const currentMemberRoles = ref<
+const currentAccessRoles = ref<
   {
     userID: string;
     role: TeamAccessRole;
@@ -231,31 +231,31 @@ const currentMemberRoles = ref<
 >([]);
 
 // Roles of the members in the team after the updates but before saving
-const updatedMemberRoles = ref<
+const updatedAccessRoles = ref<
   {
     userID: string;
     role: TeamAccessRole;
   }[]
->(cloneDeep(currentMemberRoles.value));
+>(cloneDeep(currentAccessRoles.value));
 
 // Check if the roles of the members have been updated
 const areRolesUpdated = computed(() =>
-  currentMemberRoles.value && updatedMemberRoles.value
-    ? !isEqual(currentMemberRoles.value, updatedMemberRoles.value)
+  currentAccessRoles.value && updatedAccessRoles.value
+    ? !isEqual(currentAccessRoles.value, updatedAccessRoles.value)
     : false
 );
 
 // Update the role of the member selected in the UI
-const updateMemberRole = (userID: string, role: TeamAccessRole) => {
-  const updateIndex = updatedMemberRoles.value.findIndex(
+const updateAccessRole = (userID: string, role: TeamAccessRole) => {
+  const updateIndex = updatedAccessRoles.value.findIndex(
     (item) => item.userID === userID
   );
   if (updateIndex !== -1) {
     // Role Update exists
-    updatedMemberRoles.value[updateIndex].role = role;
+    updatedAccessRoles.value[updateIndex].role = role;
   } else {
     // Role Update does not exist
-    updatedMemberRoles.value.push({
+    updatedAccessRoles.value.push({
       userID,
       role,
     });
@@ -266,7 +266,7 @@ const updateMemberRole = (userID: string, role: TeamAccessRole) => {
 const membersList = computed(() => {
   if (!team.value) return [];
   const members = (team.value.teamMembers ?? []).map((member) => {
-    const updatedRole = updatedMemberRoles.value.find(
+    const updatedRole = updatedAccessRoles.value.find(
       (update) => update.userID === member.user.uid
     );
 
@@ -312,20 +312,20 @@ const saveUpdatedTeam = async () => {
     return;
   }
 
-  updatedMemberRoles.value.forEach(async (update) => {
+  updatedAccessRoles.value.forEach(async (update) => {
     if (!team.value) return;
 
-    const updateMemberRoleResult = await changeUserRoleInTeam(
+    const updateAccessRoleResult = await changeUserRoleInTeam(
       update.userID,
       team.value.id,
       update.role
     );
-    if (updateMemberRoleResult.error) {
+    if (updateAccessRoleResult.error) {
       toast.error(t('state.role_update_failed'));
     } else {
       toast.success(t('state.role_update_success'));
-      currentMemberRoles.value = updatedMemberRoles.value;
-      updatedMemberRoles.value = cloneDeep(currentMemberRoles.value);
+      currentAccessRoles.value = updatedAccessRoles.value;
+      updatedAccessRoles.value = cloneDeep(currentAccessRoles.value);
     }
     isLoading.value = false;
   });

--- a/packages/hoppscotch-sh-admin/src/components/teams/Members.vue
+++ b/packages/hoppscotch-sh-admin/src/components/teams/Members.vue
@@ -76,7 +76,7 @@
                       :active="member.role === 'OWNER'"
                       @click="
                         () => {
-                          updateMemberRole(member.userID, TeamMemberRole.Owner);
+                          updateMemberRole(member.userID, TeamAccessRole.Owner);
                           hide();
                         }
                       "
@@ -91,7 +91,7 @@
                         () => {
                           updateMemberRole(
                             member.userID,
-                            TeamMemberRole.Editor
+                            TeamAccessRole.Editor
                           );
                           hide();
                         }
@@ -107,7 +107,7 @@
                         () => {
                           updateMemberRole(
                             member.userID,
-                            TeamMemberRole.Viewer
+                            TeamAccessRole.Viewer
                           );
                           hide();
                         }
@@ -179,7 +179,7 @@ import {
   RemoveUserFromTeamByAdminDocument,
   TeamInfoDocument,
   TeamInfoQuery,
-  TeamMemberRole,
+  TeamAccessRole,
 } from '../../helpers/backend/graphql';
 
 const t = useI18n();
@@ -226,7 +226,7 @@ const tippyActions = ref<any | null>(null);
 const currentMemberRoles = ref<
   {
     userID: string;
-    role: TeamMemberRole;
+    role: TeamAccessRole;
   }[]
 >([]);
 
@@ -234,7 +234,7 @@ const currentMemberRoles = ref<
 const updatedMemberRoles = ref<
   {
     userID: string;
-    role: TeamMemberRole;
+    role: TeamAccessRole;
   }[]
 >(cloneDeep(currentMemberRoles.value));
 
@@ -246,7 +246,7 @@ const areRolesUpdated = computed(() =>
 );
 
 // Update the role of the member selected in the UI
-const updateMemberRole = (userID: string, role: TeamMemberRole) => {
+const updateMemberRole = (userID: string, role: TeamAccessRole) => {
   const updateIndex = updatedMemberRoles.value.findIndex(
     (item) => item.userID === userID
   );
@@ -287,7 +287,7 @@ const changeUserRoleInTeamMutation = useMutation(
 const changeUserRoleInTeam = (
   userUID: string,
   teamID: string,
-  newRole: TeamMemberRole
+  newRole: TeamAccessRole
 ) => {
   return changeUserRoleInTeamMutation.executeMutation({
     userUID,
@@ -303,7 +303,7 @@ const saveUpdatedTeam = async () => {
   isLoading.value = true;
 
   const isOwnerPresent = membersList.value.some(
-    (member) => member.role === TeamMemberRole.Owner
+    (member) => member.role === TeamAccessRole.Owner
   );
 
   if (!isOwnerPresent) {

--- a/packages/hoppscotch-sh-admin/src/helpers/backend/gql/mutations/AddUserToTeamByAdmin.graphql
+++ b/packages/hoppscotch-sh-admin/src/helpers/backend/gql/mutations/AddUserToTeamByAdmin.graphql
@@ -1,6 +1,6 @@
 mutation AddUserToTeamByAdmin(
   $userEmail: String!
-  $role: TeamMemberRole!
+  $role: TeamAccessRole!
   $teamID: ID!
 ) {
   addUserToTeamByAdmin(role: $role, userEmail: $userEmail, teamID: $teamID) {

--- a/packages/hoppscotch-sh-admin/src/helpers/backend/gql/mutations/ChangeUserRoleInTeamByAdmin.graphql
+++ b/packages/hoppscotch-sh-admin/src/helpers/backend/gql/mutations/ChangeUserRoleInTeamByAdmin.graphql
@@ -1,7 +1,7 @@
 mutation ChangeUserRoleInTeamByAdmin(
   $userUID: ID!
   $teamID: ID!
-  $newRole: TeamMemberRole!
+  $newRole: TeamAccessRole!
 ) {
   changeUserRoleInTeamByAdmin(
     userUID: $userUID

--- a/packages/hoppscotch-sh-admin/src/helpers/backend/gql/mutations/CreateTeamInvitation.graphql
+++ b/packages/hoppscotch-sh-admin/src/helpers/backend/gql/mutations/CreateTeamInvitation.graphql
@@ -1,4 +1,4 @@
-mutation CreateTeamInvitation($inviteeEmail: String!, $inviteeRole: TeamMemberRole!, $teamID: ID!) {
+mutation CreateTeamInvitation($inviteeEmail: String!, $inviteeRole: TeamAccessRole!, $teamID: ID!) {
   createTeamInvitation(inviteeRole: $inviteeRole, inviteeEmail: $inviteeEmail, teamID: $teamID) {
     id
     teamID


### PR DESCRIPTION
### What's changed
Renamed `TeamMemberRole` to `TeamAccessRole` to better reflect a broader and more generic usage scope beyond just team members.

### Why
The updated enum name improves clarity and reusability across different contexts where access roles are relevant, not limited to a specific entity.