### PR TITLE
feat(common): unit tests for authentication helpers

### DIFF
--- a/packages/hoppscotch-common/src/helpers/auth/types/__tests__/api-key.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/types/__tests__/api-key.spec.ts
@@ -1,0 +1,113 @@
+import { HoppRESTAuth } from "@hoppscotch/data"
+import { describe, expect, test } from "vitest"
+import { generateApiKeyAuthHeaders, generateApiKeyAuthParams } from "../api-key"
+import { mockEnvVars, mockRequest } from "./test-utils"
+
+describe("API Key Auth", () => {
+  describe("generateApiKeyAuthHeaders", () => {
+    test("generates headers when addTo is HEADERS", async () => {
+      const auth: HoppRESTAuth & { authType: "api-key" } = {
+        authActive: true,
+        authType: "api-key",
+        addTo: "HEADERS",
+        key: "X-API-Key",
+        value: "{{API_VALUE}}",
+      }
+
+      const headers = await generateApiKeyAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0]).toEqual({
+        active: true,
+        key: "X-API-Key",
+        value: "secret-value",
+        description: "",
+      })
+    })
+
+    test("returns empty array when addTo is not HEADERS", async () => {
+      const auth: HoppRESTAuth & { authType: "api-key" } = {
+        authActive: true,
+        authType: "api-key",
+        addTo: "QUERY_PARAMS",
+        key: "api_key",
+        value: "test-value",
+      }
+
+      const headers = await generateApiKeyAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(0)
+    })
+
+    test("handles template strings in key and value", async () => {
+      const auth: HoppRESTAuth & { authType: "api-key" } = {
+        authActive: true,
+        authType: "api-key",
+        addTo: "HEADERS",
+        key: "{{API_KEY}}",
+        value: "{{API_VALUE}}",
+      }
+
+      const headers = await generateApiKeyAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].key).toBe("test-key-123")
+      expect(headers[0].value).toBe("secret-value")
+    })
+  })
+
+  describe("generateApiKeyAuthParams", () => {
+    test("generates params when addTo is QUERY_PARAMS", async () => {
+      const auth: HoppRESTAuth & { authType: "api-key" } = {
+        authActive: true,
+        authType: "api-key",
+        addTo: "QUERY_PARAMS",
+        key: "api_key",
+        value: "{{API_VALUE}}",
+      }
+
+      const params = await generateApiKeyAuthParams(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(params).toHaveLength(1)
+      expect(params[0]).toEqual({
+        active: true,
+        key: "api_key",
+        value: "secret-value",
+        description: "",
+      })
+    })
+
+    test("returns empty array when addTo is not QUERY_PARAMS", async () => {
+      const auth: HoppRESTAuth & { authType: "api-key" } = {
+        authActive: true,
+        authType: "api-key",
+        addTo: "HEADERS",
+        key: "X-API-Key",
+        value: "test-value",
+      }
+
+      const params = await generateApiKeyAuthParams(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(params).toHaveLength(0)
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/auth/types/__tests__/aws-signature.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/types/__tests__/aws-signature.spec.ts
@@ -1,0 +1,161 @@
+import { HoppRESTAuth } from "@hoppscotch/data"
+import { beforeEach, describe, expect, test, vi } from "vitest"
+import {
+  generateAwsSignatureAuthHeaders,
+  generateAwsSignatureAuthParams,
+} from "../aws-signature"
+import { mockEnvVars, mockRequest } from "./test-utils"
+
+// Mock the AwsV4Signer
+vi.mock("aws4fetch", () => ({
+  AwsV4Signer: vi.fn(),
+}))
+
+const { AwsV4Signer } = await import("aws4fetch")
+
+describe("AWS Signature Auth", () => {
+  const awsMockRequest = mockRequest
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("generateAwsSignatureAuthHeaders", () => {
+    test("generates AWS signature headers when addTo is HEADERS", async () => {
+      const mockSign = vi.fn().mockResolvedValue({
+        headers: new Map([
+          ["Authorization", "AWS4-HMAC-SHA256 Credential=..."],
+          ["x-amz-date", "20230101T000000Z"],
+        ]),
+      })
+
+      vi.mocked(AwsV4Signer).mockImplementation(
+        () =>
+          ({
+            sign: mockSign,
+          }) as any
+      )
+
+      const auth: HoppRESTAuth & { authType: "aws-signature" } = {
+        authActive: true,
+        authType: "aws-signature",
+        addTo: "HEADERS",
+        accessKey: "{{AWS_ACCESS_KEY}}",
+        secretKey: "{{AWS_SECRET_KEY}}",
+        region: "{{AWS_REGION}}",
+        serviceName: "s3",
+      }
+
+      const headers = await generateAwsSignatureAuthHeaders(
+        auth,
+        awsMockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(2)
+      expect(headers).toEqual([
+        {
+          active: true,
+          key: "Authorization",
+          value: "AWS4-HMAC-SHA256 Credential=...",
+          description: "",
+        },
+        {
+          active: true,
+          key: "x-amz-date",
+          value: "20230101T000000Z",
+          description: "",
+        },
+      ])
+    })
+
+    test("returns empty array when addTo is not HEADERS", async () => {
+      const auth: HoppRESTAuth & { authType: "aws-signature" } = {
+        authActive: true,
+        authType: "aws-signature",
+        addTo: "QUERY_PARAMS",
+        accessKey: "key",
+        secretKey: "secret",
+        region: "us-east-1",
+        serviceName: "s3",
+      }
+
+      const headers = await generateAwsSignatureAuthHeaders(
+        auth,
+        awsMockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(0)
+    })
+  })
+
+  describe("generateAwsSignatureAuthParams", () => {
+    test("generates AWS signature params when addTo is QUERY_PARAMS", async () => {
+      const mockSign = vi.fn().mockResolvedValue({
+        url: new URL(
+          "https://s3.amazonaws.com/bucket/object?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=test"
+        ),
+      })
+
+      vi.mocked(AwsV4Signer).mockImplementation(
+        () =>
+          ({
+            sign: mockSign,
+          }) as any
+      )
+
+      const auth: HoppRESTAuth & { authType: "aws-signature" } = {
+        authActive: true,
+        authType: "aws-signature",
+        addTo: "QUERY_PARAMS",
+        accessKey: "{{AWS_ACCESS_KEY}}",
+        secretKey: "{{AWS_SECRET_KEY}}",
+        region: "{{AWS_REGION}}",
+        serviceName: "s3",
+      }
+
+      const params = await generateAwsSignatureAuthParams(
+        auth,
+        awsMockRequest,
+        mockEnvVars
+      )
+
+      expect(params).toHaveLength(2)
+      expect(params).toEqual([
+        {
+          active: true,
+          key: "X-Amz-Algorithm",
+          value: "AWS4-HMAC-SHA256",
+          description: "",
+        },
+        {
+          active: true,
+          key: "X-Amz-Credential",
+          value: "test",
+          description: "",
+        },
+      ])
+    })
+
+    test("returns empty array when addTo is not QUERY_PARAMS", async () => {
+      const auth: HoppRESTAuth & { authType: "aws-signature" } = {
+        authActive: true,
+        authType: "aws-signature",
+        addTo: "HEADERS",
+        accessKey: "key",
+        secretKey: "secret",
+        region: "us-east-1",
+        serviceName: "s3",
+      }
+
+      const params = await generateAwsSignatureAuthParams(
+        auth,
+        awsMockRequest,
+        mockEnvVars
+      )
+
+      expect(params).toHaveLength(0)
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/auth/types/__tests__/basic.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/types/__tests__/basic.spec.ts
@@ -1,0 +1,65 @@
+import { HoppRESTAuth } from "@hoppscotch/data"
+import { describe, expect, test } from "vitest"
+import { generateBasicAuthHeaders } from "../basic"
+import { mockEnvVars, mockRequest } from "./test-utils"
+
+describe("Basic Auth", () => {
+  describe("generateBasicAuthHeaders", () => {
+    test("generates basic auth header with credentials", async () => {
+      const auth: HoppRESTAuth & { authType: "basic" } = {
+        authActive: true,
+        authType: "basic",
+        username: "admin",
+        password: "secret123",
+      }
+
+      const headers = await generateBasicAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0]).toEqual({
+        active: true,
+        key: "Authorization",
+        value: `Basic ${btoa("admin:secret123")}`,
+        description: "",
+      })
+    })
+
+    test("handles template strings in username and password", async () => {
+      const auth: HoppRESTAuth & { authType: "basic" } = {
+        authActive: true,
+        authType: "basic",
+        username: "{{USERNAME}}",
+        password: "{{PASSWORD}}",
+      }
+
+      const headers = await generateBasicAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe(`Basic ${btoa("testuser:testpass")}`)
+    })
+
+    test("handles empty credentials", async () => {
+      const auth: HoppRESTAuth & { authType: "basic" } = {
+        authActive: true,
+        authType: "basic",
+        username: "",
+        password: "",
+      }
+
+      const headers = await generateBasicAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe(`Basic ${btoa(":")}`)
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/auth/types/__tests__/bearer.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/types/__tests__/bearer.spec.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect } from "vitest"
+import { generateBearerAuthHeaders } from "../bearer"
+import { mockRequest, mockEnvVars } from "./test-utils"
+import { HoppRESTAuth } from "@hoppscotch/data"
+
+describe("Bearer Auth", () => {
+  describe("generateBearerAuthHeaders", () => {
+    test("generates bearer auth header with token", async () => {
+      const auth: HoppRESTAuth & { authType: "bearer" } = {
+        authActive: true,
+        authType: "bearer",
+        token: "abc123token",
+      }
+
+      const headers = await generateBearerAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0]).toEqual({
+        active: true,
+        key: "Authorization",
+        value: "Bearer abc123token",
+        description: "",
+      })
+    })
+
+    test("handles template strings in token", async () => {
+      const auth: HoppRESTAuth & { authType: "bearer" } = {
+        authActive: true,
+        authType: "bearer",
+        token: "{{ACCESS_TOKEN}}",
+      }
+
+      const headers = await generateBearerAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe(
+        "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+      )
+    })
+
+    test("handles empty token", async () => {
+      const auth: HoppRESTAuth & { authType: "bearer" } = {
+        authActive: true,
+        authType: "bearer",
+        token: "",
+      }
+
+      const headers = await generateBearerAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe("Bearer ")
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/auth/types/__tests__/digest.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/types/__tests__/digest.spec.ts
@@ -1,0 +1,547 @@
+import { describe, test, expect, vi, beforeEach } from "vitest"
+import { generateDigestAuthHeaders } from "../digest"
+import { mockRequest, mockEnvVars } from "./test-utils"
+import { HoppRESTAuth } from "@hoppscotch/data"
+
+// Mock the digest helper functions
+vi.mock("~/helpers/auth/digest", () => ({
+  generateDigestAuthHeader: vi.fn(),
+  fetchInitialDigestAuthInfo: vi.fn(),
+}))
+
+import {
+  generateDigestAuthHeader,
+  fetchInitialDigestAuthInfo,
+} from "~/helpers/auth/digest"
+
+describe("Digest Auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("generateDigestAuthHeaders", () => {
+    test("generates digest auth header with basic configuration", async () => {
+      const mockDigestHeader =
+        'Digest username="testuser", realm="Protected Area", nonce="abc123", uri="/api/data", algorithm="MD5", response="def456", qop=auth, nc=00000001, cnonce="xyz789"'
+
+      vi.mocked(generateDigestAuthHeader).mockResolvedValue(mockDigestHeader)
+
+      const auth: HoppRESTAuth & { authType: "digest" } = {
+        authActive: true,
+        authType: "digest",
+        username: "testuser",
+        password: "testpass",
+        realm: "Protected Area",
+        nonce: "abc123",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "xyz789",
+        opaque: "",
+        disableRetry: false,
+      }
+
+      const headers = await generateDigestAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(generateDigestAuthHeader).toHaveBeenCalledWith({
+        username: "testuser",
+        password: "testpass",
+        realm: "Protected Area",
+        nonce: "abc123",
+        endpoint: "https://api.example.com/data",
+        method: "GET",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "xyz789",
+        opaque: "",
+        reqBody: "",
+      })
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0]).toEqual({
+        active: true,
+        key: "Authorization",
+        value: mockDigestHeader,
+        description: "",
+      })
+    })
+
+    test("handles MD5-sess algorithm", async () => {
+      const mockDigestHeader =
+        'Digest username="user", realm="Test", nonce="nonce123", uri="/api", algorithm="MD5-sess", response="response456", qop=auth, nc=00000001, cnonce="client789"'
+
+      vi.mocked(generateDigestAuthHeader).mockResolvedValue(mockDigestHeader)
+
+      const auth: HoppRESTAuth & { authType: "digest" } = {
+        authActive: true,
+        authType: "digest",
+        username: "user",
+        password: "pass",
+        realm: "Test",
+        nonce: "nonce123",
+        algorithm: "MD5-sess",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "client789",
+        opaque: "",
+        disableRetry: false,
+      }
+
+      const headers = await generateDigestAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(generateDigestAuthHeader).toHaveBeenCalledWith({
+        username: "user",
+        password: "pass",
+        realm: "Test",
+        nonce: "nonce123",
+        endpoint: "https://api.example.com/data",
+        method: "GET",
+        algorithm: "MD5-sess",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "client789",
+        opaque: "",
+        reqBody: "",
+      })
+
+      expect(headers[0].value).toBe(mockDigestHeader)
+    })
+
+    test("handles auth-int qop with request body", async () => {
+      const mockDigestHeader =
+        'Digest username="user", realm="Protected", nonce="nonce456", uri="/api/update", algorithm="MD5", response="response789", qop=auth-int, nc=00000001, cnonce="client123"'
+
+      vi.mocked(generateDigestAuthHeader).mockResolvedValue(mockDigestHeader)
+
+      const requestWithBody = {
+        ...mockRequest,
+        method: "POST",
+        body: {
+          contentType: "application/json" as const,
+          body: '{"name": "test", "value": 123}',
+        },
+      }
+
+      const auth: HoppRESTAuth & { authType: "digest" } = {
+        authActive: true,
+        authType: "digest",
+        username: "user",
+        password: "pass",
+        realm: "Protected",
+        nonce: "nonce456",
+        algorithm: "MD5",
+        qop: "auth-int",
+        nc: "00000001",
+        cnonce: "client123",
+        opaque: "",
+        disableRetry: false,
+      }
+
+      const headers = await generateDigestAuthHeaders(
+        auth,
+        requestWithBody,
+        mockEnvVars
+      )
+
+      expect(generateDigestAuthHeader).toHaveBeenCalledWith({
+        username: "user",
+        password: "pass",
+        realm: "Protected",
+        nonce: "nonce456",
+        endpoint: "https://api.example.com/data",
+        method: "POST",
+        algorithm: "MD5",
+        qop: "auth-int",
+        nc: "00000001",
+        cnonce: "client123",
+        opaque: "",
+        reqBody: '{"name": "test", "value": 123}',
+      })
+
+      expect(headers[0].value).toBe(mockDigestHeader)
+    })
+
+    test("handles template variables in username and password", async () => {
+      const mockDigestHeader =
+        'Digest username="testuser", realm="realm", nonce="nonce", uri="/api/data", algorithm="MD5", response="response", qop=auth, nc=00000001, cnonce="cnonce"'
+
+      vi.mocked(generateDigestAuthHeader).mockResolvedValue(mockDigestHeader)
+
+      const auth: HoppRESTAuth & { authType: "digest" } = {
+        authActive: true,
+        authType: "digest",
+        username: "{{DIGEST_USER}}",
+        password: "{{DIGEST_PASS}}",
+        realm: "realm",
+        nonce: "nonce",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "cnonce",
+        opaque: "",
+        disableRetry: false,
+      }
+
+      const headers = await generateDigestAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(generateDigestAuthHeader).toHaveBeenCalledWith({
+        username: "testuser",
+        password: "testpass",
+        realm: "realm",
+        nonce: "nonce",
+        endpoint: "https://api.example.com/data",
+        method: "GET",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "cnonce",
+        opaque: "",
+        reqBody: "",
+      })
+
+      expect(headers[0].value).toBe(mockDigestHeader)
+    })
+
+    test("handles opaque value", async () => {
+      const mockDigestHeader =
+        'Digest username="user", realm="Protected", nonce="nonce123", uri="/api/data", algorithm="MD5", response="response456", qop=auth, nc=00000001, cnonce="cnonce789", opaque="opaque-value-123"'
+
+      vi.mocked(generateDigestAuthHeader).mockResolvedValue(mockDigestHeader)
+
+      const auth: HoppRESTAuth & { authType: "digest" } = {
+        authActive: true,
+        authType: "digest",
+        username: "user",
+        password: "pass",
+        realm: "Protected",
+        nonce: "nonce123",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "cnonce789",
+        opaque: "opaque-value-123",
+        disableRetry: false,
+      }
+
+      const headers = await generateDigestAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(generateDigestAuthHeader).toHaveBeenCalledWith({
+        username: "user",
+        password: "pass",
+        realm: "Protected",
+        nonce: "nonce123",
+        endpoint: "https://api.example.com/data",
+        method: "GET",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "cnonce789",
+        opaque: "opaque-value-123",
+        reqBody: "",
+      })
+
+      expect(headers[0].value).toBe(mockDigestHeader)
+    })
+
+    test("auto-generates cnonce when not provided", async () => {
+      const mockDigestHeader =
+        'Digest username="user", realm="realm", nonce="nonce", uri="/api/data", algorithm="MD5", response="response", qop=auth, nc=00000001, cnonce="auto-generated"'
+
+      vi.mocked(generateDigestAuthHeader).mockResolvedValue(mockDigestHeader)
+
+      const auth: HoppRESTAuth & { authType: "digest" } = {
+        authActive: true,
+        authType: "digest",
+        username: "user",
+        password: "pass",
+        realm: "realm",
+        nonce: "nonce",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "", // Empty cnonce should be auto-generated
+        opaque: "",
+        disableRetry: false,
+      }
+
+      const headers = await generateDigestAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(generateDigestAuthHeader).toHaveBeenCalledWith({
+        username: "user",
+        password: "pass",
+        realm: "realm",
+        nonce: "nonce",
+        endpoint: "https://api.example.com/data",
+        method: "GET",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "", // Implementation should handle auto-generation
+        opaque: "",
+        reqBody: "",
+      })
+
+      expect(headers[0].value).toBe(mockDigestHeader)
+    })
+
+    test("handles initial digest auth info fetch", async () => {
+      const mockDigestInfo = {
+        realm: "Fetched Realm",
+        nonce: "fetched-nonce-123",
+        qop: "auth",
+        algorithm: "MD5",
+        opaque: "fetched-opaque",
+      }
+
+      const mockDigestHeader =
+        'Digest username="user", realm="Fetched Realm", nonce="fetched-nonce-123", uri="/api/data", algorithm="MD5", response="response", qop=auth, nc=00000001, cnonce="cnonce"'
+
+      vi.mocked(fetchInitialDigestAuthInfo).mockResolvedValue(mockDigestInfo)
+      vi.mocked(generateDigestAuthHeader).mockResolvedValue(mockDigestHeader)
+
+      const auth: HoppRESTAuth & { authType: "digest" } = {
+        authActive: true,
+        authType: "digest",
+        username: "user",
+        password: "pass",
+        realm: "", // Empty realm should trigger fetch
+        nonce: "",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "cnonce",
+        opaque: "",
+        disableRetry: false,
+      }
+
+      const headers = await generateDigestAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(fetchInitialDigestAuthInfo).toHaveBeenCalledWith(
+        "https://api.example.com/data",
+        "GET"
+      )
+
+      expect(headers[0].value).toBe(mockDigestHeader)
+    })
+
+    test("handles empty credentials", async () => {
+      const mockDigestHeader =
+        'Digest username="", realm="realm", nonce="nonce", uri="/api/data", algorithm="MD5", response="response", qop=auth, nc=00000001, cnonce="cnonce"'
+
+      vi.mocked(generateDigestAuthHeader).mockResolvedValue(mockDigestHeader)
+
+      const auth: HoppRESTAuth & { authType: "digest" } = {
+        authActive: true,
+        authType: "digest",
+        username: "",
+        password: "",
+        realm: "realm",
+        nonce: "nonce",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "cnonce",
+        opaque: "",
+        disableRetry: false,
+      }
+
+      const headers = await generateDigestAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe(mockDigestHeader)
+    })
+
+    test("handles digest auth generation failure", async () => {
+      vi.mocked(generateDigestAuthHeader).mockRejectedValue(
+        new Error("Invalid digest parameters")
+      )
+
+      const auth: HoppRESTAuth & { authType: "digest" } = {
+        authActive: true,
+        authType: "digest",
+        username: "user",
+        password: "pass",
+        realm: "realm",
+        nonce: "nonce",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "cnonce",
+        opaque: "",
+        disableRetry: false,
+      }
+
+      const headers = await generateDigestAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0].value).toBe("")
+    })
+
+    test("handles different HTTP methods", async () => {
+      const methods = ["GET", "POST", "PUT", "DELETE", "PATCH"]
+
+      for (const method of methods) {
+        const mockDigestHeader = `Digest username="user", realm="realm", nonce="nonce", uri="/api/data", algorithm="MD5", response="response-${method}", qop=auth, nc=00000001, cnonce="cnonce"`
+
+        vi.mocked(generateDigestAuthHeader).mockResolvedValue(mockDigestHeader)
+
+        const requestWithMethod = {
+          ...mockRequest,
+          method,
+        }
+
+        const auth: HoppRESTAuth & { authType: "digest" } = {
+          authActive: true,
+          authType: "digest",
+          username: "user",
+          password: "pass",
+          realm: "realm",
+          nonce: "nonce",
+          algorithm: "MD5",
+          qop: "auth",
+          nc: "00000001",
+          cnonce: "cnonce",
+          opaque: "",
+          disableRetry: false,
+        }
+
+        const headers = await generateDigestAuthHeaders(
+          auth,
+          requestWithMethod,
+          mockEnvVars
+        )
+
+        expect(generateDigestAuthHeader).toHaveBeenCalledWith({
+          username: "user",
+          password: "pass",
+          realm: "realm",
+          nonce: "nonce",
+          endpoint: "https://api.example.com/data",
+          method,
+          algorithm: "MD5",
+          qop: "auth",
+          nc: "00000001",
+          cnonce: "cnonce",
+          opaque: "",
+          reqBody: "",
+        })
+
+        expect(headers[0].value).toBe(mockDigestHeader)
+        vi.clearAllMocks()
+      }
+    })
+
+    test("handles disable retry flag", async () => {
+      const mockDigestHeader =
+        'Digest username="user", realm="realm", nonce="nonce", uri="/api/data", algorithm="MD5", response="response", qop=auth, nc=00000001, cnonce="cnonce"'
+
+      vi.mocked(generateDigestAuthHeader).mockResolvedValue(mockDigestHeader)
+
+      const auth: HoppRESTAuth & { authType: "digest" } = {
+        authActive: true,
+        authType: "digest",
+        username: "user",
+        password: "pass",
+        realm: "realm",
+        nonce: "nonce",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "cnonce",
+        opaque: "",
+        disableRetry: true,
+      }
+
+      const headers = await generateDigestAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe(mockDigestHeader)
+      // The disableRetry flag would be used in the actual digest auth flow
+    })
+
+    test("handles complex URI paths with query parameters", async () => {
+      const mockDigestHeader =
+        'Digest username="user", realm="realm", nonce="nonce", uri="/api/data?param=value&other=test", algorithm="MD5", response="response", qop=auth, nc=00000001, cnonce="cnonce"'
+
+      vi.mocked(generateDigestAuthHeader).mockResolvedValue(mockDigestHeader)
+
+      const requestWithQueryParams = {
+        ...mockRequest,
+        endpoint: "https://api.example.com/api/data?param=value&other=test",
+      }
+
+      const auth: HoppRESTAuth & { authType: "digest" } = {
+        authActive: true,
+        authType: "digest",
+        username: "user",
+        password: "pass",
+        realm: "realm",
+        nonce: "nonce",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "cnonce",
+        opaque: "",
+        disableRetry: false,
+      }
+
+      const headers = await generateDigestAuthHeaders(
+        auth,
+        requestWithQueryParams,
+        mockEnvVars
+      )
+
+      expect(generateDigestAuthHeader).toHaveBeenCalledWith({
+        username: "user",
+        password: "pass",
+        realm: "realm",
+        nonce: "nonce",
+        endpoint: "https://api.example.com/api/data?param=value&other=test",
+        method: "GET",
+        algorithm: "MD5",
+        qop: "auth",
+        nc: "00000001",
+        cnonce: "cnonce",
+        opaque: "",
+        reqBody: "",
+      })
+
+      expect(headers[0].value).toBe(mockDigestHeader)
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/auth/types/__tests__/hawk.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/types/__tests__/hawk.spec.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect, vi, beforeEach } from "vitest"
+import { generateHawkAuthHeaders } from "../hawk"
+import { mockRequest, mockEnvVars } from "./test-utils"
+import { HoppRESTAuth } from "@hoppscotch/data"
+
+// Mock the calculateHawkHeader function
+vi.mock("@hoppscotch/data", async () => {
+  const actual = await vi.importActual("@hoppscotch/data")
+  return {
+    ...actual,
+    calculateHawkHeader: vi.fn(),
+  }
+})
+
+// Mock the getFinalBodyFromRequest function
+vi.mock("~/helpers/utils/EffectiveURL", () => ({
+  getFinalBodyFromRequest: vi.fn(),
+}))
+
+const { calculateHawkHeader } = await import("@hoppscotch/data")
+const { getFinalBodyFromRequest } = await import("~/helpers/utils/EffectiveURL")
+
+describe("Hawk Auth", () => {
+  const jsonBodyRequest = {
+    method: "POST" as const,
+    endpoint: "https://api.example.com/data",
+    headers: [],
+    params: [],
+    body: { contentType: "application/json", body: '{"test": "data"}' },
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("generateHawkAuthHeaders", () => {
+    test("generates hawk authorization header", async () => {
+      vi.mocked(calculateHawkHeader).mockResolvedValue(
+        'Hawk id="test-hawk-id", ts="1234567890", nonce="abcdef", mac="xyz123"'
+      )
+      vi.mocked(getFinalBodyFromRequest).mockReturnValue('{"test": "data"}')
+
+      const auth: HoppRESTAuth & { authType: "hawk" } = {
+        authActive: true,
+        authType: "hawk",
+        authId: "{{HAWK_ID}}",
+        authKey: "{{HAWK_KEY}}",
+        algorithm: "sha256",
+        includePayloadHash: true,
+      }
+
+      const headers = await generateHawkAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0]).toEqual({
+        active: true,
+        key: "Authorization",
+        value:
+          'Hawk id="test-hawk-id", ts="1234567890", nonce="abcdef", mac="xyz123"',
+        description: "",
+      })
+    })
+
+    test("returns empty array for non-hawk auth type", async () => {
+      const auth: HoppRESTAuth & { authType: "basic" } = {
+        authActive: true,
+        authType: "basic",
+        username: "user",
+        password: "pass",
+      }
+
+      const headers = await generateHawkAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(0)
+    })
+
+    test("handles template strings in auth parameters", async () => {
+      vi.mocked(calculateHawkHeader).mockResolvedValue(
+        'Hawk id="test-hawk-id", mac="xyz123"'
+      )
+      vi.mocked(getFinalBodyFromRequest).mockReturnValue("")
+
+      const auth: HoppRESTAuth & { authType: "hawk" } = {
+        authActive: true,
+        authType: "hawk",
+        authId: "{{HAWK_ID}}",
+        authKey: "{{HAWK_KEY}}",
+        algorithm: "sha1",
+        includePayloadHash: false,
+      }
+
+      await generateHawkAuthHeaders(auth, mockRequest, mockEnvVars)
+
+      expect(calculateHawkHeader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "test-hawk-id",
+          key: "test-hawk-key",
+          algorithm: "sha1",
+        })
+      )
+    })
+
+    test("handles optional hawk parameters", async () => {
+      vi.mocked(calculateHawkHeader).mockResolvedValue(
+        'Hawk id="test-hawk-id", mac="xyz123"'
+      )
+      vi.mocked(getFinalBodyFromRequest).mockReturnValue("")
+
+      const auth: HoppRESTAuth & { authType: "hawk" } = {
+        authActive: true,
+        authType: "hawk",
+        authId: "{{HAWK_ID}}",
+        authKey: "{{HAWK_KEY}}",
+        algorithm: "sha256",
+        nonce: "custom-nonce",
+        ext: "custom-ext",
+        app: "custom-app",
+        dlg: "custom-dlg",
+        timestamp: "1234567890",
+        includePayloadHash: false,
+      }
+
+      await generateHawkAuthHeaders(auth, mockRequest, mockEnvVars)
+
+      expect(calculateHawkHeader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nonce: "custom-nonce",
+          ext: "custom-ext",
+          app: "custom-app",
+          dlg: "custom-dlg",
+          timestamp: 1234567890,
+        })
+      )
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/auth/types/__tests__/jwt.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/types/__tests__/jwt.spec.ts
@@ -1,0 +1,375 @@
+import { describe, test, expect, vi, beforeEach } from "vitest"
+import { generateJWTAuthHeaders } from "../jwt"
+import { mockRequest, mockEnvVars } from "./test-utils"
+import { HoppRESTAuth } from "@hoppscotch/data"
+
+// Mock the jwt helper
+vi.mock("@hoppscotch/data", async () => {
+  const actual = await vi.importActual("@hoppscotch/data")
+  return {
+    ...actual,
+    generateJWTToken: vi.fn(),
+  }
+})
+
+import { generateJWTToken } from "@hoppscotch/data"
+
+describe("JWT Auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("generateJWTAuthHeaders", () => {
+    test("generates JWT auth header with basic configuration", async () => {
+      const mockToken =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+
+      vi.mocked(generateJWTToken).mockResolvedValue(mockToken)
+
+      const auth: HoppRESTAuth & { authType: "jwt" } = {
+        authActive: true,
+        authType: "jwt",
+        secret: "my-secret-key",
+        privateKey: "",
+        algorithm: "HS256",
+        payload: '{"sub": "1234567890", "name": "John Doe"}',
+        addTo: "HEADERS",
+        isSecretBase64Encoded: false,
+        headerPrefix: "Bearer ",
+        paramName: "token",
+        jwtHeaders: "{}",
+      }
+
+      const headers = await generateJWTAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(generateJWTToken).toHaveBeenCalledWith({
+        secret: "my-secret-key",
+        algorithm: "HS256",
+        payload: '{"sub": "1234567890", "name": "John Doe"}',
+        isSecretBase64Encoded: false,
+        privateKey: "",
+        jwtHeaders: "{}",
+      })
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0]).toEqual({
+        active: true,
+        key: "Authorization",
+        value:
+          "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+        description: "",
+      })
+    })
+
+    test("adds JWT token to query params when addTo is QUERY_PARAMS", async () => {
+      const mockToken = "jwt.token.here"
+      vi.mocked(generateJWTToken).mockResolvedValue(mockToken)
+
+      const auth: HoppRESTAuth & { authType: "jwt" } = {
+        authActive: true,
+        authType: "jwt",
+        secret: "secret",
+        privateKey: "",
+        algorithm: "HS256",
+        payload: "{}",
+        addTo: "QUERY_PARAMS",
+        isSecretBase64Encoded: false,
+        headerPrefix: "Bearer ",
+        paramName: "access_token",
+        jwtHeaders: "{}",
+      }
+
+      const headers = await generateJWTAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(0)
+      // Note: Query params would be handled differently in the actual implementation
+    })
+
+    test("handles template variables in secret", async () => {
+      const mockToken = "generated.jwt.token"
+      vi.mocked(generateJWTToken).mockResolvedValue(mockToken)
+
+      const auth: HoppRESTAuth & { authType: "jwt" } = {
+        authActive: true,
+        authType: "jwt",
+        secret: "{{JWT_SECRET}}",
+        privateKey: "",
+        algorithm: "HS256",
+        payload: "{{JWT_PAYLOAD}}",
+        addTo: "HEADERS",
+        isSecretBase64Encoded: false,
+        headerPrefix: "Bearer ",
+        paramName: "token",
+        jwtHeaders: "{}",
+      }
+
+      const headers = await generateJWTAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(generateJWTToken).toHaveBeenCalledWith({
+        secret: "my-secret-key",
+        algorithm: "HS256",
+        payload: '{"sub": "1234567890", "name": "John Doe"}',
+        isSecretBase64Encoded: false,
+        privateKey: "",
+        jwtHeaders: "{}",
+      })
+
+      expect(headers[0].value).toBe("Bearer generated.jwt.token")
+    })
+
+    test("handles RSA algorithm with private key", async () => {
+      const mockToken = "rsa.signed.token"
+      vi.mocked(generateJWTToken).mockResolvedValue(mockToken)
+
+      const auth: HoppRESTAuth & { authType: "jwt" } = {
+        authActive: true,
+        authType: "jwt",
+        secret: "",
+        privateKey:
+          "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC4...",
+        algorithm: "RS256",
+        payload: '{"iss": "test"}',
+        addTo: "HEADERS",
+        isSecretBase64Encoded: false,
+        headerPrefix: "JWT ",
+        paramName: "token",
+        jwtHeaders: '{"typ": "JWT"}',
+      }
+
+      const headers = await generateJWTAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(generateJWTToken).toHaveBeenCalledWith({
+        secret: "",
+        algorithm: "RS256",
+        payload: '{"iss": "test"}',
+        isSecretBase64Encoded: false,
+        privateKey:
+          "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC4...",
+        jwtHeaders: '{"typ": "JWT"}',
+      })
+
+      expect(headers[0].value).toBe("JWT rsa.signed.token")
+    })
+
+    test("handles base64 encoded secret", async () => {
+      const mockToken = "base64.encoded.token"
+      vi.mocked(generateJWTToken).mockResolvedValue(mockToken)
+
+      const auth: HoppRESTAuth & { authType: "jwt" } = {
+        authActive: true,
+        authType: "jwt",
+        secret: "bXktc2VjcmV0LWtleQ==", // base64 for "my-secret-key"
+        privateKey: "",
+        algorithm: "HS512",
+        payload: "{}",
+        addTo: "HEADERS",
+        isSecretBase64Encoded: true,
+        headerPrefix: "Token ",
+        paramName: "token",
+        jwtHeaders: "{}",
+      }
+
+      const headers = await generateJWTAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(generateJWTToken).toHaveBeenCalledWith({
+        secret: "bXktc2VjcmV0LWtleQ==",
+        algorithm: "HS512",
+        payload: "{}",
+        isSecretBase64Encoded: true,
+        privateKey: "",
+        jwtHeaders: "{}",
+      })
+
+      expect(headers[0].value).toBe("Token base64.encoded.token")
+    })
+
+    test("handles custom header prefix", async () => {
+      const mockToken = "custom.prefix.token"
+      vi.mocked(generateJWTToken).mockResolvedValue(mockToken)
+
+      const auth: HoppRESTAuth & { authType: "jwt" } = {
+        authActive: true,
+        authType: "jwt",
+        secret: "secret",
+        privateKey: "",
+        algorithm: "HS256",
+        payload: "{}",
+        addTo: "HEADERS",
+        isSecretBase64Encoded: false,
+        headerPrefix: "Custom-Auth ",
+        paramName: "token",
+        jwtHeaders: "{}",
+      }
+
+      const headers = await generateJWTAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe("Custom-Auth custom.prefix.token")
+    })
+
+    test("handles empty header prefix", async () => {
+      const mockToken = "no.prefix.token"
+      vi.mocked(generateJWTToken).mockResolvedValue(mockToken)
+
+      const auth: HoppRESTAuth & { authType: "jwt" } = {
+        authActive: true,
+        authType: "jwt",
+        secret: "secret",
+        privateKey: "",
+        algorithm: "HS256",
+        payload: "{}",
+        addTo: "HEADERS",
+        isSecretBase64Encoded: false,
+        headerPrefix: "",
+        paramName: "token",
+        jwtHeaders: "{}",
+      }
+
+      const headers = await generateJWTAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe("no.prefix.token")
+    })
+
+    test("handles JWT generation failure", async () => {
+      vi.mocked(generateJWTToken).mockRejectedValue(new Error("Invalid secret"))
+
+      const auth: HoppRESTAuth & { authType: "jwt" } = {
+        authActive: true,
+        authType: "jwt",
+        secret: "",
+        privateKey: "",
+        algorithm: "HS256",
+        payload: "{}",
+        addTo: "HEADERS",
+        isSecretBase64Encoded: false,
+        headerPrefix: "Bearer ",
+        paramName: "token",
+        jwtHeaders: "{}",
+      }
+
+      const headers = await generateJWTAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0].value).toBe("Bearer ")
+    })
+
+    test("handles different JWT algorithms", async () => {
+      const algorithms = ["HS384", "RS384", "PS256", "ES256"] as const
+
+      for (const algorithm of algorithms) {
+        const mockToken = `${algorithm.toLowerCase()}.token`
+        vi.mocked(generateJWTToken).mockResolvedValue(mockToken)
+
+        const auth: HoppRESTAuth & { authType: "jwt" } = {
+          authActive: true,
+          authType: "jwt",
+          secret: "secret",
+          privateKey: algorithm.startsWith("HS") ? "" : "private-key",
+          algorithm,
+          payload: "{}",
+          addTo: "HEADERS",
+          isSecretBase64Encoded: false,
+          headerPrefix: "Bearer ",
+          paramName: "token",
+          jwtHeaders: "{}",
+        }
+
+        const headers = await generateJWTAuthHeaders(
+          auth,
+          mockRequest,
+          mockEnvVars
+        )
+
+        expect(generateJWTToken).toHaveBeenCalledWith({
+          secret: "secret",
+          algorithm,
+          payload: "{}",
+          isSecretBase64Encoded: false,
+          privateKey: algorithm.startsWith("HS") ? "" : "private-key",
+          jwtHeaders: "{}",
+        })
+
+        expect(headers[0].value).toBe(`Bearer ${mockToken}`)
+        vi.clearAllMocks()
+      }
+    })
+
+    test("handles complex payload with claims", async () => {
+      const mockToken = "complex.payload.token"
+      vi.mocked(generateJWTToken).mockResolvedValue(mockToken)
+
+      const complexPayload = JSON.stringify({
+        iss: "https://example.com",
+        sub: "user123",
+        aud: "api.example.com",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iat: Math.floor(Date.now() / 1000),
+        nbf: Math.floor(Date.now() / 1000),
+        jti: "unique-id",
+        custom_claim: "custom_value",
+      })
+
+      const auth: HoppRESTAuth & { authType: "jwt" } = {
+        authActive: true,
+        authType: "jwt",
+        secret: "secret",
+        privateKey: "",
+        algorithm: "HS256",
+        payload: complexPayload,
+        addTo: "HEADERS",
+        isSecretBase64Encoded: false,
+        headerPrefix: "Bearer ",
+        paramName: "token",
+        jwtHeaders: '{"alg": "HS256", "typ": "JWT", "kid": "key-id"}',
+      }
+
+      const headers = await generateJWTAuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(generateJWTToken).toHaveBeenCalledWith({
+        secret: "secret",
+        algorithm: "HS256",
+        payload: complexPayload,
+        isSecretBase64Encoded: false,
+        privateKey: "",
+        jwtHeaders: '{"alg": "HS256", "typ": "JWT", "kid": "key-id"}',
+      })
+
+      expect(headers[0].value).toBe("Bearer complex.payload.token")
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/auth/types/__tests__/oauth2.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/types/__tests__/oauth2.spec.ts
@@ -1,0 +1,402 @@
+import { describe, test, expect } from "vitest"
+import { generateOAuth2AuthHeaders } from "../oauth2"
+import { mockRequest, mockEnvVars } from "./test-utils"
+import { HoppRESTAuth } from "@hoppscotch/data"
+
+describe("OAuth2 Auth", () => {
+  describe("generateOAuth2AuthHeaders", () => {
+    test("generates OAuth2 auth header for Authorization Code grant type", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "AUTHORIZATION_CODE",
+          authEndpoint: "https://auth.example.com/oauth/authorize",
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "my-client-id",
+          clientSecret: "my-client-secret",
+          scopes: "read write",
+          token: "oauth2_access_token_123",
+          isPKCE: false,
+          refreshToken: "refresh_token_456",
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0]).toEqual({
+        active: true,
+        key: "Authorization",
+        value: "Bearer oauth2_access_token_123",
+        description: "",
+      })
+    })
+
+    test("adds OAuth2 token to query params when addTo is QUERY_PARAMS", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "AUTHORIZATION_CODE",
+          authEndpoint: "https://auth.example.com/oauth/authorize",
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "client-id",
+          clientSecret: "client-secret",
+          scopes: "read",
+          token: "query_param_token",
+          isPKCE: false,
+        },
+        addTo: "QUERY_PARAMS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(0)
+      // Note: Query params would be handled differently in the actual implementation
+    })
+
+    test("handles Client Credentials grant type", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "CLIENT_CREDENTIALS",
+          authEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "client-credentials-id",
+          clientSecret: "client-credentials-secret",
+          scopes: "api:read api:write",
+          token: "client_credentials_token",
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0]).toEqual({
+        active: true,
+        key: "Authorization",
+        value: "Bearer client_credentials_token",
+        description: "",
+      })
+    })
+
+    test("handles Password grant type", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "PASSWORD",
+          authEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "password-client-id",
+          clientSecret: "password-client-secret",
+          scopes: "user:profile",
+          username: "testuser",
+          password: "testpass",
+          token: "password_grant_token",
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0]).toEqual({
+        active: true,
+        key: "Authorization",
+        value: "Bearer password_grant_token",
+        description: "",
+      })
+    })
+
+    test("handles Implicit grant type", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "IMPLICIT",
+          authEndpoint: "https://auth.example.com/oauth/authorize",
+          clientID: "implicit-client-id",
+          scopes: "read",
+          token: "implicit_token_123",
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0]).toEqual({
+        active: true,
+        key: "Authorization",
+        value: "Bearer implicit_token_123",
+        description: "",
+      })
+    })
+
+    test("handles template variables in token", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "AUTHORIZATION_CODE",
+          authEndpoint: "https://auth.example.com/oauth/authorize",
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "{{CLIENT_ID}}",
+          clientSecret: "{{CLIENT_SECRET}}",
+          scopes: "read write",
+          token: "{{OAUTH_TOKEN}}",
+          isPKCE: false,
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe("Bearer oauth2_access_token_123")
+    })
+
+    test("handles empty token", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "AUTHORIZATION_CODE",
+          authEndpoint: "https://auth.example.com/oauth/authorize",
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "client-id",
+          clientSecret: "client-secret",
+          scopes: "read",
+          token: "",
+          isPKCE: false,
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe("Bearer ")
+    })
+
+    test("handles PKCE flow with Authorization Code", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "AUTHORIZATION_CODE",
+          authEndpoint: "https://auth.example.com/oauth/authorize",
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "pkce-client-id",
+          scopes: "openid profile",
+          token: "pkce_token_123",
+          isPKCE: true,
+          codeVerifierMethod: "S256",
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers).toHaveLength(1)
+      expect(headers[0]).toEqual({
+        active: true,
+        key: "Authorization",
+        value: "Bearer pkce_token_123",
+        description: "",
+      })
+    })
+
+    test("handles optional client secret for Authorization Code", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "AUTHORIZATION_CODE",
+          authEndpoint: "https://auth.example.com/oauth/authorize",
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "public-client-id",
+          scopes: "read",
+          token: "public_client_token",
+          isPKCE: true,
+          codeVerifierMethod: "plain",
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe("Bearer public_client_token")
+    })
+
+    test("handles refresh token for Authorization Code grant", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "AUTHORIZATION_CODE",
+          authEndpoint: "https://auth.example.com/oauth/authorize",
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "refresh-client-id",
+          clientSecret: "refresh-client-secret",
+          scopes: "offline_access",
+          token: "access_token_with_refresh",
+          isPKCE: false,
+          refreshToken: "refresh_token_xyz",
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe("Bearer access_token_with_refresh")
+    })
+
+    test("handles optional scopes", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "CLIENT_CREDENTIALS",
+          authEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "no-scope-client",
+          clientSecret: "no-scope-secret",
+          token: "no_scope_token",
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe("Bearer no_scope_token")
+    })
+
+    test("handles optional client secret for Password grant", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "PASSWORD",
+          authEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "password-public-client",
+          username: "user",
+          password: "pass",
+          token: "password_public_token",
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe("Bearer password_public_token")
+    })
+
+    test("handles various scope formats", async () => {
+      const scopeFormats = [
+        "read write admin",
+        "user:profile user:email",
+        "https://www.googleapis.com/auth/userinfo.profile",
+        "openid profile email offline_access",
+      ]
+
+      for (const scopes of scopeFormats) {
+        const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+          authActive: true,
+          authType: "oauth-2",
+          grantTypeInfo: {
+            grantType: "CLIENT_CREDENTIALS",
+            authEndpoint: "https://auth.example.com/oauth/token",
+            clientID: "scope-test-client",
+            clientSecret: "scope-test-secret",
+            scopes,
+            token: "scope_test_token",
+          },
+          addTo: "HEADERS",
+        }
+
+        const headers = await generateOAuth2AuthHeaders(
+          auth,
+          mockRequest,
+          mockEnvVars
+        )
+
+        expect(headers[0].value).toBe("Bearer scope_test_token")
+      }
+    })
+
+    test("preserves token case sensitivity", async () => {
+      const auth: HoppRESTAuth & { authType: "oauth-2" } = {
+        authActive: true,
+        authType: "oauth-2",
+        grantTypeInfo: {
+          grantType: "AUTHORIZATION_CODE",
+          authEndpoint: "https://auth.example.com/oauth/authorize",
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+          clientID: "case-client",
+          clientSecret: "case-secret",
+          scopes: "read",
+          token: "CaSe_SeNsItIvE_ToKeN_123",
+          isPKCE: false,
+        },
+        addTo: "HEADERS",
+      }
+
+      const headers = await generateOAuth2AuthHeaders(
+        auth,
+        mockRequest,
+        mockEnvVars
+      )
+
+      expect(headers[0].value).toBe("Bearer CaSe_SeNsItIvE_ToKeN_123")
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/auth/types/__tests__/test-utils.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/types/__tests__/test-utils.ts
@@ -1,0 +1,112 @@
+import { HoppRESTRequest, Environment } from "@hoppscotch/data"
+
+export const mockRequest: HoppRESTRequest = {
+  v: "14",
+  method: "GET",
+  endpoint: "https://api.example.com/data",
+  headers: [],
+  params: [],
+  body: { contentType: "application/json", body: "" },
+  auth: {
+    authActive: false,
+    authType: "none",
+  },
+  name: "Mock Request",
+  preRequestScript: "",
+  testScript: "",
+  requestVariables: [],
+  responses: {},
+}
+
+export const mockEnvVars: Environment["variables"] = [
+  {
+    key: "API_KEY",
+    secret: false,
+    initialValue: "test-key-123",
+    currentValue: "test-key-123",
+  },
+  {
+    key: "API_VALUE",
+    secret: true,
+    initialValue: "secret-value",
+    currentValue: "secret-value",
+  },
+  {
+    key: "ACCESS_TOKEN",
+    secret: true,
+    initialValue: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+    currentValue: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+  },
+  {
+    key: "USERNAME",
+    secret: false,
+    initialValue: "testuser",
+    currentValue: "testuser",
+  },
+  {
+    key: "PASSWORD",
+    secret: true,
+    initialValue: "testpass",
+    currentValue: "testpass",
+  },
+  {
+    key: "OAUTH_TOKEN",
+    secret: true,
+    initialValue: "oauth2_access_token_123",
+    currentValue: "oauth2_access_token_123",
+  },
+  {
+    key: "JWT_SECRET",
+    secret: true,
+    initialValue: "my-secret-key",
+    currentValue: "my-secret-key",
+  },
+  {
+    key: "JWT_PAYLOAD",
+    secret: false,
+    initialValue: '{"sub": "1234567890", "name": "John Doe"}',
+    currentValue: '{"sub": "1234567890", "name": "John Doe"}',
+  },
+  {
+    key: "AWS_ACCESS_KEY",
+    secret: true,
+    initialValue: "AKIAIOSFODNN7EXAMPLE",
+    currentValue: "AKIAIOSFODNN7EXAMPLE",
+  },
+  {
+    key: "AWS_SECRET_KEY",
+    secret: true,
+    initialValue: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    currentValue: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  },
+  {
+    key: "AWS_REGION",
+    secret: false,
+    initialValue: "us-east-1",
+    currentValue: "us-east-1",
+  },
+  {
+    key: "HAWK_ID",
+    secret: false,
+    initialValue: "test-hawk-id",
+    currentValue: "test-hawk-id",
+  },
+  {
+    key: "HAWK_KEY",
+    secret: true,
+    initialValue: "test-hawk-key",
+    currentValue: "test-hawk-key",
+  },
+  {
+    key: "DIGEST_USER",
+    secret: false,
+    initialValue: "testuser",
+    currentValue: "testuser",
+  },
+  {
+    key: "DIGEST_PASS",
+    secret: true,
+    initialValue: "testpass",
+    currentValue: "testpass",
+  },
+]


### PR DESCRIPTION
This pull request introduces comprehensive unit tests for various authentication mechanisms in the `hoppscotch-common` package. These tests ensure that the authentication headers and parameters are generated correctly for different scenarios, including handling template strings, optional parameters, and edge cases like empty values.