### PR TITLE
fix: use `HOPP_AIO_ALTERNATE_PORT` in healthcheck

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -9,7 +9,7 @@ curlCheck() {
 }
 
 if [ "$ENABLE_SUBPATH_BASED_ACCESS" = "true" ]; then
-  curlCheck "http://localhost:80/backend/ping" || exit 1
+  curlCheck "http://localhost:${HOPP_AIO_ALTERNATE_PORT:-80}/backend/ping" || exit 1
 else
   curlCheck "http://localhost:3000" || exit 1
   curlCheck "http://localhost:3100" || exit 1


### PR DESCRIPTION
Fixes healthcheck.sh not considering the value of HOPP_AIO_ALTERNATE_PORT, thus reporting unhealthy for any custom port that differs from 80

### What's changed
Uses the port set in HOPP_AIO_ALTERNATE_PORT (defaults to 80) for the healthcheck to prevent wrongfully reporting unhealthy status when HOPP_AIO_ALTERNATE_PORT set to custom port

### Notes to reviewers
Tested successfully with the latest version of AIO Container (at time of pull request was 2025.5.1)
