### PR TITLE
fix: preserve full cookie values when importing cURL cookies (#5500)

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/cookies.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/cookies.ts
@@ -58,7 +58,10 @@ const parseCookieString = (cookieString: string): Record<string, string> => {
     .map((pair) => pair.trim())
     .filter(Boolean)
     .reduce((acc, pair) => {
-      const [key, value] = pair.split("=", 2)
-      return { ...acc, [key]: value || "" }
+      const [rawKey, ...rest] = pair.split("=")
+      if (!rawKey) return acc
+
+      const value = rest.join("=")
+      return { ...acc, [rawKey]: value }
     }, {})
 }


### PR DESCRIPTION
Closes #5500

### What's changed

- Fixed an issue where cookie values imported via `-b` / `--cookie` in cURL were being truncated when the value contained additional `=` characters.
- Updated `parseCookieString` so that:
  - The segment before the first `=` is treated as the cookie key.
  - All remaining segments after the first `=` are joined back together and preserved as the full cookie value.
- This ensures that cookies such as `cookie=subprop1=val1` are imported correctly without losing value segments.

### Notes to reviewers

This change is limited to cookie parsing logic in `curl/sub_helpers/cookies.ts`.  
The updated approach preserves all characters in the cookie value, including multiple `=` signs, which aligns with expected cURL behavior and common real-world cookie formats (e.g., encoded values, tokens, JWT-like structures).

No impact on other parts of the cURL import flow — single-equals cookies remain unaffected.

Manual tests were performed on:
- simple `key=value` cookies
- cookies containing multiple `=` symbols in their values  
All tests confirmed correct parsing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cURL cookie import to preserve full values with multiple "=" when using -b/--cookie. Updated parsing to use the first "=" for the key and keep the rest as the value.

<sup>Written for commit 583bb39668ef87e5f0bb34f8f0f6a542b8e1ecdf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

