### PR TITLE
fix(desktop): extend file-write permissions

### DIFF
--- a/packages/hoppscotch-desktop/src-tauri/capabilities/default.json
+++ b/packages/hoppscotch-desktop/src-tauri/capabilities/default.json
@@ -16,6 +16,7 @@
     "dialog:default",
     "process:default",
     "updater:default",
+    "fs:allow-write-file",
     "fs:allow-write-text-file",
     "deep-link:default",
     "appload:default",


### PR DESCRIPTION
When trying to save non-text files, i.e. binary, etc. the call fails with `Command plugin:fs|write_file not allowed by ACL`.

This is due to capabilities config only allowing permission for writing text files, and none other.

This is part of the new Tauri v2 permissions framework.

Closes HFE-874
Closes #4934

#### Notes to reviewers:

Try something like GET https://www.filesampleshub.com/download/document/doc/sample2.doc.

Once there's a response, click "Download file" -> select a location -> save the file.

The download should fail on older version, and should successfully save response with this patch.