### PR TITLE
refactor(backend): enhance auth strategies with type safety and better error handling

### DIFF
--- a/packages/hoppscotch-backend/src/auth/strategies/github.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/github.strategy.ts
@@ -30,7 +30,7 @@ export class GithubStrategy extends PassportStrategy(Strategy) {
     refreshToken: string,
     profile: Profile,
     done,
-  ): Promise<any> {
+  ) {
     const email = profile.emails?.[0].value;
 
     if (!validateEmail(email))

--- a/packages/hoppscotch-backend/src/auth/strategies/github.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/github.strategy.ts
@@ -1,4 +1,4 @@
-import { Strategy } from 'passport-github2';
+import { Strategy, Profile } from 'passport-github2';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthService } from '../auth.service';
@@ -15,56 +15,62 @@ export class GithubStrategy extends PassportStrategy(Strategy) {
     private configService: ConfigService,
   ) {
     super({
-      clientID: configService.get('INFRA.GITHUB_CLIENT_ID'),
-      clientSecret: configService.get('INFRA.GITHUB_CLIENT_SECRET'),
-      callbackURL: configService.get('INFRA.GITHUB_CALLBACK_URL'),
-      scope: [configService.get('INFRA.GITHUB_SCOPE')],
+      clientID: configService.get<string>('INFRA.GITHUB_CLIENT_ID'),
+      clientSecret: configService.get<string>('INFRA.GITHUB_CLIENT_SECRET'),
+      callbackURL: configService.get<string>('INFRA.GITHUB_CALLBACK_URL'),
+      scope: [configService.get<string>('INFRA.GITHUB_SCOPE')],
       store: true,
     });
   }
 
-  async validate(accessToken, refreshToken, profile, done) {
-    const user = await this.usersService.findUserByEmail(
-      profile.emails[0].value,
-    );
-
-    if (O.isNone(user)) {
-      const createdUser = await this.usersService.createUserSSO(
-        accessToken,
-        refreshToken,
-        profile,
-      );
-      return createdUser;
-    }
-
-    /**
-     * * displayName and photoURL maybe null if user logged-in via magic-link before SSO
-     */
-    if (!user.value.displayName || !user.value.photoURL) {
-      const updatedUser = await this.usersService.updateUserDetails(
-        user.value,
-        profile,
-      );
-      if (E.isLeft(updatedUser)) {
-        throw new UnauthorizedException(updatedUser.left);
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+    done: Function,
+  ): Promise<any> {
+    try {
+      if (!profile.emails || profile.emails.length === 0) {
+        throw new UnauthorizedException('Email not provided by GitHub');
       }
+
+      const email = profile.emails[0].value;
+      const user = await this.usersService.findUserByEmail(email);
+
+      if (O.isNone(user)) {
+        const createdUser = await this.usersService.createUserSSO(
+          accessToken,
+          refreshToken,
+          profile,
+        );
+        return done(null, createdUser);
+      }
+
+      if (!user.value.displayName || !user.value.photoURL) {
+        const updatedUser = await this.usersService.updateUserDetails(
+          user.value,
+          profile,
+        );
+        if (E.isLeft(updatedUser)) {
+          return done(new UnauthorizedException(updatedUser.left), false);
+        }
+      }
+
+      const providerAccountExists =
+        await this.authService.checkIfProviderAccountExists(user.value, profile);
+
+      if (O.isNone(providerAccountExists)) {
+        await this.usersService.createProviderAccount(
+          user.value,
+          accessToken,
+          refreshToken,
+          profile,
+        );
+      }
+
+      return done(null, user.value);
+    } catch (error) {
+      return done(error, false);
     }
-
-    /**
-     * * Check to see if entry for Github is present in the Account table for user
-     * * If user was created with another provider findUserByEmail may return true
-     */
-    const providerAccountExists =
-      await this.authService.checkIfProviderAccountExists(user.value, profile);
-
-    if (O.isNone(providerAccountExists))
-      await this.usersService.createProviderAccount(
-        user.value,
-        accessToken,
-        refreshToken,
-        profile,
-      );
-
-    return user.value;
   }
 }

--- a/packages/hoppscotch-backend/src/auth/strategies/github.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/github.strategy.ts
@@ -6,6 +6,8 @@ import { UserService } from 'src/user/user.service';
 import * as O from 'fp-ts/Option';
 import * as E from 'fp-ts/Either';
 import { ConfigService } from '@nestjs/config';
+import { validateEmail } from 'src/utils';
+import { AUTH_EMAIL_NOT_PROVIDED_BY_OAUTH } from 'src/errors';
 
 @Injectable()
 export class GithubStrategy extends PassportStrategy(Strategy) {
@@ -27,50 +29,52 @@ export class GithubStrategy extends PassportStrategy(Strategy) {
     accessToken: string,
     refreshToken: string,
     profile: Profile,
-    done: Function,
+    done,
   ): Promise<any> {
-    try {
-      if (!profile.emails || profile.emails.length === 0) {
-        throw new UnauthorizedException('Email not provided by GitHub');
-      }
+    const email = profile.emails?.[0].value;
 
-      const email = profile.emails[0].value;
-      const user = await this.usersService.findUserByEmail(email);
+    if (!validateEmail(email))
+      throw new UnauthorizedException(AUTH_EMAIL_NOT_PROVIDED_BY_OAUTH);
 
-      if (O.isNone(user)) {
-        const createdUser = await this.usersService.createUserSSO(
-          accessToken,
-          refreshToken,
-          profile,
-        );
-        return done(null, createdUser);
-      }
+    const user = await this.usersService.findUserByEmail(email);
 
-      if (!user.value.displayName || !user.value.photoURL) {
-        const updatedUser = await this.usersService.updateUserDetails(
-          user.value,
-          profile,
-        );
-        if (E.isLeft(updatedUser)) {
-          return done(new UnauthorizedException(updatedUser.left), false);
-        }
-      }
-
-      const providerAccountExists =
-        await this.authService.checkIfProviderAccountExists(user.value, profile);
-
-      if (O.isNone(providerAccountExists)) {
-        await this.usersService.createProviderAccount(
-          user.value,
-          accessToken,
-          refreshToken,
-          profile,
-        );
-      }
-
-      return done(null, user.value);
-    } catch (error) {
-      return done(error, false);
+    if (O.isNone(user)) {
+      const createdUser = await this.usersService.createUserSSO(
+        accessToken,
+        refreshToken,
+        profile,
+      );
+      return createdUser;
     }
+
+    /**
+     * displayName and photoURL maybe null if user logged-in via magic-link before SSO
+     */
+    if (!user.value.displayName || !user.value.photoURL) {
+      const updatedUser = await this.usersService.updateUserDetails(
+        user.value,
+        profile,
+      );
+      if (E.isLeft(updatedUser)) {
+        throw new UnauthorizedException(updatedUser.left);
+      }
+    }
+
+    /**
+     * Check to see if entry for Github is present in the Account table for user
+     * If user was created with another provider findUserByEmail may return true
+     */
+    const providerAccountExists =
+      await this.authService.checkIfProviderAccountExists(user.value, profile);
+
+    if (O.isNone(providerAccountExists))
+      await this.usersService.createProviderAccount(
+        user.value,
+        accessToken,
+        refreshToken,
+        profile,
+      );
+
+    return user.value;
   }
 }

--- a/packages/hoppscotch-backend/src/auth/strategies/google.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/google.strategy.ts
@@ -6,6 +6,9 @@ import * as O from 'fp-ts/Option';
 import { AuthService } from '../auth.service';
 import * as E from 'fp-ts/Either';
 import { ConfigService } from '@nestjs/config';
+import { Request } from 'express';
+import { validateEmail } from 'src/utils';
+import { AUTH_EMAIL_NOT_PROVIDED_BY_OAUTH } from 'src/errors';
 
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy) {
@@ -31,48 +34,50 @@ export class GoogleStrategy extends PassportStrategy(Strategy) {
     profile: Profile,
     done: VerifyCallback,
   ): Promise<any> {
-    try {
-      if (!profile.emails || profile.emails.length === 0) {
-        return done(new UnauthorizedException('Email not provided by Google'), false);
-      }
+    const email = profile.emails?.[0].value;
 
-      const email = profile.emails[0].value;
-      const user = await this.usersService.findUserByEmail(email);
+    if (!validateEmail(email))
+      throw new UnauthorizedException(AUTH_EMAIL_NOT_PROVIDED_BY_OAUTH);
 
-      if (O.isNone(user)) {
-        const createdUser = await this.usersService.createUserSSO(
-          accessToken,
-          refreshToken,
-          profile,
-        );
-        return done(null, createdUser);
-      }
+    const user = await this.usersService.findUserByEmail(email);
 
-      if (!user.value.displayName || !user.value.photoURL) {
-        const updatedUser = await this.usersService.updateUserDetails(
-          user.value,
-          profile,
-        );
-        if (E.isLeft(updatedUser)) {
-          return done(new UnauthorizedException(updatedUser.left), false);
-        }
-      }
-
-      const providerAccountExists =
-        await this.authService.checkIfProviderAccountExists(user.value, profile);
-
-      if (O.isNone(providerAccountExists)) {
-        await this.usersService.createProviderAccount(
-          user.value,
-          accessToken,
-          refreshToken,
-          profile,
-        );
-      }
-
-      return done(null, user.value);
-    } catch (error) {
-      return done(error, false);
+    if (O.isNone(user)) {
+      const createdUser = await this.usersService.createUserSSO(
+        accessToken,
+        refreshToken,
+        profile,
+      );
+      return createdUser;
     }
+
+    /**
+     * displayName and photoURL maybe null if user logged-in via magic-link before SSO
+     */
+    if (!user.value.displayName || !user.value.photoURL) {
+      const updatedUser = await this.usersService.updateUserDetails(
+        user.value,
+        profile,
+      );
+      if (E.isLeft(updatedUser)) {
+        throw new UnauthorizedException(updatedUser.left);
+      }
+    }
+
+    /**
+     * Check to see if entry for Google is present in the Account table for user
+     * If user was created with another provider findUserByEmail may return true
+     */
+    const providerAccountExists =
+      await this.authService.checkIfProviderAccountExists(user.value, profile);
+
+    if (O.isNone(providerAccountExists))
+      await this.usersService.createProviderAccount(
+        user.value,
+        accessToken,
+        refreshToken,
+        profile,
+      );
+
+    return user.value;
   }
 }

--- a/packages/hoppscotch-backend/src/auth/strategies/google.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/google.strategy.ts
@@ -33,7 +33,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy) {
     refreshToken: string,
     profile: Profile,
     done: VerifyCallback,
-  ): Promise<any> {
+  ) {
     const email = profile.emails?.[0].value;
 
     if (!validateEmail(email))

--- a/packages/hoppscotch-backend/src/auth/strategies/google.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/google.strategy.ts
@@ -1,4 +1,4 @@
-import { Strategy, VerifyCallback } from 'passport-google-oauth20';
+import { Strategy, VerifyCallback, Profile } from 'passport-google-oauth20';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { UserService } from 'src/user/user.service';
@@ -15,10 +15,10 @@ export class GoogleStrategy extends PassportStrategy(Strategy) {
     private configService: ConfigService,
   ) {
     super({
-      clientID: configService.get('INFRA.GOOGLE_CLIENT_ID'),
-      clientSecret: configService.get('INFRA.GOOGLE_CLIENT_SECRET'),
-      callbackURL: configService.get('INFRA.GOOGLE_CALLBACK_URL'),
-      scope: configService.get('INFRA.GOOGLE_SCOPE').split(','),
+      clientID: configService.get<string>('INFRA.GOOGLE_CLIENT_ID'),
+      clientSecret: configService.get<string>('INFRA.GOOGLE_CLIENT_SECRET'),
+      callbackURL: configService.get<string>('INFRA.GOOGLE_CALLBACK_URL'),
+      scope: configService.get<string>('INFRA.GOOGLE_SCOPE').split(','),
       passReqToCallback: true,
       store: true,
     });
@@ -26,52 +26,53 @@ export class GoogleStrategy extends PassportStrategy(Strategy) {
 
   async validate(
     req: Request,
-    accessToken,
-    refreshToken,
-    profile,
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
     done: VerifyCallback,
-  ) {
-    const user = await this.usersService.findUserByEmail(
-      profile.emails[0].value,
-    );
-
-    if (O.isNone(user)) {
-      const createdUser = await this.usersService.createUserSSO(
-        accessToken,
-        refreshToken,
-        profile,
-      );
-      return createdUser;
-    }
-
-    /**
-     * * displayName and photoURL maybe null if user logged-in via magic-link before SSO
-     */
-    if (!user.value.displayName || !user.value.photoURL) {
-      const updatedUser = await this.usersService.updateUserDetails(
-        user.value,
-        profile,
-      );
-      if (E.isLeft(updatedUser)) {
-        throw new UnauthorizedException(updatedUser.left);
+  ): Promise<any> {
+    try {
+      if (!profile.emails || profile.emails.length === 0) {
+        return done(new UnauthorizedException('Email not provided by Google'), false);
       }
+
+      const email = profile.emails[0].value;
+      const user = await this.usersService.findUserByEmail(email);
+
+      if (O.isNone(user)) {
+        const createdUser = await this.usersService.createUserSSO(
+          accessToken,
+          refreshToken,
+          profile,
+        );
+        return done(null, createdUser);
+      }
+
+      if (!user.value.displayName || !user.value.photoURL) {
+        const updatedUser = await this.usersService.updateUserDetails(
+          user.value,
+          profile,
+        );
+        if (E.isLeft(updatedUser)) {
+          return done(new UnauthorizedException(updatedUser.left), false);
+        }
+      }
+
+      const providerAccountExists =
+        await this.authService.checkIfProviderAccountExists(user.value, profile);
+
+      if (O.isNone(providerAccountExists)) {
+        await this.usersService.createProviderAccount(
+          user.value,
+          accessToken,
+          refreshToken,
+          profile,
+        );
+      }
+
+      return done(null, user.value);
+    } catch (error) {
+      return done(error, false);
     }
-
-    /**
-     * * Check to see if entry for Google is present in the Account table for user
-     * * If user was created with another provider findUserByEmail may return true
-     */
-    const providerAccountExists =
-      await this.authService.checkIfProviderAccountExists(user.value, profile);
-
-    if (O.isNone(providerAccountExists))
-      await this.usersService.createProviderAccount(
-        user.value,
-        accessToken,
-        refreshToken,
-        profile,
-      );
-
-    return user.value;
   }
 }

--- a/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
@@ -98,17 +98,13 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   }
 
   async validate(payload: AccessTokenPayload): Promise<any> {
-    try {
-      if (!payload) throw new ForbiddenException(INVALID_ACCESS_TOKEN);
+    if (!payload) throw new ForbiddenException(INVALID_ACCESS_TOKEN);
 
-      const user = await this.usersService.findUserById(payload.sub);
-      if (O.isNone(user)) {
-        throw new UnauthorizedException(USER_NOT_FOUND);
-      }
-
-      return user.value;
-    } catch (error) {
-      throw error;
+    const user = await this.usersService.findUserById(payload.sub);
+    if (O.isNone(user)) {
+      throw new UnauthorizedException(USER_NOT_FOUND);
     }
+
+    return user.value;
   }
 }

--- a/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
@@ -93,18 +93,22 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
             ),
           ),
       ]),
-      secretOrKey: configService.get('JWT_SECRET'),
+      secretOrKey: configService.get<string>('JWT_SECRET'),
     });
   }
 
-  async validate(payload: AccessTokenPayload) {
-    if (!payload) throw new ForbiddenException(INVALID_ACCESS_TOKEN);
+  async validate(payload: AccessTokenPayload): Promise<any> {
+    try {
+      if (!payload) throw new ForbiddenException(INVALID_ACCESS_TOKEN);
 
-    const user = await this.usersService.findUserById(payload.sub);
-    if (O.isNone(user)) {
-      throw new UnauthorizedException(USER_NOT_FOUND);
+      const user = await this.usersService.findUserById(payload.sub);
+      if (O.isNone(user)) {
+        throw new UnauthorizedException(USER_NOT_FOUND);
+      }
+
+      return user.value;
+    } catch (error) {
+      throw error;
     }
-
-    return user.value;
   }
 }

--- a/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
@@ -97,7 +97,7 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     });
   }
 
-  async validate(payload: AccessTokenPayload): Promise<any> {
+  async validate(payload: AccessTokenPayload) {
     if (!payload) throw new ForbiddenException(INVALID_ACCESS_TOKEN);
 
     const user = await this.usersService.findUserById(payload.sub);

--- a/packages/hoppscotch-backend/src/auth/strategies/microsoft.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/microsoft.strategy.ts
@@ -1,4 +1,4 @@
-import { Strategy } from 'passport-microsoft';
+import { Strategy, Profile } from 'passport-microsoft';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthService } from '../auth.service';
@@ -15,57 +15,70 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy) {
     private configService: ConfigService,
   ) {
     super({
-      clientID: configService.get('INFRA.MICROSOFT_CLIENT_ID'),
-      clientSecret: configService.get('INFRA.MICROSOFT_CLIENT_SECRET'),
-      callbackURL: configService.get('INFRA.MICROSOFT_CALLBACK_URL'),
-      scope: configService.get('INFRA.MICROSOFT_SCOPE').split(','),
-      tenant: configService.get('INFRA.MICROSOFT_TENANT'),
+      clientID: configService.get<string>('INFRA.MICROSOFT_CLIENT_ID'),
+      clientSecret: configService.get<string>('INFRA.MICROSOFT_CLIENT_SECRET'),
+      callbackURL: configService.get<string>('INFRA.MICROSOFT_CALLBACK_URL'),
+      scope: configService.get<string>('INFRA.MICROSOFT_SCOPE').split(','),
+      tenant: configService.get<string>('INFRA.MICROSOFT_TENANT'),
       store: true,
     });
   }
 
-  async validate(accessToken: string, refreshToken: string, profile, done) {
-    const user = await this.usersService.findUserByEmail(
-      profile.emails[0].value,
-    );
-
-    if (O.isNone(user)) {
-      const createdUser = await this.usersService.createUserSSO(
-        accessToken,
-        refreshToken,
-        profile,
-      );
-      return createdUser;
-    }
-
-    /**
-     * * displayName and photoURL maybe null if user logged-in via magic-link before SSO
-     */
-    if (!user.value.displayName || !user.value.photoURL) {
-      const updatedUser = await this.usersService.updateUserDetails(
-        user.value,
-        profile,
-      );
-      if (E.isLeft(updatedUser)) {
-        throw new UnauthorizedException(updatedUser.left);
+  async validate(
+    accessToken: string,
+    refreshToken: string,
+    profile: Profile,
+    done: Function,
+  ): Promise<any> {
+    try {
+      if (!profile.emails || profile.emails.length === 0) {
+        return done(new UnauthorizedException('Email not provided by Microsoft'), false);
       }
+
+      const email = profile.emails[0].value;
+      const user = await this.usersService.findUserByEmail(email);
+
+      if (O.isNone(user)) {
+        const createdUser = await this.usersService.createUserSSO(
+          accessToken,
+          refreshToken,
+          profile,
+        );
+        return done(null, createdUser);
+      }
+
+      /**
+       * * displayName and photoURL maybe null if user logged-in via magic-link before SSO
+       */
+      if (!user.value.displayName || !user.value.photoURL) {
+        const updatedUser = await this.usersService.updateUserDetails(
+          user.value,
+          profile,
+        );
+        if (E.isLeft(updatedUser)) {
+          return done(new UnauthorizedException(updatedUser.left), false);
+        }
+      }
+
+      /**
+       * * Check to see if entry for Microsoft is present in the Account table for user
+       * * If user was created with another provider findUserByEmail may return true
+       */
+      const providerAccountExists =
+        await this.authService.checkIfProviderAccountExists(user.value, profile);
+
+      if (O.isNone(providerAccountExists)) {
+        await this.usersService.createProviderAccount(
+          user.value,
+          accessToken,
+          refreshToken,
+          profile,
+        );
+      }
+
+      return done(null, user.value);
+    } catch (error) {
+      return done(error, false);
     }
-
-    /**
-     * * Check to see if entry for Microsoft is present in the Account table for user
-     * * If user was created with another provider findUserByEmail may return true
-     */
-    const providerAccountExists =
-      await this.authService.checkIfProviderAccountExists(user.value, profile);
-
-    if (O.isNone(providerAccountExists))
-      await this.usersService.createProviderAccount(
-        user.value,
-        accessToken,
-        refreshToken,
-        profile,
-      );
-
-    return user.value;
   }
 }

--- a/packages/hoppscotch-backend/src/auth/strategies/microsoft.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/microsoft.strategy.ts
@@ -31,7 +31,7 @@ export class MicrosoftStrategy extends PassportStrategy(Strategy) {
     refreshToken: string,
     profile,
     done,
-  ): Promise<any> {
+  ) {
     const email = profile?.emails?.[0]?.value;
 
     if (!validateEmail(email))

--- a/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
@@ -37,7 +37,7 @@ export class RTJwtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
     });
   }
 
-  async validate(payload: RefreshTokenPayload): Promise<any> {
+  async validate(payload: RefreshTokenPayload) {
     if (!payload) throw new ForbiddenException(INVALID_REFRESH_TOKEN);
 
     const user = await this.usersService.findUserById(payload.sub);

--- a/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
@@ -38,17 +38,13 @@ export class RTJwtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
   }
 
   async validate(payload: RefreshTokenPayload): Promise<any> {
-    try {
-      if (!payload) throw new ForbiddenException(INVALID_REFRESH_TOKEN);
+    if (!payload) throw new ForbiddenException(INVALID_REFRESH_TOKEN);
 
-      const user = await this.usersService.findUserById(payload.sub);
-      if (O.isNone(user)) {
-        throw new UnauthorizedException(USER_NOT_FOUND);
-      }
-
-      return user.value;
-    } catch (error) {
-      throw error;
+    const user = await this.usersService.findUserById(payload.sub);
+    if (O.isNone(user)) {
+      throw new UnauthorizedException(USER_NOT_FOUND);
     }
+
+    return user.value;
   }
 }

--- a/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
@@ -25,7 +25,7 @@ export class RTJwtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
         (request: Request) => {
-          const RTCookie = request.cookies['refresh_token'];
+          const RTCookie = request.cookies?.['refresh_token'];
           if (!RTCookie) {
             console.error('`refresh_token` not found');
             throw new ForbiddenException(COOKIES_NOT_FOUND);
@@ -33,18 +33,22 @@ export class RTJwtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
           return RTCookie;
         },
       ]),
-      secretOrKey: configService.get('JWT_SECRET'),
+      secretOrKey: configService.get<string>('JWT_SECRET'),
     });
   }
 
-  async validate(payload: RefreshTokenPayload) {
-    if (!payload) throw new ForbiddenException(INVALID_REFRESH_TOKEN);
+  async validate(payload: RefreshTokenPayload): Promise<any> {
+    try {
+      if (!payload) throw new ForbiddenException(INVALID_REFRESH_TOKEN);
 
-    const user = await this.usersService.findUserById(payload.sub);
-    if (O.isNone(user)) {
-      throw new UnauthorizedException(USER_NOT_FOUND);
+      const user = await this.usersService.findUserById(payload.sub);
+      if (O.isNone(user)) {
+        throw new UnauthorizedException(USER_NOT_FOUND);
+      }
+
+      return user.value;
+    } catch (error) {
+      throw error;
     }
-
-    return user.value;
   }
 }

--- a/packages/hoppscotch-backend/src/errors.ts
+++ b/packages/hoppscotch-backend/src/errors.ts
@@ -44,6 +44,13 @@ export const AUTH_PROVIDER_NOT_CONFIGURED =
   'auth/provider_not_configured_correctly';
 
 /**
+ * Email not provided by OAuth provider
+ * (SSO Strategies)
+ */
+export const AUTH_EMAIL_NOT_PROVIDED_BY_OAUTH =
+  'auth/email_not_provided_by_oauth';
+
+/**
  * Environment variable "VITE_ALLOWED_AUTH_PROVIDERS" is not present in .env file
  */
 export const ENV_NOT_FOUND_KEY_AUTH_PROVIDERS =


### PR DESCRIPTION
refactor(auth): enhance GithubStrategy with type safety, error handling, and secure validation

- Added explicit typing for accessToken, refreshToken, and profile
- Introduced defensive checks for missing GitHub email
- Wrapped logic in try-catch for robust error handling
- Ensured use of Passport's `done()` callback
- Improved future safety with optional chaining and explicit string config values
