### PR TITLE
chore: use initial value in runtime if current value is empty

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -492,21 +492,12 @@ const saveEnvironment = () => {
 
   const variables = pipe(
     filteredVariables,
-    A.map((e) =>
-      e.secret
-        ? {
-            key: e.key,
-            secret: e.secret,
-            initialValue: e.initialValue,
-            currentValue: "",
-          }
-        : {
-            key: e.key,
-            secret: e.secret,
-            initialValue: e.initialValue,
-            currentValue: "",
-          }
-    )
+    A.map((e) => ({
+      key: e.key,
+      secret: e.secret,
+      initialValue: e.initialValue || "",
+      currentValue: "",
+    }))
   )
 
   const environmentUpdated: Environment = {

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -437,7 +437,7 @@ const saveEnvironment = async () => {
     A.map((e) => ({
       key: e.key,
       secret: e.secret,
-      initialValue: e.initialValue,
+      initialValue: e.initialValue || "",
       currentValue: "",
     }))
   )

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -222,7 +222,7 @@ const getEnvironmentVariableValue = (
  * @param env The environment variable to be transformed
  * @returns The transformed environment variable with currentValue set to initialValue if empty
  */
-const getTranformedEnvs = (
+const getTransformedEnvs = (
   env: Environment["variables"][number]
 ): Environment["variables"][number] => {
   return {
@@ -242,7 +242,7 @@ const filterNonEmptyEnvironmentVariables = (
 ): Environment["variables"] => {
   const envsMap = new Map<string, Environment["variables"][number]>()
   envs.forEach((env) => {
-    const transformedEnv = getTranformedEnvs(env)
+    const transformedEnv = getTransformedEnvs(env)
 
     if (transformedEnv.secret) {
       envsMap.set(transformedEnv.key, transformedEnv)

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -100,6 +100,16 @@ export const getTestableBody = (
   return x
 }
 
+/**
+ * Combines the environment variables from the request and the selected, global, and temporary environments.
+ * The priority is as follows:
+ * 1. Request variables
+ * 2. Temporary variables (if any)
+ * 3. Selected environment variables
+ * 4. Global environment variables
+ * @param variables The environment variables to combine
+ * @returns The combined environment variables
+ */
 export const combineEnvVariables = (variables: {
   environments: {
     selected: Environment["variables"]
@@ -244,9 +254,7 @@ const filterNonEmptyEnvironmentVariables = (
   envs.forEach((env) => {
     const transformedEnv = getTransformedEnvs(env)
 
-    if (transformedEnv.secret) {
-      envsMap.set(transformedEnv.key, transformedEnv)
-    } else if (envsMap.has(transformedEnv.key)) {
+    if (envsMap.has(transformedEnv.key)) {
       const existingEnv = envsMap.get(transformedEnv.key)
 
       if (

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -119,8 +119,8 @@ export const executedResponses$ = new Subject<
 >()
 
 /**
- * Used to update the environment schema with the secret variables
- * and store the secret variable values in the secret environment service
+ * This will update the environment variables in the current environment
+ * and secret environment service.
  * @param envs The environment variables to update
  * @param type Whether the environment variables are global or selected
  * @returns the updated environment variables
@@ -217,7 +217,23 @@ const getEnvironmentVariableValue = (
 }
 
 /**
+ * Set currentValue as initialValue if currentValue is empty
+ * This is set just for request runtime and it will not be persisted.
+ * @param env The environment variable to be transformed
+ * @returns The transformed environment variable with currentValue set to initialValue if empty
+ */
+const getTranformedEnvs = (
+  env: Environment["variables"][number]
+): Environment["variables"][number] => {
+  return {
+    ...env,
+    currentValue: env.currentValue || env.initialValue,
+  }
+}
+
+/**
  * Transforms the environment list to a list with unique keys with value
+ * and set currentValue as initialValue if currentValue is empty.
  * @param envs The environment list to be transformed
  * @returns The transformed environment list with keys with value
  */
@@ -226,21 +242,23 @@ const filterNonEmptyEnvironmentVariables = (
 ): Environment["variables"] => {
   const envsMap = new Map<string, Environment["variables"][number]>()
   envs.forEach((env) => {
-    if (env.secret) {
-      envsMap.set(env.key, env)
-    } else if (envsMap.has(env.key)) {
-      const existingEnv = envsMap.get(env.key)
+    const transformedEnv = getTranformedEnvs(env)
+
+    if (transformedEnv.secret) {
+      envsMap.set(transformedEnv.key, transformedEnv)
+    } else if (envsMap.has(transformedEnv.key)) {
+      const existingEnv = envsMap.get(transformedEnv.key)
 
       if (
         existingEnv &&
         "currentValue" in existingEnv &&
         existingEnv.currentValue === "" &&
-        env.currentValue !== ""
+        transformedEnv.currentValue !== ""
       ) {
-        envsMap.set(env.key, env)
+        envsMap.set(transformedEnv.key, transformedEnv)
       }
     } else {
-      envsMap.set(env.key, env)
+      envsMap.set(transformedEnv.key, transformedEnv)
     }
   })
 
@@ -565,13 +583,15 @@ export function runTestRunnerRequest(
       id: "env-id",
       v: 2,
       name: "Env",
-      variables: combineEnvVariables({
-        environments: {
-          ...preRequestScriptResult.right.envs,
-          temp: !persistEnv ? getTemporaryVariables() : [],
-        },
-        requestVariables: [],
-      }),
+      variables: filterNonEmptyEnvironmentVariables(
+        combineEnvVariables({
+          environments: {
+            ...preRequestScriptResult.right.envs,
+            temp: !persistEnv ? getTemporaryVariables() : [],
+          },
+          requestVariables: [],
+        })
+      ),
     })
 
     const [stream] = createRESTNetworkRequestStream(effectiveRequest)

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -520,7 +520,7 @@ function updateEnvsAfterTestScript(runResult: E.Right<SandboxTestResult>) {
     v: 2,
     variables: globalEnvVariables,
   })
-  updateEnvironments(
+  const selectedEnvVariables = updateEnvironments(
     // @ts-expect-error Typescript can't figure out this inference for some reason
     cloneDeep(runResult.right.envs.selected),
     "selected"
@@ -534,7 +534,7 @@ function updateEnvsAfterTestScript(runResult: E.Right<SandboxTestResult>) {
       name: env.name,
       v: 2,
       id: "id" in env ? env.id : "",
-      variables: runResult.right.envs.selected,
+      variables: selectedEnvVariables,
     })
   } else if (
     environmentsStore.value.selectedEnvironmentIndex.type === "TEAM_ENV"
@@ -544,7 +544,7 @@ function updateEnvsAfterTestScript(runResult: E.Right<SandboxTestResult>) {
     })
     pipe(
       updateTeamEnvironment(
-        JSON.stringify(runResult.right.envs.selected),
+        JSON.stringify(selectedEnvVariables),
         environmentsStore.value.selectedEnvironmentIndex.teamEnvID,
         env.name
       )

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -57,7 +57,11 @@ const filterNonEmptyEnvironmentVariables = (
     if (envsMap.has(env.key)) {
       const existingEnv = envsMap.get(env.key)
 
-      if (existingEnv?.currentValue === "" && env.currentValue !== "") {
+      if (
+        existingEnv?.currentValue === "" &&
+        existingEnv?.initialValue === "" &&
+        (env.currentValue || env.initialValue)
+      ) {
         envsMap.set(env.key, env)
       }
     } else {

--- a/packages/hoppscotch-common/src/helpers/utils/environments.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/environments.ts
@@ -40,10 +40,7 @@ const unWrapEnvironments = (
     }
     return {
       ...globalVar,
-      currentValue:
-        currentVar?.currentValue ??
-        globalVar.currentValue ??
-        globalVar.initialValue,
+      currentValue: currentVar?.currentValue || globalVar.currentValue,
     }
   })
 
@@ -65,10 +62,7 @@ const unWrapEnvironments = (
       }
       return {
         ...selectedVar,
-        currentValue:
-          currentVar?.currentValue ??
-          selectedVar.currentValue ??
-          selectedVar.initialValue,
+        currentValue: currentVar?.currentValue || selectedVar.currentValue,
       }
     }
   )

--- a/packages/hoppscotch-common/src/helpers/utils/environments.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/environments.ts
@@ -40,7 +40,7 @@ const unWrapEnvironments = (
     }
     return {
       ...globalVar,
-      currentValue: currentVar?.currentValue || globalVar.currentValue,
+      currentValue: currentVar?.currentValue || globalVar.currentValue || "",
     }
   })
 
@@ -62,7 +62,8 @@ const unWrapEnvironments = (
       }
       return {
         ...selectedVar,
-        currentValue: currentVar?.currentValue || selectedVar.currentValue,
+        currentValue:
+          currentVar?.currentValue || selectedVar.currentValue || "",
       }
     }
   )

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -447,24 +447,6 @@ export const aggregateEnvs$: Observable<AggregateEnvironment[]> = combineLatest(
 
     const aggregateEnvKeys = effectiveAggregateEnvs.map(({ key }) => key)
 
-    selectedEnv?.variables.forEach((variable) => {
-      const { key, secret } = variable
-      const currentValue =
-        "currentValue" in variable ? variable.currentValue : ""
-      const initialValue =
-        "initialValue" in variable ? variable.initialValue : ""
-
-      if (!aggregateEnvKeys.includes(key)) {
-        effectiveAggregateEnvs.push({
-          key,
-          currentValue,
-          initialValue,
-          secret,
-          sourceEnv: selectedEnv.name,
-        })
-      }
-    })
-
     globalEnv.variables.forEach((variable) => {
       const { key, secret } = variable
       const currentValue =
@@ -483,6 +465,24 @@ export const aggregateEnvs$: Observable<AggregateEnvironment[]> = combineLatest(
       }
     })
 
+    selectedEnv?.variables.forEach((variable) => {
+      const { key, secret } = variable
+      const currentValue =
+        "currentValue" in variable ? variable.currentValue : ""
+      const initialValue =
+        "initialValue" in variable ? variable.initialValue : ""
+
+      if (!aggregateEnvKeys.includes(key)) {
+        effectiveAggregateEnvs.push({
+          key,
+          currentValue,
+          initialValue,
+          secret,
+          sourceEnv: selectedEnv.name,
+        })
+      }
+    })
+
     return effectiveAggregateEnvs
   }),
   distinctUntilChanged(isEqual)
@@ -492,7 +492,7 @@ export function getAggregateEnvs() {
   const currentEnv = getCurrentEnvironment()
   return [
     ...currentEnv.variables.map((x) => {
-      let currentValue
+      let currentValue = ""
       if (!x.secret) {
         currentValue = x.currentValue
       }
@@ -506,7 +506,7 @@ export function getAggregateEnvs() {
       }
     }),
     ...getGlobalVariables().map((x) => {
-      let currentValue
+      let currentValue = ""
       if (!x.secret) {
         currentValue = x.currentValue
       }


### PR DESCRIPTION
Closes HFE-890

This PR updates the environment usage flow where the initial environment variable value is used as the environment value if current value is empty at the time of request run without persisting the value.
