### PR TITLE
fix: correctly resolve inherited properties before request runs

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/Collection.vue
@@ -82,7 +82,6 @@
             @click="emit('add-folder')"
           />
           <HoppButtonSecondary
-            v-if="!isEmpty"
             v-tippy="{ theme: 'tooltip' }"
             :icon="IconPlaySquare"
             :title="t('collection_runner.run_collection')"
@@ -145,7 +144,6 @@
                     "
                   />
                   <HoppSmartItem
-                    v-if="!isEmpty"
                     ref="runCollectionAction"
                     :icon="IconPlaySquare"
                     :label="t('collection_runner.run_collection')"
@@ -371,28 +369,6 @@ const dragging = ref(false)
 const ordering = ref(false)
 const orderingLastItem = ref(false)
 const dropItemID = ref("")
-
-/**
- * Determines if the collection/folder is empty.
- * A collection/folder is considered empty if it has no requests and no child folders.
- */
-const isEmpty = computed(() => {
-  if (!props.data) return true
-
-  if (props.collectionsType === "my-collections") {
-    const collection = props.data as HoppCollection
-    const req = collection.requests.length
-    const fol = collection.folders.length
-
-    return req === 0 && fol === 0
-  }
-
-  const teamCollection = props.data as TeamCollection
-  const req = teamCollection.requests?.length ?? 0
-  const child = teamCollection.children?.length ?? 0
-
-  return req === 0 && child === 0
-})
 
 /**
  * Determines if the collection/folder is sortable.

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -459,11 +459,12 @@ export function runRESTRequest$(
         secret,
       }))
 
+    // settting the inherited values the higer priority than the current request
     const finalRequest = {
       ...tab.value.document.request,
+      ...(preRequestScriptResult.right.updatedRequest ?? {}),
       auth: requestAuth ?? { authType: "none", authActive: false },
       headers: requestHeaders as HoppRESTHeaders,
-      ...(preRequestScriptResult.right.updatedRequest ?? {}),
     }
 
     // Propagate changes to request variables from the scripting context to the UI

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -459,7 +459,7 @@ export function runRESTRequest$(
         secret,
       }))
 
-    // settting the inherited values the higer priority than the current request
+    // setting the inherited values the higher priority than the current request
     const finalRequest = {
       ...tab.value.document.request,
       ...(preRequestScriptResult.right.updatedRequest ?? {}),


### PR DESCRIPTION
Closes #5416 

This PR fixes the issue where the inherited auth and headers were overridden in request execution and was replaced by preRequestScriptResult.


