### PR TITLE
feat: allow non-empty shared workspace names

### DIFF
--- a/packages/hoppscotch-backend/src/team/team.service.spec.ts
+++ b/packages/hoppscotch-backend/src/team/team.service.spec.ts
@@ -361,7 +361,7 @@ describe('renameTeam', () => {
     ).resolves.toEqualLeft(TEAM_INVALID_ID);
   });
 
-  test('rejects for new team name length < 6 with TEAM_NAME_INVALID', () => {
+  test('rejects for new team name empty with TEAM_NAME_INVALID', () => {
     const newTeamName = 'smol';
 
     // Prisma doesn't care about the team name length, so it will resolve
@@ -668,7 +668,7 @@ describe('createTeam', () => {
     ).resolves.toEqualRight(expect.objectContaining(team));
   });
 
-  test('rejects for team name length < 6 with TEAM_NAME_INVALID', () => {
+  test('rejects for team name empty with TEAM_NAME_INVALID', () => {
     const newName = 'smol';
 
     // Prisma doesn't care

--- a/packages/hoppscotch-backend/src/team/team.service.spec.ts
+++ b/packages/hoppscotch-backend/src/team/team.service.spec.ts
@@ -362,7 +362,7 @@ describe('renameTeam', () => {
   });
 
   test('rejects for new team name empty with TEAM_NAME_INVALID', () => {
-    const newTeamName = 'smol';
+    const newTeamName = '';
 
     // Prisma doesn't care about the team name length, so it will resolve
     mockPrisma.team.update.mockResolvedValue({
@@ -669,7 +669,7 @@ describe('createTeam', () => {
   });
 
   test('rejects for team name empty with TEAM_NAME_INVALID', () => {
-    const newName = 'smol';
+    const newName = '';
 
     // Prisma doesn't care
     mockPrisma.team.create.mockResolvedValue({

--- a/packages/hoppscotch-backend/src/team/team.service.ts
+++ b/packages/hoppscotch-backend/src/team/team.service.ts
@@ -124,7 +124,7 @@ export class TeamService implements UserDataHandler, OnModuleInit {
   }
 
   validateTeamName(title: string): E.Left<string> | E.Right<boolean> {
-    if (!title || title.length < 6) return E.left(TEAM_NAME_INVALID);
+    if (!title || title.trim() === '') return E.left(TEAM_NAME_INVALID);
     return E.right(true);
   }
 

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1521,7 +1521,7 @@
     "member_role_updated": "User roles updated",
     "members": "Members",
     "more_members": "+{count} more",
-    "name_length_insufficient": "Workspace name should be at least 6 characters long",
+    "name_length_insufficient": "Workspace name should not be empty",
     "name_updated": "Workspace name updated",
     "new": "New Workspace",
     "new_created": "New workspace created",

--- a/packages/hoppscotch-common/src/helpers/backend/types/TeamName.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/types/TeamName.ts
@@ -6,7 +6,7 @@ interface TeamNameBrand {
 
 export const TeamNameCodec = t.brand(
   t.string,
-  (x): x is t.Branded<string, TeamNameBrand> => x.trim().length >= 6,
+  (x): x is t.Branded<string, TeamNameBrand> => x.trim() !== "",
   "TeamName"
 )
 


### PR DESCRIPTION
Closes FE-943 #5271 

This PR updates the shared workspace name validation to check for a non-empty string instead of enforcing a minimum length of 6 characters. 