### PR TITLE
feat(common): change REST method text color based on selected method

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -20,6 +20,9 @@
                 :value="tab.document.request.method"
                 :readonly="!isCustomMethod"
                 :placeholder="`${t('request.method')}`"
+                :style="{
+                  color: getMethodLabelColor(tab.document.request.method),
+                }"
                 @input="onSelectMethod($event)"
               />
             </HoppSmartSelectWrapper>


### PR DESCRIPTION
This PR adds color styling to the selected HTTP request type to make the color consistent with:
- The color of the request type in the tab
- The color of the request type in the dropdown selector

Before:
<img width="129" alt="image" src="https://github.com/user-attachments/assets/888d4825-8dad-41f5-bd03-2adb14e2d41a" />
<img width="126" alt="image" src="https://github.com/user-attachments/assets/417eebd8-cb55-43db-8d5a-818e384b1bdc" />
<img width="126" alt="image" src="https://github.com/user-attachments/assets/c27ca2d4-7f95-4931-9ff5-a258ceba10f4" />

After:
<img width="116" alt="image" src="https://github.com/user-attachments/assets/2d55cc7b-fa0c-4662-a637-16cb036cf549" />
<img width="111" alt="image" src="https://github.com/user-attachments/assets/067f5f4b-fc6a-4c28-9d8e-cce8c58e55e2" />
<img width="123" alt="image" src="https://github.com/user-attachments/assets/9f7ecd62-3548-4e73-89ad-45a923004a6a" />

Closes #5112 

### What's changed
Added a color style to the `input` element of `HoppSmartSelectWrapper` based on the active REST request method type

### Notes to reviewers

