### PR TITLE
fix: team environment user access bug

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -35,7 +35,6 @@
             :placeholder="`${t('action.search')}`"
             :context-menu-enabled="false"
             class="border border-dividerDark focus:border-primaryDark rounded"
-            :readonly="isFilterInputDisabled"
           />
           <HoppSmartItem
             v-if="!isScopeSelector"
@@ -700,14 +699,6 @@ const environmentVariables = computed(() => {
 const editGlobalEnv = () => {
   invokeAction("modals.global.environment.update", {})
 }
-
-// Filter input disabled if no environments are available
-const isFilterInputDisabled = computed(() => {
-  if (selectedEnvTab.value === "my-environments") {
-    return myEnvironments.value.length === 0
-  }
-  return teamEnvironmentList.value.length === 0
-})
 
 const editEnv = () => {
   if (selectedEnv.value.type === "MY_ENV" && selectedEnv.value.name) {

--- a/packages/hoppscotch-common/src/components/environments/my/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/index.vue
@@ -6,7 +6,6 @@
       autocomplete="off"
       class="flex w-full bg-transparent px-4 py-2 h-8 border-b border-dividerLight"
       :placeholder="t('action.search')"
-      :disabled="!environments.length"
     />
     <div
       class="sticky top-upperPrimaryStickyFold z-10 flex flex-1 flex-shrink-0 justify-between overflow-x-auto border-b border-dividerLight bg-primary"

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -88,7 +88,10 @@
                       :placeholder="`${t('count.variable', {
                         count: index + 1,
                       })}`"
-                      :name="'param' + index"
+                      :class="{
+                        'opacity-25': isViewer,
+                      }"
+                      :name="'variable' + index"
                       :disabled="isViewer"
                     />
                     <SmartEnvInput
@@ -100,6 +103,7 @@
                       :select-text-on-mount="
                         env.key ? env.key === editingVariableName : false
                       "
+                      :readonly="isViewer"
                     />
                     <SmartEnvInput
                       v-model="env.currentValue"
@@ -495,8 +499,13 @@ const saveEnvironment = async () => {
         secretVariables
       )
 
+      currentEnvironmentValueService.addEnvironment(
+        editingID.value,
+        nonSecretVariables
+      )
+
       // If the user is a viewer, we don't need to update the environment in BE
-      // just update the secret environment in the local storage
+      // just update the secret environment and current environment in the local storage
       if (props.isViewer) {
         hideModal()
         toast.success(`${t("environment.updated")}`)
@@ -521,12 +530,6 @@ const saveEnvironment = async () => {
             toast.success(`${t("environment.updated")}`)
 
             isLoading.value = false
-            if (editingID.value) {
-              currentEnvironmentValueService.addEnvironment(
-                editingID.value,
-                nonSecretVariables
-              )
-            }
           }
         )
       )()

--- a/packages/hoppscotch-common/src/components/environments/teams/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/index.vue
@@ -6,7 +6,7 @@
       autocomplete="off"
       class="flex w-full bg-transparent px-4 py-2 h-8 border-b border-dividerLight"
       :placeholder="t('action.search')"
-      :disabled="loading || !teamEnvironments.length"
+      :disabled="loading"
     />
     <div
       class="sticky top-upperPrimaryStickyFold z-10 flex flex-1 flex-shrink-0 justify-between overflow-x-auto border-b border-dividerLight bg-primary"


### PR DESCRIPTION
Closes #5148 

This PR fixes the bug with team environment where user with `VIEWER` access could not save current environment value. 
Also enabled environment search in empty cases with proper placeholder in place.

