### PR TITLE
feat(kernel): multi-instance support for `store`

### DIFF
--- a/packages/hoppscotch-common/src/kernel/store.ts
+++ b/packages/hoppscotch-common/src/kernel/store.ts
@@ -6,41 +6,65 @@ import type {
 } from "@hoppscotch/kernel"
 import * as E from "fp-ts/Either"
 import { getModule } from "."
+import { invoke } from "@tauri-apps/api/core"
+import { join } from "@tauri-apps/api/path"
+
+const STORE_PATH = `${window.location.host}.hoppscotch.store`
 
 export const Store = (() => {
   const module = () => getModule("store")
 
   return {
     capabilities: () => module().capabilities,
-    init: () => module().init(),
-    set: (
+
+    init: async () => {
+      return module().init(STORE_PATH)
+    },
+
+    set: async (
       namespace: string,
       key: string,
       value: unknown,
       options?: StorageOptions
-    ): Promise<E.Either<StoreError, void>> =>
-      module().set(namespace, key, value, options),
-    get: <T>(
+    ): Promise<E.Either<StoreError, void>> => {
+      return module().set(STORE_PATH, namespace, key, value, options)
+    },
+
+    get: async <T>(
       namespace: string,
       key: string
-    ): Promise<E.Either<StoreError, T | undefined>> =>
-      module().get<T>(namespace, key),
-    remove: (
+    ): Promise<E.Either<StoreError, T | undefined>> => {
+      return module().get<T>(STORE_PATH, namespace, key)
+    },
+
+    remove: async (
       namespace: string,
       key: string
-    ): Promise<E.Either<StoreError, boolean>> =>
-      module().remove(namespace, key),
-    clear: (namespace?: string): Promise<E.Either<StoreError, void>> =>
-      module().clear(namespace),
-    has: (
+    ): Promise<E.Either<StoreError, boolean>> => {
+      return module().remove(STORE_PATH, namespace, key)
+    },
+
+    clear: async (namespace?: string): Promise<E.Either<StoreError, void>> => {
+      return module().clear(STORE_PATH, namespace)
+    },
+
+    has: async (
       namespace: string,
       key: string
-    ): Promise<E.Either<StoreError, boolean>> => module().has(namespace, key),
-    listNamespaces: (): Promise<E.Either<StoreError, string[]>> =>
-      module().listNamespaces(),
-    listKeys: (namespace: string): Promise<E.Either<StoreError, string[]>> =>
-      module().listKeys(namespace),
-    watch: (namespace: string, key: string): StoreEventEmitter<StoreEvents> =>
-      module().watch(namespace, key),
+    ): Promise<E.Either<StoreError, boolean>> => {
+      return module().has(STORE_PATH, namespace, key)
+    },
+
+    listNamespaces: async (): Promise<E.Either<StoreError, string[]>> => {
+      return module().listNamespaces(STORE_PATH)
+    },
+
+    listKeys: async (namespace: string): Promise<E.Either<StoreError, string[]>> => {
+      return module().listKeys(STORE_PATH, namespace)
+    },
+
+    watch: async (namespace: string, key: string): Promise<StoreEventEmitter<StoreEvents>> => {
+      return module().watch(STORE_PATH, namespace, key)
+    },
   } as const
 })()

--- a/packages/hoppscotch-common/src/kernel/store.ts
+++ b/packages/hoppscotch-common/src/kernel/store.ts
@@ -6,8 +6,6 @@ import type {
 } from "@hoppscotch/kernel"
 import * as E from "fp-ts/Either"
 import { getModule } from "."
-import { invoke } from "@tauri-apps/api/core"
-import { join } from "@tauri-apps/api/path"
 
 const STORE_PATH = `${window.location.host}.hoppscotch.store`
 

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/index.ts
@@ -147,7 +147,7 @@ export class AgentKernelInterceptorService
           ...effectiveRequest.headers,
           "User-Agent": existingUserAgentHeader
             ? effectiveRequest.headers[existingUserAgentHeader]
-            : "HoppscotchKernel/0.1.0",
+            : "HoppscotchKernel/0.2.0",
         },
       }
 

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/store.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/store.ts
@@ -90,8 +90,9 @@ export class KernelInterceptorAgentStore extends Service {
     }
   }
 
-  private setupWatchers() {
-    Store.watch(STORE_NAMESPACE, STORE_KEYS.SETTINGS).on(
+  private async setupWatchers() {
+    const watcher = await Store.watch(STORE_NAMESPACE, STORE_KEYS.SETTINGS)
+    watcher.on(
       "change",
       async ({ value }) => {
         if (value) {

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/extension/store.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/extension/store.ts
@@ -88,7 +88,8 @@ export class KernelInterceptorExtensionStore extends Service {
       this.setupExtensionStatusListener()
     }
 
-    Store.watch(STORE_NAMESPACE, SETTINGS_KEY).on(
+    const watcher = await Store.watch(STORE_NAMESPACE, SETTINGS_KEY)
+    watcher.on(
       "change",
       async ({ value }) => {
         if (value) {

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/native/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/native/index.ts
@@ -207,7 +207,7 @@ export class NativeKernelInterceptorService
           ...effectiveRequest.headers,
           "User-Agent": existingUserAgentHeader
             ? effectiveRequest.headers[existingUserAgentHeader]
-            : "HoppscotchKernel/0.1.0",
+            : "HoppscotchKernel/0.2.0",
         },
       }
 

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/native/store.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/native/store.ts
@@ -72,8 +72,9 @@ export class KernelInterceptorNativeStore extends Service {
     }
   }
 
-  private setupWatchers() {
-    Store.watch(STORE_NAMESPACE, STORE_KEYS.SETTINGS).on(
+  private async setupWatchers() {
+    const watcher = await Store.watch(STORE_NAMESPACE, STORE_KEYS.SETTINGS)
+    watcher.on(
       "change",
       async ({ value }) => {
         if (value) {

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/store.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/store.ts
@@ -38,7 +38,8 @@ export class KernelInterceptorProxyStore extends Service {
 
     await this.loadSettings()
 
-    Store.watch(STORE_NAMESPACE, SETTINGS_KEY).on(
+    const watcher = await Store.watch(STORE_NAMESPACE, SETTINGS_KEY)
+    watcher.on(
       "change",
       async ({ value }) => {
         if (value) {

--- a/packages/hoppscotch-kernel/README.md
+++ b/packages/hoppscotch-kernel/README.md
@@ -42,7 +42,7 @@ Cross-platform persistence with encryption support:
 interface StoreV1 {
   readonly capabilities: Set<StoreCapability>
   set(namespace: string, key: string, value: unknown, options?: StorageOptions): Promise<Either<StoreError, void>>
-  watch(namespace: string, key: string): StoreEventEmitter<StoreEvents>
+  watch(namespace: string, key: string): Promise<StoreEventEmitter<StoreEvents>>
 }
 ```
 

--- a/packages/hoppscotch-kernel/README.md
+++ b/packages/hoppscotch-kernel/README.md
@@ -86,7 +86,8 @@ await kernel.store.set("collections", "team-a", data, {
 })
 
 // Watch for changes
-kernel.store.watch("collections", "team-a").on("change", 
+const watcher = await kernel.store.watch("collections", "team-a")
+watcher.on("change", 
   (update) => console.log("Collection updated:", update)
 )
 ```

--- a/packages/hoppscotch-kernel/package.json
+++ b/packages/hoppscotch-kernel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoppscotch/kernel",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cross-platform runtime kernel for Hoppscotch platform-ops",
   "type": "module",
   "main": "dist/hoppscotch-kernel.cjs",

--- a/packages/hoppscotch-kernel/src/store/impl/web/v/1.ts
+++ b/packages/hoppscotch-kernel/src/store/impl/web/v/1.ts
@@ -91,7 +91,7 @@ class BrowserStoreManager {
             .map(key => key.replace(`${namespace}:`, ''));
     }
 
-    watch(namespace: string, key: string): StoreEventEmitter<StoreEvents> {
+    async watch(namespace: string, key: string): Promise<StoreEventEmitter<StoreEvents>> {
         const fullKey = this.getFullKey(namespace, key);
         return {
             on: (event, handler) => {
@@ -129,7 +129,10 @@ export const implementation: VersionedAPI<StoreV1> = {
         id: 'browser-store',
         capabilities: new Set(['permanent', 'structured', 'watch', 'namespace']),
 
-        async init() {
+        // `init` and other methods in `web` don't `storePath`
+        // but having a consistent API where first param of every method
+        // is the path that filteres to the "realm" makes it easier to reason around
+        async init(_storePath) {
             try {
                 return E.right(undefined);
             } catch (e) {
@@ -141,7 +144,7 @@ export const implementation: VersionedAPI<StoreV1> = {
             }
         },
 
-        async set(namespace, key, value, options) {
+        async set(_storePath, namespace, key, value, options) {
             try {
                 const manager = BrowserStoreManager.new();
                 const existingData = await manager.getRaw(namespace, key);
@@ -172,7 +175,7 @@ export const implementation: VersionedAPI<StoreV1> = {
             }
         },
 
-        async get(namespace, key) {
+        async get(_storePath, namespace, key) {
             try {
                 const manager = BrowserStoreManager.new();
                 return E.right(await manager.get(namespace, key));
@@ -185,7 +188,7 @@ export const implementation: VersionedAPI<StoreV1> = {
             }
         },
 
-        async has(namespace, key) {
+        async has(_storePath, namespace, key) {
             try {
                 const manager = BrowserStoreManager.new();
                 return E.right(await manager.has(namespace, key));
@@ -198,7 +201,7 @@ export const implementation: VersionedAPI<StoreV1> = {
             }
         },
 
-        async remove(namespace, key) {
+        async remove(_storePath, namespace, key) {
             try {
                 const manager = BrowserStoreManager.new();
                 return E.right(await manager.delete(namespace, key));
@@ -211,7 +214,7 @@ export const implementation: VersionedAPI<StoreV1> = {
             }
         },
 
-        async clear(namespace) {
+        async clear(_storePath, namespace) {
             try {
                 const manager = BrowserStoreManager.new();
                 await manager.clear(namespace);
@@ -225,7 +228,7 @@ export const implementation: VersionedAPI<StoreV1> = {
             }
         },
 
-        async listNamespaces() {
+        async listNamespaces(_storePath){
             try {
                 const manager = BrowserStoreManager.new();
                 return E.right(await manager.listNamespaces());
@@ -238,7 +241,7 @@ export const implementation: VersionedAPI<StoreV1> = {
             }
         },
 
-        async listKeys(namespace) {
+        async listKeys(_storePath, namespace) {
             try {
                 const manager = BrowserStoreManager.new();
                 return E.right(await manager.listKeys(namespace));
@@ -251,7 +254,7 @@ export const implementation: VersionedAPI<StoreV1> = {
             }
         },
 
-        watch(namespace, key) {
+        async watch(_storePath, namespace, key) {
             const manager = BrowserStoreManager.new();
             return manager.watch(namespace, key);
         },

--- a/packages/hoppscotch-kernel/src/store/v/1.ts
+++ b/packages/hoppscotch-kernel/src/store/v/1.ts
@@ -84,15 +84,15 @@ export interface StoreV1 {
   readonly id: string
   readonly capabilities: Set<StoreCapability>
 
-  init(): Promise<E.Either<StoreError, void>>
-  set(namespace: string, key: string, value: unknown, options?: StorageOptions): Promise<E.Either<StoreError, void>>
-  get<T>(namespace: string, key: string): Promise<E.Either<StoreError, T | undefined>>
-  remove(namespace: string, key: string): Promise<E.Either<StoreError, boolean>>
-  clear(namespace?: string): Promise<E.Either<StoreError, void>>
-  has(namespace: string, key: string): Promise<E.Either<StoreError, boolean>>
-  listNamespaces(): Promise<E.Either<StoreError, string[]>>
-  listKeys(namespace: string): Promise<E.Either<StoreError, string[]>>
-  watch(namespace: string, key: string): StoreEventEmitter<StoreEvents>
+  init(storePath: string): Promise<E.Either<StoreError, void>>
+  set(storePath: string, namespace: string, key: string, value: unknown, options?: StorageOptions): Promise<E.Either<StoreError, void>>
+  get<T>(storePath: string, namespace: string, key: string): Promise<E.Either<StoreError, T | undefined>>
+  remove(storePath: string, namespace: string, key: string): Promise<E.Either<StoreError, boolean>>
+  clear(storePath: string, namespace?: string): Promise<E.Either<StoreError, void>>
+  has(storePath: string, namespace: string, key: string): Promise<E.Either<StoreError, boolean>>
+  listNamespaces(storePath: string): Promise<E.Either<StoreError, string[]>>
+  listKeys(storePath: string, namespace: string): Promise<E.Either<StoreError, string[]>>
+  watch(storePath: string, namespace: string, key: string): Promise<StoreEventEmitter<StoreEvents>>
 }
 
 export const v1: VersionedAPI<StoreV1> = {
@@ -109,7 +109,7 @@ export const v1: VersionedAPI<StoreV1> = {
     has: async () => E.left({ kind: 'version', message: 'Not implemented' }),
     listNamespaces: async () => E.left({ kind: 'version', message: 'Not implemented' }),
     listKeys: async () => E.left({ kind: 'version', message: 'Not implemented' }),
-    watch: () => ({
+    watch: async () => ({
       on: () => () => {},
       once: () => () => {},
       off: () => {}


### PR DESCRIPTION
### Summery

This adds a multi-store architecture to the kernel storage module, adding ability to manages persistent data across execution environments.

It also bubbles up the storage realm setup from library level to consumer API level, basically moving

```typescript
const STORE_PATH = `${window.location.host}.hoppscotch.store`
```

from `hoppscotch-kernel/store` to `hoppscotch-common/kernel/store`

This basically allows for concurrent access to multiple isolated storage instances, each addressable by a distinct path, and this also addresses an architectural limitation in the current implementation, which relies on a singleton pattern plus a constant.

Closes HFE-877

### Notes to reviewers

There are no functional changes so we only need to make sure everything works as expected, especially the store operation.

### Details

The existing approach lacked flexibility for adapting to different deployments, for example in cases where storage path requirements vary based on context.

Note that library version has changed since this introduces new param, but store version hasn't changed (from major 1) since these changes do not require migrating data.

By moving from a singleton design to a multi-instance architecture, this provides the foundation for supporting "application modes", multi-profile configurations, and isolation between storage domains.

This keeps the `TauriStoreManager` into a singleton model, but adds support for a multi-instance architecture managed through a static map:

Essentially from

```typescript
private static instance: TauriStoreManager;
```

to

```typescript
private static instances: Map<string, TauriStoreManager> = new Map();
```

These change extends to every storage operation in the API surface.

Previously, storage operations implicitly operated against a single hardcoded storage path. Now, all operations accept an explicit `storePath` parameter, allowing them to target specific storage instances based on runtime requirements, also makes sure isolation between different storage domains.

Essentially from

```typescript
async get<T>(namespace: string, key: string): Promise<E.Either<StoreError, T | undefined>>
```

to

```typescript
async get<T>(storePath: string, namespace: string, key: string): Promise<E.Either<StoreError, T | undefined>>
```

Think of this as rather than implicitly targeting a global singleton, each operation now explicitly specifies which "storage realm" it intends to interact with.

There are also now methods for resource lifecycle management:

```typescript
static async closeAll(): Promise<void> { ... }
static async closeStore(storePath: string): Promise<void> { .. }
```

although it is not necessary to use those since much of the lifecycle handling is done by `LazyStore` implicitly.

The implementation also refactors the manager's constructor to receive and store the path identifier, to create a direct association between each instance and its storage location. This is mainly to maintain their identity throughout their lifecycle.

```typescript
private constructor(storePath: string) {
    this.storePath = storePath;
}
```

One of the major future goals associated with this is dynamic storage path resolution based on execution context.

Essentially different environments have different conventions and requirements for data storage. The desktop app needs to respect system-specific directory permissions, think when running in portable mode without installation privileges.

Here's an example of path resolution strategy that abstract these complexities from the consuming code:

```typescript
const getStorePath = async (): Promise<string> => {
  try {
    const instanceDir = await invoke<string>('get_instance_dir')
    return join(instanceDir, STORE_PATH)
  } catch (error) {
    console.error('Failed to get instance directory:', error)
    return 'hoppscotch-unified.selfhost.store'
  }
}
const path = await getStorePath()
```

vs what we had before:

```typescript
const STORE_PATH = `${window.location.host}.hoppscotch.store`
const path = STORE_PATH
```

Now this way we get the ability to add methods for discovering storage locations based on app mode where the boundary is determined by the underlying backend:

```rust
pub fn instance_dir() -> io::Result<PathBuf> {
    let path = config_dir()?.join("instance");
    std::fs::create_dir_all(&path)?;
    Ok(path)
}

pub fn get_instance_dir() -> Result<String, String> {
    instance_dir()
        .map(|path| path.to_string_lossy().to_string())
        .map_err(|err| err.to_string())
}
```

Also the previous impl returned event emitters synchronously, which conflicts with the new approach where store path resolution involve async ops (path resolution -> IPC calls). So this also refactors the watcher pattern to be fully async:

```typescript
const watcher = await Store.watch(STORE_NAMESPACE, STORE_KEYS.SETTINGS)
watcher.on(
  "change",
  async ({ value }) => { ... }
);
```