### PR TITLE
fix: ensure npm is installed for Node.js base image

### DIFF
--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -44,10 +44,10 @@ RUN go build
 
 # Shared Node.js base with optimized NPM installation
 FROM alpine:3.22.1 AS node_base
-RUN apk add --no-cache nodejs curl tini && \
+RUN apk add --no-cache nodejs npm curl tini bash && \
   # Install NPM from source, as Alpine version is old and has dependency vulnerabilities
   # TODO: Find a better method which is resistant to supply chain attacks
-  sh -c "curl -qL https://www.npmjs.com/install.sh | env npm_install=11.5.2 sh" && \
+  npm install -g npm@11.5.2 && \
   npm install -g pnpm@10.15.0 @import-meta-env/cli
 
 

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -45,7 +45,7 @@ RUN go build
 # Shared Node.js base with optimized NPM installation
 FROM alpine:3.22.1 AS node_base
 RUN apk add --no-cache nodejs npm curl tini bash && \
-  # Install NPM from source, as Alpine version is old and has dependency vulnerabilities
+  # apk provides an outdated npm; immediately upgrade to a pinned version to avoid vulnerabilities
   # TODO: Find a better method which is resistant to supply chain attacks
   npm install -g npm@11.5.2 && \
   npm install -g pnpm@10.15.0 @import-meta-env/cli


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->
This PR updates the [prod.Dockerfile](vscode-file://vscode-app/c:/Users/LELUU2/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to explicitly install npm alongside nodejs in the Alpine base image. 

On Alpine, nodejs does not include npm by default, which caused build failures when running npm install -g .... 

The fix adds npm to the apk add command, ensuring the Node.js environment is complete and compatible with subsequent global package installations.

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->
https://github.com/hoppscotch/hoppscotch/issues/5396

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
Add npm to the apk add --no-cache nodejs npm curl tini bash command in the Node.js base stage.
This resolves /bin/sh: npm: not found errors during Docker builds in CI and local environments.
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
