### PR TITLE
feat(desktop): tab shortcuts discoverability

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1114,6 +1114,16 @@
       "download": "Download response as file",
       "title": "Response"
     },
+    "tabs": {
+      "title": "Tabs",
+      "new_tab": "New Tab",
+      "close_tab": "Close Tab",
+      "reopen_tab": "Reopen Closed Tab",
+      "next_tab": "Next Tab",
+      "previous_tab": "Previous Tab",
+      "first_tab": "Switch to First Tab",
+      "last_tab": "Switch to Last Tab"
+    },
     "theme": {
       "black": "Switch theme to Black Mode",
       "dark": "Switch theme to Dark Mode",

--- a/packages/hoppscotch-common/src/helpers/shortcuts.ts
+++ b/packages/hoppscotch-common/src/helpers/shortcuts.ts
@@ -1,4 +1,5 @@
 import { getPlatformAlternateKey, getPlatformSpecialKey } from "./platformutils"
+import { getKernelMode } from "@hoppscotch/kernel"
 
 export type ShortcutDef = {
   label: string
@@ -7,8 +8,11 @@ export type ShortcutDef = {
 }
 
 export function getShortcuts(t: (x: string) => string): ShortcutDef[] {
-  // General
-  return [
+  const kernelMode = getKernelMode()
+  const isDesktop = kernelMode === "desktop"
+
+  const baseShortcuts: ShortcutDef[] = [
+    // General
     {
       label: t("shortcut.general.help_menu"),
       keys: ["?"],
@@ -143,4 +147,41 @@ export function getShortcuts(t: (x: string) => string): ShortcutDef[] {
       section: t("shortcut.miscellaneous.title"),
     },
   ]
+
+  // Desktop-only shortcuts
+  const desktopShortcuts: ShortcutDef[] = [
+    {
+      keys: [getPlatformSpecialKey(), "T"],
+      label: t("shortcut.tabs.new_tab"),
+      section: t("shortcut.tabs.title"),
+    },
+    {
+      keys: [getPlatformSpecialKey(), "W"],
+      label: t("shortcut.tabs.close_tab"),
+      section: t("shortcut.tabs.title"),
+    },
+    {
+      keys: [getPlatformSpecialKey(), getPlatformAlternateKey(), "→"],
+      label: t("shortcut.tabs.next_tab"),
+      section: t("shortcut.tabs.title"),
+    },
+    {
+      keys: [getPlatformSpecialKey(), getPlatformAlternateKey(), "←"],
+      label: t("shortcut.tabs.previous_tab"),
+      section: t("shortcut.tabs.title"),
+    },
+    {
+      keys: [getPlatformSpecialKey(), getPlatformAlternateKey(), "9"],
+      label: t("shortcut.tabs.first_tab"),
+      section: t("shortcut.tabs.title"),
+    },
+    {
+      keys: [getPlatformSpecialKey(), getPlatformAlternateKey(), "0"],
+      label: t("shortcut.tabs.last_tab"),
+      section: t("shortcut.tabs.title"),
+    },
+  ]
+
+  // Return base shortcuts + desktop shortcuts only if in desktop mode
+  return isDesktop ? [...baseShortcuts, ...desktopShortcuts] : baseShortcuts
 }


### PR DESCRIPTION
This adds tab navigation shortcuts to the shortcuts help dialog for desktop users and conditionally shows them only in desktop mode.

| Web app | Desktop app |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/97c15625-b323-4bc0-9382-78cf1fd78ae4) | ![image](https://github.com/user-attachments/assets/4211aa82-2b24-4472-bc30-94b94accda9d) |

The shortcuts help now includes a "Tabs" section with all available tab management shortcuts, but only displays them when running in desktop kernel mode to avoid confusing web users with non-functional shortcuts.

Closes FE-917

The desktop app already had functional tab navigation shortcuts, but they weren't documented in the app's shortcuts help dialog (accessible via `?` or `Cmd/Ctrl+/`). This made the shortcuts less discoverable for users who wanted to learn about available keyboard controls.

The shortcuts helper now uses `getKernelMode()` to determine whether to include desktop-specific shortcuts in the help dialog.

The call to `getKernelMode()` is quite cheap so there won't be any issues if the call was made during every re-render.

### What's changed

- Added conditional shortcut loading in `shortcuts.ts` based on kernel mode detection
- Added "Tabs" section translations to `en.json` with all tab navigation shortcuts
- Implemented desktop-only shortcut filtering so web users only see applicable shortcuts

### Implementation

The solution splits shortcuts into `baseShortcuts` (available on all platforms) and `desktopShortcuts` (desktop-only), then conditionally combines them based on the current kernel mode.

### Notes to reviewers

This change only affects the shortcuts help dialog display and doesn't modify any functional behavior. All existing shortcuts continue to work exactly as before.

Testing should verify that Desktop app shows the new "Tabs" section in shortcuts help and Web app doesn't.
