### PR TITLE
fix: handle edge cases and bugs in collection variables

### DIFF
--- a/packages/hoppscotch-common/src/components/app/Inspection.vue
+++ b/packages/hoppscotch-common/src/components/app/Inspection.vue
@@ -52,11 +52,11 @@
                 </HoppSmartLink>
               </span>
               <span
-                v-if="inspector.action && inspector.action.showAction"
+                v-if="inspector.action ? inspector.action.showAction : true"
                 class="flex space-x-2 p-2"
               >
                 <HoppButtonSecondary
-                  :label="inspector.action.text"
+                  :label="inspector.action?.text"
                   outline
                   filled
                   @click="

--- a/packages/hoppscotch-common/src/components/app/Inspection.vue
+++ b/packages/hoppscotch-common/src/components/app/Inspection.vue
@@ -51,7 +51,10 @@
                   <icon-lucide-arrow-up-right class="svg-icons" />
                 </HoppSmartLink>
               </span>
-              <span v-if="inspector.action" class="flex space-x-2 p-2">
+              <span
+                v-if="inspector.action && inspector.action.showAction"
+                class="flex space-x-2 p-2"
+              >
                 <HoppButtonSecondary
                   :label="inspector.action.text"
                   outline

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -2296,8 +2296,15 @@ const isMoveToSameLocation = (
 const dropCollection = (payload: {
   collectionIndexDragged: string
   destinationCollectionIndex: string
+  destinationParentPath?: string
+  currentParentIndex?: string
 }) => {
-  const { collectionIndexDragged, destinationCollectionIndex } = payload
+  const {
+    collectionIndexDragged,
+    destinationCollectionIndex,
+    destinationParentPath,
+    currentParentIndex,
+  } = payload
   if (!collectionIndexDragged || !destinationCollectionIndex) return
   if (collectionIndexDragged === destinationCollectionIndex) return
 
@@ -2339,18 +2346,20 @@ const dropCollection = (payload: {
       "drop"
     )
 
+    const newCollectionPath = `${destinationCollectionIndex}/${totalFoldersOfDestinationCollection}`
+
     updateSaveContextForAffectedRequests(
       collectionIndexDragged,
-      `${destinationCollectionIndex}/${totalFoldersOfDestinationCollection}`
+      newCollectionPath
     )
 
     const inheritedProperty = cascadeParentCollectionForProperties(
-      `${destinationCollectionIndex}/${totalFoldersOfDestinationCollection}`,
+      newCollectionPath,
       "rest"
     )
 
     updateInheritedPropertiesForAffectedRequests(
-      `${destinationCollectionIndex}/${totalFoldersOfDestinationCollection}`,
+      newCollectionPath,
       inheritedProperty,
       "rest"
     )
@@ -2381,16 +2390,25 @@ const dropCollection = (payload: {
             1
           )
 
+          if (destinationParentPath && currentParentIndex) {
+            updateSaveContextForAffectedRequests(
+              currentParentIndex,
+              `${destinationParentPath}`
+            )
+          }
+
           const inheritedProperty =
             teamCollectionAdapter.cascadeParentCollectionForProperties(
-              `${destinationCollectionIndex}/${collectionIndexDragged}`
+              `${destinationParentPath}/${collectionIndexDragged}`
             )
 
-          updateInheritedPropertiesForAffectedRequests(
-            `${destinationCollectionIndex}/${collectionIndexDragged}`,
-            inheritedProperty,
-            "rest"
-          )
+          setTimeout(() => {
+            updateInheritedPropertiesForAffectedRequests(
+              `${destinationParentPath}/${collectionIndexDragged}`,
+              inheritedProperty,
+              "rest"
+            )
+          }, 300)
         }
       )
     )()

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -2383,11 +2383,11 @@ const dropCollection = (payload: {
 
           const inheritedProperty =
             teamCollectionAdapter.cascadeParentCollectionForProperties(
-              destinationCollectionIndex
+              `${destinationCollectionIndex}/${collectionIndexDragged}`
             )
 
           updateInheritedPropertiesForAffectedRequests(
-            `${destinationCollectionIndex}`,
+            `${destinationCollectionIndex}/${collectionIndexDragged}`,
             inheritedProperty,
             "rest"
           )
@@ -2429,6 +2429,17 @@ const dropToRoot = ({ dataTransfer }: DragEvent) => {
         updateSaveContextForAffectedRequests(
           collectionIndexDragged,
           `${rootLength - 1}`
+        )
+
+        const inheritedProperty = cascadeParentCollectionForProperties(
+          `${rootLength - 1}`,
+          "rest"
+        )
+
+        updateInheritedPropertiesForAffectedRequests(
+          `${rootLength - 1}`,
+          inheritedProperty,
+          "rest"
         )
       }
 
@@ -2989,7 +3000,7 @@ const setCollectionProperties = (newCollection: {
         "rest",
         collectionId
       )
-    }, 200)
+    }, 300)
   }
 
   displayModalEditProperties(false)

--- a/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/AllCollectionImport.vue
+++ b/packages/hoppscotch-common/src/components/importExport/ImportExportSteps/AllCollectionImport.vue
@@ -94,6 +94,7 @@
 import {
   GQLHeader,
   HoppCollection,
+  HoppCollectionVariable,
   HoppGQLAuth,
   HoppGQLRequest,
   HoppRESTAuth,
@@ -261,11 +262,13 @@ const convertToInheritedProperties = (
 ): {
   auth: HoppRESTAuth | HoppGQLAuth
   headers: Array<HoppRESTHeader | GQLHeader>
+  variables: HoppCollectionVariable[]
 } => {
   const collectionLevelAuthAndHeaders = data
     ? (JSON.parse(data) as {
         auth: HoppRESTAuth | HoppGQLAuth
         headers: Array<HoppRESTHeader | GQLHeader>
+        variables: HoppCollectionVariable[]
       })
     : null
 
@@ -276,9 +279,12 @@ const convertToInheritedProperties = (
     authActive: true,
   }
 
+  const variables = collectionLevelAuthAndHeaders?.variables ?? []
+
   return {
     auth,
     headers,
+    variables,
   }
 }
 

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -405,13 +405,12 @@ const envVars = computed(() => {
     )
   }
 
-  // Grab the current active tab to avoid repeating this long chain everywhere
   const currentTab = tabs.currentActiveTab.value
   const { document } = currentTab
   const isRequest = document.type === "request"
   const isExample = document.type === "example-response"
 
-  // Pull variables inherited from the collection if we're in a request or example
+  // variables inherited from the collection if we're in a request or example
   const collectionVariables =
     isRequest || isExample
       ? transformInheritedCollectionVariablesToAggregateEnv(
@@ -420,14 +419,14 @@ const envVars = computed(() => {
         )
       : []
 
-  // Gather request-level variables (different shape for request vs example)
+  // request-level variables
   const rawRequestVars = isRequest
     ? document.request.requestVariables
     : isExample
       ? document.response.originalRequest.requestVariables
       : []
 
-  // Filter out inactive ones and normalize the shape
+  // formated request variables
   const requestVariables = rawRequestVars
     .filter((v) => v.active)
     .map(({ key, value }) => ({
@@ -438,7 +437,6 @@ const envVars = computed(() => {
       secret: false,
     }))
 
-  // Merge everything: request vars, collection vars, and aggregated envs
   return [...requestVariables, ...collectionVariables, ...aggregateEnvs.value]
 })
 

--- a/packages/hoppscotch-common/src/helpers/backend/gql/subscriptions/TeamCollectionMoved.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/subscriptions/TeamCollectionMoved.graphql
@@ -5,5 +5,6 @@ subscription TeamCollectionMoved($teamID: ID!) {
     parent {
       id
     }
+    data
   }
 }

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -204,11 +204,16 @@ const orderCollectionVariables = (
   return vars.sort((a, b) => {
     if (a.parentPath && b.parentPath) {
       return a.parentPath.localeCompare(b.parentPath)
-    } else if (a.parentPath) {
+    }
+
+    if (a.parentPath) {
       return -1
-    } else if (b.parentPath) {
+    }
+
+    if (b.parentPath) {
       return 1
     }
+
     return a.parentID.localeCompare(b.parentID)
   })
 }

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -166,6 +166,27 @@ function removeDuplicatesAndKeepLast(arr: HoppInheritedProperty["headers"]) {
   return result
 }
 
+/**
+ * Order collection variables based on their parentPath and parentID
+ * eg: path like 4/0/0 should come before 4/0/1 nad 4 should come before 4/0
+ * @param vars Collection of variables to be ordered
+ * @returns Ordered collection of variables
+ */
+const orderCollectionVariables = (
+  vars: HoppInheritedProperty["variables"]
+): HoppInheritedProperty["variables"] => {
+  return vars.sort((a, b) => {
+    if (a.parentPath && b.parentPath) {
+      return a.parentPath.localeCompare(b.parentPath)
+    } else if (a.parentPath) {
+      return -1
+    } else if (b.parentPath) {
+      return 1
+    }
+    return a.parentID.localeCompare(b.parentID)
+  })
+}
+
 export function updateInheritedPropertiesForAffectedRequests(
   path: string,
   inheritedProperties: HoppInheritedProperty,
@@ -252,7 +273,9 @@ export function updateInheritedPropertiesForAffectedRequests(
         (variable) => variable.parentID === collectionId
       )
 
-      const finalVariables = [...inheritedVariables, ...tabInheritedVariables]
+      const finalVariables = orderCollectionVariables([
+        ...new Set([...inheritedVariables, ...tabInheritedVariables]),
+      ])
 
       tab.value.document.inheritedProperties.variables = finalVariables
     }

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -78,7 +78,12 @@ export function resolveSaveContextOnCollectionReorder(
   }
 }
 
-const getParentFolderPath = (path?: string) => {
+/**
+ * Returns the last folder path from the given path.
+ * @param path Path can be folder path or collection path
+ * @returns Get the last folder path from the given path
+ */
+const getLastParentFolderPath = (path?: string) => {
   if (!path) return ""
   const pathArray = path.split("/")
   return pathArray.slice(pathArray.length - 1, pathArray.length).join("/")
@@ -229,7 +234,8 @@ export function updateInheritedPropertiesForAffectedRequests(
 
     return (
       (saveContextPath?.startsWith(path) ||
-        getParentFolderPath(saveContextPath) === getParentFolderPath(path)) ??
+        getLastParentFolderPath(saveContextPath) ===
+          getLastParentFolderPath(path)) ??
       false
     )
   })

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -217,7 +217,8 @@ export function updateInheritedPropertiesForAffectedRequests(
 
       // filter out the headers with the parentID as the path in the inheritedProperties
       const inheritedHeaders = inheritedProperties.headers.filter(
-        (header) => header.parentID === path
+        (header) =>
+          path.startsWith(header.parentID ?? "") || header.parentID === path
       )
 
       // merge the headers with the parentID as the path
@@ -228,7 +229,19 @@ export function updateInheritedPropertiesForAffectedRequests(
       tab.value.document.inheritedProperties.headers = mergedHeaders
     }
 
-    if (tab.value.document.inheritedProperties?.variables && collectionId) {
+    if (tab.value.document.inheritedProperties?.variables && !collectionId) {
+      // filter out the variables with the parentPath as the path in the inheritedProperties
+      const inheritedVariables = inheritedProperties.variables.filter(
+        (variable) =>
+          path.startsWith(variable.parentPath ?? "") ||
+          variable.parentPath === path
+      )
+
+      tab.value.document.inheritedProperties.variables = inheritedVariables
+    } else if (
+      tab.value.document.inheritedProperties?.variables &&
+      collectionId
+    ) {
       const tabInheritedVariables =
         tab.value.document.inheritedProperties.variables.filter(
           (variable) => variable.parentID !== collectionId

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v2.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/example-generators/v2.ts
@@ -133,7 +133,7 @@ const generateRequestBodyExampleFromOpenAPIV2BodySchema = (
       )
     ),
     O.map((schema) => schema.items as OpenAPIV2.ItemsObject),
-    O.filter((items) => items != null), // Filter out null/undefined items
+    O.filter((items) => items !== null), // Filter out null/undefined items
     O.map(generateExampleArrayFromOpenAPIV2ItemsObject)
   )
 

--- a/packages/hoppscotch-common/src/helpers/teams/TeamCollection.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamCollection.ts
@@ -13,7 +13,7 @@ export interface TeamCollection {
   title: string
   children: TeamCollection[] | null
   requests: TeamRequest[] | null
-  data: string | null
+  data?: string | null
 }
 
 export const getSingleCollection = (collectionID: string) =>

--- a/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
@@ -230,6 +230,10 @@ export default class NewTeamCollectionAdapter {
   private teamRequestOrderUpdatedSub: WSubscription | null
   private teamCollectionOrderUpdatedSub: WSubscription | null
 
+  //collection variables current value and secret value
+  private secretEnvironmentService = getService(SecretEnvironmentService)
+  private currentEnvironmentValueService = getService(CurrentValueService)
+
   constructor(private teamID: string | null) {
     this.collections$ = new BehaviorSubject<TeamCollection[]>([])
     this.loadingCollections$ = new BehaviorSubject<string[]>([])
@@ -1044,17 +1048,13 @@ export default class NewTeamCollectionAdapter {
     varIndex: number,
     collectionID: string
   ) => {
-    //collection variables current value and secret value
-    const secretEnvironmentService = getService(SecretEnvironmentService)
-    const currentEnvironmentValueService = getService(CurrentValueService)
-
     if (env && env.secret) {
-      return secretEnvironmentService.getSecretEnvironmentVariable(
+      return this.secretEnvironmentService.getSecretEnvironmentVariable(
         collectionID,
         varIndex
       )?.value
     }
-    return currentEnvironmentValueService.getEnvironmentVariable(
+    return this.currentEnvironmentValueService.getEnvironmentVariable(
       collectionID,
       varIndex
     )?.currentValue

--- a/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
@@ -556,7 +556,7 @@ export default class NewTeamCollectionAdapter {
         children: null,
         requests: null,
         title: title,
-        data: data,
+        data,
       },
       parentID ?? null
     )

--- a/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
+++ b/packages/hoppscotch-common/src/helpers/teams/TeamCollectionAdapter.ts
@@ -534,7 +534,8 @@ export default class NewTeamCollectionAdapter {
   private async moveCollection(
     collectionID: string,
     parentID: string | null,
-    title: string
+    title: string,
+    data?: string | null
   ) {
     // Remove the collection from the current position
     this.removeCollection(collectionID)
@@ -551,7 +552,7 @@ export default class NewTeamCollectionAdapter {
         children: null,
         requests: null,
         title: title,
-        data: null,
+        data: data,
       },
       parentID ?? null
     )
@@ -851,11 +852,11 @@ export default class NewTeamCollectionAdapter {
         )
 
       const { teamCollectionMoved } = result.right
-      const { id, parent, title } = teamCollectionMoved
+      const { id, parent, title, data } = teamCollectionMoved
 
       const parentID = parent?.id ?? null
 
-      this.moveCollection(id, parentID, title)
+      this.moveCollection(id, parentID, title, data)
     })
 
     const [teamRequestOrderUpdated$, teamRequestOrderUpdated] =
@@ -1190,6 +1191,7 @@ export default class NewTeamCollectionAdapter {
         const currentPath = [...path.slice(0, i + 1)].join("/")
 
         variables.push({
+          parentPath: path.slice(0, i + 1).join("/"),
           parentID: parentFolder.id ?? currentPath,
           parentName: parentFolder.title,
           inheritedVariables: this.populateValues(

--- a/packages/hoppscotch-common/src/helpers/types/HoppInheritedProperties.ts
+++ b/packages/hoppscotch-common/src/helpers/types/HoppInheritedProperties.ts
@@ -18,6 +18,7 @@ export type HoppInheritedProperty = {
     inheritedHeader: HoppRESTHeader | GQLHeader
   }[]
   variables: {
+    parentPath?: string
     parentID: string
     parentName: string
     inheritedVariables: HoppCollectionVariable[]

--- a/packages/hoppscotch-common/src/helpers/utils/inheritedCollectionVarTransformer.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/inheritedCollectionVarTransformer.ts
@@ -54,7 +54,7 @@ export const transformInheritedCollectionVariablesToAggregateEnv = (
     )
   )
 
-  // later values override earlier ones
+  // Later values override earlier ones
   const mapByKey = new Map<string, AggregateEnvironment>()
   flattened.forEach((variable) => {
     mapByKey.set(variable.key, variable)

--- a/packages/hoppscotch-common/src/helpers/utils/inheritedCollectionVarTransformer.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/inheritedCollectionVarTransformer.ts
@@ -28,16 +28,19 @@ const getCurrentValue = (
 }
 
 /**
- * Function to transform inherited collection variables into an array of `AggregateEnvironment` objects.
+ * Transforms inherited collection variables into a normalized array of `AggregateEnvironment` objects.
+ * Ensures no duplicate keys exist — the last encountered value overrides earlier ones.
+ *
  * @param variables - The inherited collection variables to transform.
- * @param showSecret - Whether to show secret values in the transformed variables.
- * @returns An array of `AggregateEnvironment` objects representing the transformed collection variables.
+ * @param showSecret - Whether to reveal secret values or mask them.
+ * @returns A de-duplicated array of `AggregateEnvironment` objects.
  */
 export const transformInheritedCollectionVariablesToAggregateEnv = (
   variables: HoppInheritedProperty["variables"],
   showSecret: boolean = true
 ): AggregateEnvironment[] => {
-  return variables.flatMap(({ parentID, inheritedVariables }) =>
+  // Flatten the inherited variables into a single array
+  const flattened = variables.flatMap(({ parentID, inheritedVariables }) =>
     inheritedVariables.map(
       ({ currentValue, initialValue, key, secret }, index) => ({
         key,
@@ -50,6 +53,14 @@ export const transformInheritedCollectionVariablesToAggregateEnv = (
       })
     )
   )
+
+  // later values override earlier ones
+  const mapByKey = new Map<string, AggregateEnvironment>()
+  flattened.forEach((variable) => {
+    mapByKey.set(variable.key, variable)
+  })
+
+  return Array.from(mapByKey.values())
 }
 
 /**

--- a/packages/hoppscotch-common/src/helpers/utils/inheritedCollectionVarTransformer.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/inheritedCollectionVarTransformer.ts
@@ -5,16 +5,16 @@ import { CurrentValueService } from "~/services/current-environment-value.servic
 import { getService } from "~/modules/dioc"
 import { HoppCollectionVariable } from "@hoppscotch/data"
 
+//collection variables current value and secret value
+const secretEnvironmentService = getService(SecretEnvironmentService)
+const currentEnvironmentValueService = getService(CurrentValueService)
+
 const getCurrentValue = (
   isSecret: boolean,
   varIndex: number,
   collectionID: string,
   showSecret: boolean = false
 ) => {
-  //collection variables current value and secret value
-  const secretEnvironmentService = getService(SecretEnvironmentService)
-  const currentEnvironmentValueService = getService(CurrentValueService)
-
   if (isSecret && showSecret) {
     return secretEnvironmentService.getSecretEnvironmentVariable(
       collectionID,

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -21,6 +21,10 @@ import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
 import { CurrentValueService } from "~/services/current-environment-value.service"
 
+//collection variables current value and secret value
+const secretEnvironmentService = getService(SecretEnvironmentService)
+const currentEnvironmentValueService = getService(CurrentValueService)
+
 const defaultRESTCollectionState = {
   state: [
     makeCollection({
@@ -80,10 +84,6 @@ const getCurrentValue = (
   collectionID: string,
   showSecret: boolean
 ) => {
-  //collection variables current value and secret value
-  const secretEnvironmentService = getService(SecretEnvironmentService)
-  const currentEnvironmentValueService = getService(CurrentValueService)
-
   if (env && env.secret && showSecret) {
     return secretEnvironmentService.getSecretEnvironmentVariable(
       collectionID,

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -211,6 +211,7 @@ export function cascadeParentCollectionForProperties(
       const currentPath = [...path.slice(0, i + 1)].join("/")
 
       variables.push({
+        parentPath: currentPath,
         parentID: parentFolder._ref_id ?? parentFolder.id ?? currentPath,
         parentName: parentFolder.name,
         inheritedVariables: populateValues(

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -167,7 +167,6 @@ export function cascadeParentCollectionForProperties(
     const parentFolderHeaders = parentFolder.headers as
       | HoppRESTHeaders
       | GQLHeader[]
-
     const parentFolderVariables =
       parentFolder.variables as HoppCollectionVariable[]
 
@@ -182,7 +181,6 @@ export function cascadeParentCollectionForProperties(
         inheritedAuth: auth.inheritedAuth,
       }
     }
-
     if (parentFolderAuth?.authType !== "inherit") {
       auth = {
         parentID: [...path.slice(0, i + 1)].join("/"),
@@ -195,24 +193,17 @@ export function cascadeParentCollectionForProperties(
     if (parentFolderHeaders) {
       const activeHeaders = parentFolderHeaders.filter((h) => h.active)
       activeHeaders.forEach((header) => {
-        const index = headers.findIndex(
+        const idx = headers.findIndex(
           (h) => h.inheritedHeader?.key === header.key
         )
         const currentPath = [...path.slice(0, i + 1)].join("/")
-        if (index !== -1) {
-          // Replace the existing header with the same key
-          headers[index] = {
-            parentID: currentPath,
-            parentName: parentFolder.name,
-            inheritedHeader: header,
-          }
-        } else {
-          headers.push({
-            parentID: currentPath,
-            parentName: parentFolder.name,
-            inheritedHeader: header,
-          })
+        const headerObj = {
+          parentID: currentPath,
+          parentName: parentFolder.name,
+          inheritedHeader: header,
         }
+        if (idx !== -1) headers[idx] = headerObj
+        else headers.push(headerObj)
       })
     }
 

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -14,7 +14,6 @@ import DispatchingStore, {
 } from "~/newstore/DispatchingStore"
 import { CurrentValueService } from "~/services/current-environment-value.service"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
-import { RESTTabService } from "~/services/tab/rest"
 
 export type SelectedEnvironmentIndex =
   | { type: "NO_ENV_SELECTED" }
@@ -438,19 +437,6 @@ export const aggregateEnvs$: Observable<AggregateEnvironment[]> = combineLatest(
   [currentEnvironment$, globalEnv$]
 ).pipe(
   map(([selectedEnv, globalEnv]) => {
-    const restTabs = getService(RESTTabService)
-
-    const currentTab = restTabs.currentActiveTab.value
-
-    const currentTabRequest =
-      currentTab.document.type === "example-response"
-        ? currentTab.document.response.originalRequest
-        : currentTab.document.request
-
-    const requestVariables = currentTabRequest?.requestVariables
-      ? currentTabRequest.requestVariables
-      : []
-
     const effectiveAggregateEnvs: AggregateEnvironment[] = []
 
     // Ensure pre-defined variables are prioritised over other environment variables with the same name
@@ -465,18 +451,6 @@ export const aggregateEnvs$: Observable<AggregateEnvironment[]> = combineLatest(
     })
 
     const aggregateEnvKeys = effectiveAggregateEnvs.map(({ key }) => key)
-
-    requestVariables.forEach(({ key, value, active }) => {
-      if (!aggregateEnvKeys.includes(key) && active) {
-        effectiveAggregateEnvs.push({
-          key,
-          currentValue: value,
-          initialValue: value,
-          secret: false,
-          sourceEnv: "RequestVariable",
-        })
-      }
-    })
 
     selectedEnv?.variables.forEach((variable) => {
       const { key, secret } = variable
@@ -520,19 +494,7 @@ export const aggregateEnvs$: Observable<AggregateEnvironment[]> = combineLatest(
 )
 
 export function getAggregateEnvs() {
-  const restTabs = getService(RESTTabService)
-
   const currentEnv = getCurrentEnvironment()
-  const currentTab = restTabs.currentActiveTab.value
-
-  const currentTabRequest =
-    currentTab.document.type === "example-response"
-      ? currentTab.document.response.originalRequest
-      : currentTab.document.request
-
-  const requestVariables = currentTabRequest?.requestVariables
-    ? currentTabRequest.requestVariables
-    : []
 
   return [
     ...HOPP_SUPPORTED_PREDEFINED_VARIABLES.map(({ key, getValue }) => {
@@ -544,22 +506,6 @@ export function getAggregateEnvs() {
         sourceEnv: currentEnv.name,
       }
     }),
-
-    ...requestVariables
-      .map(({ key, value, active }) => {
-        if (active) {
-          return <AggregateEnvironment>{
-            key,
-            currentValue: value,
-            initialValue: value,
-            sourceEnv: "RequestVariable",
-            secret: false,
-          }
-        }
-
-        return
-      })
-      .filter((v): v is AggregateEnvironment => v !== undefined),
 
     ...currentEnv.variables.map((x) => {
       let currentValue = ""
@@ -592,22 +538,10 @@ export function getAggregateEnvs() {
 }
 
 export function getAggregateEnvsWithCurrentValue() {
-  const restTabs = getService(RESTTabService)
-
   const secretEnvironmentService = getService(SecretEnvironmentService)
   const currentEnvironmentValueService = getService(CurrentValueService)
 
   const currentEnv = getCurrentEnvironment()
-  const currentTab = restTabs.currentActiveTab.value
-
-  const currentTabRequest =
-    currentTab.document.type === "example-response"
-      ? currentTab.document.response.originalRequest
-      : currentTab.document.request
-
-  const requestVariables = currentTabRequest?.requestVariables
-    ? currentTabRequest.requestVariables
-    : []
 
   return [
     ...HOPP_SUPPORTED_PREDEFINED_VARIABLES.map(({ key, getValue }) => {
@@ -619,21 +553,6 @@ export function getAggregateEnvsWithCurrentValue() {
         sourceEnv: currentEnv.name,
       }
     }),
-
-    ...requestVariables
-      .map(({ key, value, active }) => {
-        if (active) {
-          return <AggregateEnvironment>{
-            key,
-            currentValue: value,
-            initialValue: value,
-            sourceEnv: "RequestVariable",
-            secret: false,
-          }
-        }
-        return
-      })
-      .filter((v): v is AggregateEnvironment => v !== undefined),
 
     ...currentEnv.variables.map((x, index) => {
       let currentValue = x.currentValue
@@ -685,21 +604,8 @@ export const aggregateEnvsWithCurrentValue$: Observable<
   AggregateEnvironment[]
 > = combineLatest([currentEnvironment$, globalEnv$]).pipe(
   map(([selectedEnv, globalEnv]) => {
-    const restTabs = getService(RESTTabService)
-
     const secretEnvironmentService = getService(SecretEnvironmentService)
     const currentEnvironmentValueService = getService(CurrentValueService)
-
-    const currentTab = restTabs.currentActiveTab.value
-
-    const currentTabRequest =
-      currentTab.document.type === "example-response"
-        ? currentTab.document.response.originalRequest
-        : currentTab.document.request
-
-    const requestVariables = currentTabRequest?.requestVariables
-      ? currentTabRequest.requestVariables
-      : []
 
     const results: AggregateEnvironment[] = []
 
@@ -712,18 +618,6 @@ export const aggregateEnvsWithCurrentValue$: Observable<
         secret: false,
         sourceEnv: selectedEnv?.name ?? "Global",
       })
-    })
-
-    requestVariables.map(({ key, value, active }) => {
-      if (active) {
-        results.push({
-          key,
-          currentValue: value,
-          initialValue: value,
-          secret: false,
-          sourceEnv: "RequestVariable",
-        })
-      }
     })
 
     selectedEnv?.variables.map((x, index) => {

--- a/packages/hoppscotch-common/src/services/inspection/index.ts
+++ b/packages/hoppscotch-common/src/services/inspection/index.ts
@@ -62,6 +62,7 @@ export interface InspectorResult {
   action?: {
     text: string
     apply: () => void
+    showAction?: boolean
   }
   doc?: {
     text: string

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -168,7 +168,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
 
   /**
    * Keeps only unique environment variables and prefers ones with values.
-   *  * @param envs The environment list to be transformed
+   * @param envs The environment list to be transformed
    * @returns The transformed environment list with keys with value
    */
   private filterNonEmptyEnvironmentVariables = (

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -28,9 +28,7 @@ import { transformInheritedCollectionVariablesToAggregateEnv } from "~/helpers/u
 
 const HOPP_ENVIRONMENT_REGEX = /(<<[a-zA-Z0-9-_]+>>)/g
 
-const isENVInString = (str: string) => {
-  return HOPP_ENVIRONMENT_REGEX.test(str)
-}
+const isENVInString = (str: string) => HOPP_ENVIRONMENT_REGEX.test(str)
 
 /**
  * This inspector is responsible for inspecting the environment variables of a input.
@@ -64,19 +62,28 @@ export class EnvironmentInspectorService extends Service implements Inspector {
   }
 
   /**
-   * Validates the environment variables in the target array
-   * @param target The target array to validate
+   * Looks for environment variables in an array of strings.
+   * Reports variables that are referenced but not defined.
+   * * @param target The target array to validate
    * @param locations The location where results are to be displayed
    * @returns The results array containing the results of the validation
    */
   private validateEnvironmentVariables = (
-    target: any[],
+    target: string[],
     locations: InspectorLocation
   ) => {
     const newErrors: InspectorResult[] = []
-
     const currentTab = this.restTabs.currentActiveTab.value
 
+    // Get the current request or example-response request
+    const currentTabRequest =
+      currentTab.document.type === "request"
+        ? currentTab.document.request
+        : currentTab.document.type === "example-response"
+          ? currentTab.document.response.originalRequest
+          : null
+
+    // inherited collection-level variables
     const collectionVariables =
       currentTab.document.type === "request" ||
       currentTab.document.type === "example-response"
@@ -85,71 +92,83 @@ export class EnvironmentInspectorService extends Service implements Inspector {
           )
         : []
 
-    const environmentVariables = [
-      ...this.aggregateEnvsWithValue.value,
-      ...collectionVariables,
-    ]
+    // request variables (active only)
+    const requestVariables =
+      currentTabRequest?.requestVariables
+        .filter((v) => v.active)
+        .map(({ key, value }) => ({
+          key,
+          currentValue: value,
+          initialValue: value,
+          sourceEnv: "RequestVariable",
+          secret: false,
+        })) ?? []
 
+    // combine everything into one list
+    const environmentVariables = [
+      ...requestVariables,
+      ...collectionVariables,
+      ...this.aggregateEnvsWithValue.value,
+    ]
     const envKeys = environmentVariables.map((e) => e.key)
 
+    // Scan each string for <<VAR>> patterns
     target.forEach((element, index) => {
-      if (isENVInString(element)) {
-        const extractedEnv = element.match(HOPP_ENVIRONMENT_REGEX)
+      if (!isENVInString(element)) return
+      const matches = element.match(HOPP_ENVIRONMENT_REGEX)
+      matches?.forEach((exEnv) => {
+        const formattedExEnv = exEnv.slice(2, -2)
+        const itemLocation: InspectorLocation = {
+          type: locations.type,
+          position:
+            locations.type === "url" ||
+            locations.type === "body" ||
+            locations.type === "response" ||
+            locations.type === "body-content-type-header"
+              ? "key"
+              : locations.position,
+          index,
+          key: element,
+        }
 
-        if (extractedEnv) {
-          extractedEnv.forEach((exEnv: string) => {
-            const formattedExEnv = exEnv.slice(2, -2)
-            const itemLocation: InspectorLocation = {
-              type: locations.type,
-              position:
-                locations.type === "url" ||
-                locations.type === "body" ||
-                locations.type === "response" ||
-                locations.type === "body-content-type-header"
-                  ? "key"
-                  : locations.position,
-              index: index,
-              key: element,
-            }
-            if (!envKeys.includes(formattedExEnv)) {
-              newErrors.push({
-                id: `environment-not-found-${newErrors.length}`,
-                text: {
-                  type: "text",
-                  text: this.t("inspections.environment.not_found", {
-                    environment: exEnv,
-                  }),
-                },
-                icon: markRaw(IconPlusCircle),
-                action: {
-                  text: this.t("inspections.environment.add_environment"),
-                  apply: () => {
-                    invokeAction("modals.environment.add", {
-                      envName: formattedExEnv,
-                      variableName: "",
-                    })
-                  },
-                },
-                severity: 3,
-                isApplicable: true,
-                locations: itemLocation,
-                doc: {
-                  text: this.t("action.learn_more"),
-                  link: "https://docs.hoppscotch.io/documentation/features/inspections",
-                },
-              })
-            }
+        // If the variable doesn't exist, add an inspection
+        if (!envKeys.includes(formattedExEnv)) {
+          newErrors.push({
+            id: `environment-not-found-${newErrors.length}`,
+            text: {
+              type: "text",
+              text: this.t("inspections.environment.not_found", {
+                environment: exEnv,
+              }),
+            },
+            icon: markRaw(IconPlusCircle),
+            action: {
+              text: this.t("inspections.environment.add_environment"),
+              apply: () =>
+                invokeAction("modals.environment.add", {
+                  envName: formattedExEnv,
+                  variableName: "",
+                }),
+              showAction: true,
+            },
+            severity: 3,
+            isApplicable: true,
+            locations: itemLocation,
+            doc: {
+              text: this.t("action.learn_more"),
+              link: "https://docs.hoppscotch.io/documentation/features/inspections",
+            },
           })
         }
-      }
+      })
     })
 
     return newErrors
   }
 
   /**
-   * Transforms the environment list to a list with unique keys with value
-   * @param envs The environment list to be transformed
+   * Keeps only unique environment variables and prefers ones with values.
+   *  * @param envs The environment list to be transformed
    * @returns The transformed environment list with keys with value
    */
   private filterNonEmptyEnvironmentVariables = (
@@ -160,7 +179,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
     envs.forEach((env) => {
       if (envsMap.has(env.key)) {
         const existingEnv = envsMap.get(env.key)
-
+        // Replace if existing is empty and this one has a value
         if (existingEnv?.currentValue === "" && env.currentValue !== "") {
           envsMap.set(env.key, env)
         }
@@ -173,244 +192,222 @@ export class EnvironmentInspectorService extends Service implements Inspector {
   }
 
   /**
-   * Checks if the environment variables in the target have empty current value or initial value.
+   * Looks for variables that exist but are empty (no value or secret).
+   * Suggests adding a value for them.
    * @param target The target array to validate
    * @param locations The location where results are to be displayed
    * @returns The results array containing the results of the validation
    */
   private validateEmptyEnvironmentVariables = (
-    target: any[],
+    target: string[],
     locations: InspectorLocation
   ) => {
     const newErrors: InspectorResult[] = []
 
     target.forEach((element, index) => {
-      if (isENVInString(element)) {
-        const extractedEnv = element.match(HOPP_ENVIRONMENT_REGEX)
+      if (!isENVInString(element)) return
+      const matches = element.match(HOPP_ENVIRONMENT_REGEX)
+      matches?.forEach((exEnv) => {
+        const formattedExEnv = exEnv.slice(2, -2)
+        const currentSelectedEnvironment = getCurrentEnvironment()
+        const currentTab = this.restTabs.currentActiveTab.value
 
-        if (extractedEnv) {
-          extractedEnv.forEach((exEnv: string) => {
-            const formattedExEnv = exEnv.slice(2, -2)
-            const currentSelectedEnvironment = getCurrentEnvironment()
+        // Get current request or example
+        const currentTabRequest =
+          currentTab.document.type === "request"
+            ? currentTab.document.request
+            : currentTab.document.type === "example-response"
+              ? currentTab.document.response.originalRequest
+              : null
 
-            const currentTab = this.restTabs.currentActiveTab.value
-            const collectionVariables =
-              currentTab.document.type === "request" ||
-              currentTab.document.type === "example-response"
-                ? transformInheritedCollectionVariablesToAggregateEnv(
-                    currentTab.document.inheritedProperties?.variables ?? [],
-                    false
-                  )
-                : []
+        // request variables (active only)
+        const requestVariables =
+          currentTabRequest?.requestVariables
+            .filter((v) => v.active)
+            .map(({ key, value }) => ({
+              key,
+              currentValue: value,
+              initialValue: value,
+              sourceEnv: "RequestVariable",
+              secret: false,
+            })) ?? []
 
-            const environmentVariables =
-              this.filterNonEmptyEnvironmentVariables([
-                ...this.aggregateEnvsWithValue.value,
-                ...collectionVariables,
-              ])
-
-            environmentVariables.forEach((env) => {
-              let tooltipSourceEnvID = "Global"
-
-              if (env?.sourceEnv === "Global") {
-                tooltipSourceEnvID = "Global"
-              } else {
-                tooltipSourceEnvID =
-                  env?.sourceEnv === "CollectionVariable"
-                    ? env.sourceEnvID!
-                    : currentSelectedEnvironment.id
-              }
-
-              const hasSecretEnv = this.secretEnvs.hasSecretValue(
-                tooltipSourceEnvID,
-                env.key
+        // inherited collection variables
+        const collectionVariables =
+          currentTab.document.type === "request" ||
+          currentTab.document.type === "example-response"
+            ? transformInheritedCollectionVariablesToAggregateEnv(
+                currentTab.document.inheritedProperties?.variables ?? [],
+                false
               )
+            : []
 
-              const hasValue =
-                this.currentEnvs.hasValue(
-                  env.sourceEnv !== "Global"
-                    ? currentSelectedEnvironment.id
-                    : "Global",
-                  env.key
-                ) ||
-                env.currentValue !== "" ||
-                env.initialValue !== ""
+        // Merge all variables
+        const environmentVariables = this.filterNonEmptyEnvironmentVariables([
+          ...requestVariables,
+          ...collectionVariables,
+          ...this.aggregateEnvsWithValue.value,
+        ])
 
-              if (env.key === formattedExEnv) {
-                if (env.secret ? !hasSecretEnv : !hasValue) {
-                  const itemLocation: InspectorLocation = {
-                    type: locations.type,
-                    position:
-                      locations.type === "url" ||
-                      locations.type === "body" ||
-                      locations.type === "response" ||
-                      locations.type === "body-content-type-header"
-                        ? "key"
-                        : locations.position,
-                    index: index,
-                    key: element,
-                  }
+        // Check each variable for missing values
+        environmentVariables.forEach((env) => {
+          const sourceEnvID =
+            env.sourceEnv === "Global"
+              ? "Global"
+              : env.sourceEnv === "CollectionVariable"
+                ? env.sourceEnvID!
+                : currentSelectedEnvironment.id
 
-                  const currentEnvironmentType = getSelectedEnvironmentType()
+          const hasSecretEnv = this.secretEnvs.hasSecretValue(
+            sourceEnvID,
+            env.key
+          )
 
-                  let invokeActionType:
-                    | "modals.my.environment.edit"
-                    | "modals.team.environment.edit"
-                    | "modals.global.environment.update" =
-                    "modals.my.environment.edit"
+          const hasValue =
+            this.currentEnvs.hasValue(
+              env.sourceEnv !== "Global"
+                ? currentSelectedEnvironment.id
+                : "Global",
+              env.key
+            ) ||
+            env.currentValue !== "" ||
+            env.initialValue !== ""
 
-                  if (env.sourceEnv === "Global") {
-                    invokeActionType = "modals.global.environment.update"
-                  } else if (currentEnvironmentType === "MY_ENV") {
-                    invokeActionType = "modals.my.environment.edit"
-                  } else if (currentEnvironmentType === "TEAM_ENV") {
-                    invokeActionType = "modals.team.environment.edit"
+          if (env.key !== formattedExEnv) return
+
+          // Flag variables that are empty
+          if (env.secret ? !hasSecretEnv : !hasValue) {
+            const itemLocation: InspectorLocation = {
+              type: locations.type,
+              position:
+                locations.type === "url" ||
+                locations.type === "body" ||
+                locations.type === "response" ||
+                locations.type === "body-content-type-header"
+                  ? "key"
+                  : locations.position,
+              index,
+              key: element,
+            }
+
+            // Pick the right modal to open for editing
+            const currentEnvironmentType = getSelectedEnvironmentType()
+            const invokeActionType:
+              | "modals.my.environment.edit"
+              | "modals.team.environment.edit"
+              | "modals.global.environment.update" =
+              env.sourceEnv === "Global"
+                ? "modals.global.environment.update"
+                : currentEnvironmentType === "TEAM_ENV"
+                  ? "modals.team.environment.edit"
+                  : "modals.my.environment.edit"
+
+            newErrors.push({
+              id: `environment-empty-${newErrors.length}`,
+              text: {
+                type: "text",
+                text: this.t("inspections.environment.empty_value", {
+                  variable: exEnv,
+                }),
+              },
+              icon: markRaw(IconPlusCircle),
+              action: {
+                text: this.t("inspections.environment.add_environment_value"),
+                apply: () => {
+                  // If it's a request variable, open the requestVariables tab
+                  if (
+                    env.sourceEnv === "RequestVariable" &&
+                    currentTab.document.type === "request"
+                  ) {
+                    currentTab.document.optionTabPreference = "requestVariables"
                   } else {
-                    invokeActionType = "modals.my.environment.edit"
+                    invokeAction(invokeActionType, {
+                      envName:
+                        env.sourceEnv === "Global"
+                          ? "Global"
+                          : currentSelectedEnvironment.name,
+                      variableName: formattedExEnv,
+                      isSecret: env.secret,
+                    })
                   }
-
-                  newErrors.push({
-                    id: `environment-empty-${newErrors.length}`,
-                    text: {
-                      type: "text",
-                      text: this.t("inspections.environment.empty_value", {
-                        variable: exEnv,
-                      }),
-                    },
-                    icon: markRaw(IconPlusCircle),
-                    action: {
-                      text: this.t(
-                        "inspections.environment.add_environment_value"
-                      ),
-                      apply: () => {
-                        if (
-                          env.sourceEnv === "RequestVariable" &&
-                          currentTab.document.type === "request"
-                        ) {
-                          currentTab.document.optionTabPreference =
-                            "requestVariables"
-                        } else {
-                          invokeAction(invokeActionType, {
-                            envName:
-                              env.sourceEnv === "Global"
-                                ? "Global"
-                                : currentSelectedEnvironment.name,
-                            variableName: formattedExEnv,
-                            isSecret: env.secret,
-                          })
-                        }
-                      },
-                      showAction: env.sourceEnv !== "CollectionVariable",
-                    },
-                    severity: 2,
-                    isApplicable: true,
-                    locations: itemLocation,
-                    doc: {
-                      text: this.t("action.learn_more"),
-                      link: "https://docs.hoppscotch.io/documentation/features/inspections",
-                    },
-                  })
-                }
-              }
+                },
+                showAction: env.sourceEnv !== "CollectionVariable", // skip collection vars for now
+              },
+              severity: 2,
+              isApplicable: true,
+              locations: itemLocation,
+              doc: {
+                text: this.t("action.learn_more"),
+                link: "https://docs.hoppscotch.io/documentation/features/inspections",
+              },
             })
-          })
-        }
-      }
+          }
+        })
+      })
     })
 
     return newErrors
   }
 
+  /**
+   * Runs all inspections for a given request and returns a computed list of results.
+   */
   getInspections(
     req: Readonly<Ref<HoppRESTRequest | HoppRESTResponseOriginalRequest>>
   ) {
     return computed(() => {
       const results: InspectorResult[] = []
-
       if (!req.value) return results
 
-      const headers = req.value.headers
+      const { endpoint, headers, params } = req.value
 
-      const params = req.value.params
-
-      /**
-       * Validate the environment variables in the URL
-       */
-      const url = req.value.endpoint
-
+      // URL check
       results.push(
-        ...this.validateEnvironmentVariables([url], {
-          type: "url",
-        })
-      )
-      results.push(
-        ...this.validateEmptyEnvironmentVariables([url], {
-          type: "url",
-        })
+        ...this.validateEnvironmentVariables([endpoint], { type: "url" }),
+        ...this.validateEmptyEnvironmentVariables([endpoint], { type: "url" })
       )
 
-      /**
-       * Validate the environment variables in the headers
-       */
-      const headerKeys = Object.values(headers).map((header) => header.key)
+      // Header keys and values
+      const headerKeys = Object.values(headers).map((h) => h.key)
+      const headerValues = Object.values(headers).map((h) => h.value)
 
       results.push(
         ...this.validateEnvironmentVariables(headerKeys, {
           type: "header",
           position: "key",
-        })
-      )
-      results.push(
+        }),
         ...this.validateEmptyEnvironmentVariables(headerKeys, {
           type: "header",
           position: "key",
-        })
-      )
-
-      const headerValues = Object.values(headers).map((header) => header.value)
-
-      results.push(
+        }),
         ...this.validateEnvironmentVariables(headerValues, {
           type: "header",
           position: "value",
-        })
-      )
-      results.push(
+        }),
         ...this.validateEmptyEnvironmentVariables(headerValues, {
           type: "header",
           position: "value",
         })
       )
 
-      /**
-       * Validate the environment variables in the parameters
-       */
-      const paramsKeys = Object.values(params).map((param) => param.key)
+      // Parameter keys and values
+      const paramKeys = Object.values(params).map((p) => p.key)
+      const paramValues = Object.values(params).map((p) => p.value)
 
       results.push(
-        ...this.validateEnvironmentVariables(paramsKeys, {
+        ...this.validateEnvironmentVariables(paramKeys, {
           type: "parameter",
           position: "key",
-        })
-      )
-      results.push(
-        ...this.validateEmptyEnvironmentVariables(paramsKeys, {
+        }),
+        ...this.validateEmptyEnvironmentVariables(paramKeys, {
           type: "parameter",
           position: "key",
-        })
-      )
-
-      const paramsValues = Object.values(params).map((param) => param.value)
-
-      results.push(
-        ...this.validateEnvironmentVariables(paramsValues, {
+        }),
+        ...this.validateEnvironmentVariables(paramValues, {
           type: "parameter",
           position: "value",
-        })
-      )
-
-      results.push(
-        ...this.validateEmptyEnvironmentVariables(paramsValues, {
+        }),
+        ...this.validateEmptyEnvironmentVariables(paramValues, {
           type: "parameter",
           position: "value",
         })

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -300,6 +300,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
                           })
                         }
                       },
+                      showAction: env.sourceEnv !== "CollectionVariable",
                     },
                     severity: 2,
                     isApplicable: true,

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -64,7 +64,7 @@ export class EnvironmentInspectorService extends Service implements Inspector {
   /**
    * Looks for environment variables in an array of strings.
    * Reports variables that are referenced but not defined.
-   * * @param target The target array to validate
+   * @param target The target array to validate
    * @param locations The location where results are to be displayed
    * @returns The results array containing the results of the validation
    */

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -317,6 +317,7 @@ const HoppInheritedPropertySchema = z
     variables: z
       .array(
         z.object({
+          parentPath: z.optional(z.string()),
           parentID: z.string(),
           parentName: z.string(),
           inheritedVariables: z.array(CollectionVariable),


### PR DESCRIPTION
Closes FE-992

This PR fixes some edge cases and bug's with collection variables

- [x] Import from 'Another Workspace' to Team workspace fails to import collection variables
- [x] Hide action button in collection variable empty inspector (can be iterated in future to open the collection properties)
- [x] Add collection variable when moving or reordering personal collection 
- [x] opened tabs in team collection variable when moving does not get updated.
- [x] Collection request variable priority bug over collection var