### PR TITLE
docs: unified fields for bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/--bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/--bug-report.yaml
@@ -1,134 +1,117 @@
-name: Bug report
+name: Bug Report
 description: Create a bug report to help us improve Hoppscotch
 title: "[bug]: "
 labels: [bug, need testing]
 body:
-- type: markdown
-  attributes:
-    value: |
-      Thank you for taking the time to report this issue. Complete information helps us resolve issues faster.
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report this issue. Complete information helps us resolve it faster.
 
-- type: checkboxes
-  attributes:
-    label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the bug you encountered
-    options:
-    - label: I have searched existing issues and this bug hasn't been reported yet
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered
+      options:
+        - label: I have searched existing issues and this bug hasn't been reported yet
+          required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: How are you accessing Hoppscotch?
+      options:
+        - Web App
+        - Desktop App
+    validations:
       required: true
 
-- type: textarea
-  attributes:
-    label: Current behavior
-    description: A concise description of what you're experiencing and what you expect
-    placeholder: |
-      When I do <X>, <Y> happens and I see the error message attached below:
-      ```...```
-      What I expect is <Z>
-  validations:
-    required: true
+  - type: dropdown
+    id: browser
+    attributes:
+      label: Browser
+      description: |
+        Which browser is affected?
+        - For web app: Select the browser you're using
+        - For desktop app: Select your default browser
+      options:
+        - Chrome
+        - Firefox
+        - Safari
+        - Edge
+        - Opera
+        - Other (specify in additional info)
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
-    label: Steps to reproduce
-    description: Add steps to reproduce this behaviour, include console or network logs and screenshots
-    placeholder: |
-      1. Go to '...'
-      2. Click on '....'
-      3. Scroll down to '....'
-      4. See error
-  validations:
-    required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      description: Which operating system are you using?
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other (specify in additional info)
+    validations:
+      required: true
 
-- type: textarea
-  id: logs
-  attributes:
-    label: Logs and Screenshots
-    description: Include any relevant anonymized console logs, network errors, or screenshots
-    placeholder: |
-      ```
-      Uncaught TypeError: Cannot read property 'data' of undefined
-          at GraphQLModule.processResponse (graphql.js:242)
-      ```
+  - type: textarea
+    attributes:
+      label: Bug Description
+      description: |
+        Describe the bug, how to reproduce it, and any additional context that would help us fix it. Include screenshots when possible.
 
-      [Attach screenshots if available]
-    render: shell
+        **For request-related issues:** Please specify which interceptor you're using (Browser, Agent, Extension, Proxy, Native, etc.)
+      placeholder: |
+        ## What happened?
+        When I do <X>, <Y> happens and I see the error:
+        ```
+        [paste error message here]
+        ```
+        What I expected is <Z>
 
-- type: dropdown
-  id: env
-  attributes:
-    label: Environment
-    description: Where did you encounter this issue?
-    options:
-      - Production
-      - Release
-      - Deploy preview
-  validations:
-    required: true
+        ## Steps to reproduce
+        1. Go to '...'
+        2. Click on '....'
+        3. See error
 
-- type: dropdown
-  id: version
-  attributes:
-    label: Hoppscotch Version
-    description: Which version of Hoppscotch are you using?
-    options:
-      - Cloud
-      - Self-hosted
-      - Local
-  validations:
-    required: true
+        ## Screenshots
+        [Attach screenshots here if available - they're really helpful!]
 
-- type: dropdown
-  id: interceptor
-  attributes:
-    label: Interceptor
-    description: Which request interceptor are you using? (Select "Not Applicable" if your issue isn't related to network requests)
-    options:
-      - Not Applicable - Issue not related to network requests
-      - Browser - Web App
-      - Agent - Web App
-      - Extension - Web App
-      - Proxy - Web App
-      - Native - Desktop App
-      - Proxy - Desktop App
-    default: 0
-  validations:
-    required: true
+        ## Additional context
+        Interceptor used (if request-related): [Browser/Agent/Extension/Proxy/Native/etc.]
 
-- type: dropdown
-  id: browsers
-  attributes:
-    label: Browsers Affected
-    description: Which browsers have you seen this issue on? (Select all that apply)
-    multiple: true
-    options:
-      - Chrome
-      - Firefox
-      - Safari
-      - Edge
-      - Opera
-      - Other (specify in additional info)
-      - Not browser-specific
-      - Not applicable (Desktop app)
+        ## Logs and Console Output (if available)
+        ```
+        Paste any relevant logs here
+        ```
 
-- type: dropdown
-  id: os
-  attributes:
-    label: Operating System
-    description: Which operating system are you using?
-    options:
-      - Windows
-      - MacOS
-      - Linux
-      - Other (specify in additional info)
+        ## Additional details (if relevant)
+        - Device specifics:
+        - Special configurations:
+    validations:
+      required: true
 
-- type: textarea
-  id: additional
-  attributes:
-    label: Additional Information
-    description: Any other details that might help us understand and fix the issue
-    placeholder: |
-      - Self Hosted instance version if not latest
-      - Desktop app version if not latest
-      - Device specifics
-      - Special configurations
-      - Context about your use case
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment Type
+      description: What type of Hoppscotch deployment are you using?
+      options:
+        - Hoppscotch Cloud
+        - Self-hosted (on-prem deployment)
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: |
+        For Self-Hosted deployments: Specify your deployment version
+        For Desktop App: Specify your app version
+    validations:
+      required: false


### PR DESCRIPTION
This PR simplifies the bug report template by combining similar sections into common ones with unified fields, and also reorders required information at the top.

This also fixes an issue where section requiring log and screenshot didn't show the file upload section causing confusion, see https://github.com/hoppscotch/hoppscotch/issues/5134#issue-3124592715.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/2b382a81-a24b-407e-9e45-835b5afc368e) | ![image](https://github.com/user-attachments/assets/c0be0972-76f2-4c90-bb67-ffe073f62c1b) |

