### PR TITLE
fix(curl): improve line continuation parsing in cURL import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/preproc.ts
@@ -17,8 +17,8 @@ const replaceables: { [key: string]: string } = {
 }
 
 const paperCuts = flow(
-  // remove '\' and newlines
-  S.replace(/ ?\\ ?$/gm, " "),
+  // remove '\' and newlines - FIXED LINE
+  S.replace(/\\\s*\r?\n\s*/g, " "),
   S.replace(/\n/g, " "),
   // remove all $ symbols from start of argument values
   S.replace(/\$'/g, "'"),


### PR DESCRIPTION
## Description
Fixes cURL import functionality that was failing for multi-line commands with line continuations.

The issue was caused by an overly restrictive regex pattern in the `preProcessCurlCommand` function that couldn't properly handle backslash line continuations (`\`) in multi-line cURL commands.

## Problem
Users were getting "cURL is not formatted properly" errors when trying to import valid multi-line cURL commands like:
```bash
curl --location 'https://host/kg-chat/chat' \
--header 'access-time: 1751435171000' \
--header 'appId: aaa' \
--data '{
    "space": "product",
    "query": "some query"
}'