### PR TITLE
fix: add fallback for isSecret schema

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -460,7 +460,7 @@ const saveEnvironment = () => {
             key: e.key,
             currentValue: e.currentValue,
             varIndex: i,
-            isSecret: e.secret,
+            isSecret: e.secret ?? false,
           })
         : O.none
     )

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -426,7 +426,7 @@ const saveEnvironment = async () => {
             key: e.key,
             currentValue: e.currentValue,
             varIndex: i,
-            isSecret: e.secret,
+            isSecret: e.secret ?? false,
           })
         : O.none
     )

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -164,7 +164,7 @@ const updateEnvironments = (
 
       nonSecretVariables.push({
         key: e.key,
-        isSecret: e.secret,
+        isSecret: e.secret ?? false,
         varIndex: index,
         currentValue: e.currentValue ?? "",
       })

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -386,7 +386,7 @@ export const CURRENT_ENVIRONMENT_VALUE_SCHEMA = z.union([
           key: z.string(),
           currentValue: z.string(),
           varIndex: z.number(),
-          isSecret: z.boolean(),
+          isSecret: z.boolean().catch(false),
         })
         .strict()
     )


### PR DESCRIPTION
This PR fixes an issue with schema validation failing in some edge cases where isSecret value get null, and default value to false is added in that case now for CurrentValue persistance.


