### PR TITLE
fix: remove `ref_id` field before collection exports and address race conditions

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -116,7 +116,7 @@ const handleImportToStore = async (collections: HoppCollection[]) => {
 
 /**
  * Import collections to personal workspace
- * We sanitize the collections before importing to remove old id from the imported  collection and folders and transform it to new collection format
+ * We sanitize the collections before importing to remove old id from the imported collection and folders and transform it to new collection format
  * @param collections Collections to import
  */
 const importToPersonalWorkspace = (collections: HoppCollection[]) => {
@@ -127,7 +127,7 @@ const importToPersonalWorkspace = (collections: HoppCollection[]) => {
     platform.sync.collections.importToPersonalWorkspace &&
     currentUser.value
   ) {
-    // The SH add's the id to the collection and folders but for safety we remove it
+    // The SH adds the id to the collection and folders but for safety we remove it
     return platform.sync.collections.importToPersonalWorkspace(
       sanitizedCollections,
       ReqType.Rest

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -127,7 +127,7 @@ const importToPersonalWorkspace = (collections: HoppCollection[]) => {
     platform.sync.collections.importToPersonalWorkspace &&
     currentUser.value
   ) {
-    // The SH adds the id to the collection and folders but for safety we remove it
+    // The SH adds the id to the collection and folders but for safety we remove it by sanitizeCollection
     return platform.sync.collections.importToPersonalWorkspace(
       sanitizedCollections,
       ReqType.Rest

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -60,6 +60,7 @@ import { GistSource } from "~/helpers/import-export/import/import-sources/GistSo
 import { TeamWorkspace } from "~/services/workspace.service"
 import { invokeAction } from "~/helpers/actions"
 import { ReqType } from "~/helpers/backend/graphql"
+import { sanitizeCollection } from "~/helpers/import-export/import"
 
 const isInsomniaImporterInProgress = ref(false)
 const isOpenAPIImporterInProgress = ref(false)
@@ -113,21 +114,35 @@ const handleImportToStore = async (collections: HoppCollection[]) => {
   }
 }
 
+/**
+ * Import collections to personal workspace
+ * We sanitize the collections before importing to remove old id from the imported  collection and folders and transform it to new collection format
+ * @param collections Collections to import
+ */
 const importToPersonalWorkspace = (collections: HoppCollection[]) => {
+  // Remove old id from the imported  collection and folders and transform it to new collection format
+  const sanitizedCollections = collections.map(sanitizeCollection)
+
   if (
     platform.sync.collections.importToPersonalWorkspace &&
     currentUser.value
   ) {
+    // The SH add's the id to the collection and folders but for safety we remove it
     return platform.sync.collections.importToPersonalWorkspace(
-      collections,
+      sanitizedCollections,
       ReqType.Rest
     )
   }
 
-  appendRESTCollections(collections)
+  appendRESTCollections(sanitizedCollections)
   return E.right({ success: true })
 }
 
+/**
+ * Import collections to teams workspace
+ * No need to sanitize the collections before importing to teams workspace because the BE handles this and add the new id to the collection and folders
+ * @param collections Collections to import
+ */
 const importToTeamsWorkspace = async (collections: HoppCollection[]) => {
   if (!hasTeamWriteAccess.value || !selectedTeamID.value) {
     return E.left({

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -120,7 +120,7 @@ const handleImportToStore = async (collections: HoppCollection[]) => {
  * @param collections Collections to import
  */
 const importToPersonalWorkspace = (collections: HoppCollection[]) => {
-  // Remove old id from the imported  collection and folders and transform it to new collection format
+  // Remove old id from the imported collection and folders and transform it to new collection format
   const sanitizedCollections = collections.map(sanitizeCollection)
 
   if (

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -313,6 +313,7 @@ import {
   resolveSaveContextOnRequestReorder,
 } from "~/helpers/collection/request"
 import { TeamCollection } from "~/helpers/teams/TeamCollection"
+import { stripRefIdReplacer } from "~/helpers/import-export/export"
 import TeamEnvironmentAdapter from "~/helpers/teams/TeamEnvironmentAdapter"
 import { TeamSearchService } from "~/helpers/teams/TeamsSearch.service"
 import { HoppInheritedProperty } from "~/helpers/types/HoppInheritedProperties"
@@ -2871,7 +2872,8 @@ const initializeDownloadCollection = async (
  */
 const exportData = async (collection: HoppCollection | TeamCollection) => {
   if (collectionsType.value.type === "my-collections") {
-    const collectionJSON = JSON.stringify(collection, null, 2)
+    console.log("Exporting collection", collection)
+    const collectionJSON = JSON.stringify(collection, stripRefIdReplacer, 2)
 
     // Strip `export {};\n` from `testScript` and `preRequestScript` fields
     const cleanedCollectionJSON = collectionJSON.replace(
@@ -2896,7 +2898,11 @@ const exportData = async (collection: HoppCollection | TeamCollection) => {
         },
         async (coll) => {
           const hoppColl = teamCollToHoppRESTColl(coll)
-          const collectionJSONString = JSON.stringify(hoppColl, null, 2)
+          const collectionJSONString = JSON.stringify(
+            hoppColl,
+            stripRefIdReplacer,
+            2
+          )
 
           // Strip `export {};\n` from `testScript` and `preRequestScript` fields
           const cleanedCollectionJSON = collectionJSONString.replace(

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -2872,7 +2872,6 @@ const initializeDownloadCollection = async (
  */
 const exportData = async (collection: HoppCollection | TeamCollection) => {
   if (collectionsType.value.type === "my-collections") {
-    console.log("Exporting collection", collection)
     const collectionJSON = JSON.stringify(collection, stripRefIdReplacer, 2)
 
     // Strip `export {};\n` from `testScript` and `preRequestScript` fields

--- a/packages/hoppscotch-common/src/helpers/backend/helpers.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/helpers.ts
@@ -25,6 +25,7 @@ import {
   GetCollectionRequestsDocument,
   GetCollectionTitleAndDataDocument,
 } from "./graphql"
+import { stripRefIdReplacer } from "../import-export/export"
 
 type TeamCollectionJSON = {
   id: string
@@ -286,7 +287,7 @@ export const getTeamCollectionJSON = async (teamID: string) => {
   }
 
   const hoppCollections = collections.map(teamCollectionJSONToHoppRESTColl)
-  return E.right(JSON.stringify(hoppCollections, null, 2))
+  return E.right(JSON.stringify(hoppCollections, stripRefIdReplacer, 2))
 }
 
 /**

--- a/packages/hoppscotch-common/src/helpers/backend/queries/PublishedDocs.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/queries/PublishedDocs.ts
@@ -54,7 +54,7 @@ export type PublishedDocQuery = {
   publishedDoc: PublishedDoc
 }
 
-type CollectionFolder = {
+export type CollectionFolder = {
   id?: string
   folders: CollectionFolder[]
   // Backend stores this as any, we translate it to HoppRESTRequest via translateToNewRequest

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -8,6 +8,8 @@ import { RESTTabService } from "~/services/tab/rest"
 import { GQLTabService } from "~/services/tab/graphql"
 import { TeamCollectionsService } from "~/services/team-collection.service"
 import { cascadeParentCollectionForProperties } from "~/newstore/collections"
+import { CollectionDataProps } from "../backend/helpers"
+import { CollectionFolder } from "../backend/queries/PublishedDocs"
 
 /**
  * Resolve save context on reorder
@@ -289,25 +291,27 @@ export function getFoldersByPath(
 
 /**
  * Transforms a collection to the format expected by team or personal collections.
- * Extracts auth, headers, and variables into a data object and recursively processes folders.
+ * BE expects CollectionFolder format with a data field containing auth, headers, variables, and description.
  * @param collection The collection to transform
  * @returns The transformed collection
  */
-export function transformCollectionForImport(collection: any): any {
-  const folders: any[] = (collection.folders ?? []).map(
-    transformCollectionForImport
-  )
+export function transformCollectionForImport(
+  collection: HoppCollection
+): CollectionFolder {
+  const folders = (collection.folders ?? []).map(transformCollectionForImport)
 
-  const data = {
+  const data: CollectionDataProps = {
     auth: collection.auth,
     headers: collection.headers,
     variables: collection.variables,
+    description: collection.description,
   }
 
-  const obj = {
-    ...collection,
-    folders,
-    data,
+  const obj: CollectionFolder = {
+    name: collection.name,
+    folders: folders,
+    requests: collection.requests,
+    data: JSON.stringify(data),
   }
 
   if (collection.id) obj.id = collection.id

--- a/packages/hoppscotch-common/src/helpers/import-export/export/gqlCollections.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/gqlCollections.ts
@@ -1,5 +1,6 @@
 import { HoppCollection } from "@hoppscotch/data"
+import { stripRefIdReplacer } from "."
 
 export const gqlCollectionsExporter = (gqlCollections: HoppCollection[]) => {
-  return JSON.stringify(gqlCollections, null, 2)
+  return JSON.stringify(gqlCollections, stripRefIdReplacer, 2)
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/export/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/index.ts
@@ -34,3 +34,10 @@ export const initializeDownloadFile = async (
 
   return E.left("state.download_failed")
 }
+
+/**
+ * JSON replacer to remove `_ref_id` from the exported JSON
+ */
+export const stripRefIdReplacer = (key: string, value: any) => {
+  return key === "_ref_id" ? undefined : value
+}

--- a/packages/hoppscotch-common/src/helpers/import-export/export/myCollections.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/myCollections.ts
@@ -1,5 +1,6 @@
 import { HoppCollection } from "@hoppscotch/data"
+import { stripRefIdReplacer } from "."
 
 export const myCollectionsExporter = (myCollections: HoppCollection[]) => {
-  return JSON.stringify(myCollections, null, 2)
+  return JSON.stringify(myCollections, stripRefIdReplacer, 2)
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/index.ts
@@ -78,13 +78,10 @@ export const defineImporter = <ReturnType, StepType, Errors>(input: {
 export const sanitizeCollection = (
   collection: HoppCollection
 ): HoppCollection => {
-  const newCollection = translateToNewRESTCollection(collection)
+  const { id: _id, ...rest } = translateToNewRESTCollection(collection)
 
-  if (newCollection.id) {
-    delete newCollection.id
+  return {
+    ...rest,
+    folders: rest.folders.map(sanitizeCollection),
   }
-
-  newCollection.folders = newCollection.folders.map(sanitizeCollection)
-
-  return newCollection
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/index.ts
@@ -1,6 +1,7 @@
 import * as TE from "fp-ts/TaskEither"
 import type { Component } from "vue"
 import { StepsOutputList } from "../steps"
+import { HoppCollection, translateToNewRESTCollection } from "@hoppscotch/data"
 
 /**
  * A common error state to be used when the file formats are not expected
@@ -66,4 +67,24 @@ export const defineImporter = <ReturnType, StepType, Errors>(input: {
   return <HoppImporterDefinition<ReturnType, StepType, Errors>>{
     ...input,
   }
+}
+
+/**
+ * Sanitize collection for import, removes old id from collection and folders and transform it to
+ * new collection format with new ref_id
+ * @param collection The collection to sanitize
+ * @returns The sanitized collection with new ref_id
+ */
+export const sanitizeCollection = (
+  collection: HoppCollection
+): HoppCollection => {
+  const newCollection = translateToNewRESTCollection(collection)
+
+  if (newCollection.id) {
+    delete newCollection.id
+  }
+
+  newCollection.folders = newCollection.folders.map(sanitizeCollection)
+
+  return newCollection
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/index.ts
@@ -1,7 +1,11 @@
 import * as TE from "fp-ts/TaskEither"
 import type { Component } from "vue"
 import { StepsOutputList } from "../steps"
-import { HoppCollection, translateToNewRESTCollection } from "@hoppscotch/data"
+import {
+  HoppCollection,
+  makeCollection,
+  translateToNewRESTCollection,
+} from "@hoppscotch/data"
 
 /**
  * A common error state to be used when the file formats are not expected
@@ -70,18 +74,23 @@ export const defineImporter = <ReturnType, StepType, Errors>(input: {
 }
 
 /**
- * Sanitize collection for import, removes old id from collection and folders and transform it to
- * new collection format with new ref_id
+ * Sanitize collection for import, removes old id and ref_id from collection and folders, and transforms it to
+ * new collection format with a newly generated ref_id.
  * @param collection The collection to sanitize
  * @returns The sanitized collection with new ref_id
  */
 export const sanitizeCollection = (
   collection: HoppCollection
 ): HoppCollection => {
-  const { id: _id, ...rest } = translateToNewRESTCollection(collection)
+  const {
+    id: _id,
+    _ref_id: _refId,
+    v: _v,
+    ...rest
+  } = translateToNewRESTCollection(collection)
 
-  return {
+  return makeCollection({
     ...rest,
     folders: rest.folders.map(sanitizeCollection),
-  }
+  })
 }

--- a/packages/hoppscotch-common/src/services/__tests__/workspace.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/workspace.service.spec.ts
@@ -293,6 +293,13 @@ describe("WorkspaceService", () => {
 
     it("should call clearCollections and fetchUserPublishedDocs when workspace changes to personal workspace", async () => {
       const container = new TestContainer()
+
+      // Mock user for this test
+      platformMock.auth.getCurrentUser.mockReturnValue({ uid: "test-user" })
+      platformMock.auth.getCurrentUserStream.mockReturnValue(
+        new BehaviorSubject({ uid: "test-user" })
+      )
+
       const service = container.bind(WorkspaceService)
 
       // Start with a team workspace
@@ -324,6 +331,13 @@ describe("WorkspaceService", () => {
 
     it("should call clearCollections and fetchUserPublishedDocs when workspace changes to team workspace without teamID", async () => {
       const container = new TestContainer()
+
+      // Mock user for this test
+      platformMock.auth.getCurrentUser.mockReturnValue({ uid: "test-user" })
+      platformMock.auth.getCurrentUserStream.mockReturnValue(
+        new BehaviorSubject({ uid: "test-user" })
+      )
+
       const service = container.bind(WorkspaceService)
 
       const teamCollectionServiceMock = (service as any).teamCollectionService
@@ -409,6 +423,35 @@ describe("WorkspaceService", () => {
       )
 
       consoleSpy.mockRestore()
+    })
+
+    it("should fetch user published docs only when user is authenticated", async () => {
+      // Case 1: No user
+      platformMock.auth.getCurrentUser.mockReturnValue(null)
+      platformMock.auth.getCurrentUserStream.mockReturnValue(
+        new BehaviorSubject(null)
+      )
+      const container1 = new TestContainer()
+      const service1 = container1.bind(WorkspaceService)
+      const docMock1 = (service1 as any).documentationService
+      docMock1.fetchUserPublishedDocs.mockClear()
+
+      service1.changeWorkspace({ type: "personal" })
+      await nextTick()
+      expect(docMock1.fetchUserPublishedDocs).not.toHaveBeenCalled()
+
+      // Case 2: With user
+      platformMock.auth.getCurrentUser.mockReturnValue({ uid: "test-user" })
+      platformMock.auth.getCurrentUserStream.mockReturnValue(
+        new BehaviorSubject({ uid: "test-user" })
+      )
+      const container2 = new TestContainer()
+      const service2 = container2.bind(WorkspaceService)
+      const docMock2 = (service2 as any).documentationService
+
+      // We check if it was called on initialization
+      await nextTick()
+      expect(docMock2.fetchUserPublishedDocs).toHaveBeenCalled()
     })
   })
 

--- a/packages/hoppscotch-common/src/services/__tests__/workspace.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/workspace.service.spec.ts
@@ -54,6 +54,7 @@ describe("WorkspaceService", () => {
     auth: {
       getCurrentUserStream: vi.fn(),
       getCurrentUser: vi.fn(),
+      waitProbableLoginToConfirm: vi.fn().mockResolvedValue(undefined),
     },
   }
 
@@ -267,6 +268,13 @@ describe("WorkspaceService", () => {
   describe("Workspace Synchronization", () => {
     it("should call changeTeamID and fetchTeamPublishedDocs when workspace changes to a team workspace", async () => {
       const container = new TestContainer()
+
+      // Mock user for this test
+      platformMock.auth.getCurrentUser.mockReturnValue({ uid: "test-user" })
+      platformMock.auth.getCurrentUserStream.mockReturnValue(
+        new BehaviorSubject({ uid: "test-user" })
+      )
+
       const service = container.bind(WorkspaceService)
 
       // Access the mocks
@@ -418,7 +426,7 @@ describe("WorkspaceService", () => {
       await nextTick()
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "Failed to sync team collections and published docs:",
+        "Failed to sync workspace data:",
         expect.any(Error)
       )
 

--- a/packages/hoppscotch-common/src/services/workspace.service.ts
+++ b/packages/hoppscotch-common/src/services/workspace.service.ts
@@ -117,10 +117,14 @@ export class WorkspaceService extends Service<WorkspaceServiceEvent> {
    */
   private setupWorkspaceSync() {
     watch(
-      this._currentWorkspace,
-      (newWorkspace, oldWorkspace) => {
-        // Skip update if workspaces are effectively the same
-        if (this.areWorkspacesEqual(newWorkspace, oldWorkspace)) return
+      [this._currentWorkspace, this.currentUser],
+      ([newWorkspace, user], [oldWorkspace, oldUser]) => {
+        // Skip update if workspaces are effectively the same and user hasn't changed
+        if (
+          this.areWorkspacesEqual(newWorkspace, oldWorkspace) &&
+          user?.uid === oldUser?.uid
+        )
+          return
 
         try {
           if (newWorkspace.type === "team" && newWorkspace.teamID) {
@@ -130,7 +134,9 @@ export class WorkspaceService extends Service<WorkspaceServiceEvent> {
             )
           } else {
             this.teamCollectionService.clearCollections()
-            this.documentationService.fetchUserPublishedDocs()
+            if (user) {
+              this.documentationService.fetchUserPublishedDocs()
+            }
           }
         } catch (error) {
           console.error(

--- a/packages/hoppscotch-common/src/services/workspace.service.ts
+++ b/packages/hoppscotch-common/src/services/workspace.service.ts
@@ -112,39 +112,49 @@ export class WorkspaceService extends Service<WorkspaceServiceEvent> {
   }
 
   /**
-   * Sets up synchronization with team collection service and documentation service
-   * This ensures team collections and published docs are updated when workspace changes
-   * This watch for user changes so the initial fetch is done when the user logs and pass the correct auth credentials
-   * There was a bug where the initial fetch was not done when the user logs in cloud instance causing the getUserPublishedDocs to fail
+   * Sets up synchronization between team collection service and documentation service.
+   * Ensures that team collections and published docs stay updated whenever
+   * the workspace or user changes.
+   *
+   * Fixes a bug where the initial fetch failed on cloud instances because
+   * authorization was null during user login. Now we wait for authentication
+   * to be ready before fetching team collections and published docs.
    */
   private setupWorkspaceSync() {
     watch(
       [this._currentWorkspace, this.currentUser],
-      ([newWorkspace, user], [oldWorkspace, oldUser]) => {
-        // Skip update if workspaces are effectively the same and user hasn't changed
+      async ([newWorkspace, user], [oldWorkspace, oldUser]) => {
+        // Skip if workspace and user haven't changed
         if (
           this.areWorkspacesEqual(newWorkspace, oldWorkspace) &&
           user?.uid === oldUser?.uid
-        )
+        ) {
           return
+        }
 
         try {
-          if (newWorkspace.type === "team" && newWorkspace.teamID) {
+          // Ensure authentication is ready before fetching docs
+          if (user) {
+            await platform.auth.waitProbableLoginToConfirm()
+          }
+
+          if (newWorkspace?.type === "team" && newWorkspace.teamID) {
             this.teamCollectionService.changeTeamID(newWorkspace.teamID)
-            this.documentationService.fetchTeamPublishedDocs(
-              newWorkspace.teamID
-            )
+
+            if (user) {
+              await this.documentationService.fetchTeamPublishedDocs(
+                newWorkspace.teamID
+              )
+            }
           } else {
             this.teamCollectionService.clearCollections()
+
             if (user) {
-              this.documentationService.fetchUserPublishedDocs()
+              await this.documentationService.fetchUserPublishedDocs()
             }
           }
         } catch (error) {
-          console.error(
-            "Failed to sync team collections and published docs:",
-            error
-          )
+          console.error("Failed to sync workspace data:", error)
         }
       },
       { immediate: true }

--- a/packages/hoppscotch-common/src/services/workspace.service.ts
+++ b/packages/hoppscotch-common/src/services/workspace.service.ts
@@ -114,6 +114,8 @@ export class WorkspaceService extends Service<WorkspaceServiceEvent> {
   /**
    * Sets up synchronization with team collection service and documentation service
    * This ensures team collections and published docs are updated when workspace changes
+   * This watch for user changes so the initial fetch is done when the user logs and pass the correct auth credentials
+   * There was a bug where the initial fetch was not done when the user logs in cloud instance causing the getUserPublishedDocs to fail
    */
   private setupWorkspaceSync() {
     watch(

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -3,6 +3,7 @@ import {
   appendGraphqlCollections,
   appendRESTCollections,
 } from "@hoppscotch/common/newstore/collections"
+import { CollectionDataProps } from "@hoppscotch/common/helpers/backend/helpers"
 import { HoppCollection } from "@hoppscotch/data"
 import * as E from "fp-ts/Either"
 import {
@@ -64,10 +65,11 @@ export function translateToPersonalCollectionFormat(x: HoppCollection) {
     translateToPersonalCollectionFormat
   )
 
-  const data = {
+  const data: CollectionDataProps = {
     auth: x.auth,
     headers: x.headers,
     variables: x.variables,
+    description: x.description,
   }
 
   const obj = {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes FE-1074 FE-1075

This PR fixes two issues:

- This issue occurs only in the cloud instance, where the initial page load causes the UserPublishedDocsList call to fail because the authorization is passed as null.

- While exporting a collection, the _ref_id, which should be unique, was not being stripped. It is now removed before exporting.

- While importing a collection the id is removed and a new _ref_id is added.

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


















<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes _ref_id from exported collections and fixes a race condition that caused UserPublishedDocsList to fail on first load when auth was null. Addresses FE-1074 and FE-1075.

- **Bug Fixes**
  - Import/Export: strip `_ref_id` in personal and team exports; sanitize personal imports by dropping legacy `id`/`_ref_id` and converting to the new format.
  - Workspace: watch `currentUser` along with workspace, wait for login to confirm, and only fetch user/team published docs when authenticated.
  - Tests: add coverage for authenticated vs unauthenticated fetch behavior and workspace transitions.

<sup>Written for commit cad9e6620dd8fe7642517e3db6f06060683e7089. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

















