### PR TITLE
fix: focus existing request tab instead of duplicating

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -2085,7 +2085,9 @@ const selectRequest = (selectedRequest: {
       originLocation: "user-collection",
       requestIndex: parseInt(requestIndex),
       folderPath: folderPath!,
+      requestRefID: request._ref_id ?? request.id,
     })
+
     if (possibleTab) {
       tabs.setActiveTab(possibleTab.value.id)
     } else {


### PR DESCRIPTION
Closes #5447 

This PR fixes an issue where multiple tabs would open even when a request tab was already active. It now correctly switches to the active tab instead.

Clicking a request in the personal workspace opened a new duplicate tab even if that request was already open. The tab lookup lacked a stable request reference identifier, so it failed to match the existing tab and created a new one.

The `User-Collection` tab uses identity matching with the `folderPath` + `requestIndex` (+ `exampleID`), but not a persistent reference ID. Imported/duplicated items or structural changes could keep indices while still representing the same logical request, and the matching was too weak.

### What’s Changed
- Added `requestRefID` (from `request._ref_id ?? request.id`) into the user-collection saveContext passed to `getTabRefWithSaveContext` during selection.
- Ensures the lookup matches the original tab (which already stores `requestRefID` on creation) and activates it instead of spawning a duplicate.

