### PR TITLE
fix: correct import order for HoppRESTAuth

### DIFF
--- a/packages/hoppscotch-data/src/rest/index.ts
+++ b/packages/hoppscotch-data/src/rest/index.ts
@@ -17,8 +17,8 @@ import V7_VERSION, { HoppRESTHeaders, HoppRESTParams } from "./v/7"
 import V8_VERSION from "./v/8"
 import V9_VERSION from "./v/9"
 import V10_VERSION, { HoppRESTReqBody } from "./v/10"
-import V11_VERSION, { HoppRESTAuth, HoppRESTRequestResponses } from "./v/11"
-import V12_VERSION from "./v/12"
+import V11_VERSION, { HoppRESTRequestResponses } from "./v/11"
+import V12_VERSION, { HoppRESTAuth } from "./v/12"
 
 export * from "./content-types"
 


### PR DESCRIPTION
Adjust the import statements in the REST module for consistency and clarity.