### PR TITLE
#5408 GraphQL tab lacked HTTP headers visibility that REST tab had, making debugging difficult.

### DIFF
--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -60,6 +60,7 @@ export type GQLResponseEvent =
       operationName: string | undefined
       operationType: OperationType
       data: string
+      headers?: Record<string, string>
       rawQuery?: RunQueryOptions
       document?: {
         type: string
@@ -479,6 +480,7 @@ export const runGQLOperation = async (options: RunQueryOptions) => {
 
     gqlMessageEvent.value = {
       ...parsedResponse,
+      headers: relayResponse.headers,
       document: {
         type: "success",
         statusCode: relayResponse.status,
@@ -623,6 +625,7 @@ export const runSubscription = (
           operationName,
           data: JSON.stringify(data.payload),
           operationType: "subscription",
+          headers: headers,
         }
         break
       }

--- a/packages/hoppscotch-common/src/helpers/kernel/gql/response.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/gql/response.ts
@@ -11,6 +11,7 @@ export type HoppGQLSuccessResponse = {
   operationName: string | undefined
   operationType: OperationType
   data: string
+  headers?: Record<string, string>
   rawQuery?: RunQueryOptions
 }
 
@@ -77,6 +78,7 @@ export const GQLResponse = {
                 operationName: options.operationName,
                 operationType: determineOperationType(options.query),
                 data: JSON.stringify(validBody, null, 2),
+                headers: response.headers,
                 rawQuery: options,
               }
             : createTransformError("Invalid GraphQL response structure")


### PR DESCRIPTION
Problem Solved: GraphQL tab lacked HTTP headers visibility that REST tab had, making debugging difficult.

Solution: Added a Headers tab to GraphQL responses showing all HTTP headers with copy functionality.

Technical Implementation:

Updated response types to include headers
Enhanced kernel parser to pass through headers
Added tabbed UI using existing components
Maintained backward compatibility
Impact: Enables debugging of caching, tracing, rate limiting, security headers, and CORS issues in GraphQL APIs.
