### PR TITLE
fix: include request body to AWS V4 signer in effective request functions

### DIFF
--- a/packages/hoppscotch-cli/src/utils/pre-request.ts
+++ b/packages/hoppscotch-cli/src/utils/pre-request.ts
@@ -202,8 +202,11 @@ export async function getEffectiveRESTRequest(
       const amzDate = currentDate.toISOString().replace(/[:-]|\.\d{3}/g, "");
       const { method, endpoint } = request;
 
+      const body = getFinalBodyFromRequest(request, resolvedVariables);
+
       const signer = new AwsV4Signer({
         method,
+        body: E.isRight(body) ? body.right?.toString() : undefined,
         datetime: amzDate,
         signQuery: addTo === "QUERY_PARAMS",
         accessKeyId: parseTemplateString(

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -222,8 +222,12 @@ export const getComputedAuthHeaders = async (
       const currentDate = new Date()
       const amzDate = currentDate.toISOString().replace(/[:-]|\.\d{3}/g, "")
       const { method, endpoint } = req as HoppRESTRequest
+
+      const body = getFinalBodyFromRequest(request, envVars)
+
       const signer = new AwsV4Signer({
         method: method,
+        body: body?.toString(),
         datetime: amzDate,
         accessKeyId: parseTemplateString(request.auth.accessKey, envVars),
         secretAccessKey: parseTemplateString(request.auth.secretKey, envVars),


### PR DESCRIPTION
Closes #5064

### What's changed
This pull request addresses issue #5084 by modifying the effective request functions to include the request body when signing requests with AWS V4. This enhancement ensures that the request signature is generated accurately, taking into account the content of the request body, which is crucial for the integrity and security of the requests made to AWS services.