### PR TITLE
chore: replace all instances of `twitter.com` with `x.com`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   </b>
   <p>
 
-[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen?logo=github)](CODE_OF_CONDUCT.md) [![Website](https://img.shields.io/website?url=https%3A%2F%2Fhoppscotch.io&logo=hoppscotch)](https://hoppscotch.io) [![Tests](https://github.com/hoppscotch/hoppscotch/actions/workflows/tests.yml/badge.svg)](https://github.com/hoppscotch/hoppscotch/actions) [![Tweet](https://img.shields.io/twitter/url?url=https%3A%2F%2Fhoppscotch.io%2F)](https://twitter.com/share?text=%F0%9F%91%BD%20Hoppscotch%20%E2%80%A2%20Open%20source%20API%20development%20ecosystem%20-%20Helps%20you%20create%20requests%20faster,%20saving%20precious%20time%20on%20development.&url=https://hoppscotch.io&hashtags=hoppscotch&via=hoppscotch_io)
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen?logo=github)](CODE_OF_CONDUCT.md) [![Website](https://img.shields.io/website?url=https%3A%2F%2Fhoppscotch.io&logo=hoppscotch)](https://hoppscotch.io) [![Tests](https://github.com/hoppscotch/hoppscotch/actions/workflows/tests.yml/badge.svg)](https://github.com/hoppscotch/hoppscotch/actions) [![Tweet](https://img.shields.io/twitter/url?url=https%3A%2F%2Fhoppscotch.io%2F)](https://x.com/share?text=%F0%9F%91%BD%20Hoppscotch%20%E2%80%A2%20Open%20source%20API%20development%20ecosystem%20-%20Helps%20you%20create%20requests%20faster,%20saving%20precious%20time%20on%20development.&url=https://hoppscotch.io&hashtags=hoppscotch&via=hoppscotch_io)
 
   </p>
   <p>

--- a/netlify.toml
+++ b/netlify.toml
@@ -45,7 +45,7 @@
 
 [[redirects]]
   from = "/twitter"
-  to = "https://twitter.com/hoppscotch_io"
+  to = "https://x.com/hoppscotch_io"
   status = 301
   force = true
 

--- a/packages/hoppscotch-common/src/components/app/Share.vue
+++ b/packages/hoppscotch-common/src/components/app/Share.vue
@@ -84,7 +84,7 @@ const platforms = [
   {
     name: "Twitter",
     icon: IconTwitter,
-    link: `https://twitter.com/intent/tweet?text=${text} ${description}&url=${url}&via=${twitter}`,
+    link: `https://x.com/intent/tweet?text=${text} ${description}&url=${url}&via=${twitter}`,
   },
   {
     name: "Facebook",

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/general.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/general.searcher.ts
@@ -73,7 +73,7 @@ export class GeneralSpotlightSearcherService extends StaticSpotlightSearcherServ
       text: [this.t("spotlight.general.social"), "Twitter"],
       alternates: ["social", "twitter", "link"],
       icon: markRaw(IconTwitter),
-      action: () => this.openURL("https://twitter.com/hoppscotch_io"),
+      action: () => this.openURL("https://x.com/hoppscotch_io"),
     },
     link_discord: {
       text: [this.t("spotlight.general.social"), "Discord"],


### PR DESCRIPTION
This PR updates references from the deprecated [twitter.com](http://twitter.com) domain to the current [x.com](http://x.com) branding for consistency and to avoid user-facing legacy brand usage. The change is mechanical (string/domain replacement) and does not introduce functional logic changes.

### What's changed

Replaced all occurrences of `twitter.com` with `x.com` in:
- Documentation (README/markdown files)
-  Metadata/config files
- UI or footer/social link definitions

### Notes to reviewers

N/A