### PR TITLE
fix: team env not migrating in edge cases

### DIFF
--- a/packages/hoppscotch-common/src/helpers/teams/TeamEnvironmentAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamEnvironmentAdapter.ts
@@ -10,7 +10,11 @@ import {
   TeamEnvironmentUpdatedDocument,
 } from "../backend/graphql"
 import { TeamEnvironment } from "./TeamEnvironment"
-import { Environment, EnvironmentSchemaVersion } from "@hoppscotch/data"
+import {
+  Environment,
+  EnvironmentSchemaVersion,
+  translateToNewEnvironmentVariables,
+} from "@hoppscotch/data"
 
 type EntityType = "environment"
 type EntityID = `${EntityType}-${string}`
@@ -115,9 +119,13 @@ export default class TeamEnvironmentAdapter {
       results.push(
         ...result.right.team.teamEnvironments.map((x) => {
           const environment = <Environment>{
+            v: EnvironmentSchemaVersion,
             id: x.id,
             name: x.name,
-            variables: JSON.parse(x.variables),
+            variables: JSON.parse(x.variables).map(
+              (variable: Environment["variables"][number]) =>
+                translateToNewEnvironmentVariables(variable)
+            ),
           }
 
           const parsedEnvironment = Environment.safeParse(environment)
@@ -128,10 +136,7 @@ export default class TeamEnvironmentAdapter {
             environment:
               parsedEnvironment.type === "ok"
                 ? parsedEnvironment.value
-                : {
-                    ...environment,
-                    v: EnvironmentSchemaVersion,
-                  },
+                : environment,
           }
         })
       )

--- a/packages/hoppscotch-common/src/helpers/teams/TeamEnvironmentAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamEnvironmentAdapter.ts
@@ -118,6 +118,7 @@ export default class TeamEnvironmentAdapter {
     if (result.right.team) {
       results.push(
         ...result.right.team.teamEnvironments.map((x) => {
+          // Keep the environment structure consistent with the new schema
           const environment = <Environment>{
             v: EnvironmentSchemaVersion,
             id: x.id,


### PR DESCRIPTION
This PR fixes the bug with migrating team environments leading to empty values. Now the fetched team environment variables is parsed to latest new environment schema.

Related to #5104.