### PR TITLE
fix: tooltip alignment update

### DIFF
--- a/packages/hoppscotch-common/assets/scss/styles.scss
+++ b/packages/hoppscotch-common/assets/scss/styles.scss
@@ -167,8 +167,12 @@ a {
   @apply rounded;
   @apply shadow;
 
+  .env-tooltip-content {
+    @apply flex-col;
+  }
+
   .tippy-content {
-    @apply flex flex-col;
+    @apply flex;
     @apply text-tiny text-primary;
     @apply font-semibold;
     @apply px-2 py-1;

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -300,7 +300,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
           envContainer.appendChild(initialValueBlock)
           envContainer.appendChild(currentValueBlock)
 
-          tooltipContainer.className = "tippy-content"
+          tooltipContainer.className = "tippy-content env-tooltip-content"
           dom.className = "tippy-box"
           dom.dataset.theme = "tooltip"
           dom.appendChild(tooltipContainer)

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppPredefinedVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppPredefinedVariables.ts
@@ -130,7 +130,7 @@ const cursorTooltipField = () =>
           dom.className = "tippy-box"
           dom.dataset.theme = "tooltip"
 
-          tooltipContainer.className = "tippy-content"
+          tooltipContainer.className = "tippy-content env-tooltip-content"
 
           dom.appendChild(tooltipContainer)
           return { dom }


### PR DESCRIPTION
This PR fixes the alignment issue with tooltips where the flex direction was set to column for env tooltip but the other tooltip was not accounted.

### Before
<img width="309" alt="image" src="https://github.com/user-attachments/assets/4eccf81d-88d6-4184-a0c2-ced23d9f05ce" />


### After
<img width="309" alt="image" src="https://github.com/user-attachments/assets/b21b3761-54a3-41aa-9072-9414fd81cc48" />
