### PR TITLE
fix: correct MIME type detection for .m4a file uploads (#5223)

### DIFF
--- a/packages/hoppscotch-common/src/components/http/BodyBinary.vue
+++ b/packages/hoppscotch-common/src/components/http/BodyBinary.vue
@@ -2,9 +2,16 @@
 import { watch } from "vue"
 
 type BinaryBody = {
-  contentType: "application/octet-stream"
+  contentType:
+    | "application/octet-stream"
+    | "audio/x-m4a"
+    | "audio/mpeg"
+    | "video/mp4"
+    | "audio/wav"
+    | "audio/ogg"
   body: File | null
 }
+
 
 const props = defineProps<{
   modelValue: BinaryBody
@@ -38,22 +45,38 @@ watch(
   }
 )
 
+const guessMimeType = (filename: string): BinaryBody["contentType"] => {
+  const ext = filename.split(".").pop()?.toLowerCase()
+  switch (ext) {
+    case "m4a":
+      return "audio/x-m4a"
+    case "mp3":
+      return "audio/mpeg"
+    case "mp4":
+      return "video/mp4"
+    case "wav":
+      return "audio/wav"
+    case "ogg":
+      return "audio/ogg"
+    default:
+      return "application/octet-stream"
+  }
+}
+
+
 const handleFileChange = (e: Event) => {
   const target = e.target as HTMLInputElement
   const file = target.files?.[0]
 
-  if (file) {
-    emit("update:modelValue", {
-      body: file,
-      contentType: "application/octet-stream",
-    })
-  } else {
-    emit("update:modelValue", {
-      body: null,
-      contentType: "application/octet-stream",
-    })
-  }
+  const mimeType = file ? guessMimeType(file.name) : "application/octet-stream"
+
+  emit("update:modelValue", {
+    body: file ?? null,
+    contentType: mimeType,
+  })
 }
+
+
 </script>
 <template>
   <div class="flex items-center px-4 py-2">


### PR DESCRIPTION
## Description
Fixes the bug where uploading `.m4a` files incorrectly sets the `Content-Type` as `text/plain`.

### What was the issue?
When users upload `.m4a` files via multipart/form-data, the MIME type is not inferred properly.

### What’s fixed?
- Added logic to detect common audio types (`.m4a`, `.mp3`, etc.)
- `.m4a` now sets `Content-Type` to `audio/x-m4a`

## Issue Reference
Closes #5223

## Checklist
- 

- 

- [x] Tested on desktop app
- [x] Checked browser devtools – correct MIME type sent
- [x] Uploaded `.m4a` shows `audio/x-m4a` in request payload

Let me know if any refinements are needed. Happy to update!
