### PR TITLE
fix: add debounce to search input

### DIFF
--- a/packages/hoppscotch-common/src/components/app/spotlight/index.vue
+++ b/packages/hoppscotch-common/src/components/app/spotlight/index.vue
@@ -90,6 +90,7 @@ import { useI18n } from "@composables/i18n"
 import { useService } from "dioc/vue"
 import { isEqual } from "lodash-es"
 import { computed, ref, watch } from "vue"
+import { debounce } from "lodash-es"
 import { platform } from "~/platform"
 import { HoppSpotlightSessionEventData } from "~/platform/analytics"
 import {
@@ -157,6 +158,16 @@ platform.spotlight?.additionalSearchers?.forEach((searcher) =>
 
 const search = ref("")
 
+const debouncedSearch = ref("")
+
+const updateSearch = debounce((val: string) => {
+  debouncedSearch.value = val
+}, 400)
+
+watch(search, (val) => {
+  updateSearch(val)
+})
+
 const searchSession = ref<SpotlightSearchState>()
 const stopSearchSession = ref<() => void>()
 
@@ -175,7 +186,7 @@ watch(
 
     if (show) {
       const [session, onSessionEnd] =
-        spotlightService.createSearchSession(search)
+        spotlightService.createSearchSession(debouncedSearch)
 
       searchSession.value = session.value
       stopSearchSession.value = onSessionEnd
@@ -213,7 +224,7 @@ const onMouseOver = (
 function newUseArrowKeysForNavigation() {
   const selectedEntry = ref<[number, number]>([0, 0]) // [sectionIndex, entryIndex]
 
-  watch(search, () => {
+  watch(debouncedSearch, () => {
     selectedEntry.value = [0, 0]
   })
 


### PR DESCRIPTION
Closes #5556

<!-- Intro -->

This PR fixes the issue where the Spotlight search was triggering searches on every keystroke. By adding a debounce, the search runs only after the user pauses typing, reducing unnecessary calls and improving performance.

<!-- What's Changed -->

Added 400ms debounce to the Spotlight search input.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 400ms debounce to the Spotlight search input so searches run after a brief pause instead of every keystroke, reducing unnecessary calls and improving responsiveness. Keyboard selection resets on debounced query changes to keep navigation consistent.

<sup>Written for commit f59ca31ab469f3d906f7fa878ba47195ad756ae6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

