### PR TITLE
feat: use VITE_PROXY_URL for default proxy URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,3 +91,6 @@ VITE_PROXYSCOTCH_ACCESS_TOKEN=
 
 # Set to `true` for subpath based access
 ENABLE_SUBPATH_BASED_ACCESS=false
+
+# Set the default proxy URL, default to https://proxy.hoppscotch.io/
+VITE_PROXY_URL=

--- a/packages/hoppscotch-common/src/newstore/settings.ts
+++ b/packages/hoppscotch-common/src/newstore/settings.ts
@@ -90,6 +90,10 @@ getDefaultProxyUrl().then((url) => {
   defaultProxyURL = url
 })
 
+if (import.meta.env.VITE_PROXY_URL) {
+  defaultProxyURL = import.meta.env.VITE_PROXY_URL
+}
+
 export const getDefaultSettings = (): SettingsDef => {
   return {
     syncCollections: true,


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4450  <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

Use VITE_PROXY_URL for PROXY_URL or fallback to the default logic. Make default hoppscotch proxy URL configurable through env.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
