### PR TITLE
chore: add arm runner to matrix-based docker build

### DIFF
--- a/.github/workflows/release-push-docker.yml
+++ b/.github/workflows/release-push-docker.yml
@@ -13,19 +13,16 @@ jobs:
     strategy:
       matrix:
         platform: [
-          { platform: linux/amd64, cache: docker-release-amd64, artifactSuffix: amd64 },
-          { platform: linux/arm64, cache: docker-release-arm64, artifactSuffix: arm64 },
+          { runner: ubuntu-latest, platform: linux/amd64, cache: docker-release-amd64, artifactSuffix: amd64 },
+          { runner: ubuntu-24.04-arm, platform: linux/arm64, cache: docker-release-arm64, artifactSuffix: arm64 },
         ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Setup environment
         run: cp .env.example .env
-
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   </b>
   <p>
 
-[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen?logo=github)](CODE_OF_CONDUCT.md) [![Website](https://img.shields.io/website?url=https%3A%2F%2Fhoppscotch.io&logo=hoppscotch)](https://hoppscotch.io) [![Tests](https://github.com/hoppscotch/hoppscotch/actions/workflows/tests.yml/badge.svg)](https://github.com/hoppscotch/hoppscotch/actions) [![Tweet](https://img.shields.io/twitter/url?url=https%3A%2F%2Fhoppscotch.io%2F)](https://twitter.com/share?text=%F0%9F%91%BD%20Hoppscotch%20%E2%80%A2%20Open%20source%20API%20development%20ecosystem%20-%20Helps%20you%20create%20requests%20faster,%20saving%20precious%20time%20on%20development.&url=https://hoppscotch.io&hashtags=hoppscotch&via=hoppscotch_io)
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen?logo=github)](CODE_OF_CONDUCT.md) [![Website](https://img.shields.io/website?url=https%3A%2F%2Fhoppscotch.io&logo=hoppscotch)](https://hoppscotch.io) [![Tests](https://github.com/hoppscotch/hoppscotch/actions/workflows/tests.yml/badge.svg)](https://github.com/hoppscotch/hoppscotch/actions) [![Tweet](https://img.shields.io/twitter/url?url=https%3A%2F%2Fhoppscotch.io%2F)](https://x.com/share?text=%F0%9F%91%BD%20Hoppscotch%20%E2%80%A2%20Open%20source%20API%20development%20ecosystem%20-%20Helps%20you%20create%20requests%20faster,%20saving%20precious%20time%20on%20development.&url=https://hoppscotch.io&hashtags=hoppscotch&via=hoppscotch_io)
 
   </p>
   <p>

--- a/netlify.toml
+++ b/netlify.toml
@@ -45,7 +45,7 @@
 
 [[redirects]]
   from = "/twitter"
-  to = "https://twitter.com/hoppscotch_io"
+  to = "https://x.com/hoppscotch_io"
   status = 301
   force = true
 

--- a/packages/hoppscotch-common/src/components/app/Share.vue
+++ b/packages/hoppscotch-common/src/components/app/Share.vue
@@ -84,7 +84,7 @@ const platforms = [
   {
     name: "Twitter",
     icon: IconTwitter,
-    link: `https://twitter.com/intent/tweet?text=${text} ${description}&url=${url}&via=${twitter}`,
+    link: `https://x.com/intent/tweet?text=${text} ${description}&url=${url}&via=${twitter}`,
   },
   {
     name: "Facebook",

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/general.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/general.searcher.ts
@@ -73,7 +73,7 @@ export class GeneralSpotlightSearcherService extends StaticSpotlightSearcherServ
       text: [this.t("spotlight.general.social"), "Twitter"],
       alternates: ["social", "twitter", "link"],
       icon: markRaw(IconTwitter),
-      action: () => this.openURL("https://twitter.com/hoppscotch_io"),
+      action: () => this.openURL("https://x.com/hoppscotch_io"),
     },
     link_discord: {
       text: [this.t("spotlight.general.social"), "Discord"],


### PR DESCRIPTION
<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
Refactors matrix strategy to use [Github's ARM Runner](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#supported-runners-and-hardware-resources) (free for open source) for the ARM build variant, which should dramatically improve the overall Docker build since it won't need emulation.

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
* Added `runner: ubuntu-latest` and `runner: ubuntu-24.04-arm` to the respective entries in the matrix strategy.
* Updated `runs-on:` to use matrix strategy value.
<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
The following can be removed in a separate PR once desired behavior is confirmed, or happy to do it as part of this PR if scope is reasonable: 

```yaml
      - name: Setup QEMU
        uses: docker/setup-qemu-action@v3
```
