### PR TITLE
Removed always truthy condition from recursivelySyncCollections function

### DIFF
--- a/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/gqlCollections.sync.ts
@@ -164,13 +164,11 @@ const recursivelySyncCollections = async (
   // create the requests
   if (parentCollectionID) {
     collection.requests.forEach(async (request) => {
-      const res =
-        parentCollectionID &&
-        (await createGQLUserRequest(
-          request.name,
-          JSON.stringify(request),
-          parentCollectionID
-        ))
+      const res = await createGQLUserRequest(
+        request.name,
+        JSON.stringify(request),
+        parentCollectionID
+      )
 
       if (res && E.isRight(res)) {
         const requestId = res.right.createGQLUserRequest.id


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
<b>File path:</b>  packages\hoppscotch-selfhost-web\src\platform\collections\desktop\gqlCollections.sync.ts
<b>Function name:</b>  recursivelySyncCollections
<b>Fixed:</b>  Removed the always truthy condition from line 168

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

<!-- Any information you feel the reviewer should know about when reviewing your PR -->
