### PR TITLE
fix(auth): allow refresh token extraction from Authorization header f…

### DIFF
--- a/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
@@ -34,7 +34,10 @@ export class RTJwtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
     // 2️. Fallback to Authorization header
     const authHeader = request.headers?.authorization;
     if (authHeader?.startsWith('Bearer ')) {
-      return authHeader.split(' ')[1];
+      const token = authHeader.slice(7).trim();
+      if (token) {
+        return token;
+      }
     }
 
     console.error('Refresh token not found in cookie or Authorization header');

--- a/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
@@ -31,7 +31,7 @@ export class RTJwtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
       return RTCookie;
     }
 
-    // 2️. Fallback to Authorization header
+    // 2. Fallback to Authorization header
     const authHeader = request.headers?.authorization;
     if (authHeader?.startsWith('Bearer ')) {
       const token = authHeader.slice(7).trim();

--- a/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
@@ -36,10 +36,23 @@ export class RTJwtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
     if (authHeader?.startsWith('Bearer ')) {
       const token = authHeader.slice(7).trim();
       if (token) {
-        return token;
-      }
+
+    let bearerHeader: string | undefined;
+
+    if (Array.isArray(authHeader)) {
+      bearerHeader = authHeader.find(
+        (value) => typeof value === 'string' && value.startsWith('Bearer '),
+      );
+    } else if (typeof authHeader === 'string' && authHeader.startsWith('Bearer ')) {
+      bearerHeader = authHeader;
     }
 
+    if (bearerHeader) {
+      const parts = bearerHeader.split(' ');
+      if (parts.length >= 2 && parts[1]) {
+        return parts[1];
+      }
+    }
     console.error('Refresh token not found in cookie or Authorization header');
     throw new ForbiddenException(COOKIES_NOT_FOUND);
   },

--- a/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/rt-jwt.strategy.ts
@@ -24,15 +24,23 @@ export class RTJwtStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromExtractors([
-        (request: Request) => {
-          const RTCookie = request.cookies?.['refresh_token'];
-          if (!RTCookie) {
-            console.error('`refresh_token` not found');
-            throw new ForbiddenException(COOKIES_NOT_FOUND);
-          }
-          return RTCookie;
-        },
-      ]),
+  (request: Request) => {
+    // 1. Check cookie first
+    const RTCookie = request.cookies?.['refresh_token'];
+    if (RTCookie) {
+      return RTCookie;
+    }
+
+    // 2️. Fallback to Authorization header
+    const authHeader = request.headers?.authorization;
+    if (authHeader?.startsWith('Bearer ')) {
+      return authHeader.split(' ')[1];
+    }
+
+    console.error('Refresh token not found in cookie or Authorization header');
+    throw new ForbiddenException(COOKIES_NOT_FOUND);
+  },
+]),
       secretOrKey: configService.get('INFRA.JWT_SECRET'),
     });
   }


### PR DESCRIPTION
Closes #5635 

This PR fixes an issue where the desktop client cannot refresh authentication tokens after the access token expires. The backend currently only extracts the refresh token from cookies, while the desktop client sends it through the Authorization Bearer header. As a result, the refresh request fails with COOKIES_NOT_FOUND, forcing users to repeatedly log in.

What's changed

Updated the refresh token extraction logic in RTJwtStrategy.

Added support for extracting the refresh token from the Authorization: Bearer <token> header.

Kept the existing cookie-based extraction to ensure the web client continues to work as before.

Added a fallback mechanism so the backend now accepts refresh tokens from:

refresh_token cookie (web client)

Authorization header (desktop client)

Notes to reviewers

The desktop client already sends the refresh token using the Authorization header during refresh requests. However, the backend strategy only checked for the token in cookies, causing refresh requests to fail with COOKIES_NOT_FOUND.

This change preserves the current cookie-based flow used by the web application while adding compatibility with the desktop client by supporting header-based token extraction.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow refresh tokens to be read from the Authorization: Bearer header, fixing desktop token refresh failures. Keeps the cookie flow for web and resolves #5635.

- **Bug Fixes**
  - RTJwtStrategy checks the refresh_token cookie first, then parses Authorization: Bearer from string or array headers; standardized ASCII error message.
  - Prevents COOKIES_NOT_FOUND on desktop and avoids forced re-logins after access token expiry.

<sup>Written for commit 3bd64b5066003ab9630b70407558dbf1c05a5868. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

