### PR TITLE
feat(envSet): enhance envSetFn to automatically convert values to strings

### DIFF
--- a/packages/hoppscotch-common/src/helpers/terndoc/pw-test.json
+++ b/packages/hoppscotch-common/src/helpers/terndoc/pw-test.json
@@ -21,7 +21,7 @@
       "body": "?"
     },
     "env": {
-      "set": "fn(key: string, value: string)",
+      "set": "fn(key: string, value: any)",
       "unset": "fn(key: string)",
       "get": "fn(key: string) -> string",
       "getResolve": "fn(key: string) -> string",

--- a/packages/hoppscotch-js-sandbox/src/shared-utils.ts
+++ b/packages/hoppscotch-js-sandbox/src/shared-utils.ts
@@ -129,16 +129,15 @@ export const getSharedMethods = (envs: TestResult["envs"]) => {
     return result
   }
 
-  const envSetFn = (key: any, value: any) => {
+  const envSetFn = (key: any, value: any = "") => {
     if (typeof key !== "string") {
       throw new Error("Expected key to be a string")
     }
 
-    if (typeof value !== "string") {
-      throw new Error("Expected value to be a string")
-    }
-
-    updatedEnvs = setEnv(key, value, updatedEnvs)
+    // Convert value to a string if it's not already to ensure compatibility.
+    // This simplifies the process of setting environment variables from
+    // responses in test scripts where the value may not be a string.
+    updatedEnvs = setEnv(key, String(value), updatedEnvs)
 
     return undefined
   }


### PR DESCRIPTION

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #[4490](https://github.com/hoppscotch/hoppscotch/issues/4490)

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This PR introduces an enhancement to the `envSetFn` utility function used within test scripts to set environment variables. The goal of this enhancement is to simplify the usage of `envSetFn` by automatically converting any value assigned to an environment variable into a string, reducing the need for manual string conversion and improving code cleanliness and efficiency.

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
- Modified `envSetFn` to automatically convert `value` parameter to a string using `String(value)`.
- Maintained the function's integrity by still requiring that the `key` parameter be a string.
- Default value for `value` set as an empty string, ensuring backwards compatibility and fault tolerance if no value is provided.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
