### PR TITLE
docs: removed repeated  bold formatting from headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,31 +256,31 @@ _Add-ons are developed and maintained under **[Hoppscotch Organization](https://
 - Web : [hoppscotch.io](https://hoppscotch.io)
 - Windows/Linux/macOS : [Desktop Apps](https://docs.hoppscotch.io/documentation/clients/desktop#download-hoppscotch-desktop-app)
 
-## **Usage**
+## Usage
 
 1. Provide your API endpoint in the URL field
 2. Click "Send" to simulate the request
 3. View the response
 
-## **Developing**
+## Developing
 
 Follow our [self-hosting documentation](https://docs.hoppscotch.io/documentation/self-host/getting-started) to get started with the development environment.
 
-## **Contributing**
+## Contributing
 
 Please contribute using [GitHub Flow](https://guides.github.com/introduction/flow). Create a branch, add commits, and [open a pull request](https://github.com/hoppscotch/hoppscotch/compare).
 
 Please read [`CONTRIBUTING`](CONTRIBUTING.md) for details on our [`CODE OF CONDUCT`](CODE_OF_CONDUCT.md), and the process for submitting pull requests to us.
 
-## **Continuous Integration**
+## Continuous Integration
 
 We use [GitHub Actions](https://github.com/features/actions) for continuous integration. Check out our [build workflows](https://github.com/hoppscotch/hoppscotch/actions).
 
-## **Changelog**
+## Changelog
 
 See the [`CHANGELOG`](CHANGELOG.md) file for details.
 
-## **Authors**
+## Authors
 
 This project owes its existence to the collective efforts of all those who contribute — [contribute now](CONTRIBUTING.md).
 
@@ -292,7 +292,7 @@ This project owes its existence to the collective efforts of all those who contr
   </a>
 </div>
 
-## **License**
+## License
 
 This project is licensed under the [MIT License](https://opensource.org/licenses/MIT) — see the [`LICENSE`](LICENSE) file for details.
 


### PR DESCRIPTION
This PR cleans up the README by removing redundant bold (`**...**`) syntax from section headers to ensure consistent and professional Markdown formatting throughout the document.
