### PR TITLE
fix: ensure deterministic pagination by using cursor field for sorting

### DIFF
--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -385,9 +385,7 @@ export class TeamCollectionService {
       where: {
         parentID: collectionID,
       },
-      orderBy: {
-        orderIndex: 'asc',
-      },
+      orderBy: [{ orderIndex: 'asc' }, { id: 'asc' }],
       take: take, // default: 10
       skip: cursor ? 1 : 0,
       cursor: cursor ? { id: cursor } : undefined,
@@ -418,9 +416,7 @@ export class TeamCollectionService {
         teamID,
         parentID: null,
       },
-      orderBy: {
-        orderIndex: 'asc',
-      },
+      orderBy: [{ orderIndex: 'asc' }, { id: 'asc' }],
       take: take, // default: 10
       skip: cursor ? 1 : 0,
       cursor: cursor ? { id: cursor } : undefined,


### PR DESCRIPTION
Closes #5301 

It was observed that if there are more than 10 records sharing the same orderIndex, then while fetching the collections from the DB - some collections can be skipped whereas some other collections can be duplicated. This can lead to a very confusing user experience.

**Root cause of this bug:** We are ordering by `orderIndex` but cursor is placed on `id`field.

**Why does it cause an issue?**
Here's an example to understand:

```
Consider you get these records the first time the query is made. For simplicity, let's say we pick 3 records at a time.

id1 orderIndex=1
id2 orderIndex=1
id3 orderIndex=1 ---> fetch till here in the first network call and place cursor
id4 orderIndex=1
id5 orderIndex=1
id6 orderIndex=1
```

During the next fetch, the order in which the above records are returned can be different - causing skips and duplicates

```
id5 orderIndex=1                    // skipped
id4 orderIndex=1                    // skipped
id3 orderIndex=1 ---> cursor starts from here skipping some records and duplicating some other records
id2 orderIndex=1                    // duplicated
id1 orderIndex=1                    // duplicated
id6 orderIndex=1
```

### What's changed
Instead of just sorting by `orderIndex`, we sort by `id` as well to ensure that for a particular `orderIndex`, we get a deterministic order of records on different fetches. This PR proposes to implement that change.
**Why use the id field?**
- Because `id` field is used as the cursor

**Reference read for more info: https://www.prisma.io/docs/orm/prisma-client/queries/pagination**

### Screen Recording for Fix
https://github.com/user-attachments/assets/64413031-8349-4167-91a2-8806910cc666

