### PR TITLE
HSB-514 refactor: remove unused `CollType` GQL enum

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -28,7 +28,7 @@ services:
     environment:
       # DATABASE_URL is read from the .env file to allow the backend to connect with an external database.
       # This allows the backend to retain existing data and prevents database resets during deployments.
-      - DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch
+      # - DATABASE_URL=postgresql://postgres:testpass@hoppscotch-db:5432/hoppscotch
       - ENABLE_SUBPATH_BASED_ACCESS=true
     env_file:
       - ./.env

--- a/packages/hoppscotch-backend/src/user-collection/user-collections.model.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collections.model.ts
@@ -58,10 +58,6 @@ export class UserCollectionRemovedData {
   type: ReqType;
 }
 
-registerEnumType(ReqType, {
-  name: 'CollType',
-});
-
 @ObjectType()
 export class UserCollectionExportJSONData {
   @Field(() => ID, {
@@ -119,7 +115,3 @@ export class UserCollectionDuplicatedData {
   })
   requests: UserRequest[];
 }
-
-registerEnumType(ReqType, {
-  name: 'CollType',
-});


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes HSB-514

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
This PR performs a cleanup by removing an unused GraphQL enum named `CollType`.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
No functional changes introduced. This is purely a cleanup PR to keep the codebase tidy.