### PR TITLE
fix(desktop): prevent navigation on file drops

### DIFF
--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -126,7 +126,71 @@ async function initApp() {
     headerPaddingTop.value = "0px"
     headerPaddingLeft.value = "80px"
 
-    // Add backspace prevention for non-text inputs
+    const ALLOWED_DROP_SELECTORS = [
+      '[draggable="true"]',
+      '.draggable-content',
+      '.draggable-handle',
+      '.sortable-ghost',
+      '.sortable-drag',
+      '.sortable-chosen',
+      '.vue-draggable',
+
+      'input[type="file"]',
+      'label[for*="attachment"]',
+      '.file-chips-container',
+      '.file-chips-wrapper',
+
+      '.cm-editor',
+      '.cm-content',
+      '.cm-scroller',
+      '.ace_editor',
+
+      '[data-allow-drop]',
+      '.drop-zone',
+
+      '[ondrop]',
+      '[data-drop-handler]'
+    ].join(', ');
+
+    const isAllowedDropTarget = (target: EventTarget | null): boolean => {
+      if (!target || !(target instanceof HTMLElement)) {
+        return false;
+      }
+
+      if (target.closest(ALLOWED_DROP_SELECTORS)) {
+        return true;
+      }
+
+      const element = target as any;
+      if (element._vei?.onDrop || element.__vueListeners__?.drop) {
+        return true;
+      }
+
+      return false;
+    };
+
+    document.addEventListener('drop', (e) => {
+      if (!isAllowedDropTarget(e.target)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+    }, false);
+
+    document.addEventListener('dragover', (e) => {
+      e.preventDefault();
+    }, false);
+
+    document.addEventListener('dragstart', (e) => {
+      if (!e.target || !(e.target instanceof HTMLElement)) {
+        return;
+      }
+
+      const target = e.target as HTMLElement;
+      if (!target.draggable && !target.closest('[draggable="true"], .draggable-content')) {
+        e.preventDefault();
+      }
+    }, false);
+
     window.addEventListener(
       "keydown",
       function (e) {


### PR DESCRIPTION
This adds drag/drop event listeners to prevent Tauri's WebView from opening files when users accidentally drop files outside of intended drop zone.

This fixes that while preserving drag/drop functionality in rest of the inputs like vuedraggable components, file uploads, and code editors (CodeMirror), "browse", etc.

Closes HFE-886
Closes #5089

This occurred because Tauri's WebView inherits standard browser behavior of opening dropped files when they land outside of components designed to handle them.

The current impl uses event listeners that simply skip legitimate drop targets via selectors. The allowed list is made by checking against known patterns from the codebase, things like vuedraggable with `.draggable-content` and `[draggable="true"]`, file upload inputs using `input[type="file"]` and `.file-chips-container`, code editors with `.cm-editor` and `.ace_editor`, plus future-proof selectors like `[data-allow-drop]` and `.drop-zone` for new components (planned with portable).

### How it works

#### Navigation prevention on reordering

https://github.com/user-attachments/assets/cd91be10-ad6c-466e-8cd9-7e892b7d7878

#### Navigation prevention on file drop

https://github.com/user-attachments/assets/71d2b8bd-6fdf-43b8-b20d-4892b4a5186e

### Notes to reviewers

This change only affects desktop mode when `kernelMode === "desktop"` and preserves all existing functionality.

Testing should verify that all existing drag/drop functionality works, file uploads in multipart form data components, bulk editor drag/drop in CodeMirror instances, and header/parameter drag reordering.