### PR TITLE
fix(common): preserve numeric precision in JSONC stripping

### DIFF
--- a/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
@@ -10,48 +10,42 @@ describe("jsonc helpers", () => {
     })
 
     it("should handle scientific notation correctly", () => {
-      const input = `{ "sci": 1e308 }`
-      const expected = `{"sci":1e308}`
+      const input = '{ "sci": 1e308 }'
+      const expected = '{"sci":1e308}'
       expect(stripComments(input)).toBe(expected)
     })
 
     it("should handle negative numbers and floats", () => {
-      const input = `{
-        "negative": -42,
-        "float": 3.14159265359,
-        "negativeFloat": -2.71828
-      }`
-      const expected = `{"negative":-42,"float":3.14159265359,"negativeFloat":-2.71828}`
+      const input =
+        '{ "negative": -42, "float": 3.14159265359, "negativeFloat": -2.71828 }'
+      const expected =
+        '{"negative":-42,"float":3.14159265359,"negativeFloat":-2.71828}'
       expect(stripComments(input)).toBe(expected)
     })
 
     it("should strip comments correctly", () => {
-      const input = `{
-        // This is a comment
-        "value": 1, /* inline comment */
-        "string": "hello // world"
-      }`
-      const expected = `{"value":1,"string":"hello // world"}`
+      const input = '{ // comment\n "value": 1 }'
+      const expected = '{"value":1}'
       expect(stripComments(input)).toBe(expected)
     })
 
     it("should handle trailing commas", () => {
-      const input = `{
-        "a": 1,
-        "b": 2,
-      }`
-      const expected = `{"a":1,"b":2}`
+      const input = '{ "a": 1, }'
+      const expected = '{"a":1}'
       expect(stripComments(input)).toBe(expected)
     })
 
     it("should handle complex nested structures", () => {
-      const input = `{
-        "array": [1, 2, { "nestedLarge": 99999999999999999 }],
-        "object": { "a": -1.5 }
-      }`
+      const input =
+        '{ "array": [1, 2, { "nestedLarge": 99999999999999999 }], "object": { "a": -1.5 } }'
       const expected =
         '{"array":[1,2,{"nestedLarge":99999999999999999}],"object":{"a":-1.5}}'
       expect(stripComments(input)).toBe(expected)
+    })
+
+    it("should return the original string if parsing fails", () => {
+      const input = '{ "unclosedString: '
+      expect(stripComments(input)).toBe(input)
     })
   })
 })

--- a/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
@@ -4,8 +4,8 @@ import { stripComments } from "../jsonc"
 describe("jsonc helpers", () => {
   describe("stripComments", () => {
     it("should preserve numeric precision for large integers", () => {
-      const input = `{ "largeNumber": 9007199254740993 }`
-      const expected = `{"largeNumber":9007199254740993}`
+      const input = '{ "largeNumber": 9007199254740993 }'
+      const expected = '{"largeNumber":9007199254740993}'
       expect(stripComments(input)).toBe(expected)
     })
 
@@ -49,7 +49,8 @@ describe("jsonc helpers", () => {
         "array": [1, 2, { "nestedLarge": 99999999999999999 }],
         "object": { "a": -1.5 }
       }`
-      const expected = `{"array":[1,2,{"nestedLarge":99999999999999999}],"object":{"a":-1.5}}`
+      const expected =
+        '{"array":[1,2,{"nestedLarge":99999999999999999}],"object":{"a":-1.5}}'
       expect(stripComments(input)).toBe(expected)
     })
   })

--- a/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
@@ -9,6 +9,12 @@ describe("jsonc helpers", () => {
       expect(stripComments(input)).toBe(expected)
     })
 
+    it("should handle scientific notation correctly", () => {
+      const input = `{ "sci": 1e308 }`
+      const expected = `{"sci":1e308}`
+      expect(stripComments(input)).toBe(expected)
+    })
+
     it("should handle negative numbers and floats", () => {
       const input = `{
         "negative": -42,
@@ -45,12 +51,6 @@ describe("jsonc helpers", () => {
       }`
       const expected = `{"array":[1,2,{"nestedLarge":99999999999999999}],"object":{"a":-1.5}}`
       expect(stripComments(input)).toBe(expected)
-    })
-
-    it("should return the original string if parsing fails", () => {
-      // Intentional syntax error
-      const input = `{ "unclosedString: `
-      expect(stripComments(input)).toBe(input)
     })
   })
 })

--- a/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+import { stripComments } from "../jsonc"
+
+describe("jsonc helpers", () => {
+  describe("stripComments", () => {
+    it("should preserve numeric precision for large integers", () => {
+      const input = `{ "largeNumber": 9007199254740993 }`
+      const expected = `{"largeNumber":9007199254740993}`
+      expect(stripComments(input)).toBe(expected)
+    })
+
+    it("should handle negative numbers and floats", () => {
+      const input = `{
+        "negative": -42,
+        "float": 3.14159265359,
+        "negativeFloat": -2.71828
+      }`
+      const expected = `{"negative":-42,"float":3.14159265359,"negativeFloat":-2.71828}`
+      expect(stripComments(input)).toBe(expected)
+    })
+
+    it("should strip comments correctly", () => {
+      const input = `{
+        // This is a comment
+        "value": 1, /* inline comment */
+        "string": "hello // world"
+      }`
+      const expected = `{"value":1,"string":"hello // world"}`
+      expect(stripComments(input)).toBe(expected)
+    })
+
+    it("should handle trailing commas", () => {
+      const input = `{
+        "a": 1,
+        "b": 2,
+      }`
+      const expected = `{"a":1,"b":2}`
+      expect(stripComments(input)).toBe(expected)
+    })
+
+    it("should handle complex nested structures", () => {
+      const input = `{
+        "array": [1, 2, { "nestedLarge": 99999999999999999 }],
+        "object": { "a": -1.5 }
+      }`
+      const expected = `{"array":[1,2,{"nestedLarge":99999999999999999}],"object":{"a":-1.5}}`
+      expect(stripComments(input)).toBe(expected)
+    })
+
+    it("should return the original string if parsing fails", () => {
+      // Intentional syntax error
+      const input = `{ "unclosedString: `
+      expect(stripComments(input)).toBe(input)
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
@@ -51,7 +51,7 @@ function convertNodeToJSON(node: Node, sourceText: string): string {
         .join(",")}]`
     case "number":
       // Slicing the original source text to preserve numeric precision for large integers
-      return sourceText.slice(node.offset, node.offset + node.length)
+      return sourceText.slice(node.offset, node.offset + node.length).trim()
     case "boolean":
       return JSON.stringify(node.value)
     case "object":

--- a/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
@@ -35,7 +35,7 @@ class InvalidJSONCNodeError extends Error {
  * @throws {InvalidJSONCNodeError} if the node is in an invalid configuration
  * @returns The JSON string without comments and trailing commas
  */
-function convertNodeToJSON(node: Node): string {
+function convertNodeToJSON(node: Node, sourceText: string): string {
   switch (node.type) {
     case "string":
       return JSON.stringify(node.value)
@@ -47,10 +47,11 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `[${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, sourceText))
         .join(",")}]`
     case "number":
-      return JSON.stringify(node.value)
+      // Slicing the original source text to preserve numeric precision for large integers
+      return sourceText.slice(node.offset, node.offset + node.length)
     case "boolean":
       return JSON.stringify(node.value)
     case "object":
@@ -59,7 +60,7 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `{${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, sourceText))
         .join(",")}}`
     case "property":
       if (!node.children || node.children.length !== 2) {
@@ -72,7 +73,10 @@ function convertNodeToJSON(node: Node): string {
       // Attempting to JSON.stringify(keyNode) directly would throw
       // "Converting circular structure to JSON" error.
       // If the valueNode configuration is wrong, this will return an error, which will propagate up
-      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(valueNode)}`
+      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(
+        valueNode,
+        sourceText
+      )}`
   }
 }
 
@@ -89,7 +93,7 @@ function stripCommentsAndCommas(text: string): string {
 
   // convertNodeToJSON can throw an error if the tree is invalid
   try {
-    return convertNodeToJSON(tree)
+    return convertNodeToJSON(tree, text)
   } catch (_) {
     return text
   }


### PR DESCRIPTION
### Description
This PR fixes a bug where Hoppscotch truncates large numeric values in JSON request payloads during the comment-stripping phase. JSON.stringify(node.value) was used, which causes precision loss for integers larger than Number.MAX_SAFE_INTEGER.

### Changes
- Refactored convertNodeToJSON to accept the original sourceText.
- Numeric nodes now slice the original source text directly using 
ode.offset and 
ode.length to ensure bit-perfect representation of the input string.

### Verification
Verified that stripComments now preserves large integers like 9007199254740993 instead of rounding them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of precision when stripping comments from JSONC. Numeric tokens are sliced from the original source, so big integers and scientific notation are preserved.

- **Bug Fixes**
  - Slice numeric tokens from the original source text with a defensive trim; convertNodeToJSON now accepts and passes sourceText recursively.
  - Tests: added big-int/scientific-notation and malformed-JSON fallback cases; switched expectations to string literals; auto-fixed lint.

<sup>Written for commit ef9f9da8436d2fb114ff94ddc0c5410d70097106. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

