### PR TITLE
fix(common): preserve team environment name during collection runs

### DIFF
--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -616,8 +616,8 @@ export function runRESTRequest$(
               updateEnvsAfterTestScript(
                 combinedResult,
                 initialEnvironmentIndex,
-                initialEnvID,
-                initialEnvName
+                initialEnvName,
+                initialEnvID
               )
             }
 
@@ -673,8 +673,8 @@ export function runRESTRequest$(
 function updateEnvsAfterTestScript(
   runResult: E.Right<SandboxTestResult>,
   initialEnvironmentIndex: SelectedEnvironmentIndex,
-  initialEnvID?: string,
-  initialEnvName?: string
+  initialEnvName: string,
+  initialEnvID?: string
 ) {
   const globalEnvVariables = updateEnvironments(
     runResult.right.envs.global,
@@ -905,8 +905,8 @@ export function runTestRunnerRequest(
                 updateEnvsAfterTestScript(
                   postRequestScriptResult,
                   initialEnvironmentIndex,
-                  initialEnvID,
-                  initialEnvName
+                  initialEnvName,
+                  initialEnvID
                 )
               }
             } else {

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -705,7 +705,8 @@ function updateEnvsAfterTestScript(
     })
   } else if (initialEnvironmentIndex.type === "TEAM_ENV") {
     // Use the initial environment name to avoid issues when environment changes during request execution
-    const envName = initialEnvName || getCurrentEnvironment().name
+    // adding a fallback to current environment name just in case so it's not null
+    const envName = initialEnvName ?? getCurrentEnvironment().name
     pipe(
       updateTeamEnvironment(
         JSON.stringify(selectedEnvVariables),

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -87,6 +87,7 @@ export type InitialEnvironmentState = {
   initialEnvID: string
   initialSelectedEnvs: Environment["variables"]
   initialEnvironmentIndex: SelectedEnvironmentIndex
+  initialEnvName: string
   initialEnvs: TestResult["envs"] & {
     temp: Environment["variables"]
   }
@@ -115,6 +116,9 @@ export const captureInitialEnvironmentState = (): InitialEnvironmentState => {
     environmentsStore.value.selectedEnvironmentIndex
   )
 
+  // Capture the initial environment name
+  const initialEnvName = getCurrentEnvironment().name
+
   // Capture the initial script environment state (the environment passed to scripts)
   const initialEnvs = getCombinedEnvVariables()
   const initialEnvsForComparison: TestResult["envs"] = {
@@ -127,6 +131,7 @@ export const captureInitialEnvironmentState = (): InitialEnvironmentState => {
     initialEnvID,
     initialSelectedEnvs,
     initialEnvironmentIndex,
+    initialEnvName,
     initialEnvs,
     initialEnvsForComparison,
   }
@@ -489,6 +494,7 @@ export function runRESTRequest$(
     initialEnvID,
     initialSelectedEnvs,
     initialEnvironmentIndex,
+    initialEnvName,
     initialEnvs,
     initialEnvsForComparison,
   } = captureInitialEnvironmentState()
@@ -610,7 +616,8 @@ export function runRESTRequest$(
               updateEnvsAfterTestScript(
                 combinedResult,
                 initialEnvironmentIndex,
-                initialEnvID
+                initialEnvID,
+                initialEnvName
               )
             }
 
@@ -666,7 +673,8 @@ export function runRESTRequest$(
 function updateEnvsAfterTestScript(
   runResult: E.Right<SandboxTestResult>,
   initialEnvironmentIndex: SelectedEnvironmentIndex,
-  initialEnvID?: string
+  initialEnvID?: string,
+  initialEnvName?: string
 ) {
   const globalEnvVariables = updateEnvironments(
     runResult.right.envs.global,
@@ -696,14 +704,13 @@ function updateEnvsAfterTestScript(
       variables: selectedEnvVariables,
     })
   } else if (initialEnvironmentIndex.type === "TEAM_ENV") {
-    const env = getEnvironment({
-      type: "TEAM_ENV",
-    })
+    // Use the initial environment name to avoid issues when environment changes during request execution
+    const envName = initialEnvName || getCurrentEnvironment().name
     pipe(
       updateTeamEnvironment(
         JSON.stringify(selectedEnvVariables),
         initialEnvironmentIndex.teamEnvID,
-        env.name
+        envName
       )
     )()
   }
@@ -801,6 +808,7 @@ export function runTestRunnerRequest(
     initialEnvID,
     initialSelectedEnvs,
     initialEnvironmentIndex,
+    initialEnvName,
     initialEnvs,
     initialEnvsForComparison,
   } = initialEnvironmentState
@@ -897,7 +905,8 @@ export function runTestRunnerRequest(
                 updateEnvsAfterTestScript(
                   postRequestScriptResult,
                   initialEnvironmentIndex,
-                  initialEnvID
+                  initialEnvID,
+                  initialEnvName
                 )
               }
             } else {

--- a/packages/hoppscotch-common/src/services/test-runner/test-runner.service.ts
+++ b/packages/hoppscotch-common/src/services/test-runner/test-runner.service.ts
@@ -10,7 +10,6 @@ import { cloneDeep } from "lodash-es"
 import { Ref } from "vue"
 import {
   captureInitialEnvironmentState,
-  InitialEnvironmentState,
   runTestRunnerRequest,
 } from "~/helpers/RequestRunner"
 import {
@@ -182,17 +181,13 @@ export class TestRunnerService extends Service {
           headers: [...inheritedHeaders, ...request.headers],
         }
 
-        // Capture the initial environment state for a test run so that it remains consistent and unchanged when current environment changes
-        const initialEnvironmentState = captureInitialEnvironmentState()
-
         await this.runTestRequest(
           tab,
           finalRequest,
           collection,
           options,
           currentPath,
-          inheritedVariables,
-          initialEnvironmentState
+          inheritedVariables
         )
 
         if (options.delay && options.delay > 0) {
@@ -283,8 +278,7 @@ export class TestRunnerService extends Service {
     collection: HoppCollection,
     options: TestRunnerOptions,
     path: number[],
-    inheritedVariables: HoppCollectionVariable[] = [],
-    initialEnvironmentState: InitialEnvironmentState
+    inheritedVariables: HoppCollectionVariable[] = []
   ) {
     if (options.stopRef?.value) {
       throw new Error("Test execution stopped")
@@ -296,6 +290,9 @@ export class TestRunnerService extends Service {
         isLoading: true,
         error: undefined,
       })
+
+      // Capture the initial environment state for a test run so that it remains consistent and unchanged when current environment changes
+      const initialEnvironmentState = captureInitialEnvironmentState()
 
       const results = await runTestRunnerRequest(
         request,


### PR DESCRIPTION
This PR fixes the issue where, during a collection run, if an environment switch occurs while a request is running, the updated team environment captures the current environment name instead of the initial one.

Follow up to #5560.
Related to #5528.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect team environment name updates during collection runs. We now capture the environment name at the start of each request and use it for updates, so mid-run switches don’t overwrite the original name.

- **Bug Fixes**
  - Capture initialEnvName in the initial environment state and pass it through request execution.
  - Use initialEnvName (with a safe fallback to the current name) when updating TEAM_ENV after test scripts to avoid using a switched environment’s name.
  - Capture the initial environment state inside each runTestRequest, not once before the run, to keep per-request updates consistent.

<sup>Written for commit 13d59eacdd6c99023053dc6c37ed08850b4119ae. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->







