### PR TITLE
fix(js-sandbox): resolve errors with pw.env namespace in legacy sandbox

### DIFF
--- a/packages/hoppscotch-common/src/types/post-request.d.ts
+++ b/packages/hoppscotch-common/src/types/post-request.d.ts
@@ -256,9 +256,11 @@ declare namespace pw {
     headers: HoppRESTResponseHeader[]
   }>
   namespace env {
+    function set(key: string, value: string): void
+    function unset(key: string): void
     function get(key: string): string
     function getResolve(key: string): string
-    function resolve(key: string): string
+    function resolve(value: string): string
   }
 }
 

--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -158,21 +158,24 @@ export function getSharedEnvMethods(
 }
 
 /**
- * Legacy sandbox version - Returns flat methods for `pw` namespace only
+ * Legacy sandbox version - Methods pre-wrapped in `env` for direct `pw` namespace assignment
+ * (Experimental sandbox powered by `faraday-cage` handles this wrapping via bootstrap code)
  */
 export function getSharedEnvMethods(
   envs: TestResult["envs"],
   isHoppNamespace?: false
 ): {
   methods: {
-    get: (key: string, options?: EnvAPIOptions) => string | null | undefined
-    getResolve: (
-      key: string,
-      options?: EnvAPIOptions
-    ) => string | null | undefined
-    set: (key: string, value: string, options?: EnvAPIOptions) => void
-    unset: (key: string, options?: EnvAPIOptions) => void
-    resolve: (key: string) => string
+    env: {
+      get: (key: string, options?: EnvAPIOptions) => string | null | undefined
+      getResolve: (
+        key: string,
+        options?: EnvAPIOptions
+      ) => string | null | undefined
+      set: (key: string, value: string, options?: EnvAPIOptions) => void
+      unset: (key: string, options?: EnvAPIOptions) => void
+      resolve: (key: string) => string
+    }
   }
   updatedEnvs: TestResult["envs"]
 }
@@ -380,11 +383,13 @@ export function getSharedEnvMethods(
   // Legacy scripting sandbox (Only `pw` namespace)
   return {
     methods: {
-      get: envGetFn,
-      getResolve: envGetResolveFn,
-      set: envSetFn,
-      unset: envUnsetFn,
-      resolve: envResolveFn,
+      env: {
+        get: envGetFn,
+        getResolve: envGetResolveFn,
+        set: envSetFn,
+        unset: envUnsetFn,
+        resolve: envResolveFn,
+      },
     },
     updatedEnvs,
   }


### PR DESCRIPTION
The legacy scripting sandbox was returning environment methods as a flat object under `methods`, requiring consumers to manually wrap them in an `env` property. This inconsistency arose because the experimental sandbox uses bootstrap code (faraday-cage) that defines the `pw.env` structure, while the legacy sandbox doesn't.

Also updates the post-request type definitions accounting for missing `pw.env` methods. These are consumed by the Monaco-based scripting editors in the experimental scripting sandbox for IntelliSense.

### What's changed
- Updated `getSharedEnvMethods()` return type for legacy sandbox to wrap methods in `env` property.
- Modified implementation to return `methods: { env: { get, getResolve, set, unset, resolve } }`.
- Updated JSDoc comment to clarify the architectural difference between legacy and experimental sandboxes.
- This centralises the structure at the source, preventing the need to add wrapping at all consumption points.

### Notes to reviewers

Verify the relevant script execution flows in the legacy scripting sandbox, and that the issue being addressed is resolved.