### PR TITLE
fix(desktop): disk space detection on overlay fs

### DIFF
--- a/packages/hoppscotch-common/package.json
+++ b/packages/hoppscotch-common/package.json
@@ -39,7 +39,7 @@
     "@hoppscotch/httpsnippet": "3.0.7",
     "@hoppscotch/js-sandbox": "workspace:^",
     "@hoppscotch/kernel": "workspace:^",
-    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#0308b55e82f7f01d878a7fdf0f597d1dc975f2ce",
+    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a",
     "@hoppscotch/ui": "0.2.5",
     "@hoppscotch/vue-toasted": "0.1.0",
     "@lezer/highlight": "1.2.0",

--- a/packages/hoppscotch-desktop/package.json
+++ b/packages/hoppscotch-desktop/package.json
@@ -16,7 +16,7 @@
     "@fontsource-variable/material-symbols-rounded": "5.1.3",
     "@fontsource-variable/roboto-mono": "5.1.0",
     "@hoppscotch/kernel": "workspace:^",
-    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#0308b55e82f7f01d878a7fdf0f597d1dc975f2ce",
+    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a",
     "@hoppscotch/ui": "0.2.1",
     "@tauri-apps/api": "2.1.1",
     "@tauri-apps/plugin-process": "2.2.0",

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/LICENSE.md
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 - CuriousCorrelation
+Copyright (c) 2025 - CuriousCorrelation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/README.md
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/README.md
@@ -100,6 +100,6 @@ Requirements:
 
 ## License
 
-Code: (c) 2024 - CuriousCorrelation
+Code: (c) 2025 - CuriousCorrelation
 
 MIT or MIT/Apache 2.0 where applicable.

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/lib.rs
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 CuriousCorrelation
+// Copyright 2025 CuriousCorrelation
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.lock
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-appload"
 version = "0.1.0"
-source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload?rev=0308b55e82f7f01d878a7fdf0f597d1dc975f2ce#0308b55e82f7f01d878a7fdf0f597d1dc975f2ce"
+source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload?rev=6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a#6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a"
 dependencies = [
  "base64 0.22.1",
  "blake3",

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ tauri-plugin-store = "2.2.0"
 tauri-plugin-dialog = "2.2.0"
 tauri-plugin-fs = "2.2.0"
 tauri-plugin-deep-link = "2.2.0"
-tauri-plugin-appload = { git = "https://github.com/CuriousCorrelation/tauri-plugin-appload", rev = "0308b55e82f7f01d878a7fdf0f597d1dc975f2ce" }
+tauri-plugin-appload = { git = "https://github.com/CuriousCorrelation/tauri-plugin-appload", rev = "6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a" }
 tauri-plugin-relay = { git = "https://github.com/CuriousCorrelation/tauri-plugin-relay", rev = "0147ac1bb29d3b88d6652432a482bd86f0174506" }
 axum = "0.8.1"
 tower-http = { version = "0.6.2", features = ["cors"] }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -527,8 +527,8 @@ importers:
         specifier: workspace:^
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
-        specifier: github:CuriousCorrelation/tauri-plugin-appload#0308b55e82f7f01d878a7fdf0f597d1dc975f2ce
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/0308b55e82f7f01d878a7fdf0f597d1dc975f2ce'
+        specifier: github:CuriousCorrelation/tauri-plugin-appload#6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a'
       '@hoppscotch/ui':
         specifier: 0.2.5
         version: 0.2.5(eslint@8.57.0)(terser@5.39.2)(typescript@5.8.3)(vite@5.4.9(@types/node@22.15.19)(sass@1.79.5)(terser@5.39.2))(vue@3.5.12(typescript@5.8.3))
@@ -1000,8 +1000,8 @@ importers:
         specifier: workspace:^
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
-        specifier: github:CuriousCorrelation/tauri-plugin-appload#0308b55e82f7f01d878a7fdf0f597d1dc975f2ce
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/0308b55e82f7f01d878a7fdf0f597d1dc975f2ce'
+        specifier: github:CuriousCorrelation/tauri-plugin-appload#6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a'
       '@hoppscotch/ui':
         specifier: 0.2.1
         version: 0.2.1(eslint@9.27.0(jiti@2.4.2))(terser@5.39.2)(typescript@5.8.3)(vite@5.4.11(@types/node@22.15.19)(sass@1.80.3)(terser@5.39.2))(vue@3.5.12(typescript@5.8.3))
@@ -1840,8 +1840,8 @@ packages:
       graphql:
         optional: true
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/0308b55e82f7f01d878a7fdf0f597d1dc975f2ce':
-    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/0308b55e82f7f01d878a7fdf0f597d1dc975f2ce}
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a':
+    resolution: {tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a}
     version: 0.1.0
 
   '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/0147ac1bb29d3b88d6652432a482bd86f0174506':
@@ -14533,7 +14533,7 @@ snapshots:
     optionalDependencies:
       graphql: 16.11.0
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/0308b55e82f7f01d878a7fdf0f597d1dc975f2ce':
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/6494c38429a4460fb818ae1b1cdf72d8ca4c7b1a':
     dependencies:
       '@tauri-apps/api': 2.1.1
 


### PR DESCRIPTION
This fixes the storage manager incorrectly reporting 0 bytes available space on systems with overlay filesystems like `composefs`, which was causing "Insufficient disk space" errors even when adequate storage exists.

Closes FE-911
Closes #5182

The issue occurred because the disk matching logic used `starts_with` to find mount points containing the storage path, which would match the root filesystem (`/`) before finding the actual underlying filesystem with available space. On systems with overlay filesystems, the root mount point shows `0` available space even if the actual storage location has plenty of space.

### What's changed

This updates the disk matching logic in the `ensure_space` method to find the most specific (longest) mount point that contains the storage path rather than the first match. The fix filters disks where the storage path starts with the mount point and selects the disk with the longest matching mount point path.

For example, on the affected system the storage path (see the listed issue) `/home/user/.config/app` would previously match the `composefs` root `/` (0 bytes available) instead of the underlying filesystem `/var/home` (748G available).

### Notes to reviewers

This change preserves existing functionality for standard filesystem layouts and handles edge cases where canonicalization fails.

Testing should verify that disk space detection works correctly on both standard fs and systems with overlay fs like composefs, mainly on UBlue Fedora Bazzite (where the original issue was reported), should also work with NixOS.

The fix should now correctly identify the underlying filesystem with actual available space instead of overlay filesystems with 0 capacity.