### PR TITLE
fix: fill current value to existing value

### DIFF
--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -45,7 +45,7 @@ const processVariables = (variable: Environment["variables"][number]) => {
       currentValue:
         "currentValue" in variable && variable.currentValue !== ""
           ? variable.currentValue
-          : process.env[variable.key] || "",
+          : process.env[variable.key] || variable.initialValue,
     };
   }
   return variable;

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -380,7 +380,7 @@ watch(
                   ? "Global"
                   : workingEnvID.value,
                 index
-              ) ?? "",
+              ) ?? e.currentValue,
             initialValue: e.initialValue,
             secret: e.secret,
           },

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -347,7 +347,7 @@ watch(
                   props.editingEnvironment?.id ?? "",
                   index,
                   e.secret
-                ) ?? "",
+                ) ?? e.currentValue,
               initialValue: e.initialValue,
               secret: e.secret,
             },

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -125,7 +125,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
                 ? currentSelectedEnvironment.id
                 : "Global",
               tooltipEnv?.key ?? ""
-            )?.currentValue ?? "")
+            )?.currentValue ?? tooltipEnv?.currentValue)
           : tooltipEnv?.currentValue
 
       const hasSecretEnv = secretEnvironmentService.hasSecretValue(

--- a/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
@@ -47,7 +47,7 @@ export const transformEnvironmentVariables = ({
         key,
         secret,
         initialValue,
-        currentValue: "",
+        currentValue: variable.secret ? "" : (variable.currentValue ?? ""),
       }
     }),
   }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomniaEnv.ts
@@ -76,7 +76,7 @@ export const insomniaEnvImporter = (contents: string[]) => {
           ([key, value]) => ({
             key,
             initialValue: value,
-            currentValue: "",
+            currentValue: value,
             secret: false,
           })
         ),

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
@@ -57,7 +57,7 @@ export const postmanEnvImporter = (contents: string[]) => {
       variables: values.map(({ key, value, type }) => ({
         key,
         initialValue: value,
-        currentValue: "",
+        currentValue: value,
         secret: type === "secret",
       })),
     })

--- a/packages/hoppscotch-common/src/helpers/utils/environments.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/environments.ts
@@ -38,7 +38,13 @@ const unWrapEnvironments = (
         currentValue: secretVar.value,
       }
     }
-    return { ...globalVar, currentValue: currentVar?.currentValue ?? "" }
+    return {
+      ...globalVar,
+      currentValue:
+        currentVar?.currentValue ??
+        globalVar.currentValue ??
+        globalVar.initialValue,
+    }
   })
 
   const resolvedSelectedWithSecrets = selected.variables.map(
@@ -57,7 +63,13 @@ const unWrapEnvironments = (
           currentValue: secretVar.value,
         }
       }
-      return { ...selectedVar, currentValue: currentVar?.currentValue ?? "" }
+      return {
+        ...selectedVar,
+        currentValue:
+          currentVar?.currentValue ??
+          selectedVar.currentValue ??
+          selectedVar.initialValue,
+      }
     }
   )
 

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -523,17 +523,16 @@ export function getAggregateEnvs() {
 
 export function getAggregateEnvsWithSecrets() {
   const currentEnv = getCurrentEnvironment()
+
   return [
     ...currentEnv.variables.map((x, index) => {
-      let currentValue
+      let currentValue = x.currentValue
       if (x.secret) {
         currentValue =
           secretEnvironmentService.getSecretEnvironmentVariableValue(
             currentEnv.id,
             index
-          )
-      } else {
-        currentValue = x.currentValue
+          ) ?? ""
       }
 
       return <AggregateEnvironment>{
@@ -545,15 +544,13 @@ export function getAggregateEnvsWithSecrets() {
       }
     }),
     ...getGlobalVariables().map((x, index) => {
-      let currentValue
+      let currentValue = x.currentValue
       if (x.secret) {
         currentValue =
           secretEnvironmentService.getSecretEnvironmentVariableValue(
             "Global",
             index
-          )
-      } else {
-        currentValue = x.currentValue
+          ) ?? ""
       }
       return <AggregateEnvironment>{
         key: x.key,
@@ -571,19 +568,17 @@ export const aggregateEnvsWithSecrets$: Observable<AggregateEnvironment[]> =
     map(([selectedEnv, globalEnv]) => {
       const results: AggregateEnvironment[] = []
       selectedEnv?.variables.map((x, index) => {
-        let currentValue
+        let currentValue = x.currentValue
         if (x.secret) {
           currentValue =
             secretEnvironmentService.getSecretEnvironmentVariableValue(
               selectedEnv.id,
               index
-            )
-        } else {
-          currentValue = x.currentValue
+            ) ?? ""
         }
         results.push({
           key: x.key,
-          currentValue: currentValue ?? "",
+          currentValue: currentValue,
           initialValue: x.initialValue,
           secret: x.secret,
           sourceEnv: selectedEnv.name,
@@ -591,19 +586,17 @@ export const aggregateEnvsWithSecrets$: Observable<AggregateEnvironment[]> =
       })
 
       globalEnv.variables.map((x, index) => {
-        let currentValue
+        let currentValue = x.currentValue
         if (x.secret) {
           currentValue =
             secretEnvironmentService.getSecretEnvironmentVariableValue(
               "Global",
               index
-            )
-        } else {
-          currentValue = x.currentValue
+            ) ?? ""
         }
         results.push({
           key: x.key,
-          currentValue: currentValue ?? "",
+          currentValue: currentValue,
           initialValue: x.initialValue,
           secret: x.secret,
           sourceEnv: "Global",

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -221,12 +221,13 @@ export class EnvironmentInspectorService extends Service implements Inspector {
                 env.key
               )
 
-              const hasCurrentValue = this.currentEnvs.hasValue(
-                env.sourceEnv !== "Global"
-                  ? currentSelectedEnvironment.id
-                  : "Global",
-                env.key
-              )
+              const hasCurrentValue =
+                this.currentEnvs.hasValue(
+                  env.sourceEnv !== "Global"
+                    ? currentSelectedEnvironment.id
+                    : "Global",
+                  env.key
+                ) || env.currentValue !== ""
 
               if (env.key === formattedExEnv) {
                 if (env.secret ? !hasSecretEnv : !hasCurrentValue) {

--- a/packages/hoppscotch-data/src/environment/index.ts
+++ b/packages/hoppscotch-data/src/environment/index.ts
@@ -204,7 +204,7 @@ export const translateToNewEnvironmentVariables = (
   return {
     key: x.key,
     initialValue: x.initialValue ?? x.value ?? "",
-    currentValue: "",
+    currentValue: x.currentValue ?? x.value ?? "",
     secret: false,
   }
 }

--- a/packages/hoppscotch-data/src/environment/v/2.ts
+++ b/packages/hoppscotch-data/src/environment/v/2.ts
@@ -32,7 +32,7 @@ export default defineVersion({
           key,
           secret,
           initialValue: secret ? "" : variable.value,
-          currentValue: "",
+          currentValue: secret ? "" : variable.value,
         }
       }),
     }


### PR DESCRIPTION
This PR fixes the issue where current value is empty on migration.
