### PR TITLE
Removed redundant imports from settings sync file

### DIFF
--- a/packages/hoppscotch-selfhost-desktop/src/platform/settings/settings.sync.ts
+++ b/packages/hoppscotch-selfhost-desktop/src/platform/settings/settings.sync.ts
@@ -1,8 +1,6 @@
 import { settingsStore } from "@hoppscotch/common/newstore/settings"
 
-import { getSyncInitFunction } from "../../lib/sync"
-
-import { StoreSyncDefinitionOf } from "../../lib/sync"
+import { getSyncInitFunction, type StoreSyncDefinitionOf } from "../../lib/sync"
 
 import { updateUserSettings } from "./settings.api"
 


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
<b>File path:</b>  packages\hoppscotch-selfhost-desktop\src\platform\settings\settings.sync.ts
<b>Fixed:</b> Removed redundant lines of importing from same file

<b>Before:</b>
import { getSyncInitFunction } from "../../lib/sync"
import { StoreSyncDefinitionOf } from "../../lib/sync"

<b> After: <b>
import { getSyncInitFunction, type StoreSyncDefinitionOf } from "../../lib/sync"



<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

<!-- Any information you feel the reviewer should know about when reviewing your PR -->
