### PR TITLE
fix(common): auto unescape utf-8 issue in the request body

### DIFF
--- a/packages/hoppscotch-common/src/helpers/kernel/common/content.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/common/content.ts
@@ -12,7 +12,7 @@ const Processors = {
     process: (body: string): E.Either<Error, ContentType> =>
       pipe(
         parseJSONAs<unknown>(body),
-        E.map(() => content.json(body, MediaType.APPLICATION_JSON)),
+        E.map(() => content.text(body, MediaType.APPLICATION_JSON)),
         E.orElse(() => E.right(content.text(body, MediaType.TEXT_PLAIN)))
       ),
   },

--- a/packages/hoppscotch-common/src/helpers/kernel/common/content.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/common/content.ts
@@ -9,27 +9,12 @@ import { EffectiveHoppRESTRequest } from "~/helpers/utils/EffectiveURL"
 
 const Processors = {
   json: {
-    process: (body: string): E.Either<Error, ContentType> => {
-      const hasUnicodeEscapes = /\\u[0-9a-fA-F]{4}/.test(body)
-      if (hasUnicodeEscapes) {
-        return pipe(
-          E.tryCatch(() => {
-            JSON.parse(body) // Just validating it's valid JSON
-            return body
-          }, E.toError),
-          E.map((originalBody) =>
-            content.text(originalBody, MediaType.APPLICATION_JSON)
-          )
-        )
-      } else {
-        // For regular JSON without Unicode escapes, using the standard processing
-        return pipe(
-          parseJSONAs<unknown>(body),
-          E.map((json) => content.json(json, MediaType.APPLICATION_JSON)),
-          E.orElse(() => E.right(content.text(body, MediaType.TEXT_PLAIN)))
-        )
-      }
-    },
+    process: (body: string): E.Either<Error, ContentType> =>
+      pipe(
+        parseJSONAs<unknown>(body),
+        E.map(() => content.json(body, MediaType.APPLICATION_JSON)),
+        E.orElse(() => E.right(content.text(body, MediaType.TEXT_PLAIN)))
+      ),
   },
 
   binary: {


### PR DESCRIPTION
Closes HFE-905 #5159

This PR fixes the issue of auto unescaping UTF-8 in the request body. Maintain original payload integrity in HTTP request.