### PR TITLE
chore(agent): bump version to `0.1.12`

### DIFF
--- a/packages/hoppscotch-agent/package.json
+++ b/packages/hoppscotch-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hoppscotch-agent",
   "private": true,
-  "version": "0.1.11",
+  "version": "0.1.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/hoppscotch-agent/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "hoppscotch-agent"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/packages/hoppscotch-agent/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoppscotch-agent"
-version = "0.1.11"
+version = "0.1.12"
 description = "A cross-platform HTTP request agent for Hoppscotch for advanced request handling including custom headers, certificates, proxies, and local system integration."
 authors = ["AndrewBastin", "CuriousCorrelation"]
 edition = "2021"

--- a/packages/hoppscotch-agent/src-tauri/tauri.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent Portable",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Updates agent to version 0.1.12 with relay dependency that includes expanded MIME type support for file uploads.

Follows #5306