### PR TITLE
Add workflow for manual version bumps (#5379)

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,29 @@
+name: Manual Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: "Choose version bump type"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Bump version
+        uses: phips28/gh-action-bump-version@v10
+        with:
+          bump-type: ${{ github.event.inputs.release-type }}
+          tag-prefix: "v"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that allows maintainers to manually bump the project version.

- Provides workflow inputs for release type (patch, minor, major)
- Uses Universal Version Bump (phips28/gh-action-bump-version) to handle the version bump
- Updates package.json automatically and applies a version tag

Fixes #5379
