### PR TITLE
chore(desktop): update `typescript` bump hash

### DIFF
--- a/packages/hoppscotch-common/package.json
+++ b/packages/hoppscotch-common/package.json
@@ -39,7 +39,7 @@
     "@hoppscotch/httpsnippet": "3.0.7",
     "@hoppscotch/js-sandbox": "workspace:^",
     "@hoppscotch/kernel": "workspace:^",
-    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#5939b8f",
+    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#0308b55e82f7f01d878a7fdf0f597d1dc975f2ce",
     "@hoppscotch/ui": "0.2.5",
     "@hoppscotch/vue-toasted": "0.1.0",
     "@lezer/highlight": "1.2.0",

--- a/packages/hoppscotch-desktop/package.json
+++ b/packages/hoppscotch-desktop/package.json
@@ -16,7 +16,7 @@
     "@fontsource-variable/material-symbols-rounded": "5.1.3",
     "@fontsource-variable/roboto-mono": "5.1.0",
     "@hoppscotch/kernel": "workspace:^",
-    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#5939b8f",
+    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#0308b55e82f7f01d878a7fdf0f597d1dc975f2ce",
     "@hoppscotch/ui": "0.2.1",
     "@tauri-apps/api": "2.1.1",
     "@tauri-apps/plugin-process": "2.2.0",

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/pnpm-lock.yaml
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
-        version: 11.1.6(rollup@4.28.0)(tslib@2.8.1)(typescript@5.7.2)
+        version: 11.1.6(rollup@4.28.0)(tslib@2.8.1)(typescript@5.8.3)
       rollup:
         specifier: ^4.9.6
         version: 4.28.0
@@ -22,8 +22,8 @@ importers:
         specifier: ^2.6.2
         version: 2.8.1
       typescript:
-        specifier: ^5.3.3
-        version: 5.7.2
+        specifier: ^5.8.3
+        version: 5.8.3
 
 packages:
 
@@ -187,18 +187,18 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
 snapshots:
 
-  '@rollup/plugin-typescript@11.1.6(rollup@4.28.0)(tslib@2.8.1)(typescript@5.7.2)':
+  '@rollup/plugin-typescript@11.1.6(rollup@4.28.0)(tslib@2.8.1)(typescript@5.8.3)':
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.28.0)
       resolve: 1.22.8
-      typescript: 5.7.2
+      typescript: 5.8.3
     optionalDependencies:
       rollup: 4.28.0
       tslib: 2.8.1
@@ -322,4 +322,4 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.7.2: {}
+  typescript@5.8.3: {}

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/pnpm-lock.yaml
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/pnpm-lock.yaml
@@ -9,12 +9,12 @@ importers:
   .:
     dependencies:
       '@tauri-apps/api':
-        specifier: '>=2.0.0-beta.6'
+        specifier: ^2.0.0
         version: 2.1.1
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
-        version: 11.1.6(rollup@4.27.4)(tslib@2.8.1)(typescript@5.7.2)
+        version: 11.1.6(rollup@4.27.4)(tslib@2.8.1)(typescript@5.8.3)
       rollup:
         specifier: ^4.9.6
         version: 4.27.4
@@ -22,8 +22,8 @@ importers:
         specifier: ^2.6.2
         version: 2.8.1
       typescript:
-        specifier: ^5.3.3
-        version: 5.7.2
+        specifier: ^5.8.3
+        version: 5.8.3
 
 packages:
 
@@ -187,18 +187,18 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
 snapshots:
 
-  '@rollup/plugin-typescript@11.1.6(rollup@4.27.4)(tslib@2.8.1)(typescript@5.7.2)':
+  '@rollup/plugin-typescript@11.1.6(rollup@4.27.4)(tslib@2.8.1)(typescript@5.8.3)':
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
       resolve: 1.22.8
-      typescript: 5.7.2
+      typescript: 5.8.3
     optionalDependencies:
       rollup: 4.27.4
       tslib: 2.8.1
@@ -322,4 +322,4 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.7.2: {}
+  typescript@5.8.3: {}

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.lock
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-appload"
 version = "0.1.0"
-source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload?rev=5939b8f#5939b8ff3fdffeebd72749f32b3a06cd5a0c37fc"
+source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload?rev=0308b55e82f7f01d878a7fdf0f597d1dc975f2ce#0308b55e82f7f01d878a7fdf0f597d1dc975f2ce"
 dependencies = [
  "base64 0.22.1",
  "blake3",
@@ -5148,7 +5148,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-relay"
 version = "0.1.0"
-source = "git+https://github.com/CuriousCorrelation/tauri-plugin-relay?rev=3273b9b#3273b9b075f1f6fa9171799a961c435454c0c9a2"
+source = "git+https://github.com/CuriousCorrelation/tauri-plugin-relay?rev=0147ac1bb29d3b88d6652432a482bd86f0174506#0147ac1bb29d3b88d6652432a482bd86f0174506"
 dependencies = [
  "relay",
  "serde",

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.toml
@@ -29,8 +29,8 @@ tauri-plugin-store = "2.2.0"
 tauri-plugin-dialog = "2.2.0"
 tauri-plugin-fs = "2.2.0"
 tauri-plugin-deep-link = "2.2.0"
-tauri-plugin-appload = { git = "https://github.com/CuriousCorrelation/tauri-plugin-appload", rev = "5939b8f" }
-tauri-plugin-relay = { git = "https://github.com/CuriousCorrelation/tauri-plugin-relay", rev = "3273b9b" }
+tauri-plugin-appload = { git = "https://github.com/CuriousCorrelation/tauri-plugin-appload", rev = "0308b55e82f7f01d878a7fdf0f597d1dc975f2ce" }
+tauri-plugin-relay = { git = "https://github.com/CuriousCorrelation/tauri-plugin-relay", rev = "0147ac1bb29d3b88d6652432a482bd86f0174506" }
 axum = "0.8.1"
 tower-http = { version = "0.6.2", features = ["cors"] }
 portpicker = "0.1.1"

--- a/packages/hoppscotch-kernel/package.json
+++ b/packages/hoppscotch-kernel/package.json
@@ -57,6 +57,6 @@
     "@tauri-apps/plugin-dialog": "2.0.1",
     "@tauri-apps/plugin-fs": "2.0.2",
     "@tauri-apps/plugin-store": "2.2.0",
-    "@hoppscotch/plugin-relay": "github:CuriousCorrelation/tauri-plugin-relay#3273b9b"
+    "@hoppscotch/plugin-relay": "github:CuriousCorrelation/tauri-plugin-relay#0147ac1bb29d3b88d6652432a482bd86f0174506"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,8 +527,8 @@ importers:
         specifier: workspace:^
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
-        specifier: github:CuriousCorrelation/tauri-plugin-appload#5939b8f
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/5939b8f'
+        specifier: github:CuriousCorrelation/tauri-plugin-appload#0308b55e82f7f01d878a7fdf0f597d1dc975f2ce
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/0308b55e82f7f01d878a7fdf0f597d1dc975f2ce'
       '@hoppscotch/ui':
         specifier: 0.2.5
         version: 0.2.5(eslint@8.57.0)(terser@5.39.2)(typescript@5.8.3)(vite@5.4.9(@types/node@22.15.19)(sass@1.79.5)(terser@5.39.2))(vue@3.5.12(typescript@5.8.3))
@@ -1000,8 +1000,8 @@ importers:
         specifier: workspace:^
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
-        specifier: github:CuriousCorrelation/tauri-plugin-appload#5939b8f
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/5939b8f'
+        specifier: github:CuriousCorrelation/tauri-plugin-appload#0308b55e82f7f01d878a7fdf0f597d1dc975f2ce
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/0308b55e82f7f01d878a7fdf0f597d1dc975f2ce'
       '@hoppscotch/ui':
         specifier: 0.2.1
         version: 0.2.1(eslint@9.27.0(jiti@2.4.2))(terser@5.39.2)(typescript@5.8.3)(vite@5.4.11(@types/node@22.15.19)(sass@1.80.3)(terser@5.39.2))(vue@3.5.12(typescript@5.8.3))
@@ -1206,8 +1206,8 @@ importers:
   packages/hoppscotch-kernel:
     dependencies:
       '@hoppscotch/plugin-relay':
-        specifier: github:CuriousCorrelation/tauri-plugin-relay#3273b9b
-        version: '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/3273b9b'
+        specifier: github:CuriousCorrelation/tauri-plugin-relay#0147ac1bb29d3b88d6652432a482bd86f0174506
+        version: '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/0147ac1bb29d3b88d6652432a482bd86f0174506'
       '@tauri-apps/api':
         specifier: 2.1.1
         version: 2.1.1
@@ -1840,12 +1840,12 @@ packages:
       graphql:
         optional: true
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/5939b8f':
-    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/5939b8f}
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/0308b55e82f7f01d878a7fdf0f597d1dc975f2ce':
+    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/0308b55e82f7f01d878a7fdf0f597d1dc975f2ce}
     version: 0.1.0
 
-  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/3273b9b':
-    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/3273b9b}
+  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/0147ac1bb29d3b88d6652432a482bd86f0174506':
+    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/0147ac1bb29d3b88d6652432a482bd86f0174506}
     version: 0.1.0
 
   '@alloc/quick-lru@5.2.0':
@@ -14533,11 +14533,11 @@ snapshots:
     optionalDependencies:
       graphql: 16.11.0
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/5939b8f':
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/0308b55e82f7f01d878a7fdf0f597d1dc975f2ce':
     dependencies:
       '@tauri-apps/api': 2.1.1
 
-  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/3273b9b':
+  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/0147ac1bb29d3b88d6652432a482bd86f0174506':
     dependencies:
       '@tauri-apps/api': 2.1.1
 


### PR DESCRIPTION
This PR aligns `plugin-workspace` hashes post `typescript` bump to `v:^5.8.3`.