### PR TITLE
fix: (import-export) add spacing above exporter buttons

### DIFF
--- a/packages/hoppscotch-common/src/components/importExport/ImportExportList.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportList.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="flex flex-col">
+  <div
+    class="flex flex-col"
+    :class="{
+      'space-y-2': !hasTeamWriteAccess,
+    }"
+  >
     <div class="flex flex-col space-y-2">
       <HoppSmartItem
         v-for="importer in importers"
@@ -10,7 +15,7 @@
       />
     </div>
     <hr v-if="hasTeamWriteAccess" />
-    <div class="flex flex-col space-y-2 mt-2">
+    <div class="flex flex-col space-y-2">
       <template v-for="exporter in exporters" :key="exporter.id">
         <!-- adding the title to a span if the item is visible, otherwise the title won't be shown -->
 

--- a/packages/hoppscotch-common/src/components/importExport/ImportExportList.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportList.vue
@@ -10,7 +10,7 @@
       />
     </div>
     <hr v-if="hasTeamWriteAccess" />
-    <div class="flex flex-col space-y-2">
+    <div class="flex flex-col space-y-2 mt-2">
       <template v-for="exporter in exporters" :key="exporter.id">
         <!-- adding the title to a span if the item is visible, otherwise the title won't be shown -->
 


### PR DESCRIPTION
This PR improves the visual spacing of the exporter buttons in the import/export modal.
	•	Added margin-top to the exporter button list in ImportExportList.vue to provide clearer separation from the importers section.
	•	No functional changes, UI only.
	•	Aligns with Hoppscotch design consistency for modal layouts.
	
**Before**
<img width="523" alt="Screenshot 2025-07-03 at 23 12 58" src="https://github.com/user-attachments/assets/ebe4c003-157c-43d7-a920-0ab94c4e152f" />
**After**
![image](https://github.com/user-attachments/assets/53e85ec0-5c1b-41d7-8bb6-e545a9ba0322)
