### PR TITLE
fix: unicode error in postman import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -147,6 +147,23 @@ const getHoppReqVariables = (
   }
 }
 
+// This regex is used to remove unsupported unicode characters from the response body which fails in Prisma
+// https://dba.stackexchange.com/questions/115029/unicode-error-with-u0000-on-copy-of-large-json-file-into-postgres
+const UNSUPORTED_UNICODES_REGEX = /[\u0000]/g
+
+const getHoppResponseBody = (
+  body: string | ArrayBuffer | undefined
+): string => {
+  if (!body) return ""
+  if (typeof body === "string")
+    return body.replace(UNSUPORTED_UNICODES_REGEX, "")
+  if (body instanceof ArrayBuffer) {
+    return new TextDecoder().decode(body)
+  }
+
+  return ""
+}
+
 const getHoppResponses = (
   responses: Item["responses"]
 ): HoppRESTRequestResponses => {
@@ -157,7 +174,7 @@ const getHoppResponses = (
         const res = {
           name: response.name,
           status: response.status,
-          body: response.body ?? "",
+          body: getHoppResponseBody(response.body),
           headers: getHoppReqHeaders(response.headers),
           code: response.code,
           originalRequest: makeHoppRESTResponseOriginalRequest({

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -149,14 +149,14 @@ const getHoppReqVariables = (
 
 // This regex is used to remove unsupported unicode characters from the response body which fails in Prisma
 // https://dba.stackexchange.com/questions/115029/unicode-error-with-u0000-on-copy-of-large-json-file-into-postgres
-const UNSUPORTED_UNICODES_REGEX = /[\u0000]/g
+const UNSUPPORTED_UNICODES_REGEX = /[\u0000]/g
 
 const getHoppResponseBody = (
   body: string | ArrayBuffer | undefined
 ): string => {
   if (!body) return ""
   if (typeof body === "string")
-    return body.replace(UNSUPORTED_UNICODES_REGEX, "")
+    return body.replace(UNSUPPORTED_UNICODES_REGEX, "")
   if (body instanceof ArrayBuffer) {
     return new TextDecoder().decode(body)
   }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -158,7 +158,9 @@ const getHoppResponseBody = (
   if (typeof body === "string")
     return body.replace(UNSUPPORTED_UNICODES_REGEX, "")
   if (body instanceof ArrayBuffer) {
-    return new TextDecoder().decode(body)
+    return new TextDecoder()
+      .decode(body)
+      .replace(UNSUPPORTED_UNICODES_REGEX, "")
   }
 
   return ""


### PR DESCRIPTION
Closes FE-916 #4452 

This PR fixes the bug when importing a response body with a Unicode which fail while saving with Prisma.[[ref](https://dba.stackexchange.com/questions/115029/unicode-error-with-u0000-on-copy-of-large-json-file-into-postgres)]

The Unicode is now replaced with an empty string while importing a request.


