### PR TITLE
fix: prevent syncing secret variable initial values

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -436,7 +436,7 @@ const workingEnvID = computed(() => {
 
 const getCurrentValue = (id: string | "Global", varIndex: number) => {
   const env = workingEnv.value?.variables[varIndex]
-  if (env && env.secret) {
+  if (env?.secret) {
     return secretEnvironmentService.getSecretEnvironmentVariable(id, varIndex)
       ?.value
   }
@@ -446,7 +446,7 @@ const getCurrentValue = (id: string | "Global", varIndex: number) => {
 
 const getInitialValue = (id: string | "Global", varIndex: number) => {
   const env = workingEnv.value?.variables[varIndex]
-  if (env && env.secret) {
+  if (env?.secret) {
     return secretEnvironmentService.getSecretEnvironmentVariable(id, varIndex)
       ?.initialValue
   }

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -444,6 +444,15 @@ const getCurrentValue = (id: string | "Global", varIndex: number) => {
     ?.currentValue
 }
 
+const getInitialValue = (id: string | "Global", varIndex: number) => {
+  const env = workingEnv.value?.variables[varIndex]
+  if (env && env.secret) {
+    return secretEnvironmentService.getSecretEnvironmentVariable(id, varIndex)
+      ?.initialValue
+  }
+  return env?.initialValue
+}
+
 watch(
   () => props.show,
   (show) => {
@@ -469,7 +478,13 @@ watch(
                   : workingEnvID.value,
                 index
               ) ?? e.currentValue,
-            initialValue: e.initialValue,
+            initialValue:
+              getInitialValue(
+                props.editingEnvironmentIndex === "Global"
+                  ? "Global"
+                  : workingEnvID.value,
+                index
+              ) ?? e.initialValue,
             secret: e.secret,
           },
         }))
@@ -535,6 +550,7 @@ const saveEnvironment = () => {
             key: e.key,
             value: e.currentValue,
             varIndex: i,
+            initialValue: e.initialValue,
           })
         : O.none
     )
@@ -583,7 +599,7 @@ const saveEnvironment = () => {
     A.map((e) => ({
       key: e.key,
       secret: e.secret,
-      initialValue: e.initialValue || "",
+      initialValue: e.secret ? "" : e.initialValue,
       currentValue: "",
     }))
   )

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -419,6 +419,13 @@ const getCurrentValue = (
   )?.currentValue
 }
 
+const getInitialValue = (editingID: string, varIndex: number) => {
+  return secretEnvironmentService.getSecretEnvironmentVariable(
+    editingID,
+    varIndex
+  )?.initialValue
+}
+
 watch(
   () => props.show,
   (show) => {
@@ -449,7 +456,11 @@ watch(
                   index,
                   e.secret
                 ) ?? e.currentValue,
-              initialValue: e.initialValue,
+              initialValue: e.secret
+                ? (getInitialValue(props.editingEnvironment?.id ?? "", index) ??
+                  e.initialValue ??
+                  "")
+                : e.initialValue,
               secret: e.secret,
             },
           }))
@@ -516,7 +527,12 @@ const saveEnvironment = async () => {
     filteredVariables,
     A.filterMapWithIndex((i, e) =>
       e.secret
-        ? O.some({ key: e.key, value: e.currentValue, varIndex: i })
+        ? O.some({
+            key: e.key,
+            value: e.currentValue,
+            varIndex: i,
+            initialValue: e.initialValue,
+          })
         : O.none
     )
   )
@@ -540,7 +556,7 @@ const saveEnvironment = async () => {
     A.map((e) => ({
       key: e.key,
       secret: e.secret,
-      initialValue: e.initialValue || "",
+      initialValue: e.secret ? "" : e.initialValue,
       currentValue: "",
     }))
   )

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -170,8 +170,8 @@ const updateEnvironments = (
           initialValue: e.initialValue ?? "",
         })
 
-        // delete the value from the environment
-        // so that it doesn't get saved in the environment
+        // create a new object with cleared values for secret variables
+        // so that these values don't get saved in the environment
         return {
           key: e.key,
           secret: e.secret,

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -145,10 +145,15 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
             ? tooltipEnv.sourceEnvID!
             : currentSelectedEnvironment.id
 
-      const hasSecretStored = secretEnvironmentService.hasSecretValue(
+      const hasSecretValueStored = secretEnvironmentService.hasSecretValue(
         tooltipSourceEnvID,
         tooltipEnv?.key ?? ""
       )
+      const hasSecretInitialValueStored =
+        secretEnvironmentService.hasSecretInitialValue(
+          tooltipSourceEnvID,
+          tooltipEnv?.key ?? ""
+        )
 
       // We need to check if the environment is a secret and if it has a secret value stored in the secret environment service
       // If it is a secret and has a secret value, we need to show "******" in the tooltip
@@ -158,12 +163,12 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
       // If the source environment is not found, we need to show "Not Found" in the tooltip, ie the the environment
       // is not defined in the selected environment or the global environment
       if (isSecret) {
-        if (!hasSecretStored && envInitialValue) {
+        if (hasSecretValueStored && hasSecretInitialValueStored) {
           envInitialValue = "******"
-        } else if (hasSecretStored && !envInitialValue) {
           envCurrentValue = "******"
-        } else if (hasSecretStored && envInitialValue) {
+        } else if (!hasSecretValueStored && hasSecretInitialValueStored) {
           envInitialValue = "******"
+        } else if (hasSecretValueStored && !hasSecretInitialValueStored) {
           envCurrentValue = "******"
         } else {
           envInitialValue = "Empty"

--- a/packages/hoppscotch-common/src/helpers/utils/environments.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/environments.ts
@@ -36,6 +36,7 @@ const unWrapEnvironments = (
       return {
         ...globalVar,
         currentValue: secretVar.value,
+        initialValue: secretVar.initialValue ?? "",
       }
     }
     return {
@@ -58,6 +59,7 @@ const unWrapEnvironments = (
         return {
           ...selectedVar,
           currentValue: secretVar.value,
+          initialValue: secretVar.initialValue ?? "",
         }
       }
       return {

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -562,13 +562,13 @@ export function getAggregateEnvsWithCurrentValue() {
           secretEnvironmentService.getSecretEnvironmentVariableValue(
             currentEnv.id,
             index
-          ).value ?? ""
+          )?.value ?? ""
 
         initialValue =
           secretEnvironmentService.getSecretEnvironmentVariableValue(
             currentEnv.id,
             index
-          ).initialValue ?? ""
+          )?.initialValue ?? ""
       }
 
       return <AggregateEnvironment>{
@@ -591,13 +591,13 @@ export function getAggregateEnvsWithCurrentValue() {
           secretEnvironmentService.getSecretEnvironmentVariableValue(
             "Global",
             index
-          ).value ?? ""
+          )?.value ?? ""
 
         initialValue =
           secretEnvironmentService.getSecretEnvironmentVariableValue(
             "Global",
             index
-          ).initialValue ?? ""
+          )?.initialValue ?? ""
       }
       return <AggregateEnvironment>{
         key: x.key,
@@ -643,13 +643,13 @@ export const aggregateEnvsWithCurrentValue$: Observable<
             secretEnvironmentService.getSecretEnvironmentVariableValue(
               selectedEnv.id,
               index
-            ).value ?? ""
+            )?.value ?? ""
 
           initialValue =
             secretEnvironmentService.getSecretEnvironmentVariableValue(
               selectedEnv.id,
               index
-            ).initialValue ?? ""
+            )?.initialValue ?? ""
         }
         results.push({
           key: x.key,
@@ -672,13 +672,13 @@ export const aggregateEnvsWithCurrentValue$: Observable<
             secretEnvironmentService.getSecretEnvironmentVariableValue(
               "Global",
               index
-            ).value ?? ""
+            )?.value ?? ""
 
           initialValue =
             secretEnvironmentService.getSecretEnvironmentVariableValue(
               "Global",
               index
-            ).initialValue ?? ""
+            )?.initialValue ?? ""
         }
         results.push({
           key: x.key,

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -556,12 +556,19 @@ export function getAggregateEnvsWithCurrentValue() {
 
     ...currentEnv.variables.map((x, index) => {
       let currentValue = x.currentValue
+      let initialValue = x.initialValue
       if (x.secret) {
         currentValue =
           secretEnvironmentService.getSecretEnvironmentVariableValue(
             currentEnv.id,
             index
-          ) ?? ""
+          ).value ?? ""
+
+        initialValue =
+          secretEnvironmentService.getSecretEnvironmentVariableValue(
+            currentEnv.id,
+            index
+          ).initialValue ?? ""
       }
 
       return <AggregateEnvironment>{
@@ -571,19 +578,26 @@ export function getAggregateEnvsWithCurrentValue() {
             currentEnv.id,
             index
           ) ?? currentValue,
-        initialValue: x.initialValue,
+        initialValue: x.initialValue ?? initialValue,
         secret: x.secret,
         sourceEnv: currentEnv.name,
       }
     }),
     ...getGlobalVariables().map((x, index) => {
       let currentValue = x.currentValue
+      let initialValue = x.initialValue
       if (x.secret) {
         currentValue =
           secretEnvironmentService.getSecretEnvironmentVariableValue(
             "Global",
             index
-          ) ?? ""
+          ).value ?? ""
+
+        initialValue =
+          secretEnvironmentService.getSecretEnvironmentVariableValue(
+            "Global",
+            index
+          ).initialValue ?? ""
       }
       return <AggregateEnvironment>{
         key: x.key,
@@ -592,7 +606,7 @@ export function getAggregateEnvsWithCurrentValue() {
             "Global",
             index
           ) ?? currentValue,
-        initialValue: x.initialValue,
+        initialValue: x.initialValue ?? initialValue,
         secret: x.secret,
         sourceEnv: "Global",
       }
@@ -623,12 +637,19 @@ export const aggregateEnvsWithCurrentValue$: Observable<
 
       selectedEnv?.variables.map((x, index) => {
         let currentValue = x.currentValue
+        let initialValue = x.initialValue
         if (x.secret) {
           currentValue =
             secretEnvironmentService.getSecretEnvironmentVariableValue(
               selectedEnv.id,
               index
-            ) ?? ""
+            ).value ?? ""
+
+          initialValue =
+            secretEnvironmentService.getSecretEnvironmentVariableValue(
+              selectedEnv.id,
+              index
+            ).initialValue ?? ""
         }
         results.push({
           key: x.key,
@@ -637,7 +658,7 @@ export const aggregateEnvsWithCurrentValue$: Observable<
               selectedEnv.id,
               index
             ) ?? currentValue,
-          initialValue: x.initialValue,
+          initialValue: x.initialValue ?? initialValue,
           secret: x.secret,
           sourceEnv: selectedEnv.name,
         })
@@ -645,12 +666,19 @@ export const aggregateEnvsWithCurrentValue$: Observable<
 
       globalEnv.variables.map((x, index) => {
         let currentValue = x.currentValue
+        let initialValue = x.initialValue
         if (x.secret) {
           currentValue =
             secretEnvironmentService.getSecretEnvironmentVariableValue(
               "Global",
               index
-            ) ?? ""
+            ).value ?? ""
+
+          initialValue =
+            secretEnvironmentService.getSecretEnvironmentVariableValue(
+              "Global",
+              index
+            ).initialValue ?? ""
         }
         results.push({
           key: x.key,
@@ -659,7 +687,7 @@ export const aggregateEnvsWithCurrentValue$: Observable<
               "Global",
               index
             ) ?? currentValue,
-          initialValue: x.initialValue,
+          initialValue: x.initialValue ?? initialValue,
           secret: x.secret,
           sourceEnv: "Global",
         })

--- a/packages/hoppscotch-common/src/services/__tests__/secret-environment.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/secret-environment.service.spec.ts
@@ -88,7 +88,7 @@ describe("SecretEnvironmentService", () => {
       })
     })
 
-    it("should return default empty strings if the variable has no value/initialValue", () => {
+    it("should return null if the variable has no value/initialValue", () => {
       const id = "testEnvironment"
       const secretVars = [{ key: "key1", varIndex: 1 }]
 
@@ -102,7 +102,7 @@ describe("SecretEnvironmentService", () => {
       })
     })
 
-    it("should return { value: '', initialValue: '' } if the specified variable does not exist", () => {
+    it("should return null if the specified variable does not exist", () => {
       const id = "testEnvironment"
       const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
 
@@ -110,21 +110,15 @@ describe("SecretEnvironmentService", () => {
 
       const result = service.getSecretEnvironmentVariableValue(id, 2)
 
-      expect(result).toEqual({
-        value: "",
-        initialValue: "",
-      })
+      expect(result).toBeNull()
     })
 
-    it("should return { value: '', initialValue: '' } if the specified environment does not exist", () => {
+    it("should return null if the specified environment does not exist", () => {
       const id = "nonExistentEnvironment"
 
       const result = service.getSecretEnvironmentVariableValue(id, 1)
 
-      expect(result).toEqual({
-        value: "",
-        initialValue: "",
-      })
+      expect(result).toBeNull()
     })
   })
 

--- a/packages/hoppscotch-common/src/services/__tests__/secret-environment.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/secret-environment.service.spec.ts
@@ -72,18 +72,37 @@ describe("SecretEnvironmentService", () => {
   })
 
   describe("getSecretEnvironmentVariableValue", () => {
-    it("should return the value of the specified secret environment variable", () => {
+    it("should return the value and initialValue of the specified secret environment variable", () => {
       const id = "testEnvironment"
-      const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
+      const secretVars = [
+        { key: "key1", value: "value1", initialValue: "init1", varIndex: 1 },
+      ]
 
       service.secretEnvironments.set(id, secretVars)
 
       const result = service.getSecretEnvironmentVariableValue(id, 1)
 
-      expect(result).toEqual(secretVars[0].value)
+      expect(result).toEqual({
+        value: "value1",
+        initialValue: "init1",
+      })
     })
 
-    it("should return undefined if the specified variable does not exist", () => {
+    it("should return default empty strings if the variable has no value/initialValue", () => {
+      const id = "testEnvironment"
+      const secretVars = [{ key: "key1", varIndex: 1 }]
+
+      service.secretEnvironments.set(id, secretVars as any)
+
+      const result = service.getSecretEnvironmentVariableValue(id, 1)
+
+      expect(result).toEqual({
+        value: "",
+        initialValue: "",
+      })
+    })
+
+    it("should return { value: '', initialValue: '' } if the specified variable does not exist", () => {
       const id = "testEnvironment"
       const secretVars = [{ key: "key1", value: "value1", varIndex: 1 }]
 
@@ -91,15 +110,21 @@ describe("SecretEnvironmentService", () => {
 
       const result = service.getSecretEnvironmentVariableValue(id, 2)
 
-      expect(result).toBeUndefined()
+      expect(result).toEqual({
+        value: "",
+        initialValue: "",
+      })
     })
 
-    it("should return undefined if the specified environment does not exist", () => {
+    it("should return { value: '', initialValue: '' } if the specified environment does not exist", () => {
       const id = "nonExistentEnvironment"
 
       const result = service.getSecretEnvironmentVariableValue(id, 1)
 
-      expect(result).toBeUndefined()
+      expect(result).toEqual({
+        value: "",
+        initialValue: "",
+      })
     })
   })
 

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -379,6 +379,7 @@ export const SECRET_ENVIRONMENT_VARIABLE_SCHEMA = z.union([
         .object({
           key: z.string(),
           value: z.string(),
+          initialValue: z.string().optional().catch(""),
           varIndex: z.number(),
         })
         .strict()

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -4,11 +4,15 @@ import { reactive, computed, watch } from "vue"
 
 /**
  * Defines a secret environment variable.
+ * Value is the current value of the variable.
+ * InitialValue is the value of the variable when it was created.
+ * VarIndex is the index of the variable in the environment.
  */
 export type SecretVariable = {
   key: string
   value: string
   varIndex: number
+  initialValue?: string
 }
 
 /**
@@ -61,13 +65,16 @@ export class SecretEnvironmentService extends Service {
   }
 
   /**
-   * Used to get the value of a secret environment variable.
+   * Used to get the initial and current value of a secret environment variable.
    * @param id ID of the environment
    * @param varIndex Index of the variable in the environment
    */
   public getSecretEnvironmentVariableValue(id: string, varIndex: number) {
     const secretVar = this.getSecretEnvironmentVariable(id, varIndex)
-    return secretVar?.value
+    return {
+      value: secretVar?.value || "",
+      initialValue: secretVar?.initialValue || "",
+    }
   }
 
   /**
@@ -131,6 +138,23 @@ export class SecretEnvironmentService extends Service {
       this.secretEnvironments
         .get(id)!
         .some((secretVar) => secretVar.key === key && secretVar.value !== "")
+    )
+  }
+
+  /**
+   * Checks if a secret variable has an initial value set.
+   * @param id ID of the environment
+   * @param key Key of the variable to check the initial value exists
+   * @returns true if the key has an initial value
+   */
+  public hasSecretInitialValue(id: string, key: string) {
+    return (
+      this.secretEnvironments.has(id) &&
+      this.secretEnvironments
+        .get(id)!
+        .some(
+          (secretVar) => secretVar.key === key && secretVar.initialValue !== ""
+        )
     )
   }
 

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -153,12 +153,7 @@ export class SecretEnvironmentService extends Service {
       this.secretEnvironments.has(id) &&
       this.secretEnvironments
         .get(id)!
-        .some(
-          (secretVar) =>
-            secretVar.key === key &&
-            secretVar.initialValue &&
-            secretVar.initialValue !== ""
-        )
+        .some((secretVar) => secretVar.key === key && secretVar.initialValue)
     )
   }
 

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -154,7 +154,10 @@ export class SecretEnvironmentService extends Service {
       this.secretEnvironments
         .get(id)!
         .some(
-          (secretVar) => secretVar.key === key && secretVar.initialValue !== ""
+          (secretVar) =>
+            secretVar.key === key &&
+            secretVar.initialValue &&
+            secretVar.initialValue !== ""
         )
     )
   }

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -71,9 +71,10 @@ export class SecretEnvironmentService extends Service {
    */
   public getSecretEnvironmentVariableValue(id: string, varIndex: number) {
     const secretVar = this.getSecretEnvironmentVariable(id, varIndex)
+    if (!secretVar) return null
     return {
-      value: secretVar?.value || "",
-      initialValue: secretVar?.initialValue || "",
+      value: secretVar.value || "",
+      initialValue: secretVar.initialValue || "",
     }
   }
 


### PR DESCRIPTION
Closes #5430 

This PR fixes the bug where the secret initial variable value was getting synced to the server. Now the initial value is stored in the secret environment service just like the current environment value.

Previously, secret environment variable initial values were persisted and synced to the server alongside other environment data. This exposed sensitive bootstrap values that should remain local-only (similar to how secret current values are handled). This PR changes the handling so that both secret `currentValue` and `initialValue` are stored only in the local `SecretEnvironmentService` (backed by local storage) and are stripped from the synced environment payload.

Secret initial values were never separated from the canonical environment object before persistence/sync operations; only `currentValue` had partial masking logic. Save/update flows did not sanitise secret `initialValue` fields.

### What’s Changed
- SecretEnvironmentService:
  - Added initialValue support on SecretVariable.
  - getSecretEnvironmentVariableValue now returns { value, initialValue } | null.
  - Added hasSecretInitialValue() helper.
- UI & Editing (My/Team/Global environment modals):
  - When saving secrets, `initialValue` and `currentValue` are excluded from the persisted environment (replaced with "") and stored locally with varIndex.
- Request execution:
  - Consolidated secret + non-secret resolution via resolveEnvVars().
  - Ensures secret values never re-enter the persisted store during runtime updates.
- Aggregation & tooltip logic:
  - Pulls secret initial/current values from `secretEnvironmentService`.
  - Correct masking rules added (handles four presence combinations).
- Validation schema updated to allow optional initialValue on secret entries.
- Unit tests updated for new semantics (including null returns).
- Added explanatory comments and clarified masking logic.