### PR TITLE
chore(common): improved i18n strings

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -70,7 +70,8 @@
     "yes": "Yes",
     "verify": "Verify",
     "enable": "Enable",
-    "disable": "Disable"
+    "disable": "Disable",
+    "assign": "Assign"
   },
   "activity_logs": {
     "ACTIVITY_LOG_DELETE": "Activity log has been deleted",


### PR DESCRIPTION
Add a new translation string for `assign`