### PR TITLE
feat(agent): file-based logs with rotation

### DIFF
--- a/packages/hoppscotch-agent/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.lock
@@ -1477,6 +1477,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-rotate"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e8e2fa049328a1f3295991407a88585805d126dfaadf74b9fe8c194c730aafc"
+dependencies = [
+ "chrono",
+ "flate2",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2084,8 @@ dependencies = [
  "base16",
  "chrono",
  "dashmap",
+ "dirs 6.0.0",
+ "file-rotate",
  "lazy_static",
  "native-dialog",
  "rand 0.8.5",
@@ -6208,7 +6220,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/packages/hoppscotch-agent/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.toml
@@ -45,6 +45,8 @@ tauri-plugin-single-instance = "2.0.1"
 tauri-plugin-http = { version = "2.0.1", features = ["gzip"] }
 native-dialog = "0.7.0"
 sha2 = "0.10.8"
+file-rotate = "0.8.0"
+dirs = "6.0.0"
 
 [target.'cfg(windows)'.dependencies]
 tempfile = { version = "3.13.0" }

--- a/packages/hoppscotch-agent/src-tauri/src/error.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/error.rs
@@ -53,9 +53,15 @@ pub enum AgentError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
     #[error("Log init error: {0}")]
-    LogInit(#[from] tracing_appender::rolling::InitError),
+    LogInit(String),
     #[error("Log init global error: {0}")]
     LogInitGlobal(#[from] tracing::subscriber::SetGlobalDefaultError),
+}
+
+impl From<tracing_appender::rolling::InitError> for AgentError {
+    fn from(err: tracing_appender::rolling::InitError) -> Self {
+        AgentError::LogInit(err.to_string())
+    }
 }
 
 impl IntoResponse for AgentError {

--- a/packages/hoppscotch-agent/src-tauri/src/logger.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/logger.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use file_rotate::{compression::Compression, suffix::AppendCount, ContentLimit, FileRotate};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-use crate::HOPPSCOTCH_DESKTOP_IDENTIFIER;
+use crate::HOPPSCOTCH_AGENT_IDENTIFIER;
 
 pub struct LogGuard(pub tracing_appender::non_blocking::WorkerGuard);
 
@@ -12,7 +12,7 @@ pub fn setup(log_dir: &PathBuf) -> Result<LogGuard, Box<dyn std::error::Error>> 
 
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| "debug".into());
 
-    let log_file_path = log_dir.join(&format!("{}.log", HOPPSCOTCH_DESKTOP_IDENTIFIER));
+    let log_file_path = log_dir.join(&format!("{}.log", HOPPSCOTCH_AGENT_IDENTIFIER));
     tracing::info!(log_file_path =? &log_file_path);
 
     let file = FileRotate::new(
@@ -35,7 +35,8 @@ pub fn setup(log_dir: &PathBuf) -> Result<LogGuard, Box<dyn std::error::Error>> 
         .with_writer(non_blocking)
         .with_ansi(false)
         .with_thread_ids(true)
-        .with_thread_names(true);
+        .with_thread_names(true)
+        .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339());
 
     tracing_subscriber::registry()
         .with(env_filter)

--- a/packages/hoppscotch-agent/src-tauri/src/main.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/main.rs
@@ -1,16 +1,46 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use hoppscotch_agent_lib::{
+    logger::{self, LogGuard},
+    HOPPSCOTCH_AGENT_IDENTIFIER,
+};
 
 fn main() {
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| format!("{}=debug", env!("CARGO_CRATE_NAME")).into()),
-        )
-        .with(tracing_subscriber::fmt::layer().without_time())
-        .init();
+    // Follows how `tauri` does this and exactly matches desktop's approach
+    // see: https://github.com/tauri-apps/tauri/blob/dev/crates/tauri/src/path/desktop.rs
+    let path = {
+        #[cfg(target_os = "macos")]
+        let path =
+            dirs::home_dir().map(|dir| dir.join("Library/Logs").join(HOPPSCOTCH_AGENT_IDENTIFIER));
+
+        #[cfg(not(target_os = "macos"))]
+        let path =
+            dirs::data_local_dir().map(|dir| dir.join(HOPPSCOTCH_AGENT_IDENTIFIER).join("logs"));
+
+        path
+    };
+
+    let Some(log_file_path) = path else {
+        eprint!("Failed to setup logging!");
+
+        println!("Starting Hoppscotch Agent...");
+
+        return hoppscotch_agent_lib::run();
+    };
+
+    let Ok(LogGuard(guard)) = logger::setup(&log_file_path) else {
+        eprint!("Failed to setup logging!");
+
+        println!("Starting Hoppscotch Agent...");
+
+        return hoppscotch_agent_lib::run();
+    };
+
+    // This keeps the guard alive, this is scoped to `main`
+    // so it can only drop when the entire app exits,
+    // so safe to have it like this.
+    let _guard = guard;
 
     tracing::info!("Starting Hoppscotch Agent...");
 

--- a/packages/hoppscotch-agent/src-tauri/src/tray.rs
+++ b/packages/hoppscotch-agent/src-tauri/src/tray.rs
@@ -96,10 +96,9 @@ pub fn create_tray(app: &AppHandle) -> tauri::Result<()> {
                 }
             }
             "maximize_window" => {
-                app.emit("maximize-window", ())
-                    .unwrap_or_else(|e| {
-                        tracing::error!("Failed to emit maximize-window event: {}", e);
-                    });
+                app.emit("maximize-window", ()).unwrap_or_else(|e| {
+                    tracing::error!("Failed to emit maximize-window event: {}", e);
+                });
                 if let Err(e) = show_main_window(&app) {
                     tracing::error!("Failed to maximize window: {}", e);
                 }


### PR DESCRIPTION
This adds a file-based logging system with size-based rotation to the Hoppscotch Agent.

It essentially redirects existing diagnostic to size-based rotating files for troubleshooting environment-specific issues.

Closes HFE-897

Agent currently lacks a persistent logging mechanism in production environments. Logs are only available through the development mode console. Mainly aiming to understand errors in specific environments that can't be reproduced in our testing setups.

This implementation uses the tracing ecosystem (`tracing`, `tracing_subscriber`, `tracing_appender`) along with `file_rotate` to create log files in the platform's log directory.

The logs are automatically rotated when they reach 10MB, with a maximum of 5 files retained.

Thinking `10 * 5 MB` just like the desktop app is reasonable disk usage while maintaining sufficient history.

The system currently writes to both the console (with ANSI colors where supported) and to files (without ANSI formatting for readability).

Log levels in `dev` mode are currently controlled via the `RUST_LOG` environment variable, defaulting to "debug" when not specified.

| OS | Log File Path |
|---|---|
| Windows | `C:\Users\<username>\AppData\Local\io.hoppscotch.agent\logs\io.hoppscotch.agent.log` |
| macOS | `~/Library/Logs/io.hoppscotch.agent/io.hoppscotch.agent.log` |
| Linux | `~/.local/share/io.hoppscotch.agent/logs/io.hoppscotch.agent.log` |

### Notes to reviewers

#### About setting up logging in `main`

Moved `setup_logging` function from `lib.rs` to its own module in `logger.rs` to make sure it starts up before any plugins are initialized, which means we can control when the global default trace dispatcher is setup. Logger setup call in `lib.rs` (where it used to be commented out) would actually setup two dispatcher, eventually failing with panic:
```
a global default trace dispatcher has already been set
thread 'main' panicked at library/core/src/panicking.rs:218:5:
panic in a function that cannot unwind
```

The current setup avoids that and also lets the logger collect startup logs.

#### Testing

We need to make sure:

1. The agent functions normally
2. Logs are present in platform's respective directories, i.e. `~/Library/Logs/io.hoppscotch.agent/io.hoppscotch.agent.log` on MacOS
3. Logs are collected correctly

```
Library/Logs/io.hoppscotch.agent
❯ head -14 io.hoppscotch.agent.log
2025-06-12T11:17:29.434256Z  INFO main ThreadId(01) hoppscotch_agent_lib::logger: Logging initialized with rotating file log_file=/Users/curiouscorrelation/Library/Logs/io.hoppscotch.agent/io.hoppscotch.agent.log
2025-06-12T11:17:29.434797Z  INFO main ThreadId(01) hoppscotch_agent: Starting Hoppscotch Agent...
2025-06-12T11:17:29.434882Z  INFO main ThreadId(01) hoppscotch_agent_lib: Initializing Hoppscotch Agent
2025-06-12T11:17:29.435113Z DEBUG main ThreadId(01) hoppscotch_agent_lib: Building Tauri application
2025-06-12T11:17:29.436135Z  INFO main ThreadId(01) hoppscotch_agent_lib: Building Tauri application with context
2025-06-12T11:17:29.485082Z  INFO main ThreadId(01) hoppscotch_agent_lib: Running application
2025-06-12T11:17:29.512823Z  INFO main ThreadId(01) hoppscotch_agent_lib: Setting up application
2025-06-12T11:17:29.512875Z DEBUG main ThreadId(01) hoppscotch_agent_lib: Configuring autostart for desktop variant
2025-06-12T11:17:29.513158Z  INFO main ThreadId(01) hoppscotch_agent_lib: Checking autostart status enabled=true
2025-06-12T11:17:29.513183Z DEBUG main ThreadId(01) hoppscotch_agent_lib: Initializing desktop-specific features
2025-06-12T11:17:29.513825Z  INFO main ThreadId(01) create_main_window: hoppscotch_agent_lib: Creating main application window
2025-06-12T11:17:29.513973Z DEBUG main ThreadId(01) create_main_window: hoppscotch_agent_lib: Building webview window from config
2025-06-12T11:17:29.514304Z DEBUG tokio-runtime-worker ThreadId(14) tauri_plugin_updater::updater: checking for updates https://releases.hoppscotch.com/hoppscotch-agent.json
2025-06-12T11:17:29.515975Z DEBUG tokio-runtime-worker ThreadId(14) reqwest::connect: starting new connection: https://releases.hoppscotch.com/
```



