### PR TITLE
feat: support OpenAPI variables on import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/openapi-server-variables.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/openapi-server-variables.spec.ts
@@ -1,0 +1,312 @@
+import { describe, expect, test } from "vitest"
+import { OpenAPIV2, OpenAPIV3 } from "openapi-types"
+import { extractServerVariables, parseOpenAPIUrl } from "../openapi"
+
+describe("extractServerVariables", () => {
+  describe("OpenAPI V3", () => {
+    test("extracts server variables with default values", () => {
+      const doc: OpenAPIV3.Document = {
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+        servers: [
+          {
+            url: "https://{environment}.example.com/v{version}",
+            variables: {
+              environment: {
+                default: "production",
+                enum: ["production", "staging", "development"],
+              },
+              version: {
+                default: "2",
+              },
+            },
+          },
+        ],
+      }
+
+      const result = extractServerVariables(doc)
+
+      expect(result).toEqual([
+        {
+          key: "environment",
+          initialValue: "production",
+          currentValue: "production",
+          secret: false,
+        },
+        {
+          key: "version",
+          initialValue: "2",
+          currentValue: "2",
+          secret: false,
+        },
+      ])
+    })
+
+    test("returns empty array when no server variables are defined", () => {
+      const doc: OpenAPIV3.Document = {
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+        servers: [
+          {
+            url: "https://api.example.com",
+          },
+        ],
+      }
+
+      const result = extractServerVariables(doc)
+      expect(result).toEqual([])
+    })
+
+    test("returns empty array when servers is empty", () => {
+      const doc: OpenAPIV3.Document = {
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+        servers: [],
+      }
+
+      const result = extractServerVariables(doc)
+      expect(result).toEqual([])
+    })
+
+    test("returns empty array when server URL is './'", () => {
+      const doc: OpenAPIV3.Document = {
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+        servers: [
+          {
+            url: "./",
+            variables: {
+              unused: { default: "val" },
+            },
+          },
+        ],
+      }
+
+      const result = extractServerVariables(doc)
+      expect(result).toEqual([])
+    })
+
+    test("uses only the first server entry", () => {
+      const doc: OpenAPIV3.Document = {
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+        servers: [
+          {
+            url: "https://{env}.example.com",
+            variables: {
+              env: { default: "prod" },
+            },
+          },
+          {
+            url: "https://{env}.other.com",
+            variables: {
+              env: { default: "staging" },
+            },
+          },
+        ],
+      }
+
+      const result = extractServerVariables(doc)
+
+      expect(result).toEqual([
+        {
+          key: "env",
+          initialValue: "prod",
+          currentValue: "prod",
+          secret: false,
+        },
+      ])
+    })
+
+    test("handles single server variable", () => {
+      const doc: OpenAPIV3.Document = {
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+        servers: [
+          {
+            url: "https://api.example.com/{basePath}",
+            variables: {
+              basePath: { default: "v1" },
+            },
+          },
+        ],
+      }
+
+      const result = extractServerVariables(doc)
+
+      expect(result).toEqual([
+        {
+          key: "basePath",
+          initialValue: "v1",
+          currentValue: "v1",
+          secret: false,
+        },
+      ])
+    })
+  })
+
+  describe("OpenAPI V2 (Swagger)", () => {
+    test("creates baseUrl variable from host and basePath", () => {
+      const doc = {
+        swagger: "2.0",
+        info: { title: "Test", version: "1.0" },
+        host: "api.example.com",
+        basePath: "/v1",
+        paths: {},
+      } as OpenAPIV2.Document
+
+      const result = extractServerVariables(doc)
+
+      expect(result).toEqual([
+        {
+          key: "baseUrl",
+          initialValue: "api.example.com/v1",
+          currentValue: "api.example.com/v1",
+          secret: false,
+        },
+      ])
+    })
+
+    test("creates baseUrl variable from host only (no basePath)", () => {
+      const doc = {
+        swagger: "2.0",
+        info: { title: "Test", version: "1.0" },
+        host: "api.example.com",
+        paths: {},
+      } as OpenAPIV2.Document
+
+      const result = extractServerVariables(doc)
+
+      expect(result).toEqual([
+        {
+          key: "baseUrl",
+          initialValue: "api.example.com",
+          currentValue: "api.example.com",
+          secret: false,
+        },
+      ])
+    })
+
+    test("returns empty array when no host is defined", () => {
+      const doc = {
+        swagger: "2.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+      } as OpenAPIV2.Document
+
+      const result = extractServerVariables(doc)
+      expect(result).toEqual([])
+    })
+  })
+
+  describe("unknown document format", () => {
+    test("returns empty array for unrecognized document", () => {
+      const doc = {
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+      } as any
+
+      const result = extractServerVariables(doc)
+      expect(result).toEqual([])
+    })
+  })
+})
+
+describe("parseOpenAPIUrl", () => {
+  describe("OpenAPI V2 (Swagger)", () => {
+    test("uses <<baseUrl>> variable instead of hardcoded host", () => {
+      const doc = {
+        swagger: "2.0",
+        info: { title: "Test", version: "1.0" },
+        host: "api.example.com",
+        basePath: "/v1",
+        paths: {},
+      } as OpenAPIV2.Document
+
+      expect(parseOpenAPIUrl(doc)).toBe("<<baseUrl>>")
+    })
+
+    test("uses <<baseUrl>> variable when host has no basePath", () => {
+      const doc = {
+        swagger: "2.0",
+        info: { title: "Test", version: "1.0" },
+        host: "api.example.com",
+        paths: {},
+      } as OpenAPIV2.Document
+
+      expect(parseOpenAPIUrl(doc)).toBe("<<baseUrl>>")
+    })
+
+    test("uses <<baseUrl>> variable when no host is defined", () => {
+      const doc = {
+        swagger: "2.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+      } as OpenAPIV2.Document
+
+      expect(parseOpenAPIUrl(doc)).toBe("<<baseUrl>>")
+    })
+  })
+
+  describe("OpenAPI V3", () => {
+    test("replaces server variable placeholders with <<var>> syntax", () => {
+      const doc: OpenAPIV3.Document = {
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+        servers: [
+          {
+            url: "https://{environment}.example.com/v{version}",
+            variables: {
+              environment: { default: "production" },
+              version: { default: "2" },
+            },
+          },
+        ],
+      }
+
+      expect(parseOpenAPIUrl(doc)).toBe(
+        "https://<<environment>>.example.com/v<<version>>"
+      )
+    })
+
+    test("returns server URL as-is when no variables are used", () => {
+      const doc: OpenAPIV3.Document = {
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+        servers: [{ url: "https://api.example.com" }],
+      }
+
+      expect(parseOpenAPIUrl(doc)).toBe("https://api.example.com")
+    })
+
+    test("falls back to <<baseUrl>> when server URL is './'", () => {
+      const doc: OpenAPIV3.Document = {
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+        servers: [{ url: "./" }],
+      }
+
+      expect(parseOpenAPIUrl(doc)).toBe("<<baseUrl>>")
+    })
+
+    test("falls back to <<baseUrl>> when servers array is empty", () => {
+      const doc: OpenAPIV3.Document = {
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+        servers: [],
+      }
+
+      expect(parseOpenAPIUrl(doc)).toBe("<<baseUrl>>")
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/openapi-server-variables.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/openapi-server-variables.spec.ts
@@ -149,31 +149,108 @@ describe("extractServerVariables", () => {
         },
       ])
     })
-  })
 
-  describe("OpenAPI V2 (Swagger)", () => {
-    test("creates baseUrl variable from host and basePath", () => {
-      const doc = {
-        swagger: "2.0",
+    test("filters out variables not referenced in the server URL", () => {
+      const doc: OpenAPIV3.Document = {
+        openapi: "3.0.0",
         info: { title: "Test", version: "1.0" },
-        host: "api.example.com",
-        basePath: "/v1",
         paths: {},
-      } as OpenAPIV2.Document
+        servers: [
+          {
+            url: "https://{env}.example.com",
+            variables: {
+              env: { default: "prod" },
+              orphaned: { default: "unused" },
+            },
+          },
+        ],
+      }
 
       const result = extractServerVariables(doc)
 
       expect(result).toEqual([
         {
-          key: "baseUrl",
-          initialValue: "api.example.com/v1",
-          currentValue: "api.example.com/v1",
+          key: "env",
+          initialValue: "prod",
+          currentValue: "prod",
           secret: false,
         },
       ])
     })
 
-    test("creates baseUrl variable from host only (no basePath)", () => {
+    test("coerces non-string default values to strings", () => {
+      const doc = {
+        openapi: "3.0.0",
+        info: { title: "Test", version: "1.0" },
+        paths: {},
+        servers: [
+          {
+            url: "https://api.example.com/{port}",
+            variables: {
+              port: { default: 8080 as any },
+            },
+          },
+        ],
+      } as OpenAPIV3.Document
+
+      const result = extractServerVariables(doc)
+
+      expect(result).toEqual([
+        {
+          key: "port",
+          initialValue: "8080",
+          currentValue: "8080",
+          secret: false,
+        },
+      ])
+    })
+  })
+
+  describe("OpenAPI V2 (Swagger)", () => {
+    test("creates baseUrl variable with scheme, host and basePath", () => {
+      const doc = {
+        swagger: "2.0",
+        info: { title: "Test", version: "1.0" },
+        host: "api.example.com",
+        basePath: "/v1",
+        schemes: ["https"],
+        paths: {},
+      } as OpenAPIV2.Document
+
+      const result = extractServerVariables(doc)
+
+      expect(result).toEqual([
+        {
+          key: "baseUrl",
+          initialValue: "https://api.example.com/v1",
+          currentValue: "https://api.example.com/v1",
+          secret: false,
+        },
+      ])
+    })
+
+    test("uses first scheme from schemes array", () => {
+      const doc = {
+        swagger: "2.0",
+        info: { title: "Test", version: "1.0" },
+        host: "api.example.com",
+        schemes: ["http", "https"],
+        paths: {},
+      } as OpenAPIV2.Document
+
+      const result = extractServerVariables(doc)
+
+      expect(result).toEqual([
+        {
+          key: "baseUrl",
+          initialValue: "http://api.example.com",
+          currentValue: "http://api.example.com",
+          secret: false,
+        },
+      ])
+    })
+
+    test("defaults to https when no schemes defined", () => {
       const doc = {
         swagger: "2.0",
         info: { title: "Test", version: "1.0" },
@@ -186,8 +263,29 @@ describe("extractServerVariables", () => {
       expect(result).toEqual([
         {
           key: "baseUrl",
-          initialValue: "api.example.com",
-          currentValue: "api.example.com",
+          initialValue: "https://api.example.com",
+          currentValue: "https://api.example.com",
+          secret: false,
+        },
+      ])
+    })
+
+    test("strips trailing slash from basePath to avoid double-slash", () => {
+      const doc = {
+        swagger: "2.0",
+        info: { title: "Test", version: "1.0" },
+        host: "api.example.com",
+        basePath: "/",
+        paths: {},
+      } as OpenAPIV2.Document
+
+      const result = extractServerVariables(doc)
+
+      expect(result).toEqual([
+        {
+          key: "baseUrl",
+          initialValue: "https://api.example.com",
+          currentValue: "https://api.example.com",
           secret: false,
         },
       ])
@@ -243,14 +341,29 @@ describe("parseOpenAPIUrl", () => {
       expect(parseOpenAPIUrl(doc)).toBe("<<baseUrl>>")
     })
 
-    test("uses <<baseUrl>> variable when no host is defined", () => {
+    test("uses <<baseUrl>> placeholder when no host is defined (no variable created)", () => {
       const doc = {
         swagger: "2.0",
         info: { title: "Test", version: "1.0" },
         paths: {},
       } as OpenAPIV2.Document
 
+      // parseOpenAPIUrl returns <<baseUrl>> as a user-defined placeholder
       expect(parseOpenAPIUrl(doc)).toBe("<<baseUrl>>")
+      // extractServerVariables returns nothing — same behavior as the old literal fallback
+      expect(extractServerVariables(doc)).toEqual([])
+    })
+
+    test("preserves basePath when host is absent", () => {
+      const doc = {
+        swagger: "2.0",
+        info: { title: "Test", version: "1.0" },
+        basePath: "/v1",
+        paths: {},
+      } as OpenAPIV2.Document
+
+      expect(parseOpenAPIUrl(doc)).toBe("<<baseUrl>>/v1")
+      expect(extractServerVariables(doc)).toEqual([])
     })
   })
 

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -988,14 +988,16 @@ export const extractServerVariables = (
   if (objectHasProperty(doc, "swagger")) {
     const v2Doc = doc as OpenAPIV2.Document
     const host = v2Doc.host?.trim()
-    const basePath = v2Doc.basePath?.trim()
+    const basePath = (v2Doc.basePath?.trim() ?? "").replace(/\/$/, "")
+    const scheme = v2Doc.schemes?.[0] ?? "https"
 
     if (host) {
+      const value = `${scheme}://${host}${basePath}`
       return [
         {
           key: "baseUrl",
-          initialValue: `${host}${basePath ?? ""}`,
-          currentValue: `${host}${basePath ?? ""}`,
+          initialValue: value,
+          currentValue: value,
           secret: false,
         },
       ]
@@ -1011,12 +1013,14 @@ export const extractServerVariables = (
     const variables = server.variables
     if (!variables || Object.keys(variables).length === 0) return []
 
-    return Object.entries(variables).map(([key, variable]) => ({
-      key,
-      initialValue: variable.default,
-      currentValue: variable.default,
-      secret: false,
-    }))
+    return Object.entries(variables)
+      .filter(([key]) => server.url.includes(`{${key}}`))
+      .map(([key, variable]) => ({
+        key,
+        initialValue: String(variable.default ?? ""),
+        currentValue: String(variable.default ?? ""),
+        secret: false,
+      }))
   }
 
   return []
@@ -1031,11 +1035,15 @@ export const parseOpenAPIUrl = (
    * And host and basePath are in the document's host and basePath properties.
    * Relevant v2 reference: https://swagger.io/specification/v2/#:~:text=to%20be%20obscured.-,Schema,-Swagger%20Object
    **/
-
   if (objectHasProperty(doc, "swagger")) {
-    // When host is available, use <<baseUrl>> so it references the collection variable
-    // populated by extractServerVariables
-    return "<<baseUrl>>"
+    const v2Doc = doc as OpenAPIV2.Document
+    const basePath = (v2Doc.basePath?.trim() ?? "").replace(/\/$/, "")
+
+    // When host is present, <<baseUrl>> resolves via collection variable from
+    // extractServerVariables (which includes scheme + host + basePath).
+    // When host is absent, <<baseUrl>> is a user-defined placeholder and
+    // basePath is appended directly.
+    return v2Doc.host ? "<<baseUrl>>" : `<<baseUrl>>${basePath}`
   }
 
   /**

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -1037,13 +1037,14 @@ export const parseOpenAPIUrl = (
    **/
   if (objectHasProperty(doc, "swagger")) {
     const v2Doc = doc as OpenAPIV2.Document
+    const hasHost = !!v2Doc.host?.trim()
     const basePath = (v2Doc.basePath?.trim() ?? "").replace(/\/$/, "")
 
     // When host is present, <<baseUrl>> resolves via collection variable from
     // extractServerVariables (which includes scheme + host + basePath).
     // When host is absent, <<baseUrl>> is a user-defined placeholder and
     // basePath is appended directly.
-    return v2Doc.host ? "<<baseUrl>>" : `<<baseUrl>>${basePath}`
+    return hasHost ? "<<baseUrl>>" : `<<baseUrl>>${basePath}`
   }
 
   /**
@@ -1207,6 +1208,8 @@ const convertOpenApiDocsToHopp = (
       }
     })
 
+    // serverVariables are set only at root level; sub-folders inherit them
+    // through Hoppscotch's collection-variable inheritance mechanism
     const serverVariables = extractServerVariables(doc)
 
     return makeCollection({

--- a/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/openapi/index.ts
@@ -15,6 +15,7 @@ import {
   knownContentTypes,
   makeRESTRequest,
   HoppCollection,
+  HoppCollectionVariable,
   makeCollection,
   HoppRESTRequestVariable,
   HoppRESTRequest,
@@ -974,7 +975,55 @@ const parseOpenAPIAuth = (
     ? parseOpenAPIV3Auth(doc as OpenAPIV3.Document | OpenAPIV31.Document, op)
     : parseOpenAPIV2Auth(doc as OpenAPIV2.Document, op)
 
-const parseOpenAPIUrl = (
+/**
+ * Extracts server variables from an OpenAPI document and returns them as
+ * collection variables with their default values.
+ *
+ * For OpenAPI V3: parses `servers[0].variables` and creates a variable for each entry.
+ * For OpenAPI V2: creates `baseUrl` variable from `host` + `basePath` if present.
+ */
+export const extractServerVariables = (
+  doc: OpenAPI.Document | OpenAPIV2.Document | OpenAPIV3.Document
+): HoppCollectionVariable[] => {
+  if (objectHasProperty(doc, "swagger")) {
+    const v2Doc = doc as OpenAPIV2.Document
+    const host = v2Doc.host?.trim()
+    const basePath = v2Doc.basePath?.trim()
+
+    if (host) {
+      return [
+        {
+          key: "baseUrl",
+          initialValue: `${host}${basePath ?? ""}`,
+          currentValue: `${host}${basePath ?? ""}`,
+          secret: false,
+        },
+      ]
+    }
+    return []
+  }
+
+  if (objectHasProperty(doc, "servers")) {
+    const v3Doc = doc as OpenAPIV3.Document | OpenAPIV31.Document
+    const server = v3Doc.servers?.[0]
+    if (!server?.url || server.url === "./") return []
+
+    const variables = server.variables
+    if (!variables || Object.keys(variables).length === 0) return []
+
+    return Object.entries(variables).map(([key, variable]) => ({
+      key,
+      initialValue: variable.default,
+      currentValue: variable.default,
+      secret: false,
+    }))
+  }
+
+  return []
+}
+
+/** @internal Exported for testing only */
+export const parseOpenAPIUrl = (
   doc: OpenAPI.Document | OpenAPIV2.Document | OpenAPIV3.Document
 ): string => {
   /**
@@ -984,11 +1033,9 @@ const parseOpenAPIUrl = (
    **/
 
   if (objectHasProperty(doc, "swagger")) {
-    // TODO: dynamically add doc.host, doc.basePath value as variables in the environment if available. or notify user to add it.
-    // add base url variable to each request
-    const host = doc.host?.trim() || "<<baseUrl>>"
-    const basePath = doc.basePath?.trim() || ""
-    return `${host}${basePath}`
+    // When host is available, use <<baseUrl>> so it references the collection variable
+    // populated by extractServerVariables
+    return "<<baseUrl>>"
   }
 
   /**
@@ -997,9 +1044,11 @@ const parseOpenAPIUrl = (
    * Relevant v3 reference: https://swagger.io/specification/#server-object
    **/
   if (objectHasProperty(doc, "servers")) {
-    // TODO: dynamically add server URL value as variable in the environment if available, or notify user to add it.
     const serverUrl = doc.servers?.[0]?.url
-    return !serverUrl || serverUrl === "./" ? "<<baseUrl>>" : serverUrl
+    if (!serverUrl || serverUrl === "./") return "<<baseUrl>>"
+
+    // Replace server variable placeholders {varName} with Hoppscotch variable syntax <<varName>>
+    return replaceOpenApiPathTemplating(serverUrl)
   }
 
   // If the document is neither v2 nor v3 or missing required fields
@@ -1150,6 +1199,8 @@ const convertOpenApiDocsToHopp = (
       }
     })
 
+    const serverVariables = extractServerVariables(doc)
+
     return makeCollection({
       name,
       folders: Object.entries(requestsByTags).map(([name, paths]) =>
@@ -1166,7 +1217,7 @@ const convertOpenApiDocsToHopp = (
       requests: requestsWithoutTags,
       auth: { authType: "inherit", authActive: true },
       headers: [],
-      variables: [],
+      variables: serverVariables,
       description,
     })
   })


### PR DESCRIPTION
Adds support for OpenAPI server variables during schema import. Server variable placeholders (`{var}`) in URLs are converted to Hoppscotch's `<<var>>` syntax, and default values are stored as collection-level variables.

Closes #4502

### What's changed

Minor changes in import logic + test cases for both v2 and v3 import.

### Notes to reviewers

To reproduce it, I leave here two specs for v2 and v3 import. You can import them manually and see how it works.

Before (v2):
![photo_2026-03-17_13-55-14](https://github.com/user-attachments/assets/da63fb3a-112f-40db-9f89-306cf9f0e67b)

After (v2):
![photo_2026-03-17_13-56-36](https://github.com/user-attachments/assets/835c06af-c336-4294-bea5-2b937c945ce9)

Before (v3):
![photo_2026-03-17_13-54-47](https://github.com/user-attachments/assets/b61fe1d9-03ef-4006-b8dd-fc6b6f8e3143)

After (v3):
![photo_2026-03-17_13-56-14](https://github.com/user-attachments/assets/22838d30-8876-45bb-9920-7014f8616a8a)


[test-server-vars-v2.yaml](https://github.com/user-attachments/files/26050974/test-server-vars-v2.yaml)
[test-server-vars-v3.yaml](https://github.com/user-attachments/files/26050975/test-server-vars-v3.yaml)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for OpenAPI server variables on import by converting `{var}` to `<<var>>` and creating collection variables from defaults. Standardizes base URL handling across OpenAPI v2 and v3. Closes #4502.

- **New Features**
  - OpenAPI v2: create `baseUrl` from first `schemes` entry (default `https`) + `host` + `basePath` without trailing slash; imported requests use `<<baseUrl>>`; when `host` is missing, use `<<baseUrl>>` and append `/<basePath>` if present (no variables created).
  - OpenAPI v3: replace `{var}` with `<<var>>` in `servers[0].url`; import defaults only for variables referenced in that URL and coerce non-string defaults to strings; fall back to `<<baseUrl>>` when the first server URL is `./`, missing, or `servers` is empty.

<sup>Written for commit 2b6a86e45fe061a26fdddcd88ca1b4a19759f4d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

