### PR TITLE
feat: Initial and current value for environment variables

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
@@ -95,6 +95,7 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
         const testFixtures = [
           { fileName: "env-v0.json", version: 0 },
           { fileName: "env-v1.json", version: 1 },
+          { fileName: "env-v2.json", version: 2 },
         ];
 
         testFixtures.forEach(({ fileName, version }) => {

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/aws-signature-auth-envs.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/aws-signature-auth-envs.json
@@ -1,34 +1,42 @@
 {
-  "v": 1,
+  "v": 2,
   "id": "cm0dsn3v70004p4qk3l9b7sjm",
   "name": "AWS Signature - environments",
   "variables": [
     {
       "key": "awsRegion",
-      "value": "us-east-1",
+      "currentValue": "us-east-1",
+      "initialValue": "us-east-1",
       "secret": false
     },
     {
       "key": "serviceName",
-      "value": "s3",
+      "currentValue": "s3",
+      "initialValue": "s3",
       "secret": false
     },
     {
       "key": "accessKey",
-      "value": "test-access-key",
+      "currentValue": "test-access-key",
+      "initialValue": "test-access-key",
       "secret": true
     },
     {
       "key": "secretKey",
+      "currentValue": "",
+      "initialValue": "",
       "secret": true
     },
     {
       "key": "url",
-      "value": "https://echo.hoppscotch.io",
+      "currentValue": "https://echo.hoppscotch.io",
+      "initialValue": "https://echo.hoppscotch.io",
       "secret": false
     },
     {
       "key": "serviceToken",
+      "currentValue": "",
+      "initialValue": "",
       "secret": true
     }
   ]

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/digest-auth-envs.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/digest-auth-envs.json
@@ -1,21 +1,24 @@
 {
-  "v": 1,
+  "v": 2,
   "id": "cm0dsn3v70004p4qk3l9b7sjm",
   "name": "Digest Auth - environments",
   "variables": [
     {
       "key": "username",
-      "value": "admin",
+      "currentValue": "",
+      "initialValue": "admin",
       "secret": true
     },
     {
       "key": "password",
-      "value": "admin",
+      "currentValue": "",
+      "initialValue": "admin",
       "secret": true
     },
     {
       "key": "url",
-      "value": "https://test.insightres.org/digest/"
+      "currentValue": "",
+      "initialValue": "https://test.insightres.org/digest/"
     }
   ]
 }

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/env-v1.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/env-v1.json
@@ -1,10 +1,10 @@
 {
-    "name": "env-v0",
-    "variables": [
-      {
-        "key": "baseURL",
-        "value": "https://echo.hoppscotch.io",
-        "secret": false
-      }
-    ]
-  }
+  "name": "env-v1",
+  "variables": [
+    {
+      "key": "baseURL",
+      "value": "https://echo.hoppscotch.io",
+      "secret": false
+    }
+  ]
+}

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/env-v2.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/env-v2.json
@@ -1,0 +1,13 @@
+{
+  "id": "env-v2",
+  "v": 2,
+  "name": "env-v2",
+  "variables": [
+    {
+      "key": "baseURL",
+      "initialValue": "https://echo.hoppscotch.io",
+      "currentValue": "https://echo.hoppscotch.io",
+      "secret": false
+    }
+  ]
+}

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/request-vars-envs.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/request-vars-envs.json
@@ -1,33 +1,42 @@
 {
-  "v": 1,
+  "v": 2,
   "id": "cm00r7kpb0006mbd2nq1560w6",
   "name": "Request variables alongside environment variables",
   "variables": [
     {
       "key": "url",
-      "value": "https://echo.hoppscotch.io",
+      "initialValue": "https://echo.hoppscotch.io",
+      "currentValue": "https://echo.hoppscotch.io",
       "secret": false
     },
     {
       "key": "secretBasicAuthPasswordEnvVar",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "secretBasicAuthUsernameEnvVar",
-      "value": "username",
+      "initialValue": "username",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "username",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "password",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "testHeaderValue",
-      "value": "test-header-value",
+      "initialValue": "test-header-value",
+      "currentValue": "",
       "secret": false
     }
   ]

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/secret-envs-persistence-scripting-envs.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/secret-envs-persistence-scripting-envs.json
@@ -1,26 +1,36 @@
 {
-  "v": 1,
+  "v": 2,
   "id": "2",
   "name": "secret-envs-persistence-scripting-envs",
   "variables": [
     {
       "key": "preReqVarOne",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "preReqVarTwo",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "postReqVarOne",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "preReqVarTwo",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "customHeaderValueFromSecretVar",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     }
   ]

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/secret-envs.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/secret-envs.json
@@ -1,44 +1,60 @@
 {
   "id": "2",
-  "v": 1,
+  "v": 2,
   "name": "secret-envs",
   "variables": [
     {
       "key": "secretBearerToken",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "secretBasicAuthUsername",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "secretBasicAuthPassword",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "secretQueryParamValue",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "secretBodyValue",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "secretHeaderValue",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "nonExistentValueInSystemEnv",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "echoHoppBaseURL",
-      "value": "https://echo.hoppscotch.io",
+      "initialValue": "https://echo.hoppscotch.io",
+      "currentValue": "",
       "secret": false
     },
     {
       "key": "httpbinBaseURL",
-      "value": "https://httpbin.org",
+      "initialValue": "https://httpbin.org",
+      "currentValue": "",
       "secret": false
     }
   ]

--- a/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/secret-supplied-values-envs.json
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/fixtures/environments/secret-supplied-values-envs.json
@@ -1,50 +1,60 @@
 {
-  "v": 1,
+  "v": 2,
   "id": "2",
   "name": "secret-values-envs",
   "variables": [
     {
       "key": "secretBearerToken",
-      "value": "test-token",
+      "initialValue": "test-token",
+      "currentValue": "test-token",
       "secret": true
     },
     {
       "key": "secretBasicAuthUsername",
-      "value": "test-user",
+      "initialValue": "test-user",
+      "currentValue": "test-user",
       "secret": true
     },
     {
       "key": "secretBasicAuthPassword",
-      "value": "test-pass",
+      "initialValue": "test-pass",
+      "currentValue": "test-pass",
       "secret": true
     },
     {
       "key": "secretQueryParamValue",
-      "value": "secret-query-param-value",
+      "initialValue": "secret-query-param-value",
+      "currentValue": "secret-query-param-value",
       "secret": true
     },
     {
       "key": "secretBodyValue",
-      "value": "secret-body-value",
+      "initialValue": "secret-body-value",
+      "currentValue": "secret-body-value",
       "secret": true
     },
     {
       "key": "secretHeaderValue",
-      "value": "secret-header-value",
+      "initialValue": "secret-header-value",
+      "currentValue": "secret-header-value",
       "secret": true
     },
     {
       "key": "nonExistentValueInSystemEnv",
+      "initialValue": "",
+      "currentValue": "",
       "secret": true
     },
     {
       "key": "echoHoppBaseURL",
-      "value": "https://echo.hoppscotch.io",
+      "initialValue": "https://echo.hoppscotch.io",
+      "currentValue": "https://echo.hoppscotch.io",
       "secret": false
     },
     {
       "key": "httpbinBaseURL",
-      "value": "https://httpbin.org",
+      "initialValue": "https://httpbin.org",
+      "currentValue": "https://httpbin.org",
       "secret": false
     }
   ]

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -44,7 +44,12 @@ describe("getters", () => {
 
   describe("getEffectiveFinalMetaData", () => {
     const environmentVariables = [
-      { key: "PARAM", value: "parsed_param", secret: false },
+      {
+        key: "PARAM",
+        initialValue: "parsed_param",
+        currentValue: "parsed_param",
+        secret: false,
+      },
     ];
 
     test("Empty list of meta-data", () => {
@@ -421,27 +426,32 @@ describe("getters", () => {
     const environmentVariables = [
       {
         key: "SHARED_KEY_I",
-        value: "environment-variable-shared-value-I",
+        initialValue: "environment-variable-shared-value-I",
+        currentValue: "environment-variable-shared-value-I",
         secret: false,
       },
       {
         key: "SHARED_KEY_II",
-        value: "environment-variable-shared-value-II",
+        initialValue: "environment-variable-shared-value-II",
+        currentValue: "environment-variable-shared-value-II",
         secret: false,
       },
       {
         key: "ENV_VAR_III",
-        value: "environment-variable-value-III",
+        initialValue: "environment-variable-value-III",
+        currentValue: "environment-variable-value-III",
         secret: false,
       },
       {
         key: "ENV_VAR_IV",
-        value: "environment-variable-value-IV",
+        initialValue: "environment-variable-value-IV",
+        currentValue: "environment-variable-value-IV",
         secret: false,
       },
       {
         key: "ENV_VAR_V",
-        value: "environment-variable-value-V",
+        initialValue: "environment-variable-value-V",
+        currentValue: "environment-variable-value-V",
         secret: false,
       },
     ];
@@ -450,32 +460,38 @@ describe("getters", () => {
       const expected = [
         {
           key: "SHARED_KEY_I",
-          value: "request-variable-shared-value-I",
+          currentValue: "request-variable-shared-value-I",
+          initialValue: "request-variable-shared-value-I",
           secret: false,
         },
         {
           key: "REQUEST_VAR_III",
-          value: "request-variable-value-III",
+          currentValue: "request-variable-value-III",
+          initialValue: "request-variable-value-III",
           secret: false,
         },
         {
           key: "SHARED_KEY_II",
-          value: "environment-variable-shared-value-II",
+          currentValue: "environment-variable-shared-value-II",
+          initialValue: "environment-variable-shared-value-II",
           secret: false,
         },
         {
           key: "ENV_VAR_III",
-          value: "environment-variable-value-III",
+          currentValue: "environment-variable-value-III",
+          initialValue: "environment-variable-value-III",
           secret: false,
         },
         {
           key: "ENV_VAR_IV",
-          value: "environment-variable-value-IV",
+          currentValue: "environment-variable-value-IV",
+          initialValue: "environment-variable-value-IV",
           secret: false,
         },
         {
           key: "ENV_VAR_V",
-          value: "environment-variable-value-V",
+          currentValue: "environment-variable-value-V",
+          initialValue: "environment-variable-value-V",
           secret: false,
         },
       ];

--- a/packages/hoppscotch-cli/src/commands/test.ts
+++ b/packages/hoppscotch-cli/src/commands/test.ts
@@ -75,7 +75,8 @@ export const test = (pathOrId: string, options: TestCmdOptions) => async () => {
                 (key) =>
                   <IterationDataItem>{
                     key: key,
-                    value: iterationDataItem[key],
+                    initialValue: iterationDataItem[key],
+                    currentValue: iterationDataItem[key],
                     secret: false,
                   }
               )

--- a/packages/hoppscotch-cli/src/options/test/env.ts
+++ b/packages/hoppscotch-cli/src/options/test/env.ts
@@ -60,11 +60,16 @@ export async function parseEnvsData(options: TestCmdEnvironmentOptions) {
 
   if (HoppEnvKeyPairResult.success) {
     for (const [key, value] of Object.entries(HoppEnvKeyPairResult.data)) {
-      envPairs.push({ key, value, secret: false });
+      envPairs.push({
+        key,
+        initialValue: value,
+        currentValue: value,
+        secret: false,
+      });
     }
   } else if (HoppEnvExportObjectResult.type === "ok") {
     // Original environment variables from the supplied export file
-    const originalEnvVariables = (contents as NonSecretEnvironment).variables;
+    const originalEnvVariables = (contents as Environment).variables;
 
     // Above environment variables conforming to the latest schema
     // `value` fields if specified will be omitted for secret environment variables
@@ -73,10 +78,10 @@ export async function parseEnvsData(options: TestCmdEnvironmentOptions) {
     // The values supplied for secret environment variables have to be considered in the CLI
     // For each secret environment variable, include the value in case supplied
     const resolvedEnvVariables = migratedEnvVariables.map((variable, idx) => {
-      if (variable.secret && originalEnvVariables[idx].value) {
+      if (variable.secret && originalEnvVariables[idx].initialValue) {
         return {
           ...variable,
-          value: originalEnvVariables[idx].value,
+          initialValue: originalEnvVariables[idx].initialValue,
         };
       }
 

--- a/packages/hoppscotch-cli/src/utils/getters.ts
+++ b/packages/hoppscotch-cli/src/utils/getters.ts
@@ -275,9 +275,15 @@ export const getResolvedVariables = (
   requestVariables: HoppRESTRequestVariables,
   environmentVariables: EnvironmentVariable[]
 ): EnvironmentVariable[] => {
+  // Transforming request variables to the shape of environment variables
   const activeRequestVariables = requestVariables
     .filter(({ active, value }) => active && value)
-    .map(({ key, value }) => ({ key, value, secret: false }));
+    .map(({ key, value }) => ({
+      key,
+      initialValue: value,
+      currentValue: value,
+      secret: false,
+    }));
 
   const requestVariableKeys = activeRequestVariables.map(({ key }) => key);
 
@@ -286,5 +292,17 @@ export const getResolvedVariables = (
     ({ key }) => !requestVariableKeys.includes(key)
   );
 
-  return [...activeRequestVariables, ...filteredEnvironmentVariables];
+  // Setting currentValue to initialValue for environment variables
+  // because the exported file might not have the currentValue field
+  const processedEnvironmentVariables = filteredEnvironmentVariables.map(
+    ({ key, initialValue, currentValue, secret }) => ({
+      key,
+      initialValue,
+      currentValue:
+        currentValue && currentValue !== "" ? currentValue : initialValue,
+      secret,
+    })
+  );
+
+  return [...activeRequestVariables, ...processedEnvironmentVariables];
 };

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -42,8 +42,10 @@ const processVariables = (variable: Environment["variables"][number]) => {
   if (variable.secret) {
     return {
       ...variable,
-      value:
-        "value" in variable ? variable.value : process.env[variable.key] || "",
+      currentValue:
+        "currentValue" in variable && variable.currentValue !== ""
+          ? variable.currentValue
+          : process.env[variable.key] || "",
     };
   }
   return variable;

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -333,11 +333,13 @@
     }
   },
   "count": {
+    "currentValue": "Current value {count}",
+    "description": "Description {count}",
     "header": "Header {count}",
+    "initialValue": "Initial value {count}",
+    "key": "Key {count}",
     "message": "Message {count}",
     "parameter": "Parameter {count}",
-    "key": "Key {count}",
-    "description": "Description {count}",
     "protocol": "Protocol {count}",
     "value": "Value {count}",
     "variable": "Variable {count}"

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -170,7 +170,7 @@ const insomniaEnvironmentsImport: ImporterOrExporter = {
     disabled: false,
   },
   component: FileSource({
-    acceptedFileTypes: "application/json",
+    acceptedFileTypes: ".json, .yaml, .yml",
     caption: "import.insomnia_environment_description",
     onImportFromFile: async (environments) => {
       isInsomniaImporterInProgress.value = true
@@ -362,8 +362,8 @@ const handleImportToStore = async (
 ) => {
   // Add global envs to the store
   globalEnvs.forEach(({ variables }) => {
-    variables.forEach(({ key, value, secret }) => {
-      addGlobalEnvVariable({ key, value, secret })
+    variables.forEach(({ key, initialValue, currentValue, secret }) => {
+      addGlobalEnvVariable({ key, initialValue, currentValue, secret })
     })
   })
 

--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -66,6 +66,7 @@
               () => {
                 $emit('update:modelValue', {
                   type: 'global',
+                  variables: globalVals.variables,
                 })
                 hide()
               }
@@ -364,9 +365,10 @@ import IconEye from "~icons/lucide/eye"
 import IconGlobe from "~icons/lucide/globe"
 import IconLayers from "~icons/lucide/layers"
 
-type Scope =
+export type Scope =
   | {
       type: "global"
+      variables: GlobalEnvironment["variables"]
     }
   | {
       type: "my-environment"
@@ -591,6 +593,7 @@ const selectedEnv = computed(() => {
     return {
       type: "global",
       name: "Global",
+      variables: globalVals.value.variables,
     }
   }
   if (selectedEnvironmentIndex.value.type === "MY_ENV") {
@@ -657,6 +660,7 @@ onMounted(() => {
     } else {
       emit("update:modelValue", {
         type: "global",
+        variables: globalVals.value.variables,
       })
     }
   }

--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -245,7 +245,7 @@
                 </span>
               </div>
               <div
-                v-for="(variable, index) in globalEnvs.variables"
+                v-for="(variable, index) in globalEnvs"
                 :key="index"
                 class="flex flex-1 space-x-4"
               >
@@ -255,14 +255,11 @@
                 <span class="min-w-[9rem] w-full truncate text-secondaryLight">
                   <template v-if="variable.secret"> ******** </template>
                   <template v-else>
-                    {{ variable.value }}
+                    {{ variable.currentValue }}
                   </template>
                 </span>
               </div>
-              <div
-                v-if="globalEnvs.variables.length === 0"
-                class="text-secondaryLight"
-              >
+              <div v-if="globalEnvs.length === 0" class="text-secondaryLight">
                 {{ t("environment.empty_variables") }}
               </div>
             </div>
@@ -316,7 +313,7 @@
                 <span class="min-w-[9rem] w-full truncate text-secondaryLight">
                   <template v-if="variable.secret"> ******** </template>
                   <template v-else>
-                    {{ variable.value }}
+                    {{ variable.currentValue }}
                   </template>
                 </span>
               </div>
@@ -359,6 +356,7 @@ import {
   setSelectedEnvironmentIndex,
 } from "~/newstore/environments"
 import { useLocalState } from "~/newstore/localstate"
+import { CurrentValueService } from "~/services/current-environment-value.service"
 import { WorkspaceService } from "~/services/workspace.service"
 import IconCheck from "~icons/lucide/check"
 import IconEdit from "~icons/lucide/edit"
@@ -402,6 +400,8 @@ const myEnvironments = useReadonlyStream(environments$, [])
 
 const workspaceService = useService(WorkspaceService)
 const workspace = workspaceService.currentWorkspace
+
+const currentEnvironmentValueService = useService(CurrentValueService)
 
 // TeamList-Adapter
 const teamListAdapter = workspaceService.acquireTeamListAdapter(null)
@@ -577,6 +577,7 @@ const selectedEnv = computed(() => {
         index: props.modelValue.index,
         name: props.modelValue.environment?.name,
         variables: props.modelValue.environment?.variables,
+        id: props.modelValue.environment.id,
       }
     } else if (props.modelValue?.type === "team-environment") {
       return {
@@ -584,6 +585,7 @@ const selectedEnv = computed(() => {
         name: props.modelValue.environment.environment.name,
         teamEnvID: props.modelValue.environment.id,
         variables: props.modelValue.environment.environment.variables,
+        id: props.modelValue.environment.id,
       }
     }
     return {
@@ -599,6 +601,7 @@ const selectedEnv = computed(() => {
       index: selectedEnvironmentIndex.value.index,
       name: environment.name,
       variables: environment.variables,
+      id: environment.id,
     }
   } else if (selectedEnvironmentIndex.value.type === "TEAM_ENV") {
     const teamEnv = teamEnvironmentList.value.find(
@@ -613,6 +616,7 @@ const selectedEnv = computed(() => {
         name: teamEnv.environment.name,
         teamEnvID: selectedEnvironmentIndex.value.teamEnvID,
         variables: teamEnv.environment.variables,
+        id: teamEnv.id,
       }
     }
     return { type: "NO_ENV_SELECTED" }
@@ -662,11 +666,29 @@ onMounted(() => {
 const envSelectorActions = ref<TippyComponent | null>(null)
 const envQuickPeekActions = ref<TippyComponent | null>(null)
 
-const globalEnvs = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
+const globalVals = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
+
+const globalEnvs = computed(() => {
+  return globalVals.value.variables.map((variable, index) => ({
+    ...variable,
+    currentValue:
+      currentEnvironmentValueService.getEnvironmentVariableValue(
+        "Global",
+        index
+      ) ?? "",
+  }))
+})
 
 const environmentVariables = computed(() => {
-  if (selectedEnv.value.variables) {
-    return selectedEnv.value.variables
+  if (selectedEnv.value.variables && selectedEnv.value.id) {
+    return selectedEnv.value.variables.map((variable, index) => ({
+      ...variable,
+      currentValue:
+        currentEnvironmentValueService.getEnvironmentVariableValue(
+          selectedEnv.value.id ?? "",
+          index
+        ) ?? "",
+    }))
   }
   return []
 })

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -104,7 +104,7 @@ const environmentType = ref<EnvironmentsChooseType>({
 const globalEnv = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
 
 const globalEnvironment = computed<Environment>(() => ({
-  v: 1 as const,
+  v: 2 as const,
   id: "Global",
   name: "Global",
   variables: globalEnv.value.variables,

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -177,6 +177,7 @@ watch(
     // if navigating away from a team workspace
     if (
       selectedEnvironmentIndex.value.type === "TEAM_ENV" &&
+      newTeamID &&
       selectedEnvironmentIndex.value.teamID !== newTeamID
     ) {
       setSelectedEnvironmentIndex({

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -75,7 +75,7 @@
                 <template v-else>
                   <div
                     v-for="({ id, env }, index) in tab.variables"
-                    :key="`variable-${id}-${index}`"
+                    :key="`${tab.id}-${id}-${index}`"
                     class="flex divide-x divide-dividerLight"
                   >
                     <input
@@ -85,7 +85,7 @@
                       :placeholder="`${t('count.variable', {
                         count: index + 1,
                       })}`"
-                      :name="'param' + index"
+                      :name="'variable' + index"
                     />
                     <SmartEnvInput
                       v-model="env.initialValue"
@@ -331,7 +331,7 @@ const liveEnvs = computed(() => {
     ]
   }
   return [
-    ...vars.value.map((x) => ({ ...x.env, source: editingName.value! })),
+    ...vars.value.map((x) => ({ ...x.env, sourceEnv: editingName.value! })),
     ...globalEnv.value.variables.map((x) => ({ ...x, sourceEnv: "Global" })),
   ]
 })

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -3,6 +3,7 @@
     v-if="show"
     dialog
     :title="t(`environment.${action}`)"
+    styles="sm:max-w-3xl"
     @close="hideModal"
   >
     <template #body>
@@ -87,10 +88,20 @@
                       :name="'param' + index"
                     />
                     <SmartEnvInput
-                      v-model="env.value"
-                      :placeholder="`${t('count.value', { count: index + 1 })}`"
+                      v-model="env.initialValue"
+                      :placeholder="`${t('count.initialValue', { count: index + 1 })}`"
                       :envs="liveEnvs"
-                      :name="'value' + index"
+                      :name="'initialValue' + index"
+                      :secret="tab.isSecret"
+                      :select-text-on-mount="
+                        env.key ? env.key === editingVariableName : false
+                      "
+                    />
+                    <SmartEnvInput
+                      v-model="env.currentValue"
+                      :placeholder="`${t('count.currentValue', { count: index + 1 })}`"
+                      :envs="liveEnvs"
+                      :name="'currentValue' + index"
                       :secret="tab.isSecret"
                       :select-text-on-mount="
                         env.key ? env.key === editingVariableName : false
@@ -162,6 +173,7 @@ import {
   updateEnvironment,
 } from "~/newstore/environments"
 import { platform } from "~/platform"
+import { CurrentValueService } from "~/services/current-environment-value.service"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
 import IconDone from "~icons/lucide/check"
 import IconHelpCircle from "~icons/lucide/help-circle"
@@ -171,11 +183,7 @@ import IconTrash2 from "~icons/lucide/trash-2"
 
 type EnvironmentVariable = {
   id: number
-  env: {
-    value: string
-    key: string
-    secret: boolean
-  }
+  env: Environment["variables"][number]
 }
 
 const t = useI18n()
@@ -237,10 +245,14 @@ const tabsData: ComputedRef<
 const editingName = ref<string | null>(null)
 const editingID = ref<string>("")
 const vars = ref<EnvironmentVariable[]>([
-  { id: idTicker.value++, env: { key: "", value: "", secret: false } },
+  {
+    id: idTicker.value++,
+    env: { key: "", currentValue: "", initialValue: "", secret: false },
+  },
 ])
 
 const secretEnvironmentService = useService(SecretEnvironmentService)
+const currentEnvironmentValueService = useService(CurrentValueService)
 
 const secretVars = computed(() =>
   pipe(
@@ -302,8 +314,9 @@ const evnExpandError = computed(() => {
 
   return pipe(
     variables,
-    A.filter(({ secret }) => !secret),
-    A.exists(({ value }) => E.isLeft(parseTemplateStringE(value, variables)))
+    A.exists(({ currentValue }) =>
+      E.isLeft(parseTemplateStringE(currentValue, variables))
+    )
   )
 })
 
@@ -314,12 +327,12 @@ const liveEnvs = computed(() => {
 
   if (props.editingEnvironmentIndex === "Global") {
     return [
-      ...vars.value.map((x) => ({ ...x.env, source: editingName.value! })),
+      ...vars.value.map((x) => ({ ...x.env, sourceEnv: editingName.value! })),
     ]
   }
   return [
     ...vars.value.map((x) => ({ ...x.env, source: editingName.value! })),
-    ...globalEnv.value.variables.map((x) => ({ ...x, source: "Global" })),
+    ...globalEnv.value.variables.map((x) => ({ ...x, sourceEnv: "Global" })),
   ]
 })
 
@@ -332,6 +345,16 @@ const workingEnvID = computed(() => {
 
   return uniqueID()
 })
+
+const getCurrentValue = (id: string | "Global", varIndex: number) => {
+  const env = workingEnv.value?.variables[varIndex]
+  if (env && env.secret) {
+    return secretEnvironmentService.getSecretEnvironmentVariable(id, varIndex)
+      ?.value
+  }
+  return currentEnvironmentValueService.getEnvironmentVariable(id, varIndex)
+    ?.currentValue
+}
 
 watch(
   () => props.show,
@@ -351,17 +374,14 @@ watch(
           id: idTicker.value++,
           env: {
             key: e.key,
-            value: e.secret
-              ? (secretEnvironmentService.getSecretEnvironmentVariable(
-                  props.editingEnvironmentIndex === "Global"
-                    ? "Global"
-                    : workingEnvID.value,
-                  index
-                )?.value ??
-                // @ts-expect-error `value` field can exist for secret environment variables as inferred while importing
-                e.value ??
-                "")
-              : e.value,
+            currentValue:
+              getCurrentValue(
+                props.editingEnvironmentIndex === "Global"
+                  ? "Global"
+                  : workingEnvID.value,
+                index
+              ) ?? "",
+            initialValue: e.initialValue,
             secret: e.secret,
           },
         }))
@@ -384,7 +404,8 @@ const addEnvironmentVariable = () => {
     id: idTicker.value++,
     env: {
       key: "",
-      value: "",
+      currentValue: "",
+      initialValue: "",
       secret: selectedEnvOption.value === "secret",
     },
   })
@@ -421,26 +442,75 @@ const saveEnvironment = () => {
   const secretVariables = pipe(
     filteredVariables,
     A.filterMapWithIndex((i, e) =>
-      e.secret ? O.some({ key: e.key, value: e.value, varIndex: i }) : O.none
+      e.secret
+        ? O.some({
+            key: e.key,
+            value: e.currentValue,
+            varIndex: i,
+          })
+        : O.none
     )
   )
 
-  if (editingID.value) {
-    secretEnvironmentService.addSecretEnvironment(
-      editingID.value,
-      secretVariables
+  const nonSecretVariables = pipe(
+    filteredVariables,
+    A.filterMapWithIndex((i, e) =>
+      !e.secret
+        ? O.some({
+            key: e.key,
+            currentValue: e.currentValue,
+            varIndex: i,
+            isSecret: e.secret,
+          })
+        : O.none
     )
-  } else if (props.editingEnvironmentIndex === "Global") {
-    secretEnvironmentService.addSecretEnvironment("Global", secretVariables)
+  )
+
+  if (secretVariables.length > 0) {
+    if (editingID.value) {
+      secretEnvironmentService.addSecretEnvironment(
+        editingID.value,
+        secretVariables
+      )
+    } else if (props.editingEnvironmentIndex === "Global") {
+      secretEnvironmentService.addSecretEnvironment("Global", secretVariables)
+    }
+  }
+  if (nonSecretVariables.length > 0) {
+    if (editingID.value) {
+      currentEnvironmentValueService.addEnvironment(
+        editingID.value,
+        nonSecretVariables
+      )
+    } else if (props.editingEnvironmentIndex === "Global") {
+      currentEnvironmentValueService.addEnvironment(
+        "Global",
+        nonSecretVariables
+      )
+    }
   }
 
   const variables = pipe(
     filteredVariables,
-    A.map((e) => (e.secret ? { key: e.key, secret: e.secret } : e))
+    A.map((e) =>
+      e.secret
+        ? {
+            key: e.key,
+            secret: e.secret,
+            initialValue: e.initialValue,
+            currentValue: "",
+          }
+        : {
+            key: e.key,
+            secret: e.secret,
+            initialValue: e.initialValue,
+            currentValue: "",
+          }
+    )
   )
 
   const environmentUpdated: Environment = {
-    v: 1,
+    v: 2,
     id: uniqueID(),
     name: editingName.value,
     variables,

--- a/packages/hoppscotch-common/src/components/environments/my/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Environment.vue
@@ -155,6 +155,7 @@ import IconCopy from "~icons/lucide/copy"
 import IconEdit from "~icons/lucide/edit"
 import IconMoreVertical from "~icons/lucide/more-vertical"
 import IconTrash2 from "~icons/lucide/trash-2"
+import { CurrentValueService } from "~/services/current-environment-value.service"
 
 const t = useI18n()
 const toast = useToast()
@@ -183,6 +184,7 @@ const emit = defineEmits<{
 const confirmRemove = ref(false)
 
 const secretEnvironmentService = useService(SecretEnvironmentService)
+const currentEnvironmentValueService = useService(CurrentValueService)
 
 watch(
   () => props.duplicateGlobalEnvironmentLoading,
@@ -216,6 +218,7 @@ const removeEnvironment = () => {
   if (!isGlobalEnvironment.value) {
     deleteEnvironment(props.environmentIndex as number, props.environment.id)
     secretEnvironmentService.deleteSecretEnvironment(props.environment.id)
+    currentEnvironmentValueService.deleteEnvironment(props.environment.id)
   }
   toast.success(`${t("state.deleted")}`)
 }

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -3,6 +3,7 @@
     v-if="show"
     dialog
     :title="t(`environment.${action}`)"
+    styles="sm:max-w-3xl"
     @close="hideModal"
   >
     <template #body>
@@ -91,15 +92,24 @@
                       :disabled="isViewer"
                     />
                     <SmartEnvInput
-                      v-model="env.value"
+                      v-model="env.initialValue"
+                      :placeholder="`${t('count.initialValue', { count: index + 1 })}`"
+                      :envs="liveEnvs"
+                      :name="'initialValue' + index"
+                      :secret="tab.isSecret"
                       :select-text-on-mount="
                         env.key ? env.key === editingVariableName : false
                       "
-                      :placeholder="`${t('count.value', { count: index + 1 })}`"
+                    />
+                    <SmartEnvInput
+                      v-model="env.currentValue"
+                      :placeholder="`${t('count.currentValue', { count: index + 1 })}`"
                       :envs="liveEnvs"
-                      :name="'value' + index"
+                      :name="'currentValue' + index"
                       :secret="tab.isSecret"
-                      :readonly="isViewer && !tab.isSecret"
+                      :select-text-on-mount="
+                        env.key ? env.key === editingVariableName : false
+                      "
                     />
                     <div v-if="!isViewer" class="flex">
                       <HoppButtonSecondary
@@ -166,14 +176,11 @@ import { platform } from "~/platform"
 import { useService } from "dioc/vue"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
 import { getEnvActionErrorMessage } from "~/helpers/error-messages"
+import { CurrentValueService } from "~/services/current-environment-value.service"
 
 type EnvironmentVariable = {
   id: number
-  env: {
-    key: string
-    value: string
-    secret: boolean
-  }
+  env: Environment["variables"][number]
 }
 
 const t = useI18n()
@@ -239,10 +246,14 @@ const tabsData: ComputedRef<
 const editingName = ref<string | null>(null)
 const editingID = ref<string | null>(null)
 const vars = ref<EnvironmentVariable[]>([
-  { id: idTicker.value++, env: { key: "", value: "", secret: false } },
+  {
+    id: idTicker.value++,
+    env: { key: "", currentValue: "", initialValue: "", secret: false },
+  },
 ])
 
 const secretEnvironmentService = useService(SecretEnvironmentService)
+const currentEnvironmentValueService = useService(CurrentValueService)
 
 const secretVars = computed(() =>
   pipe(
@@ -275,7 +286,9 @@ const evnExpandError = computed(() => {
 
   return pipe(
     variables,
-    A.exists(({ value }) => E.isLeft(parseTemplateStringE(value, variables)))
+    A.exists(({ currentValue }) =>
+      E.isLeft(parseTemplateStringE(currentValue, variables))
+    )
   )
 })
 
@@ -283,8 +296,27 @@ const liveEnvs = computed(() => {
   if (evnExpandError.value) {
     return []
   }
-  return [...vars.value.map((x) => ({ ...x.env, source: editingName.value! }))]
+  return [
+    ...vars.value.map((x) => ({ ...x.env, sourceEnv: editingName.value! })),
+  ]
 })
+
+const getCurrentValue = (
+  editingID: string,
+  varIndex: number,
+  isSecret: boolean
+) => {
+  if (isSecret) {
+    return secretEnvironmentService.getSecretEnvironmentVariable(
+      editingID,
+      varIndex
+    )?.value
+  }
+  return currentEnvironmentValueService.getEnvironmentVariable(
+    editingID,
+    varIndex
+  )?.currentValue
+}
 
 watch(
   () => props.show,
@@ -310,15 +342,13 @@ watch(
             id: idTicker.value++,
             env: {
               key: e.key,
-              value: e.secret
-                ? (secretEnvironmentService.getSecretEnvironmentVariable(
-                    editingID.value ?? "",
-                    index
-                  )?.value ??
-                  // @ts-expect-error `value` field can exist for secret environment variables as inferred while importing
-                  e.value ??
-                  "")
-                : e.value,
+              currentValue:
+                getCurrentValue(
+                  props.editingEnvironment?.id ?? "",
+                  index,
+                  e.secret
+                ) ?? "",
+              initialValue: e.initialValue,
               secret: e.secret,
             },
           }))
@@ -339,7 +369,8 @@ const addEnvironmentVariable = () => {
     id: idTicker.value++,
     env: {
       key: "",
-      value: "",
+      currentValue: "",
+      initialValue: "",
       secret: selectedEnvOption.value === "secret",
     },
   })
@@ -377,17 +408,38 @@ const saveEnvironment = async () => {
   const secretVariables = pipe(
     filteredVariables,
     A.filterMapWithIndex((i, e) =>
-      e.secret ? O.some({ key: e.key, value: e.value, varIndex: i }) : O.none
+      e.secret
+        ? O.some({ key: e.key, value: e.currentValue, varIndex: i })
+        : O.none
+    )
+  )
+
+  const nonSecretVariables = pipe(
+    filteredVariables,
+    A.filterMapWithIndex((i, e) =>
+      !e.secret
+        ? O.some({
+            key: e.key,
+            currentValue: e.currentValue,
+            varIndex: i,
+            isSecret: e.secret,
+          })
+        : O.none
     )
   )
 
   const variables = pipe(
     filteredVariables,
-    A.map((e) => (e.secret ? { key: e.key, secret: e.secret } : e))
+    A.map((e) => ({
+      key: e.key,
+      secret: e.secret,
+      initialValue: e.initialValue,
+      currentValue: "",
+    }))
   )
 
   const environmentUpdated: Environment = {
-    v: 1,
+    v: 2,
     id: editingID.value ?? "",
     name: editingName.value,
     variables,
@@ -418,6 +470,10 @@ const saveEnvironment = async () => {
               secretEnvironmentService.addSecretEnvironment(
                 envID,
                 secretVariables
+              )
+              currentEnvironmentValueService.addEnvironment(
+                envID,
+                nonSecretVariables
               )
             }
             hideModal()
@@ -463,7 +519,14 @@ const saveEnvironment = async () => {
           () => {
             hideModal()
             toast.success(`${t("environment.updated")}`)
+
             isLoading.value = false
+            if (editingID.value) {
+              currentEnvironmentValueService.addEnvironment(
+                editingID.value,
+                nonSecretVariables
+              )
+            }
           }
         )
       )()

--- a/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Environment.vue
@@ -166,6 +166,7 @@ import IconEdit from "~icons/lucide/edit"
 import IconMoreVertical from "~icons/lucide/more-vertical"
 import IconSettings2 from "~icons/lucide/settings-2"
 import IconTrash2 from "~icons/lucide/trash-2"
+import { CurrentValueService } from "~/services/current-environment-value.service"
 
 const t = useI18n()
 const toast = useToast()
@@ -183,6 +184,7 @@ const emit = defineEmits<{
 }>()
 
 const secretEnvironmentService = useService(SecretEnvironmentService)
+const currentEnvironmentValueService = useService(CurrentValueService)
 
 const confirmRemove = ref(false)
 
@@ -214,6 +216,7 @@ const removeEnvironment = () => {
       () => {
         toast.success(`${t("team_environment.deleted")}`)
         secretEnvironmentService.deleteSecretEnvironment(props.environment.id)
+        currentEnvironmentValueService.deleteEnvironment(props.environment.id)
       }
     )
   )()

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -5,10 +5,10 @@
     >
       <input
         v-if="isSecret"
-        id="secret"
+        :id="`secret-${uniqueID()}`"
         v-model="secretText"
         name="secret"
-        :placeholder="t('environment.secret_value')"
+        :placeholder="placeholder"
         class="flex flex-1 bg-transparent pl-4"
         :class="styles"
         type="password"
@@ -97,6 +97,7 @@ import { CompletionContext, autocompletion } from "@codemirror/autocomplete"
 import { useService } from "dioc/vue"
 import { RESTTabService } from "~/services/tab/rest"
 import { syntaxTree } from "@codemirror/language"
+import { uniqueID } from "~/helpers/utils/uniqueID"
 
 const t = useI18n()
 

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -374,11 +374,13 @@ const envVars = computed(() => {
   if (props.envs) {
     return props.envs.map((x) => {
       const { key, secret } = x
-      const value = secret ? "********" : x.value
+      const currentValue = secret ? "********" : x.currentValue
+      const initialValue = secret ? "********" : x.initialValue
       const sourceEnv = "sourceEnv" in x ? x.sourceEnv : null
       return {
         key,
-        value,
+        currentValue,
+        initialValue,
         sourceEnv,
         secret,
       }
@@ -393,12 +395,14 @@ const envVars = computed(() => {
         ? tabs.currentActiveTab.value.document.request.requestVariables
         : []
 
+  // Transform request variables to match the env format
   return [
     ...requestVariables.map(({ active, key, value }) =>
       active
         ? {
             key,
-            value,
+            currentValue: value,
+            initialValue: value,
             sourceEnv: "RequestVariable",
             secret: false,
           }
@@ -412,7 +416,7 @@ function envAutoCompletion(context: CompletionContext) {
   const options = (envVars.value ?? [])
     .map((env) => ({
       label: env?.key ? `<<${env.key}>>` : "",
-      info: env?.value ?? "",
+      info: env?.currentValue ?? "",
       apply: env?.key ? `<<${env.key}>>` : "",
     }))
     .filter(Boolean)
@@ -539,6 +543,7 @@ const getExtensions = (readonly: boolean): Extension => {
           override: [envAutoCompletion],
         })
       : [],
+
     ViewPlugin.fromClass(
       class {
         update(update: ViewUpdate) {

--- a/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
@@ -19,7 +19,7 @@ const getEnvironmentJSON = (
       ? environmentIndex
       : environmentObj.id
 
-  // Eliminate `value` field from secret environment variables prior to export
+  // Eliminate `currentValue` field from environment variables prior to export
   const transformedEnvironment = transformEnvironmentVariables(newEnvironment)
 
   return environmentId !== null
@@ -39,17 +39,16 @@ export const transformEnvironmentVariables = ({
     v,
     name,
     variables: variables.map((variable) => {
-      const { key, secret } = variable
+      const { key, secret, initialValue } = variable
 
-      // Eliminate `value` field for secret environment variables
-      if (secret) {
-        return {
-          key,
-          secret,
-        }
+      // Eliminate `currentValue` field for secret environment variables and currentValue
+
+      return {
+        key,
+        secret,
+        initialValue,
+        currentValue: "",
       }
-
-      return variable
     }),
   }
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
@@ -24,8 +24,8 @@ export const hoppEnvImporter = (contents: string[]) => {
           ...contentEntry,
           variables: contentEntry.variables?.map((valueEntry) => ({
             ...valueEntry,
-            ...("value" in valueEntry
-              ? { value: String(valueEntry.value) }
+            ...("initialValue" in valueEntry
+              ? { value: String(valueEntry.initialValue) }
               : {}),
           })),
         }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
@@ -64,14 +64,18 @@ export const insomniaEnvImporter = (contents: string[]) => {
 
   insomniaEnvs.forEach((insomniaEnv) => {
     const parsedInsomniaEnv = insomniaEnvSchema.safeParse(insomniaEnv)
-
     if (parsedInsomniaEnv.success) {
       const environment: NonSecretEnvironment = {
         id: uniqueID(),
-        v: 1,
+        v: 2,
         name: parsedInsomniaEnv.data.name,
         variables: Object.entries(parsedInsomniaEnv.data.data).map(
-          ([key, value]) => ({ key, value, secret: false })
+          ([key, value]) => ({
+            key,
+            initialValue: value,
+            currentValue: value,
+            secret: false,
+          })
         ),
       }
 
@@ -83,7 +87,8 @@ export const insomniaEnvImporter = (contents: string[]) => {
     ...env,
     variables: env.variables.map((variable) => ({
       ...variable,
-      value: replaceInsomniaTemplating(variable.value),
+      initialValue: replaceInsomniaTemplating(variable.initialValue),
+      currentValue: replaceInsomniaTemplating(variable.currentValue),
     })),
   }))
 

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
@@ -52,11 +52,12 @@ export const postmanEnvImporter = (contents: string[]) => {
   const environments: Environment[] = validationResult.data.map(
     ({ name, values }) => ({
       id: uniqueID(),
-      v: 1,
+      v: 2,
       name,
       variables: values.map(({ key, value, type }) => ({
         key,
-        value,
+        initialValue: value,
+        currentValue: value,
         secret: type === "secret",
       })),
     })

--- a/packages/hoppscotch-common/src/helpers/preRequest.ts
+++ b/packages/hoppscotch-common/src/helpers/preRequest.ts
@@ -16,7 +16,7 @@ const secretEnvironmentService = getService(SecretEnvironmentService)
 const currentEnvironmentValueService = getService(CurrentValueService)
 
 /**
- * Popultae the currentValue of the environment variables and set the secret values
+ * Populate the currentValue of the environment variables and set the secret values
  * @param selected
  * @param global
  * @returns

--- a/packages/hoppscotch-common/src/helpers/teams/TeamEnvironmentAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamEnvironmentAdapter.ts
@@ -118,7 +118,7 @@ export default class TeamEnvironmentAdapter {
               id: x.id,
               teamID: x.teamID,
               environment: {
-                v: 1,
+                v: 2,
                 id: x.id,
                 name: x.name,
                 variables: JSON.parse(x.variables),
@@ -198,7 +198,7 @@ export default class TeamEnvironmentAdapter {
                 id: x.id,
                 teamID: x.teamID,
                 environment: {
-                  v: 1,
+                  v: 2,
                   id: x.id,
                   name: x.name,
                   variables: JSON.parse(x.variables),
@@ -253,7 +253,7 @@ export default class TeamEnvironmentAdapter {
                 id: x.id,
                 teamID: x.teamID,
                 environment: {
-                  v: 1,
+                  v: 2,
                   id: x.id,
                   name: x.name,
                   variables: JSON.parse(x.variables),

--- a/packages/hoppscotch-common/src/services/__tests__/current-environment-value.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/current-environment-value.service.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import { TestContainer } from "dioc/testing"
+import {
+  CurrentValueService,
+  Variable,
+} from "../current-environment-value.service"
+
+describe("CurrentValueService", () => {
+  let container: TestContainer
+  let service: CurrentValueService
+
+  beforeEach(() => {
+    container = new TestContainer()
+    service = container.bind(CurrentValueService)
+  })
+
+  describe("addEnvironment", () => {
+    it("should add a new environment with the provided ID and variables", () => {
+      const id = "env1"
+      const vars: Variable[] = [
+        { key: "key1", currentValue: "value1", varIndex: 1, isSecret: false },
+      ]
+      service.addEnvironment(id, vars)
+      expect(service.environments.get(id)).toEqual(vars)
+    })
+  })
+
+  describe("getEnvironment", () => {
+    it("should return the variables of the specified environment", () => {
+      const id = "env1"
+      const vars: Variable[] = [
+        { key: "key1", currentValue: "value1", varIndex: 1, isSecret: false },
+      ]
+      service.environments.set(id, vars)
+      expect(service.getEnvironment(id)).toEqual(vars)
+    })
+
+    it("should return undefined for non-existent environment", () => {
+      expect(service.getEnvironment("nonexistent")).toBeUndefined()
+    })
+  })
+
+  describe("getEnvironmentVariable", () => {
+    it("should return the variable at the given index", () => {
+      const id = "env1"
+      const vars: Variable[] = [
+        { key: "key1", currentValue: "value1", varIndex: 1, isSecret: false },
+      ]
+      service.environments.set(id, vars)
+      expect(service.getEnvironmentVariable(id, 1)).toEqual(vars[0])
+    })
+
+    it("should return undefined for non-existent variable", () => {
+      const id = "env1"
+      const vars: Variable[] = [
+        { key: "key1", currentValue: "value1", varIndex: 1, isSecret: false },
+      ]
+      service.environments.set(id, vars)
+      expect(service.getEnvironmentVariable(id, 2)).toBeUndefined()
+    })
+  })
+
+  describe("getEnvironmentVariableValue", () => {
+    it("should return the value of the variable", () => {
+      const id = "env1"
+      const vars: Variable[] = [
+        { key: "key1", currentValue: "value1", varIndex: 1, isSecret: false },
+      ]
+      service.environments.set(id, vars)
+      expect(service.getEnvironmentVariableValue(id, 1)).toBe("value1")
+    })
+
+    it("should return undefined if variable doesn't exist", () => {
+      expect(service.getEnvironmentVariableValue("env1", 999)).toBeUndefined()
+    })
+  })
+
+  describe("loadEnvironmentsFromPersistedState", () => {
+    it("should load environments correctly", () => {
+      const state = {
+        env1: [{ key: "k", currentValue: "v", varIndex: 0, isSecret: false }],
+      }
+      service.loadEnvironmentsFromPersistedState(state)
+      expect(service.environments.get("env1")).toEqual(state.env1)
+    })
+  })
+
+  describe("deleteEnvironment", () => {
+    it("should delete the specified environment", () => {
+      const id = "env1"
+      service.environments.set(id, [])
+      service.deleteEnvironment(id)
+      expect(service.environments.has(id)).toBe(false)
+    })
+  })
+
+  describe("removeEnvironmentVariable", () => {
+    it("should remove the specified variable", () => {
+      const id = "env1"
+      const vars = [
+        { key: "key1", currentValue: "value1", varIndex: 1, isSecret: false },
+        { key: "key2", currentValue: "value2", varIndex: 2, isSecret: false },
+      ]
+      service.environments.set(id, vars)
+      service.removeEnvironmentVariable(id, 1)
+      expect(service.environments.get(id)).toEqual([vars[1]])
+    })
+
+    it("should not fail if variable does not exist", () => {
+      const id = "env1"
+      const vars = [
+        { key: "key1", currentValue: "value1", varIndex: 1, isSecret: false },
+      ]
+      service.environments.set(id, vars)
+      service.removeEnvironmentVariable(id, 999)
+      expect(service.environments.get(id)).toEqual(vars)
+    })
+  })
+
+  describe("updateEnvironmentID", () => {
+    it("should update the environment ID", () => {
+      const oldID = "old"
+      const newID = "new"
+      const vars = [
+        { key: "k", currentValue: "v", varIndex: 0, isSecret: false },
+      ]
+      service.environments.set(oldID, vars)
+      service.updateEnvironmentID(oldID, newID)
+      expect(service.environments.has(oldID)).toBe(false)
+      expect(service.environments.get(newID)).toEqual(vars)
+    })
+  })
+
+  describe("hasValue", () => {
+    it("should return true if a variable with the key and non-empty value exists", () => {
+      const id = "env1"
+      const vars = [
+        { key: "k", currentValue: "v", varIndex: 0, isSecret: true },
+      ]
+      service.environments.set(id, vars)
+      expect(service.hasValue(id, "k")).toBe(true)
+    })
+
+    it("should return false if no variable with key exists or value is empty", () => {
+      service.environments.set("env1", [
+        { key: "k", currentValue: "", varIndex: 0, isSecret: true },
+      ])
+      expect(service.hasValue("env1", "k")).toBe(false)
+    })
+  })
+
+  describe("getEnvironmentByKey", () => {
+    it("should return variable by key", () => {
+      const id = "env1"
+      const vars = [
+        { key: "k", currentValue: "v", varIndex: 1, isSecret: false },
+      ]
+      service.environments.set(id, vars)
+      expect(service.getEnvironmentByKey(id, "k")).toEqual(vars[0])
+    })
+
+    it("should return undefined if key not found", () => {
+      service.environments.set("env1", [])
+      expect(service.getEnvironmentByKey("env1", "k")).toBeUndefined()
+    })
+  })
+
+  describe("persistableEnvironments", () => {
+    it("should return the environments in persistable format", () => {
+      const id = "env1"
+      const vars = [
+        { key: "k", currentValue: "v", varIndex: 0, isSecret: false },
+      ]
+      service.environments.set(id, vars)
+      expect(service.persistableEnvironments.value).toEqual({ [id]: vars })
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/services/current-environment-value.service.ts
+++ b/packages/hoppscotch-common/src/services/current-environment-value.service.ts
@@ -1,0 +1,144 @@
+import { Service } from "dioc"
+import { reactive, computed } from "vue"
+
+/**
+ * Defines a environment variable.
+ */
+export type Variable = {
+  key: string
+  currentValue: string
+  varIndex: number
+  isSecret: boolean
+}
+
+/**
+ * This service is used to store and manage current value of environment variables.
+ * The current value are not synced with the server.
+ * hence they are not persisted in the database. They are stored
+ * in the local storage of the browser.
+ */
+export class CurrentValueService extends Service {
+  public static readonly ID = "CURRENT_VALUE_SERVICE"
+
+  /**
+   * Map of current value of environments.
+   * The key is the ID of the environment.
+   * The value is the list of environment variables.
+   */
+  public environments = reactive(new Map<string, Variable[]>())
+
+  /**
+   * Add a new environment.
+   * @param id ID of the environment
+   * @param vars List of environment variables
+   */
+  public addEnvironment(id: string, vars: Variable[]) {
+    this.environments.set(id, vars)
+  }
+
+  /**
+   * Get a environment.
+   * @param id ID of the environment
+   */
+  public getEnvironment(id: string) {
+    return this.environments.get(id)
+  }
+
+  /**
+   * Get a environment variable.
+   * @param id ID of the environment
+   * @param varIndex Index of the variable in the environment
+   */
+  public getEnvironmentVariable(id: string, varIndex: number) {
+    const vars = this.getEnvironment(id)
+    return vars?.find((v) => v.varIndex === varIndex)
+  }
+
+  /**
+   * Used to get the value of a environment variable.
+   * @param id ID of the environment
+   * @param varIndex Index of the variable in the environment
+   */
+  public getEnvironmentVariableValue(id: string, varIndex: number) {
+    const variable = this.getEnvironmentVariable(id, varIndex)
+    return variable?.currentValue
+  }
+
+  /**
+   *
+   * @param environments Used to load environments from persisted state.
+   */
+  public loadEnvironmentsFromPersistedState(
+    environments: Record<string, Variable[]>
+  ) {
+    if (environments) {
+      this.environments.clear()
+
+      Object.entries(environments).forEach(([id, vars]) => {
+        this.addEnvironment(id, vars)
+      })
+    }
+  }
+
+  /**
+   * Delete a environment.
+   * @param id ID of the environment
+   */
+  public deleteEnvironment(id: string) {
+    this.environments.delete(id)
+  }
+
+  /**
+   * Delete a environment variable.
+   * @param id ID of the environment
+   * @param varIndex Index of the variable in the environment
+   */
+  public removeEnvironmentVariable(id: string, varIndex: number) {
+    const vars = this.getEnvironment(id)
+    const newVars = vars?.filter((v) => v.varIndex !== varIndex)
+    this.environments.set(id, newVars || [])
+  }
+
+  /**
+   * Used to update the ID of a environment.
+   * Used while syncing with the server.
+   * @param oldID old ID of the environment
+   * @param newID new ID of the environment
+   */
+  public updateEnvironmentID(oldID: string, newID: string) {
+    const vars = this.getEnvironment(oldID)
+    this.environments.set(newID, vars || [])
+    this.environments.delete(oldID)
+  }
+
+  /**
+   *
+   * @param id ID of the environment
+   * @param key Key of the variable to check the value exists
+   * @returns true if the key has a secret value
+   */
+  public hasValue(id: string, key: string) {
+    return (
+      this.environments.has(id) &&
+      this.environments
+        .get(id)!
+        .some((v) => v.key === key && v.currentValue !== "")
+    )
+  }
+
+  public getEnvironmentByKey(id: string, key: string) {
+    const vars = this.getEnvironment(id)
+    return vars?.find((v) => v.key === key)
+  }
+
+  /**
+   * Used to update the value of a environment variable.
+   */
+  public persistableEnvironments = computed(() => {
+    const environments: Record<string, Variable[]> = {}
+    this.environments.forEach((vars, id) => {
+      environments[id] = vars
+    })
+    return environments
+  })
+}

--- a/packages/hoppscotch-common/src/services/current-environment-value.service.ts
+++ b/packages/hoppscotch-common/src/services/current-environment-value.service.ts
@@ -1,4 +1,5 @@
 import { Service } from "dioc"
+import { cloneDeep } from "lodash-es"
 import { reactive, computed } from "vue"
 
 /**
@@ -42,6 +43,23 @@ export class CurrentValueService extends Service {
    */
   public getEnvironment(id: string) {
     return this.environments.get(id)
+  }
+
+  /**
+   * Add a new environment variable to the environment.
+   * If the environment does not exist, it will be created.
+   * @param id ID of the environment
+   * @param variable Environment variable to add
+   */
+  public addEnvironmentVariable(id: string, variable: Variable) {
+    const vars = this.getEnvironment(id)
+    if (vars) {
+      const newVars = cloneDeep(vars)
+      newVars.push(variable)
+      this.environments.set(id, newVars)
+    } else {
+      this.environments.set(id, [variable])
+    }
   }
 
   /**

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/__tests__/environment.inspector.spec.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/__tests__/environment.inspector.spec.ts
@@ -4,6 +4,7 @@ import { EnvironmentInspectorService } from "../environment.inspector"
 import { InspectionService } from "../../index"
 import { getDefaultRESTRequest } from "~/helpers/rest/default"
 import { ref } from "vue"
+import { CurrentValueService } from "~/services/current-environment-value.service"
 
 vi.mock("~/modules/i18n", () => ({
   __esModule: true,
@@ -16,8 +17,18 @@ vi.mock("~/newstore/environments", async () => {
   return {
     __esModule: true,
     aggregateEnvsWithSecrets$: new BehaviorSubject([
-      { key: "EXISTING_ENV_VAR", value: "test_value", secret: false },
-      { key: "EXISTING_ENV_VAR_2", value: "", secret: false },
+      {
+        key: "EXISTING_ENV_VAR",
+        currentValue: "test_value",
+        initialValue: "test_value",
+        secret: false,
+      },
+      {
+        key: "EXISTING_ENV_VAR_2",
+        currentValue: "",
+        initialValue: "",
+        secret: false,
+      },
     ]),
     getCurrentEnvironment: () => ({
       id: "1",
@@ -25,7 +36,8 @@ vi.mock("~/newstore/environments", async () => {
       v: 1,
       variables: {
         key: "EXISTING_ENV_VAR",
-        value: "test_value",
+        currentValue: "test_value",
+        initialValue: "test_value",
         secret: false,
       },
     }),
@@ -75,6 +87,12 @@ describe("EnvironmentInspectorService", () => {
 
     it("should not return an inspector result when the URL contains defined environment variables", () => {
       const container = new TestContainer()
+      container.bindMock(CurrentValueService, {
+        hasValue: vi.fn((key) => {
+          if (key === "EXISTING_ENV_VAR_2") return false
+          return true
+        }),
+      })
       const envInspector = container.bind(EnvironmentInspectorService)
 
       const req = ref({
@@ -95,7 +113,12 @@ describe("EnvironmentInspectorService", () => {
         ...getDefaultRESTRequest(),
         endpoint: "http://example.com/api/data",
         headers: [
-          { key: "<<UNDEFINED_ENV_VAR>>", value: "some-value", active: true },
+          {
+            key: "<<UNDEFINED_ENV_VAR>>",
+            value: "some-value",
+            active: true,
+            description: "",
+          },
         ],
       })
 
@@ -115,13 +138,24 @@ describe("EnvironmentInspectorService", () => {
 
     it("should not return an inspector result when the headers contain defined environment variables", () => {
       const container = new TestContainer()
+      container.bindMock(CurrentValueService, {
+        hasValue: vi.fn((key) => {
+          if (key === "EXISTING_ENV_VAR_2") return false
+          return true
+        }),
+      })
       const envInspector = container.bind(EnvironmentInspectorService)
 
       const req = ref({
         ...getDefaultRESTRequest(),
         endpoint: "http://example.com/api/data",
         headers: [
-          { key: "<<EXISTING_ENV_VAR>>", value: "some-value", active: true },
+          {
+            key: "<<EXISTING_ENV_VAR>>",
+            value: "some-value",
+            active: true,
+            description: "",
+          },
         ],
       })
 
@@ -138,7 +172,12 @@ describe("EnvironmentInspectorService", () => {
         ...getDefaultRESTRequest(),
         endpoint: "http://example.com/api/data",
         params: [
-          { key: "<<UNDEFINED_ENV_VAR>>", value: "some-value", active: true },
+          {
+            key: "<<UNDEFINED_ENV_VAR>>",
+            value: "some-value",
+            active: true,
+            description: "",
+          },
         ],
       })
 
@@ -158,6 +197,12 @@ describe("EnvironmentInspectorService", () => {
 
     it("should not return an inspector result when the params contain defined environment variables", () => {
       const container = new TestContainer()
+      container.bindMock(CurrentValueService, {
+        hasValue: vi.fn((key) => {
+          if (key === "EXISTING_ENV_VAR") return false
+          return true
+        }),
+      })
       const envInspector = container.bind(EnvironmentInspectorService)
 
       const req = ref({
@@ -165,7 +210,12 @@ describe("EnvironmentInspectorService", () => {
         endpoint: "http://example.com/api/data",
         headers: [],
         params: [
-          { key: "<<EXISTING_ENV_VAR>>", value: "some-value", active: true },
+          {
+            key: "<<EXISTING_ENV_VAR>>",
+            value: "some-value",
+            active: true,
+            description: "",
+          },
         ],
       })
 
@@ -176,6 +226,12 @@ describe("EnvironmentInspectorService", () => {
 
     it("should return an inspector result when the URL contains empty value in a environment variable", () => {
       const container = new TestContainer()
+      container.bindMock(CurrentValueService, {
+        hasValue: vi.fn((key) => {
+          if (key === "EXISTING_ENV_VAR_2") return true
+          return false
+        }),
+      })
       const envInspector = container.bind(EnvironmentInspectorService)
 
       const req = ref({
@@ -190,6 +246,12 @@ describe("EnvironmentInspectorService", () => {
 
     it("should not return an inspector result when the URL contains non empty value in a environment variable", () => {
       const container = new TestContainer()
+      container.bindMock(CurrentValueService, {
+        hasValue: vi.fn((key) => {
+          if (key === "EXISTING_ENV_VAR") return false
+          return true
+        }),
+      })
       const envInspector = container.bind(EnvironmentInspectorService)
 
       const req = ref({
@@ -210,7 +272,12 @@ describe("EnvironmentInspectorService", () => {
         ...getDefaultRESTRequest(),
         endpoint: "http://example.com/api/data",
         headers: [
-          { key: "<<EXISTING_ENV_VAR_2>>", value: "some-value", active: true },
+          {
+            key: "<<EXISTING_ENV_VAR_2>>",
+            value: "some-value",
+            active: true,
+            description: "",
+          },
         ],
       })
 
@@ -221,13 +288,24 @@ describe("EnvironmentInspectorService", () => {
 
     it("should not return an inspector result when the headers contain non empty value in a environment variable", () => {
       const container = new TestContainer()
+      container.bindMock(CurrentValueService, {
+        hasValue: vi.fn((key) => {
+          if (key === "EXISTING_ENV_VAR") return false
+          return true
+        }),
+      })
       const envInspector = container.bind(EnvironmentInspectorService)
 
       const req = ref({
         ...getDefaultRESTRequest(),
         endpoint: "http://example.com/api/data",
         headers: [
-          { key: "<<EXISTING_ENV_VAR>>", value: "some-value", active: true },
+          {
+            key: "<<EXISTING_ENV_VAR>>",
+            value: "some-value",
+            active: true,
+            description: "",
+          },
         ],
       })
 
@@ -245,7 +323,12 @@ describe("EnvironmentInspectorService", () => {
         endpoint: "http://example.com/api/data",
         headers: [],
         params: [
-          { key: "<<EXISTING_ENV_VAR_2>>", value: "some-value", active: true },
+          {
+            key: "<<EXISTING_ENV_VAR_2>>",
+            value: "some-value",
+            active: true,
+            description: "",
+          },
         ],
       })
 
@@ -256,6 +339,12 @@ describe("EnvironmentInspectorService", () => {
 
     it("should not return an inspector result when the params contain non empty value in a environment variable", () => {
       const container = new TestContainer()
+      container.bindMock(CurrentValueService, {
+        hasValue: vi.fn((key) => {
+          if (key === "EXISTING_ENV_VAR") return false
+          return true
+        }),
+      })
       const envInspector = container.bind(EnvironmentInspectorService)
 
       const req = ref({
@@ -263,7 +352,12 @@ describe("EnvironmentInspectorService", () => {
         endpoint: "http://example.com/api/data",
         headers: [],
         params: [
-          { key: "<<EXISTING_ENV_VAR>>", value: "some-value", active: true },
+          {
+            key: "<<EXISTING_ENV_VAR>>",
+            value: "some-value",
+            active: true,
+            description: "",
+          },
         ],
       })
 

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -213,7 +213,6 @@ export class EnvironmentInspectorService extends Service implements Inspector {
                 ...this.aggregateEnvsWithSecrets.value,
               ])
 
-            console.log("env", environmentVariables)
             environmentVariables.forEach((env) => {
               const hasSecretEnv = this.secretEnvs.hasSecretValue(
                 env.sourceEnv !== "Global"
@@ -227,15 +226,6 @@ export class EnvironmentInspectorService extends Service implements Inspector {
                   ? currentSelectedEnvironment.id
                   : "Global",
                 env.key
-              )
-
-              console.log(
-                "hasCurrentValue",
-                env.sourceEnv !== "Global"
-                  ? currentSelectedEnvironment.id
-                  : "Global",
-                env.key,
-                hasCurrentValue
               )
 
               if (env.key === formattedExEnv) {

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -23,6 +23,7 @@ import { computed } from "vue"
 import { useStreamStatic } from "~/composables/stream"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
 import { RESTTabService } from "~/services/tab/rest"
+import { CurrentValueService } from "~/services/current-environment-value.service"
 
 const HOPP_ENVIRONMENT_REGEX = /(<<[a-zA-Z0-9-_]+>>)/g
 
@@ -46,6 +47,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
 
   private readonly inspection = this.bind(InspectionService)
   private readonly secretEnvs = this.bind(SecretEnvironmentService)
+  private readonly currentEnvs = this.bind(CurrentValueService)
   private readonly restTabs = this.bind(RESTTabService)
 
   private aggregateEnvsWithSecrets = useStreamStatic(
@@ -157,7 +159,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
       if (envsMap.has(env.key)) {
         const existingEnv = envsMap.get(env.key)
 
-        if (existingEnv?.value === "" && env.value !== "") {
+        if (existingEnv?.currentValue === "" && env.currentValue !== "") {
           envsMap.set(env.key, env)
         }
       } else {
@@ -200,14 +202,18 @@ export class EnvironmentInspectorService extends Service implements Inspector {
 
             const environmentVariables =
               this.filterNonEmptyEnvironmentVariables([
+                // Transform the request variables to environment variables
                 ...(currentTabRequest?.requestVariables ?? []).map((env) => ({
-                  ...env,
+                  key: env.key,
+                  currentValue: env.value,
+                  initialValue: env.value,
                   secret: false,
                   sourceEnv: "RequestVariable",
                 })),
                 ...this.aggregateEnvsWithSecrets.value,
               ])
 
+            console.log("env", environmentVariables)
             environmentVariables.forEach((env) => {
               const hasSecretEnv = this.secretEnvs.hasSecretValue(
                 env.sourceEnv !== "Global"
@@ -216,8 +222,24 @@ export class EnvironmentInspectorService extends Service implements Inspector {
                 env.key
               )
 
+              const hasCurrentValue = this.currentEnvs.hasValue(
+                env.sourceEnv !== "Global"
+                  ? currentSelectedEnvironment.id
+                  : "Global",
+                env.key
+              )
+
+              console.log(
+                "hasCurrentValue",
+                env.sourceEnv !== "Global"
+                  ? currentSelectedEnvironment.id
+                  : "Global",
+                env.key,
+                hasCurrentValue
+              )
+
               if (env.key === formattedExEnv) {
-                if (env.secret ? !hasSecretEnv : env.value === "") {
+                if (env.secret ? !hasSecretEnv : !hasCurrentValue) {
                   const itemLocation: InspectorLocation = {
                     type: locations.type,
                     position:

--- a/packages/hoppscotch-common/src/services/persistence/__tests__/__mocks__/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/__tests__/__mocks__/index.ts
@@ -81,22 +81,30 @@ export const GQL_COLLECTIONS_MOCK: HoppCollection[] = [
 
 export const ENVIRONMENTS_MOCK: Environment[] = [
   {
-    v: 1,
+    v: 2,
     id: "ENV_1",
     name: "globals",
     variables: [
       {
         key: "test-global-key",
-        value: "test-global-value",
+        initialValue: "test-global-value",
+        currentValue: "test-global-value",
         secret: false,
       },
     ],
   },
   {
-    v: 1,
+    v: 2,
     id: "ENV_2",
     name: "Test",
-    variables: [{ key: "test-key", value: "test-value", secret: false }],
+    variables: [
+      {
+        key: "test-key",
+        initialValue: "test-value",
+        currentValue: "test-value",
+        secret: false,
+      },
+    ],
   },
 ]
 
@@ -127,8 +135,15 @@ export const MQTT_REQUEST_MOCK = {
 }
 
 export const GLOBAL_ENV_MOCK: GlobalEnvironment = {
-  v: 1,
-  variables: [{ key: "test-key", value: "test-value", secret: false }],
+  v: 2,
+  variables: [
+    {
+      key: "test-key",
+      currentValue: "test-value",
+      initialValue: "test-value",
+      secret: false,
+    },
+  ],
 }
 
 export const VUEX_DATA_MOCK: VUEX_DATA = {

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -69,6 +69,7 @@ import { SIORequest$, setSIORequest } from "../../newstore/SocketIOSession"
 import { WSRequest$, setWSRequest } from "../../newstore/WebSocketSession"
 
 import {
+  CURRENT_ENVIRONMENT_VALUE_SCHEMA,
   ENVIRONMENTS_SCHEMA,
   GLOBAL_ENVIRONMENT_SCHEMA,
   GQL_COLLECTION_SCHEMA,
@@ -92,6 +93,10 @@ import {
 import { PersistableTabState } from "../tab"
 import { HoppTabDocument } from "~/helpers/rest/document"
 import { HoppGQLDocument } from "~/helpers/graphql/document"
+import {
+  CurrentValueService,
+  Variable,
+} from "../current-environment-value.service"
 
 export const STORE_NAMESPACE = "persistence.v1"
 
@@ -113,6 +118,7 @@ export const STORE_KEYS = {
   REST_TABS: "restTabs",
   GQL_TABS: "gqlTabs",
   SECRET_ENVIRONMENTS: "secretEnvironments",
+  CURRENT_ENVIRONMENT_VALUE: "currentEnvironmentValue",
   SCHEMA_VERSION: "schema_version",
 } as const
 
@@ -175,6 +181,8 @@ export class PersistenceService extends Service {
   private readonly secretEnvironmentService = this.bind(
     SecretEnvironmentService
   )
+  private readonly currentEnvironmentValueService =
+    this.bind(CurrentValueService)
 
   private showErrorToast(key: string) {
     const toast = useToast()
@@ -600,6 +608,55 @@ export class PersistenceService extends Service {
     )
   }
 
+  private async setupCurrentEnvironmentValuePersistence() {
+    const loadResult = await Store.get<any>(
+      STORE_NAMESPACE,
+      STORE_KEYS.CURRENT_ENVIRONMENT_VALUE
+    )
+
+    try {
+      if (E.isRight(loadResult) && loadResult.right) {
+        const result = CURRENT_ENVIRONMENT_VALUE_SCHEMA.safeParse(
+          loadResult.right
+        )
+
+        if (result.success) {
+          this.currentEnvironmentValueService.loadEnvironmentsFromPersistedState(
+            result.data
+          )
+        } else {
+          this.showErrorToast(STORE_KEYS.CURRENT_ENVIRONMENT_VALUE)
+          await Store.set(
+            STORE_NAMESPACE,
+            `${STORE_KEYS.CURRENT_ENVIRONMENT_VALUE}-backup`,
+            loadResult.right
+          )
+          console.error(
+            `Failed parsing persisted CURRENT_ENVIRONMENT_VALUE:`,
+            JSON.stringify(loadResult.right)
+          )
+        }
+      }
+    } catch (e) {
+      console.error(
+        `Failed parsing persisted CURRENT_ENVIRONMENT_VALUE:`,
+        loadResult
+      )
+    }
+
+    watchDebounced(
+      this.currentEnvironmentValueService.persistableEnvironments,
+      async (newData: Record<string, Variable[]>) => {
+        await Store.set(
+          STORE_NAMESPACE,
+          STORE_KEYS.CURRENT_ENVIRONMENT_VALUE,
+          newData
+        )
+      },
+      { debounce: 500 }
+    )
+  }
+
   private async setupSelectedEnvPersistence() {
     const loadResult = await Store.get<any>(
       STORE_NAMESPACE,
@@ -914,6 +971,7 @@ export class PersistenceService extends Service {
       this.setupGQLTabsPersistence(),
 
       this.setupSecretEnvironmentsPersistence(),
+      this.setupCurrentEnvironmentValuePersistence(),
     ])
   }
 

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -228,12 +228,9 @@ export const MQTT_REQUEST_SCHEMA = z.nullable(
 const EnvironmentVariablesSchema = z.union([
   z.object({
     key: z.string(),
-    value: z.string(),
-    secret: z.literal(false).catch(false),
-  }),
-  z.object({
-    key: z.string(),
-    secret: z.literal(true),
+    initialValue: z.string(),
+    currentValue: z.string(),
+    secret: z.boolean(),
   }),
   z.object({
     key: z.string(),
@@ -370,6 +367,24 @@ export const SECRET_ENVIRONMENT_VARIABLE_SCHEMA = z.union([
           key: z.string(),
           value: z.string(),
           varIndex: z.number(),
+        })
+        .strict()
+    )
+  ),
+])
+
+export const CURRENT_ENVIRONMENT_VALUE_SCHEMA = z.union([
+  z.object({}).strict(),
+
+  z.record(
+    z.string(),
+    z.array(
+      z
+        .object({
+          key: z.string(),
+          currentValue: z.string(),
+          varIndex: z.number(),
+          isSecret: z.boolean(),
         })
         .strict()
     )

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -57,7 +57,7 @@ export class SecretEnvironmentService extends Service {
    * Used to get the value of a secret environment variable.
    * @param id ID of the environment
    * @param varIndex Index of the variable in the environment
-=   */
+   */
   public getSecretEnvironmentVariableValue(id: string, varIndex: number) {
     const secretVar = this.getSecretEnvironmentVariable(id, varIndex)
     return secretVar?.value
@@ -101,7 +101,7 @@ export class SecretEnvironmentService extends Service {
   }
 
   /**
-   * Used to update thye ID of a secret environment.
+   * Used to update the ID of a secret environment.
    * Used while syncing with the server.
    * @param oldID old ID of the environment
    * @param newID new ID of the environment

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/environment.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/environment.searcher.ts
@@ -82,6 +82,10 @@ export class EnvironmentsSpotlightSearcherService extends StaticSpotlightSearche
   public readonly searcherID = "environments"
   public searcherSectionTitle = this.t("spotlight.environments.title")
 
+  private readonly workspaceService = this.bind(WorkspaceService)
+
+  private workspace = this.workspaceService.currentWorkspace
+
   private readonly spotlight = this.bind(SpotlightService)
 
   private selectedEnvIndex = useStreamStatic(
@@ -239,10 +243,17 @@ export class EnvironmentsSpotlightSearcherService extends StaticSpotlightSearche
         })
         break
       case "edit_selected_env":
-        if (this.selectedEnv.value)
-          invokeAction(`modals.my.environment.edit`, {
-            envName: this.selectedEnv.value.name,
-          })
+        if (this.selectedEnv.value) {
+          if (this.workspace.value.type === "personal") {
+            invokeAction(`modals.my.environment.edit`, {
+              envName: this.selectedEnv.value.name,
+            })
+          } else {
+            invokeAction(`modals.team.environment.edit`, {
+              envName: this.selectedEnv.value.name,
+            })
+          }
+        }
         break
       case "delete_selected_env":
         invokeAction(`modals.environment.delete-selected`)

--- a/packages/hoppscotch-data/src/environment/index.ts
+++ b/packages/hoppscotch-data/src/environment/index.ts
@@ -6,6 +6,7 @@ import { z } from "zod"
 
 import V0_VERSION from "./v/0"
 import V1_VERSION, { uniqueID } from "./v/1"
+import V2_VERSION from "./v/2"
 import { HOPP_SUPPORTED_PREDEFINED_VARIABLES } from "../predefinedVariables"
 
 const versionedObject = z.object({
@@ -13,10 +14,11 @@ const versionedObject = z.object({
 })
 
 export const Environment = createVersionedEntity({
-  latestVersion: 1,
+  latestVersion: 2,
   versionMap: {
     0: V0_VERSION,
     1: V1_VERSION,
+    2: V2_VERSION,
   },
   getVersion(data) {
     const versionCheck = versionedObject.safeParse(data)
@@ -48,7 +50,7 @@ const ENV_MAX_EXPAND_LIMIT = 10
  */
 const ENV_EXPAND_LOOP = "ENV_EXPAND_LOOP" as const
 
-export const EnvironmentSchemaVersion = 1
+export const EnvironmentSchemaVersion = 2
 
 export function parseBodyEnvVariablesE(
   body: string,
@@ -72,8 +74,8 @@ export function parseBodyEnvVariablesE(
 
       const foundEnv = env.find((envVar) => envVar.key === variableName)
 
-      if (foundEnv && "value" in foundEnv) {
-        return foundEnv.value
+      if (foundEnv && "currentValue" in foundEnv) {
+        return foundEnv.currentValue
       }
       return key
     })
@@ -102,7 +104,11 @@ export function parseTemplateStringE(
   str: string,
   variables:
     | Environment["variables"]
-    | { secret: true; value: string; key: string }[],
+    | {
+        secret: true
+        currentValue: string
+        key: string
+      }[],
   maskValue = false,
   showKeyIfSecret = false
 ) {
@@ -131,7 +137,7 @@ export function parseTemplateStringE(
 
       const variable = variables.find((x) => x && x.key === p1)
 
-      if (variable && "value" in variable) {
+      if (variable && "currentValue" in variable) {
         // Show the key if it is a secret and explicitly specified
         if (variable.secret && showKeyIfSecret) {
           isSecret = true
@@ -140,11 +146,17 @@ export function parseTemplateStringE(
         // Mask the value if it is a secret and explicitly specified
         if (variable.secret && maskValue) {
           return "*".repeat(
-            (variable as { secret: true; value: string; key: string }).value
-              .length
+            (
+              variable as {
+                secret: true
+                initialValue: string
+                currentValue: string
+                key: string
+              }
+            ).currentValue.length
           )
         }
-        return variable.value
+        return variable.currentValue
       }
 
       return ""
@@ -173,7 +185,11 @@ export const parseTemplateString = (
   str: string,
   variables:
     | Environment["variables"]
-    | { secret: true; value: string; key: string }[],
+    | {
+        secret: true
+        currentValue: string
+        key: string
+      }[],
   maskValue = false,
   showKeyIfSecret = false
 ) =>
@@ -187,7 +203,8 @@ export const translateToNewEnvironmentVariables = (
 ): Environment["variables"][number] => {
   return {
     key: x.key,
-    value: x.value,
+    initialValue: x.initialValue ?? x.value ?? "",
+    currentValue: x.currentValue ?? x.value ?? "",
     secret: false,
   }
 }

--- a/packages/hoppscotch-data/src/environment/v/2.ts
+++ b/packages/hoppscotch-data/src/environment/v/2.ts
@@ -1,0 +1,40 @@
+import { boolean, z } from "zod"
+import { defineVersion } from "verzod"
+import { V1_SCHEMA } from "./1"
+
+// add initialValue and currentValue to the schema and delete value and add it to initialValue and currentValue
+export const V2_SCHEMA = V1_SCHEMA.extend({
+  v: z.literal(2),
+  variables: z.array(
+    z.object({
+      key: z.string(),
+      initialValue: z.string(),
+      currentValue: z.string(),
+      secret: z.boolean(),
+    })
+  ),
+})
+
+export default defineVersion({
+  initial: false,
+  schema: V2_SCHEMA,
+  up(old: z.infer<typeof V1_SCHEMA>) {
+    const result: z.infer<typeof V2_SCHEMA> = {
+      ...old,
+      v: 2,
+      variables: old.variables.map((variable) => {
+        // if the variable is secret, set initialValue and currentValue to empty string
+        // else set initialValue and currentValue to value
+        // and delete value
+        return {
+          ...variable,
+          initialValue: variable.secret ? "" : variable.value,
+          currentValue: variable.secret ? "" : variable.value,
+          value: undefined,
+        }
+      }),
+    }
+
+    return result
+  },
+})

--- a/packages/hoppscotch-data/src/global-environment/index.ts
+++ b/packages/hoppscotch-data/src/global-environment/index.ts
@@ -4,16 +4,18 @@ import { z } from "zod"
 
 import V0_VERSION from "./v/0"
 import V1_VERSION from "./v/1"
+import V2_VERSION from "./v/2"
 
 const versionedObject = z.object({
   v: z.number(),
 })
 
 export const GlobalEnvironment = createVersionedEntity({
-  latestVersion: 1,
+  latestVersion: 2,
   versionMap: {
     0: V0_VERSION,
     1: V1_VERSION,
+    2: V2_VERSION,
   },
   getVersion(data) {
     const versionCheck = versionedObject.safeParse(data)

--- a/packages/hoppscotch-data/src/global-environment/v/2.ts
+++ b/packages/hoppscotch-data/src/global-environment/v/2.ts
@@ -1,0 +1,39 @@
+import { z } from "zod"
+import { defineVersion } from "verzod"
+import { V1_SCHEMA } from "./1"
+
+export const V2_SCHEMA = V1_SCHEMA.extend({
+  v: z.literal(2),
+  variables: z.array(
+    z.object({
+      key: z.string(),
+      initialValue: z.string(),
+      currentValue: z.string(),
+      secret: z.boolean(),
+    })
+  ),
+})
+
+export default defineVersion({
+  initial: false,
+  schema: V2_SCHEMA,
+  up(old: z.infer<typeof V1_SCHEMA>) {
+    const result: z.infer<typeof V2_SCHEMA> = {
+      ...old,
+      v: 2,
+      variables: old.variables.map((variable) => {
+        // if the variable is secret, set initialValue and currentValue to empty string
+        // else set initialValue and currentValue to value
+        // and delete value
+        return {
+          ...variable,
+          initialValue: variable.secret ? "" : variable.value,
+          currentValue: variable.secret ? "" : variable.value,
+          value: undefined,
+        }
+      }),
+    }
+
+    return result
+  },
+})

--- a/packages/hoppscotch-js-sandbox/src/__tests__/base64-helper-functions.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/base64-helper-functions.spec.ts
@@ -11,13 +11,27 @@ describe("Base64 helper functions", () => {
     atob: {
       script: `pw.env.set("atob", atob("SGVsbG8gV29ybGQ="))`,
       environment: {
-        selected: [{ key: "atob", value: "Hello World", secret: false }],
+        selected: [
+          {
+            key: "atob",
+            currentValue: "Hello World",
+            initialValue: "Hello World",
+            secret: false,
+          },
+        ],
       },
     },
     btoa: {
       script: `pw.env.set("btoa", btoa("Hello World"))`,
       environment: {
-        selected: [{ key: "btoa", value: "SGVsbG8gV29ybGQ=", secret: false }],
+        selected: [
+          {
+            key: "btoa",
+            currentValue: "SGVsbG8gV29ybGQ=",
+            initialValue: "SGVsbG8gV29ybGQ=",
+            secret: false,
+          },
+        ],
       },
     },
   }

--- a/packages/hoppscotch-js-sandbox/src/__tests__/env/get.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/env/get.spec.ts
@@ -31,7 +31,8 @@ describe("pw.env.get", () => {
           selected: [
             {
               key: "a",
-              value: "b",
+              currentValue: "b",
+              initialValue: "b",
               secret: false,
             },
           ],
@@ -60,7 +61,8 @@ describe("pw.env.get", () => {
           global: [
             {
               key: "a",
-              value: "b",
+              currentValue: "b",
+              initialValue: "b",
               secret: false,
             },
           ],
@@ -114,14 +116,16 @@ describe("pw.env.get", () => {
           global: [
             {
               key: "a",
-              value: "global val",
+              currentValue: "global val",
+              initialValue: "global val",
               secret: false,
             },
           ],
           selected: [
             {
               key: "a",
-              value: "selected val",
+              currentValue: "selected val",
+              initialValue: "selected val",
               secret: false,
             },
           ],
@@ -151,7 +155,8 @@ describe("pw.env.get", () => {
           selected: [
             {
               key: "a",
-              value: "<<hello>>",
+              currentValue: "<<hello>>",
+              initialValue: "<<hello>>",
               secret: false,
             },
           ],

--- a/packages/hoppscotch-js-sandbox/src/__tests__/env/getResolve.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/env/getResolve.spec.ts
@@ -31,7 +31,8 @@ describe("pw.env.getResolve", () => {
           selected: [
             {
               key: "a",
-              value: "b",
+              currentValue: "b",
+              initialValue: "b",
               secret: false,
             },
           ],
@@ -60,7 +61,8 @@ describe("pw.env.getResolve", () => {
           global: [
             {
               key: "a",
-              value: "b",
+              currentValue: "b",
+              initialValue: "b",
               secret: false,
             },
           ],
@@ -114,14 +116,16 @@ describe("pw.env.getResolve", () => {
           global: [
             {
               key: "a",
-              value: "global val",
+              currentValue: "global val",
+              initialValue: "global val",
               secret: false,
             },
           ],
           selected: [
             {
               key: "a",
-              value: "selected val",
+              currentValue: "selected val",
+              initialValue: "selected val",
               secret: false,
             },
           ],
@@ -151,12 +155,14 @@ describe("pw.env.getResolve", () => {
           selected: [
             {
               key: "a",
-              value: "<<hello>>",
+              currentValue: "<<hello>>",
+              initialValue: "<<hello>>",
               secret: false,
             },
             {
               key: "hello",
-              value: "there",
+              currentValue: "there",
+              initialValue: "there",
               secret: false,
             },
           ],
@@ -186,12 +192,14 @@ describe("pw.env.getResolve", () => {
           selected: [
             {
               key: "a",
-              value: "<<hello>>",
+              currentValue: "<<hello>>",
+              initialValue: "<<hello>>",
               secret: false,
             },
             {
               key: "hello",
-              value: "<<a>>",
+              currentValue: "<<a>>",
+              initialValue: "<<a>>",
               secret: false,
             },
           ],

--- a/packages/hoppscotch-js-sandbox/src/__tests__/env/resolve.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/env/resolve.spec.ts
@@ -44,7 +44,8 @@ describe("pw.env.resolve", () => {
           global: [
             {
               key: "hello",
-              value: "there",
+              initialValue: "there",
+              currentValue: "there",
               secret: false,
             },
           ],
@@ -75,7 +76,8 @@ describe("pw.env.resolve", () => {
           selected: [
             {
               key: "hello",
-              value: "there",
+              initialValue: "there",
+              currentValue: "there",
               secret: false,
             },
           ],
@@ -104,14 +106,16 @@ describe("pw.env.resolve", () => {
           global: [
             {
               key: "hello",
-              value: "yo",
+              initialValue: "yo",
+              currentValue: "yo",
               secret: false,
             },
           ],
           selected: [
             {
               key: "hello",
-              value: "there",
+              initialValue: "there",
+              currentValue: "there",
               secret: false,
             },
           ],
@@ -141,12 +145,14 @@ describe("pw.env.resolve", () => {
           selected: [
             {
               key: "hello",
-              value: "<<there>>",
+              currentValue: "<<there>>",
+              initialValue: "<<there>>",
               secret: false,
             },
             {
               key: "there",
-              value: "<<hello>>",
+              currentValue: "<<hello>>",
+              initialValue: "<<hello>>",
               secret: false,
             },
           ],

--- a/packages/hoppscotch-js-sandbox/src/__tests__/env/set.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/env/set.spec.ts
@@ -49,7 +49,7 @@ describe("pw.env.set", () => {
           {
             key: "a",
             currentValue: "c",
-            initialValue: "c",
+            initialValue: "b",
             secret: false,
           },
         ],
@@ -81,7 +81,7 @@ describe("pw.env.set", () => {
           {
             key: "a",
             currentValue: "c",
-            initialValue: "c",
+            initialValue: "b",
             secret: false,
           },
         ],
@@ -128,7 +128,7 @@ describe("pw.env.set", () => {
           {
             key: "a",
             currentValue: "c",
-            initialValue: "c",
+            initialValue: "d",
             secret: false,
           },
         ],

--- a/packages/hoppscotch-js-sandbox/src/__tests__/env/set.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/env/set.spec.ts
@@ -36,7 +36,8 @@ describe("pw.env.set", () => {
           selected: [
             {
               key: "a",
-              value: "b",
+              currentValue: "b",
+              initialValue: "b",
               secret: false,
             },
           ],
@@ -47,7 +48,8 @@ describe("pw.env.set", () => {
         selected: [
           {
             key: "a",
-            value: "c",
+            currentValue: "c",
+            initialValue: "c",
             secret: false,
           },
         ],
@@ -65,7 +67,8 @@ describe("pw.env.set", () => {
           global: [
             {
               key: "a",
-              value: "b",
+              currentValue: "b",
+              initialValue: "b",
               secret: false,
             },
           ],
@@ -77,7 +80,8 @@ describe("pw.env.set", () => {
         global: [
           {
             key: "a",
-            value: "c",
+            currentValue: "c",
+            initialValue: "c",
             secret: false,
           },
         ],
@@ -95,14 +99,16 @@ describe("pw.env.set", () => {
           global: [
             {
               key: "a",
-              value: "b",
+              currentValue: "b",
+              initialValue: "b",
               secret: false,
             },
           ],
           selected: [
             {
               key: "a",
-              value: "d",
+              currentValue: "d",
+              initialValue: "d",
               secret: false,
             },
           ],
@@ -113,14 +119,16 @@ describe("pw.env.set", () => {
         global: [
           {
             key: "a",
-            value: "b",
+            currentValue: "b",
+            initialValue: "b",
             secret: false,
           },
         ],
         selected: [
           {
             key: "a",
-            value: "c",
+            currentValue: "c",
+            initialValue: "c",
             secret: false,
           },
         ],
@@ -145,7 +153,8 @@ describe("pw.env.set", () => {
         selected: [
           {
             key: "a",
-            value: "c",
+            currentValue: "c",
+            initialValue: "c",
             secret: false,
           },
         ],

--- a/packages/hoppscotch-js-sandbox/src/__tests__/env/unset.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/env/unset.spec.ts
@@ -36,7 +36,8 @@ describe("pw.env.unset", () => {
           selected: [
             {
               key: "baseUrl",
-              value: "https://echo.hoppscotch.io",
+              currentValue: "https://echo.hoppscotch.io",
+              initialValue: "https://echo.hoppscotch.io",
               secret: false,
             },
           ],
@@ -59,7 +60,8 @@ describe("pw.env.unset", () => {
           global: [
             {
               key: "baseUrl",
-              value: "https://echo.hoppscotch.io",
+              currentValue: "https://echo.hoppscotch.io",
+              initialValue: "https://echo.hoppscotch.io",
               secret: false,
             },
           ],
@@ -83,14 +85,16 @@ describe("pw.env.unset", () => {
           global: [
             {
               key: "baseUrl",
-              value: "https://httpbin.org",
+              currentValue: "https://httpbin.org",
+              initialValue: "https://httpbin.org",
               secret: false,
             },
           ],
           selected: [
             {
               key: "baseUrl",
-              value: "https://echo.hoppscotch.io",
+              currentValue: "https://echo.hoppscotch.io",
+              initialValue: "https://echo.hoppscotch.io",
               secret: false,
             },
           ],
@@ -101,7 +105,8 @@ describe("pw.env.unset", () => {
         global: [
           {
             key: "baseUrl",
-            value: "https://httpbin.org",
+            currentValue: "https://httpbin.org",
+            initialValue: "https://httpbin.org",
             secret: false,
           },
         ],
@@ -120,19 +125,22 @@ describe("pw.env.unset", () => {
           global: [
             {
               key: "baseUrl",
-              value: "https://echo.hoppscotch.io",
+              currentValue: "https://echo.hoppscotch.io",
+              initialValue: "https://echo.hoppscotch.io",
               secret: false,
             },
           ],
           selected: [
             {
               key: "baseUrl",
-              value: "https://httpbin.org",
+              currentValue: "https://httpbin.org",
+              initialValue: "https://httpbin.org",
               secret: false,
             },
             {
               key: "baseUrl",
-              value: "https://echo.hoppscotch.io",
+              currentValue: "https://echo.hoppscotch.io",
+              initialValue: "https://echo.hoppscotch.io",
               secret: false,
             },
           ],
@@ -143,14 +151,16 @@ describe("pw.env.unset", () => {
         global: [
           {
             key: "baseUrl",
-            value: "https://echo.hoppscotch.io",
+            currentValue: "https://echo.hoppscotch.io",
+            initialValue: "https://echo.hoppscotch.io",
             secret: false,
           },
         ],
         selected: [
           {
             key: "baseUrl",
-            value: "https://echo.hoppscotch.io",
+            currentValue: "https://echo.hoppscotch.io",
+            initialValue: "https://echo.hoppscotch.io",
             secret: false,
           },
         ],
@@ -168,12 +178,14 @@ describe("pw.env.unset", () => {
           global: [
             {
               key: "baseUrl",
-              value: "https://httpbin.org/",
+              currentValue: "https://httpbin.org",
+              initialValue: "https://httpbin.org",
               secret: false,
             },
             {
               key: "baseUrl",
-              value: "https://echo.hoppscotch.io",
+              currentValue: "https://echo.hoppscotch.io",
+              initialValue: "https://echo.hoppscotch.io",
               secret: false,
             },
           ],
@@ -185,7 +197,8 @@ describe("pw.env.unset", () => {
         global: [
           {
             key: "baseUrl",
-            value: "https://echo.hoppscotch.io",
+            currentValue: "https://echo.hoppscotch.io",
+            initialValue: "https://echo.hoppscotch.io",
             secret: false,
           },
         ],
@@ -239,7 +252,8 @@ describe("pw.env.unset", () => {
           selected: [
             {
               key: "baseUrl",
-              value: "https://echo.hoppscotch.io",
+              currentValue: "https://echo.hoppscotch.io",
+              initialValue: "https://echo.hoppscotch.io",
               secret: false,
             },
           ],

--- a/packages/hoppscotch-js-sandbox/src/__tests__/pre-request.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/pre-request.spec.ts
@@ -18,7 +18,12 @@ describe("runPreRequestScript", () => {
               initialValue: "oldbob",
               secret: false,
             },
-            { key: "foo", value: "bar", secret: false },
+            {
+              key: "foo",
+              currentValue: "bar",
+              initialValue: "bar",
+              secret: false,
+            },
           ],
         }
       )()
@@ -28,7 +33,7 @@ describe("runPreRequestScript", () => {
         {
           key: "bob",
           currentValue: "newbob",
-          initialValue: "newbob",
+          initialValue: "oldbob",
           secret: false,
         },
         {

--- a/packages/hoppscotch-js-sandbox/src/__tests__/pre-request.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/pre-request.spec.ts
@@ -12,7 +12,12 @@ describe("runPreRequestScript", () => {
         {
           global: [],
           selected: [
-            { key: "bob", value: "oldbob", secret: false },
+            {
+              key: "bob",
+              currentValue: "oldbob",
+              initialValue: "oldbob",
+              secret: false,
+            },
             { key: "foo", value: "bar", secret: false },
           ],
         }
@@ -20,8 +25,18 @@ describe("runPreRequestScript", () => {
     ).resolves.toEqualRight({
       global: [],
       selected: [
-        { key: "bob", value: "newbob", secret: false },
-        { key: "foo", value: "bar", secret: false },
+        {
+          key: "bob",
+          currentValue: "newbob",
+          initialValue: "newbob",
+          secret: false,
+        },
+        {
+          key: "foo",
+          currentValue: "bar",
+          initialValue: "bar",
+          secret: false,
+        },
       ],
     })
   })
@@ -35,8 +50,18 @@ describe("runPreRequestScript", () => {
         {
           global: [],
           selected: [
-            { key: "bob", value: "oldbob", secret: false },
-            { key: "foo", value: "bar", secret: false },
+            {
+              key: "bob",
+              currentValue: "oldbob",
+              initialValue: "oldbob",
+              secret: false,
+            },
+            {
+              key: "foo",
+              currentValue: "bar",
+              initialValue: "bar",
+              secret: false,
+            },
           ],
         }
       )()
@@ -52,8 +77,18 @@ describe("runPreRequestScript", () => {
         {
           global: [],
           selected: [
-            { key: "bob", value: "oldbob", secret: false },
-            { key: "foo", value: "bar", secret: false },
+            {
+              key: "bob",
+              currentValue: "oldbob",
+              initialValue: "oldbob",
+              secret: false,
+            },
+            {
+              key: "foo",
+              currentValue: "bar",
+              initialValue: "bar",
+              secret: false,
+            },
           ],
         }
       )()
@@ -69,8 +104,18 @@ describe("runPreRequestScript", () => {
         {
           global: [],
           selected: [
-            { key: "bob", value: "oldbob", secret: false },
-            { key: "foo", value: "bar", secret: false },
+            {
+              key: "bob",
+              currentValue: "oldbob",
+              initialValue: "oldbob",
+              secret: false,
+            },
+            {
+              key: "foo",
+              currentValue: "bar",
+              initialValue: "bar",
+              secret: false,
+            },
           ],
         }
       )()
@@ -87,7 +132,9 @@ describe("runPreRequestScript", () => {
       )()
     ).resolves.toEqualRight({
       global: [],
-      selected: [{ key: "foo", value: "bar", secret: false }],
+      selected: [
+        { key: "foo", currentValue: "bar", initialValue: "bar", secret: false },
+      ],
     })
   })
 })

--- a/packages/hoppscotch-js-sandbox/src/shared-utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/shared-utils.ts
@@ -39,16 +39,18 @@ const setEnv = (
 
   if (indexInSelected >= 0) {
     const selectedEnv = selected[indexInSelected]
-    if ("value" in selectedEnv) {
-      selectedEnv.value = envValue
+    if ("currentValue" in selectedEnv) {
+      selectedEnv.currentValue = envValue
     }
   } else if (indexInGlobal >= 0) {
-    if ("value" in global[indexInGlobal])
-      (global[indexInGlobal] as { value: string }).value = envValue
+    if ("currentValue" in global[indexInGlobal])
+      (global[indexInGlobal] as { currentValue: string }).currentValue =
+        envValue
   } else {
     selected.push({
       key: envName,
-      value: envValue,
+      currentValue: envValue,
+      initialValue: envValue,
       secret: false,
     })
   }
@@ -93,7 +95,7 @@ const getSharedMethods = (envs: TestResult["envs"]) => {
       getEnv(key, updatedEnvs),
       O.fold(
         () => undefined,
-        (env) => String(env.value)
+        (env) => String(env.currentValue)
       )
     )
 
@@ -111,11 +113,11 @@ const getSharedMethods = (envs: TestResult["envs"]) => {
 
       E.map((e) =>
         pipe(
-          parseTemplateStringE(e.value, [
+          parseTemplateStringE(e.currentValue, [
             ...updatedEnvs.selected,
             ...updatedEnvs.global,
           ]), // If the recursive resolution failed, return the unresolved value
-          E.getOrElse(() => e.value)
+          E.getOrElse(() => e.currentValue)
         )
       ),
       E.map((x) => String(x)),

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -44,7 +44,8 @@ export type TestDescriptor = {
 // Representation of a transformed state for environment variables in the sandbox
 type TransformedEnvironmentVariable = {
   key: string
-  value: string
+  currentValue: string
+  initialValue: string
   secret: boolean
 }
 

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/index.ts
@@ -84,7 +84,7 @@ async function loadUserEnvironments() {
       runDispatchWithOutSyncing(() => {
         replaceEnvironments(
           environments.map(({ id, variables, name }) => ({
-            v: 1,
+            v: 2,
             id,
             name,
             variables: JSON.parse(variables),
@@ -176,7 +176,7 @@ function setupUserEnvironmentUpdatedSubscription() {
         if ((localIndex || localIndex == 0) && name) {
           runDispatchWithOutSyncing(() => {
             updateEnvironment(localIndex, {
-              v: 1,
+              v: 2,
               id,
               name,
               variables: JSON.parse(variables),

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -110,7 +110,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         name: "",
         variables: entries,
         id: "",
-        v: 1,
+        v: 2,
       })()
     }
   },

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/index.ts
@@ -84,7 +84,7 @@ async function loadUserEnvironments() {
       runDispatchWithOutSyncing(() => {
         replaceEnvironments(
           environments.map(({ id, variables, name }) => ({
-            v: 1,
+            v: 2,
             id,
             name,
             variables: JSON.parse(variables),
@@ -176,7 +176,7 @@ function setupUserEnvironmentUpdatedSubscription() {
         if ((localIndex || localIndex == 0) && name) {
           runDispatchWithOutSyncing(() => {
             updateEnvironment(localIndex, {
-              v: 1,
+              v: 2,
               id,
               name,
               variables: JSON.parse(variables),

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -110,7 +110,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         name: "",
         variables: entries,
         id: "",
-        v: 1,
+        v: 2,
       })()
     }
   },


### PR DESCRIPTION
Closes HFE-841 HFE-846 HFE-875 #4531 

This PR add's Initial and current value for environment variables

Initial value is the value defined directly in the environment. This value gets synced to the cloud and is shared with your team. 

Current value is what gets used when you actually send a request in Hoppscotch. It’s stored locally in your browser and isn’t synced to the cloud. 

![image](https://github.com/user-attachments/assets/2bcae8cb-8649-4497-8454-c49fe5e770f6)

### Notes to reviewers
- Check old enviornment is migrated to new version.
- Perform usual request run with global, environment and request variables
- Use the variables in Tests 
- Export and import variables
- Tooltip and quickpeek is showing the current value of variables

### Todo
- [x] Team Environment selector reset bug
- [x] Add support for CLI 
- [x] Fix tests
- [ ] Update documentation for CLI and app


