### PR TITLE
fix: auth tokens not propagating to child requests

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/Properties.vue
+++ b/packages/hoppscotch-common/src/components/collections/Properties.vue
@@ -157,7 +157,7 @@ const toast = useToast()
 const props = withDefaults(
   defineProps<{
     show: boolean
-    loadingState: boolean
+    loadingState?: boolean
     editingProperties: EditingProperties
     source: "REST" | "GraphQL"
     modelValue: string

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -2801,7 +2801,7 @@ const setCollectionProperties = (newCollection: {
 
   // We default to using collection.id but during the callback to our application, collection.id is not being preserved.
   // Since path is being preserved, we extract the collectionId from path instead
-  const collectionId = collection?.id ?? path?.split("/").pop()
+  const collectionId = collection.id ?? path.split("/").pop()
 
   if (collectionsType.value.type === "my-collections") {
     if (isRootCollection) {

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -2796,6 +2796,11 @@ const setCollectionProperties = (newCollection: {
   path: string
 }) => {
   const { collection, path, isRootCollection } = newCollection
+
+  // We default to using collection.id but during the callback to our application, collection.id is not being preserved.
+  // Since path is being preserved, we extract the collectionId from path instead
+  const collectionId = (collection?.id ?? path?.split("/").pop()) as string
+
   if (!collection) return
 
   if (collectionsType.value.type === "my-collections") {
@@ -2818,13 +2823,13 @@ const setCollectionProperties = (newCollection: {
       )
     })
     toast.success(t("collection.properties_updated"))
-  } else if (hasTeamWriteAccess.value && collection.id) {
+  } else if (hasTeamWriteAccess.value && collectionId) {
     const data = {
       auth: collection.auth,
       headers: collection.headers,
     }
     pipe(
-      updateTeamCollection(collection.id, JSON.stringify(data), undefined),
+      updateTeamCollection(collectionId, JSON.stringify(data), undefined),
       TE.match(
         (err: GQLError<string>) => {
           toast.error(`${getErrorMessage(err)}`)

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -2797,11 +2797,11 @@ const setCollectionProperties = (newCollection: {
 }) => {
   const { collection, path, isRootCollection } = newCollection
 
+  if (!collection) return
+
   // We default to using collection.id but during the callback to our application, collection.id is not being preserved.
   // Since path is being preserved, we extract the collectionId from path instead
-  const collectionId = (collection?.id ?? path?.split("/").pop()) as string
-
-  if (!collection) return
+  const collectionId = collection?.id ?? path?.split("/").pop()
 
   if (collectionsType.value.type === "my-collections") {
     if (isRootCollection) {


### PR DESCRIPTION
Closes #3957 

Access tokens are not propagated to child requests when using `OAuth2.0 authorization`. This behavior is observed for `Team Workspaces` only.

### What's changed
- During the callback from auth provider to the Hoppscotch application (at route `/oauth`), `collection.id` is not preserved
- As the variable `path` is preserved, we use that to deduce the value of `collectionId`

### Notes to reviewers
**Video demonstrating the fix:**

https://github.com/user-attachments/assets/dd6524e2-b19b-4101-ac34-22836865d9e9

Key things to note in the video:
- Access token now remains preserved in collection properties dialog box after clicking on the save button
- Auth type of inherit on a child request would now successfully point to this access token
