### PR TITLE
fix(desktop): in-memory update progress polling

### DIFF
--- a/packages/hoppscotch-desktop/src/types/index.ts
+++ b/packages/hoppscotch-desktop/src/types/index.ts
@@ -31,8 +31,4 @@ export interface UpdateState {
   status: UpdateStatus;
   version?: string;
   message?: string;
-  progress?: {
-    downloaded: number;
-    total?: number;
-  };
 }

--- a/packages/hoppscotch-desktop/src/utils/updater.ts
+++ b/packages/hoppscotch-desktop/src/utils/updater.ts
@@ -97,10 +97,6 @@ export class UpdaterService {
 
       await this.saveUpdateState({
         status: UpdateStatus.DOWNLOADING,
-        progress: {
-          downloaded: 0,
-          total: undefined
-        }
       });
 
       await updateResult.downloadAndInstall(

--- a/packages/hoppscotch-desktop/src/utils/updater.ts
+++ b/packages/hoppscotch-desktop/src/utils/updater.ts
@@ -4,12 +4,18 @@ import { type LazyStore } from "@tauri-apps/plugin-store";
 import { UpdateStatus, CheckResult, UpdateState } from "~/types";
 
 export class UpdaterService {
+  private currentProgress: { downloaded: number; total?: number } = { downloaded: 0 };
+
   constructor(private store: LazyStore) {}
 
   async initialize(): Promise<void> {
     await this.saveUpdateState({
       status: UpdateStatus.IDLE
     });
+  }
+
+  getCurrentProgress(): { downloaded: number; total?: number } {
+    return this.currentProgress;
   }
 
   async checkForUpdates(timeout = 5000): Promise<CheckResult> {
@@ -86,6 +92,9 @@ export class UpdaterService {
         throw new Error("No update available to install");
       }
 
+      let totalBytes: number | undefined;
+      let downloadedBytes = 0;
+
       await this.saveUpdateState({
         status: UpdateStatus.DOWNLOADING,
         progress: {
@@ -94,33 +103,29 @@ export class UpdaterService {
         }
       });
 
-      let totalBytes: number | undefined;
-      let downloadedBytes = 0;
-
       await updateResult.downloadAndInstall(
         (event: DownloadEvent) => {
-          if (event.event === 'Started') {
-            totalBytes = event.data.contentLength;
-            this.saveUpdateState({
-              status: UpdateStatus.DOWNLOADING,
-              progress: {
-                downloaded: 0,
-                total: totalBytes
-              }
-            });
-          } else if (event.event === 'Progress') {
-            downloadedBytes += event.data.chunkLength;
-            this.saveUpdateState({
-              status: UpdateStatus.DOWNLOADING,
-              progress: {
+          try {
+            if (event.event === 'Started') {
+              totalBytes = event.data.contentLength;
+              downloadedBytes = 0;
+              console.log(`Download started, total size: ${totalBytes} bytes`);
+            } else if (event.event === 'Progress') {
+              downloadedBytes += event.data.chunkLength;
+              console.log(`Download progress: ${downloadedBytes}/${totalBytes} bytes`);
+
+              this.currentProgress = {
                 downloaded: downloadedBytes,
                 total: totalBytes
-              }
-            });
-          } else if (event.event === 'Finished') {
-            this.saveUpdateState({
-              status: UpdateStatus.INSTALLING
-            });
+              };
+            } else if (event.event === 'Finished') {
+              console.log("Download finished, starting installation");
+              this.saveUpdateState({
+                status: UpdateStatus.INSTALLING
+              });
+            }
+          } catch (error) {
+            console.warn('Progress tracking error:', error);
           }
         }
       );

--- a/packages/hoppscotch-desktop/src/views/Home.vue
+++ b/packages/hoppscotch-desktop/src/views/Home.vue
@@ -213,10 +213,6 @@ const setupUpdateStateWatcher = async () => {
       updateStatus.value = newValue.status
       updateMessage.value = newValue.message || ""
 
-      if (newValue.progress) {
-        downloadProgress.value = newValue.progress
-      }
-
       if (newValue.status === UpdateStatus.AVAILABLE) {
         appState.value = AppState.UPDATE_AVAILABLE
       } else if (newValue.status === UpdateStatus.ERROR) {

--- a/packages/hoppscotch-desktop/src/views/Home.vue
+++ b/packages/hoppscotch-desktop/src/views/Home.vue
@@ -129,7 +129,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from "vue"
+import { ref, onMounted, onUnmounted } from "vue"
 import { LazyStore } from "@tauri-apps/plugin-store"
 import { load } from "@hoppscotch/plugin-appload"
 import { getVersion } from "@tauri-apps/api/app"
@@ -183,6 +183,8 @@ const appVersion = ref("...")
 
 const updaterService = new UpdaterService(appStore)
 
+let progressPollingInterval: ReturnType<typeof setInterval> | undefined
+
 const formatBytes = (bytes: number): string => {
   if (bytes === 0) return "0 Bytes"
 
@@ -220,18 +222,47 @@ const setupUpdateStateWatcher = async () => {
       } else if (newValue.status === UpdateStatus.ERROR) {
         error.value = newValue.message || "Unknown error"
         appState.value = AppState.ERROR
+        // Stop progress polling on error
+        stopProgressPolling()
       } else if (
         newValue.status === UpdateStatus.DOWNLOADING ||
         newValue.status === UpdateStatus.INSTALLING
       ) {
         appState.value = AppState.UPDATE_IN_PROGRESS
+        // Start progress polling when downloading
+        if (newValue.status === UpdateStatus.DOWNLOADING) {
+          startProgressPolling()
+        } else {
+          // Stop progress polling when installing
+          stopProgressPolling()
+        }
       } else if (newValue.status === UpdateStatus.READY_TO_RESTART) {
         appState.value = AppState.UPDATE_READY
+        // Stop progress polling when ready to restart
+        stopProgressPolling()
       }
     }
   )
 
   return unsubscribe
+}
+
+const startProgressPolling = () => {
+  if (progressPollingInterval) return
+
+  progressPollingInterval = setInterval(() => {
+    const currentProgress = updaterService.getCurrentProgress()
+    if (currentProgress.downloaded > downloadProgress.value.downloaded) {
+      downloadProgress.value = currentProgress
+    }
+  }, 100)
+}
+
+const stopProgressPolling = () => {
+  if (progressPollingInterval) {
+    clearInterval(progressPollingInterval)
+    progressPollingInterval = undefined
+  }
 }
 
 const installUpdate = async () => {
@@ -244,6 +275,7 @@ const installUpdate = async () => {
     const errorMessage = err instanceof Error ? err.message : String(err)
     error.value = `Failed to install update: ${errorMessage}`
     appState.value = AppState.ERROR
+    stopProgressPolling()
   }
 }
 
@@ -332,6 +364,7 @@ const initialize = async () => {
   appState.value = AppState.LOADING
   error.value = ""
   downloadProgress.value = { downloaded: 0 }
+  stopProgressPolling()
 
   try {
     try {
@@ -367,5 +400,9 @@ const initialize = async () => {
 
 onMounted(() => {
   initialize()
+})
+
+onUnmounted(() => {
+  stopProgressPolling()
 })
 </script>


### PR DESCRIPTION
This fixes a Windows-specific issue where the updater would hang during download and installation.

The cause was file I/O operations called from within progress callbacks conflicting with Windows' "stricter" fs behavior during concurrent ops.

This move that to an in-memory tracking with periodic polling, removing all disk writes from the download callback to only for actual final commits.

Closes HFE-892
Closes #5038

### Notes to reviewers

This is a Windows-specific thing, doesn't affect Mac/Linux functionality.
The core change is moving from synchronous progress persistence to asynchronous polling-based updates.

Progress tracking remains fully functional with 100ms polling intervals for just a bit smooth UI updates.
The existing implementation called `saveUpdateState()` directly within the updater's progress callback.

This approach worked fine on Mac/Linux but not on Windows apparently due to Windows' mandatory file locking behavior.

According to the docs Windows uses mandatory locking where if one program locks the file, all other programs get error messages when they try to access it, unlike Unix which generally doesn't use locking at all, and when it does, lock is usually advisory.

The Windows file locking behavior stems from its inheritance of ["sharing mode" from LAN Manager in the MS-DOS
era](https://superuser.com/questions/1711476/file-locking-in-windows-linux), which implements "mandatory locking as a special case" while "Linux doesn't have an equivalent to 'share modes' (all access is allowed by default)".

The updater's internal I/O ops conflicted with progress disk writes because Windows uses whole file locking for most cases, part of the API for opening files `CreateFile`.

So the fix implements a polling-based arch where progress is stored in memory during download and periodically read by the UI through a polling function.