### PR TITLE
hotfix: pin `xmldom` to `v0.8.10` addressing breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "execa@0.10.0": "2.0.0",
       "@babel/runtime@<7.26.10": "7.26.10",
       "apiconnect-wsdl": "2.0.36",
-      "@xmldom/xmldom": "0.9.8"
+      "@xmldom/xmldom": "0.8.10"
     },
     "packageExtensions": {
       "@hoppscotch/httpsnippet": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   execa@0.10.0: 2.0.0
   '@babel/runtime@<7.26.10': 7.26.10
   apiconnect-wsdl: 2.0.36
-  '@xmldom/xmldom': 0.9.8
+  '@xmldom/xmldom': 0.8.10
 
 packageExtensionsChecksum: sha256-Qhsch/G1LLagBL1kRb8nf11C5HcyCWi8Px3h3uWxYUw=
 
@@ -6205,9 +6205,9 @@ packages:
     resolution: {integrity: sha512-4jXDeZ4IH4bylZ6wu14VEx0aDXXhrN4TC279v9rPmn08g4EYekcYf8wdcOOnS9STjDkb6x77/6xBUTqxGgjr8g==}
     engines: {node: '>=18.0.0'}
 
-  '@xmldom/xmldom@0.9.8':
-    resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
-    engines: {node: '>=14.6'}
+  '@xmldom/xmldom@0.8.10':
+    resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
+    engines: {node: '>=10.0.0'}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -19138,7 +19138,7 @@ snapshots:
       fast-querystring: 1.1.2
       tslib: 2.8.0
 
-  '@xmldom/xmldom@0.9.8': {}
+  '@xmldom/xmldom@0.8.10': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -19299,7 +19299,7 @@ snapshots:
 
   apiconnect-wsdl@2.0.36(openapi-types@12.1.3):
     dependencies:
-      '@xmldom/xmldom': 0.9.8
+      '@xmldom/xmldom': 0.8.10
       iconv-lite: 0.6.3
       js-yaml: 4.1.0
       jszip: 3.10.1


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
`@xmldom/xmldom: 0.9.8` was introduced a breaking change for some other dependent packages. So, downgraded to `0.8.10` version for stability.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Please test the insomnia-importers package thoroughly, as it might be impacted by this change. Expecting, everything will work as expected.