### PR TITLE
fix: `SmartEnvInput` environment context bug

### DIFF
--- a/packages/hoppscotch-common/src/components/http/RequestTab.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestTab.vue
@@ -4,7 +4,7 @@
       <HttpRequest v-model="tab" />
       <HttpRequestOptions
         v-model="tab.document.request"
-        v-model:option-tab="tab.document.optionTabPreference"
+        v-model:option-tab="tab.document.optionTabPreference!"
         v-model:inherited-properties="tab.document.inheritedProperties"
       />
     </template>

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -376,7 +376,7 @@ const aggregateEnvs = useReadonlyStream(
 const tabs = useService(RESTTabService)
 
 const envVars = computed(() => {
-  if (props.envs) {
+  if (props.envs && props.envs.length > 0) {
     return props.envs.map((x) => {
       const { key, secret } = x
       const currentValue = secret ? "********" : x.currentValue

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -376,7 +376,7 @@ const aggregateEnvs = useReadonlyStream(
 const tabs = useService(RESTTabService)
 
 const envVars = computed(() => {
-  if (props.envs && props.envs.length > 0) {
+  if (props.envs?.length) {
     return props.envs.map((x) => {
       const { key, secret } = x
       const currentValue = secret ? "********" : x.currentValue


### PR DESCRIPTION
Closes #5304 

This PR fixes an issue in `SmartEnvInput` where the environment variables were not being populated in the context. The root cause was that the `RequestOption` component was not correctly propagating the env prop.

With this fix, we now check if the `env` array is empty and populate `envVars` accordingly to ensure the expected environment context is applied.

