### PR TITLE
fix: fallback to initialValue for environment vars with empty currentValue in pre/post-request scripts

### DIFF
--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -195,7 +195,7 @@ export function getSharedEnvMethods(
       getEnv(key, updatedEnvs, options),
       O.fold(
         () => (options.fallbackToNull ? null : undefined),
-        (env) => String(env.currentValue)
+        (env) => String(env.currentValue || env.initialValue)
       )
     )
 
@@ -224,8 +224,8 @@ export function getSharedEnvMethods(
 
       E.map((e) =>
         pipe(
-          parseTemplateStringE(e.currentValue, envVars), // If the recursive resolution failed, return the unresolved value
-          E.getOrElse(() => e.currentValue)
+          parseTemplateStringE(e.currentValue || e.initialValue, envVars), // If the recursive resolution failed, return the unresolved value
+          E.getOrElse(() => e.currentValue || e.initialValue)
         )
       ),
       E.map((x) => String(x)),

--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -224,9 +224,13 @@ export function getSharedEnvMethods(
 
       E.map((e) =>
         pipe(
-          parseTemplateStringE(e.currentValue || e.initialValue, envVars), // If the recursive resolution failed, return the unresolved value
-          E.getOrElse(() => e.currentValue || e.initialValue)
-        )
+          parseTemplateStringE(
+            (e.currentValue !== undefined && e.currentValue !== "") ? e.currentValue : e.initialValue,
+            envVars
+          ), // If the recursive resolution failed, return the unresolved value
+          E.getOrElse(() =>
+            (e.currentValue !== undefined && e.currentValue !== "") ? e.currentValue : e.initialValue
+          )
       ),
       E.map((x) => String(x)),
 

--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -195,7 +195,7 @@ export function getSharedEnvMethods(
       getEnv(key, updatedEnvs, options),
       O.fold(
         () => (options.fallbackToNull ? null : undefined),
-        (env) => String(env.currentValue || env.initialValue)
+        (env) => env.currentValue !== '' ? String(env.currentValue) : String(env.initialValue)
       )
     )
 


### PR DESCRIPTION
Closes #5437 

This PR addresses the issue where environment variables with empty currentValue don't fall back to their initialValue in pre-request or post-request scripts. It ensures that the correct value is returned as expected.

**What's Changed**
Fixed the logic to ensure environment variables return initialValue when currentValue is empty or unset.
Updated the behavior to return undefined/empty string only when both initialValue and currentValue are not set.

**Notes to Reviewers**
Check the fallback behavior for environment variables with both initialValue and empty currentValue.
Review the changes made in the REST tab to confirm correct functionality for pre and post-request scripts.
Let me know if there are any additional edge cases to cover or feedback to address.
