### PR TITLE
feat: allow closing last tab (fixes #6005)

### DIFF
--- a/packages/hoppscotch-common/src/components/app/ShortcutsPrompt.vue
+++ b/packages/hoppscotch-common/src/components/app/ShortcutsPrompt.vue
@@ -2,38 +2,50 @@
   <div class="flex flex-col items-center justify-center text-secondaryLight">
     <div class="mb-4 flex space-x-2">
       <div class="flex flex-col items-end space-y-4 text-right">
-        <span class="flex flex-1 items-center">
-          {{ t("shortcut.request.send_request") }}
-        </span>
-        <span class="flex flex-1 items-center">
-          {{ t("shortcut.general.show_all") }}
-        </span>
-        <span class="flex flex-1 items-center">
-          {{ t("shortcut.general.command_menu") }}
-        </span>
-        <span class="flex flex-1 items-center">
-          {{ t("shortcut.general.help_menu") }}
+        <span
+          v-for="shortcut in shortcutList"
+          :key="shortcut.label"
+          class="flex flex-1 items-center"
+        >
+          {{ shortcut.label }}
         </span>
       </div>
       <div class="flex flex-col space-y-4">
-        <div class="flex">
-          <kbd class="shortcut-key">{{ getSpecialKey() }}</kbd>
-          <kbd class="shortcut-key">↩</kbd>
-        </div>
-        <div class="flex">
-          <kbd class="shortcut-key">{{ getSpecialKey() }}</kbd>
-          <kbd class="shortcut-key">/</kbd>
-        </div>
-        <div class="flex">
-          <kbd class="shortcut-key">{{ getSpecialKey() }}</kbd>
-          <kbd class="shortcut-key">K</kbd>
-        </div>
-        <div class="flex">
-          <kbd class="shortcut-key">?</kbd>
+        <div
+          v-for="shortcut in shortcutList"
+          :key="`${shortcut.label}-keys`"
+          class="flex"
+        >
+          <kbd
+            v-for="key in shortcut.keys"
+            :key="`${shortcut.label}-${key}`"
+            class="shortcut-key"
+          >
+            {{ key }}
+          </kbd>
         </div>
       </div>
     </div>
+    <div
+      v-if="primaryActionLabel || secondaryActionLabel"
+      class="mb-4 flex flex-col gap-3 sm:flex-row"
+    >
+      <HoppButtonPrimary
+        v-if="primaryActionLabel"
+        :label="primaryActionLabel"
+        outline
+        @click="emit('primary-action')"
+      />
+      <HoppButtonSecondary
+        v-if="secondaryActionLabel"
+        :label="secondaryActionLabel"
+        outline
+        filled
+        @click="emit('secondary-action')"
+      />
+    </div>
     <HoppButtonSecondary
+      v-if="showDocumentation"
       :label="`${t('app.documentation')}`"
       to="https://docs.hoppscotch.io/documentation/features/rest-api-testing#response"
       :icon="IconExternalLink"
@@ -45,9 +57,58 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue"
 import { useI18n } from "~/composables/i18n"
+import type { ShortcutDef } from "~/helpers/shortcuts"
 import IconExternalLink from "~icons/lucide/external-link"
 import { getPlatformSpecialKey as getSpecialKey } from "~/helpers/platformutils"
 
+const props = withDefaults(
+  defineProps<{
+    shortcuts?: ShortcutDef[]
+    primaryActionLabel?: string
+    secondaryActionLabel?: string
+    showDocumentation?: boolean
+  }>(),
+  {
+    shortcuts: () => [],
+    primaryActionLabel: undefined,
+    secondaryActionLabel: undefined,
+    showDocumentation: true,
+  }
+)
+
+const emit = defineEmits<{
+  (event: "primary-action"): void
+  (event: "secondary-action"): void
+}>()
+
 const t = useI18n()
+
+const shortcutList = computed(() =>
+  props.shortcuts.length > 0
+    ? props.shortcuts
+    : [
+        {
+          label: t("shortcut.request.send_request"),
+          keys: [getSpecialKey(), "Enter"],
+          section: t("shortcut.request.title"),
+        },
+        {
+          label: t("shortcut.general.show_all"),
+          keys: [getSpecialKey(), "/"],
+          section: t("shortcut.general.title"),
+        },
+        {
+          label: t("shortcut.general.command_menu"),
+          keys: [getSpecialKey(), "K"],
+          section: t("shortcut.general.title"),
+        },
+        {
+          label: t("shortcut.general.help_menu"),
+          keys: ["?"],
+          section: t("shortcut.general.title"),
+        },
+      ]
+)
 </script>

--- a/packages/hoppscotch-common/src/pages/graphql.vue
+++ b/packages/hoppscotch-common/src/pages/graphql.vue
@@ -2,10 +2,10 @@
   <div>
     <AppPaneLayout layout-id="graphql">
       <template #primary>
-        <GraphqlRequest />
+        <GraphqlRequest v-if="hasTabs" />
 
         <HoppSmartWindows
-          v-if="currentTabID"
+          v-if="hasTabs"
           :id="'gql_windows'"
           :model-value="currentTabID"
           @update:model-value="changeTab"
@@ -18,13 +18,13 @@
             :id="tab.id"
             :key="'removable_tab_' + tab.id"
             :label="tab.document.request.name"
-            :is-removable="activeTabs.length > 1"
+            :is-removable="true"
             :close-visibility="'hover'"
           >
             <template #tabhead>
               <GraphqlTabHead
                 :tab="tab"
-                :is-removable="activeTabs.length > 1"
+                :is-removable="true"
                 @open-rename-modal="openReqRenameModal(tab)"
                 @close-tab="removeTab(tab.id)"
                 @close-other-tabs="closeOtherTabsAction(tab.id)"
@@ -54,6 +54,19 @@
             />
           </HoppSmartWindow>
         </HoppSmartWindows>
+        <div
+          v-else
+          class="flex h-full w-full items-center justify-center bg-primary p-4 sm:p-8"
+        >
+          <AppShortcutsPrompt
+            :shortcuts="emptyStateShortcuts"
+            :primary-action-label="t('shortcut.tabs.new_tab')"
+            :secondary-action-label="t('collection.new')"
+            :show-documentation="false"
+            @primary-action="addNewTab"
+            @secondary-action="openNewCollection"
+          />
+        </div>
       </template>
       <template #sidebar>
         <GraphqlSidebar />
@@ -88,11 +101,12 @@ import { usePageHead } from "@composables/head"
 import { useI18n } from "@composables/i18n"
 import { useService } from "dioc/vue"
 import { computed, onBeforeUnmount, ref } from "vue"
-import { defineActionHandler } from "~/helpers/actions"
+import { defineActionHandler, invokeAction } from "~/helpers/actions"
 import { connection, disconnect } from "~/helpers/graphql/connection"
 import { getDefaultGQLRequest } from "~/helpers/graphql/default"
 import { HoppGQLDocument } from "~/helpers/graphql/document"
 import { useExplorer } from "~/helpers/graphql/explorer"
+import { getShortcuts, type ShortcutDef } from "~/helpers/shortcuts"
 import { InspectionService } from "~/services/inspection"
 import { HoppTab } from "~/services/tab"
 import { GQLTabService } from "~/services/tab/graphql"
@@ -112,6 +126,23 @@ usePageHead({
 })
 
 const activeTabs = tabs.getActiveTabs()
+const hasTabs = computed(() => activeTabs.value.length > 0)
+const emptyStateShortcuts = computed(() => {
+  const preferredShortcuts = [
+    t("shortcut.tabs.new_tab"),
+    t("shortcut.request.send_request"),
+    t("shortcut.general.show_all"),
+    t("shortcut.general.command_menu"),
+    t("shortcut.general.help_menu"),
+  ]
+
+  return preferredShortcuts
+    .map((label) =>
+      getShortcuts(t).find((shortcut) => shortcut.label === label)
+    )
+    .filter((shortcut): shortcut is ShortcutDef => shortcut !== undefined)
+})
+const openNewCollection = () => invokeAction("collection.new")
 
 const addNewTab = () => {
   const tab = tabs.createNewTab({
@@ -234,19 +265,21 @@ defineActionHandler("gql.request.open", ({ request, saveContext }) => {
 })
 
 defineActionHandler("request.rename", () => {
+  if (!currentTabID.value) return
   openReqRenameModal(tabs.getTabRef(currentTabID.value).value!)
 })
 
 defineActionHandler("tab.duplicate-tab", ({ tabID }) => {
-  duplicateTab(tabID ?? currentTabID.value)
+  const targetTabID = tabID ?? currentTabID.value
+  if (targetTabID) duplicateTab(targetTabID)
 })
 
 defineActionHandler("tab.close-current", () => {
-  removeTab(currentTabID.value)
+  if (currentTabID.value) removeTab(currentTabID.value)
 })
 
 defineActionHandler("tab.close-other", () => {
-  tabs.closeOtherTabs(currentTabID.value)
+  if (currentTabID.value) tabs.closeOtherTabs(currentTabID.value)
 })
 
 defineActionHandler("tab.open-new", addNewTab)

--- a/packages/hoppscotch-common/src/pages/index.vue
+++ b/packages/hoppscotch-common/src/pages/index.vue
@@ -3,7 +3,7 @@
     <AppPaneLayout layout-id="http">
       <template #primary>
         <HoppSmartWindows
-          v-if="currentTabID"
+          v-if="hasTabs"
           :id="'rest_windows'"
           v-model="currentTabID"
           @remove-tab="removeTab"
@@ -15,13 +15,13 @@
             :id="tab.id"
             :key="tab.id"
             :label="getTabName(tab)"
-            :is-removable="activeTabs.length > 1"
+            :is-removable="true"
             :close-visibility="'hover'"
           >
             <template v-if="tab.document.type === 'request'" #tabhead>
               <HttpTabHead
                 :tab="tab"
-                :is-removable="activeTabs.length > 1"
+                :is-removable="true"
                 @open-rename-modal="openReqRenameModal(tab.id)"
                 @close-tab="removeTab(tab.id)"
                 @close-other-tabs="closeOtherTabsAction(tab.id)"
@@ -67,6 +67,19 @@
             <EnvironmentsSelector class="h-full" />
           </template>
         </HoppSmartWindows>
+        <div
+          v-else
+          class="flex h-full w-full items-center justify-center bg-primary p-4 sm:p-8"
+        >
+          <AppShortcutsPrompt
+            :shortcuts="emptyStateShortcuts"
+            :primary-action-label="t('shortcut.tabs.new_tab')"
+            :secondary-action-label="t('collection.new')"
+            :show-documentation="false"
+            @primary-action="addNewTab"
+            @secondary-action="openNewCollection"
+          />
+        </div>
       </template>
       <template #sidebar>
         <HttpSidebar />
@@ -153,6 +166,7 @@ import { RESTTabService } from "~/services/tab/rest"
 import { HoppTab } from "~/services/tab"
 import { HoppRequestDocument, HoppTabDocument } from "~/helpers/rest/document"
 import { ScrollService } from "~/services/scroll.service"
+import { getShortcuts, type ShortcutDef } from "~/helpers/shortcuts"
 
 const scrollService = useService(ScrollService)
 
@@ -195,6 +209,23 @@ const contextMenu = ref<PopupDetails>({
 })
 
 const activeTabs = tabs.getActiveTabs()
+const hasTabs = computed(() => activeTabs.value.length > 0)
+const emptyStateShortcuts = computed(() => {
+  const preferredShortcuts = [
+    t("shortcut.tabs.new_tab"),
+    t("shortcut.request.send_request"),
+    t("shortcut.general.show_all"),
+    t("shortcut.general.command_menu"),
+    t("shortcut.general.help_menu"),
+  ]
+
+  return preferredShortcuts
+    .map((label) =>
+      getShortcuts(t).find((shortcut) => shortcut.label === label)
+    )
+    .filter((shortcut): shortcut is ShortcutDef => shortcut !== undefined)
+})
+const openNewCollection = () => invokeAction("collection.new")
 
 function bindRequestToURLParams() {
   const route = useRoute()
@@ -205,7 +236,11 @@ function bindRequestToURLParams() {
     // We skip URL params parsing
     if (Object.keys(query).length === 0 || query.code || query.error) return
 
-    if (tabs.currentActiveTab.value.document.type !== "request") return
+    if (
+      !hasTabs.value ||
+      tabs.currentActiveTab.value.document.type !== "request"
+    )
+      return
 
     const request = tabs.currentActiveTab.value.document.request
 
@@ -317,6 +352,8 @@ const openReqRenameModal = (tabID?: string) => {
     reqName.value = tab.value.document.request.name
     renameTabID.value = tabID
   } else {
+    if (!hasTabs.value) return
+
     const { id, document } = tabs.currentActiveTab.value
 
     if (document.type !== "request") return
@@ -410,20 +447,21 @@ defineActionHandler("rest.request.open", ({ doc }) => {
 })
 
 defineActionHandler("request.rename", () => {
-  if (tabs.currentActiveTab.value.document.type === "request")
+  if (hasTabs.value && tabs.currentActiveTab.value.document.type === "request")
     openReqRenameModal(tabs.currentActiveTab.value.id)
 })
 
 defineActionHandler("tab.duplicate-tab", ({ tabID }) => {
-  duplicateTab(tabID ?? currentTabID.value)
+  const targetTabID = tabID ?? currentTabID.value
+  if (targetTabID) duplicateTab(targetTabID)
 })
 
 defineActionHandler("tab.close-current", () => {
-  removeTab(currentTabID.value)
+  if (currentTabID.value) removeTab(currentTabID.value)
 })
 
 defineActionHandler("tab.close-other", () => {
-  tabs.closeOtherTabs(currentTabID.value)
+  if (currentTabID.value) tabs.closeOtherTabs(currentTabID.value)
 })
 
 defineActionHandler("tab.open-new", addNewTab)

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -936,12 +936,11 @@ export class PersistenceService extends Service {
         }
         const result = REST_TAB_STATE_SCHEMA.safeParse(transformedTabs)
         if (result.success) {
-          if (result.data.orderedDocs.length === 0) return
-
-          // SAFETY: We know the schema matches
-          this.restTabService.loadTabsFromPersistedState(
-            result.data as PersistableTabState<HoppTabDocument>
-          )
+          if (result.data.orderedDocs.length !== 0) {
+            this.restTabService.loadTabsFromPersistedState(
+              result.data as PersistableTabState<HoppTabDocument>
+            )
+          }
         } else {
           this.showErrorToast(STORE_KEYS.REST_TABS)
           await Store.set(
@@ -981,12 +980,11 @@ export class PersistenceService extends Service {
         const result = GQL_TAB_STATE_SCHEMA.safeParse(loadResult.right)
 
         if (result.success) {
-          if (result.data.orderedDocs.length === 0) return
-
-          // SAFETY: We know the schema matches
-          this.gqlTabService.loadTabsFromPersistedState(
-            result.data as PersistableTabState<HoppGQLDocument>
-          )
+          if (result.data.orderedDocs.length !== 0) {
+            this.gqlTabService.loadTabsFromPersistedState(
+              result.data as PersistableTabState<HoppGQLDocument>
+            )
+          }
         } else {
           this.showErrorToast(STORE_KEYS.GQL_TABS)
           await Store.set(

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -936,6 +936,8 @@ export class PersistenceService extends Service {
         }
         const result = REST_TAB_STATE_SCHEMA.safeParse(transformedTabs)
         if (result.success) {
+          if (result.data.orderedDocs.length === 0) return
+
           // SAFETY: We know the schema matches
           this.restTabService.loadTabsFromPersistedState(
             result.data as PersistableTabState<HoppTabDocument>
@@ -979,6 +981,8 @@ export class PersistenceService extends Service {
         const result = GQL_TAB_STATE_SCHEMA.safeParse(loadResult.right)
 
         if (result.success) {
+          if (result.data.orderedDocs.length === 0) return
+
           // SAFETY: We know the schema matches
           this.gqlTabService.loadTabsFromPersistedState(
             result.data as PersistableTabState<HoppGQLDocument>

--- a/packages/hoppscotch-common/src/services/tab/__tests__/tab.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/tab/__tests__/tab.service.spec.ts
@@ -6,6 +6,15 @@ import { reactive } from "vue"
 class MockTabService extends TabService<{ request: string }> {
   public static readonly ID = "MOCK_TAB_SERVICE"
 
+  protected createFallbackTab() {
+    return {
+      id: "__empty_mock_tab__",
+      document: {
+        request: "",
+      },
+    }
+  }
+
   override onServiceInit() {
     this.tabMap = reactive(
       new Map([
@@ -139,6 +148,17 @@ describe("TabService", () => {
     service.closeTab("test")
 
     expect(service.getActiveTabs().value.length).toEqual(1)
+  })
+
+  it("allows closing the last tab", () => {
+    const container = new TestContainer()
+
+    const service = container.bind(MockTabService)
+
+    service.closeTab("test")
+
+    expect(service.getActiveTabs().value.length).toEqual(0)
+    expect(service.getActiveTab()).toBeNull()
   })
 
   describe("Tab Navigation", () => {

--- a/packages/hoppscotch-common/src/services/tab/graphql.ts
+++ b/packages/hoppscotch-common/src/services/tab/graphql.ts
@@ -6,10 +6,22 @@ import { computed } from "vue"
 import { Container } from "dioc"
 import { getService } from "~/modules/dioc"
 import { PersistenceService, STORE_KEYS } from "../persistence"
-import { PersistableTabState } from "."
+import { HoppTab, PersistableTabState } from "."
 
 export class GQLTabService extends TabService<HoppGQLDocument> {
   public static readonly ID = "GQL_TAB_SERVICE"
+
+  protected createFallbackTab(): HoppTab<HoppGQLDocument> {
+    return {
+      id: "__empty_gql_tab__",
+      document: {
+        request: getDefaultGQLRequest(),
+        isDirty: false,
+        optionTabPreference: "query",
+        cursorPosition: 0,
+      },
+    }
+  }
 
   // TODO: Moving this to `onServiceInit` breaks `persistableTabState`
   // Figure out how to fix this

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -5,10 +5,22 @@ import { HoppRESTSaveContext, HoppTabDocument } from "~/helpers/rest/document"
 import { getService } from "~/modules/dioc"
 import { PersistenceService, STORE_KEYS } from "../persistence"
 import { TabService } from "./tab"
-import { PersistableTabState } from "."
+import { HoppTab, PersistableTabState } from "."
 
 export class RESTTabService extends TabService<HoppTabDocument> {
   public static readonly ID = "REST_TAB_SERVICE"
+
+  protected createFallbackTab(): HoppTab<HoppTabDocument> {
+    return {
+      id: "__empty_rest_tab__",
+      document: {
+        type: "request",
+        request: getDefaultRESTRequest(),
+        isDirty: false,
+        optionTabPreference: "params",
+      },
+    }
+  }
 
   // TODO: Moving this to `onServiceInit` breaks `persistableTabState`
   // Figure out how to fix this

--- a/packages/hoppscotch-common/src/services/tab/tab.ts
+++ b/packages/hoppscotch-common/src/services/tab/tab.ts
@@ -37,6 +37,10 @@ export abstract class TabService<Doc>
 
   public currentTabID = refWithControl("test", {
     onBeforeChange: (newTabID) => {
+      if (newTabID === "") {
+        return true
+      }
+
       if (!newTabID || !this.tabMap.has(newTabID)) {
         console.warn(
           `Tried to set current tab id to an invalid value. (value: ${newTabID})`
@@ -49,18 +53,22 @@ export abstract class TabService<Doc>
   })
 
   public currentActiveTab = computed(
-    () => this.tabMap.get(this.currentTabID.value)!
-  ) // Guaranteed to not be undefined
+    () => this.tabMap.get(this.currentTabID.value) ?? this.createFallbackTab()
+  )
+
+  protected abstract createFallbackTab(): HoppTab<Doc>
 
   protected watchCurrentTabID() {
     watch(
       this.tabOrdering,
       (newOrdering) => {
-        if (
-          !this.currentTabID.value ||
-          !newOrdering.includes(this.currentTabID.value)
-        ) {
-          this.setActiveTab(newOrdering[newOrdering.length - 1]) // newOrdering should always be non-empty
+        if (newOrdering.length === 0) {
+          this.currentTabID.value = ""
+          return
+        }
+
+        if (!newOrdering.includes(this.currentTabID.value)) {
+          this.setActiveTab(newOrdering[newOrdering.length - 1])
         }
       },
       { deep: true }
@@ -69,7 +77,7 @@ export abstract class TabService<Doc>
 
   public async init() {
     const persistedState = await this.loadPersistedState()
-    if (persistedState) {
+    if (persistedState && persistedState.orderedDocs.length > 0) {
       this.loadTabsFromPersistedState(persistedState)
     }
   }
@@ -135,7 +143,16 @@ export abstract class TabService<Doc>
         this.mruOrder.push(doc.tabID)
       }
 
-      this.setActiveTab(data.lastActiveTabID)
+      if (this.tabOrdering.value.length === 0) {
+        this.currentTabID.value = ""
+        return
+      }
+
+      const nextActiveTabID = this.tabMap.has(data.lastActiveTabID)
+        ? data.lastActiveTabID
+        : this.tabOrdering.value[this.tabOrdering.value.length - 1]
+
+      this.setActiveTab(nextActiveTabID)
     }
   }
 
@@ -188,13 +205,6 @@ export abstract class TabService<Doc>
       return
     }
 
-    if (this.tabOrdering.value.length === 1) {
-      console.warn(
-        `Tried to close the only tab open, which is not allowed. (tab id: ${tabID})`
-      )
-      return
-    }
-
     const tabIndex = this.tabOrdering.value.indexOf(tabID)
     const tab = this.tabMap.get(tabID)!
 
@@ -235,6 +245,8 @@ export abstract class TabService<Doc>
   }
 
   public goToNextTab(): void {
+    if (this.tabOrdering.value.length === 0) return
+
     const currentIndex = this.tabOrdering.value.indexOf(this.currentTabID.value)
     const nextIndex = (currentIndex + 1) % this.tabOrdering.value.length
     const nextTabID = this.tabOrdering.value[nextIndex]
@@ -242,6 +254,8 @@ export abstract class TabService<Doc>
   }
 
   public goToPreviousTab(): void {
+    if (this.tabOrdering.value.length === 0) return
+
     const currentIndex = this.tabOrdering.value.indexOf(this.currentTabID.value)
     const prevIndex =
       currentIndex === 0 ? this.tabOrdering.value.length - 1 : currentIndex - 1
@@ -251,6 +265,8 @@ export abstract class TabService<Doc>
 
   // NOTE: Currently inert, plumbing is done, some platform issues around shortcuts, WIP for future.
   public goToTabByIndex(index: number): void {
+    if (this.tabOrdering.value.length === 0) return
+
     if (index >= 1 && index <= this.tabOrdering.value.length) {
       const tabID = this.tabOrdering.value[index - 1]
       this.setActiveTab(tabID)
@@ -258,11 +274,15 @@ export abstract class TabService<Doc>
   }
 
   public goToFirstTab(): void {
+    if (this.tabOrdering.value.length === 0) return
+
     const firstTabID = this.tabOrdering.value[0]
     this.setActiveTab(firstTabID)
   }
 
   public goToLastTab(): void {
+    if (this.tabOrdering.value.length === 0) return
+
     const lastTabID = this.tabOrdering.value[this.tabOrdering.value.length - 1]
     this.setActiveTab(lastTabID)
   }


### PR DESCRIPTION
## Summary

This PR updates the tab behavior to allow the editor to have zero open tabs.

Previously, the application required at least one tab to remain open. With this change, the editor still opens with a default tab on startup, but users can close it if they wish.

## Changes

* The editor starts with a default tab when the application launches.
* Users are now able to close the last remaining tab.
* When no tabs are open, the editor displays an empty state instead of forcing a tab to stay open.

## Motivation

Allowing zero open tabs helps keep the workspace in a clean state and avoids distractions from previous tasks. 
## Result

* Default tab on startup
* Ability to close all tabs
* Empty workspace when no tabs are open

Closes #6005


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users close the last open tab in REST and GraphQL editors. When no tabs are open, the editor shows a clean empty state with helpful shortcuts and quick actions. Fixes #6005.

- New Features
  - Close the last tab; tabs are always removable.
  - Empty state with shortcuts plus “New Tab” and “New Collection” actions.
  - `ShortcutsPrompt` supports dynamic lists, optional primary/secondary buttons, and a docs link toggle.

- Bug Fixes
  - Tab service handles zero-tab states: safe currentTabID (including empty), navigation guards, and only loads persisted tabs when tabs exist.
  - After restoring an empty tab state, future tab changes persist correctly.
  - REST/GraphQL pages guard tab actions (rename, duplicate, close other) when no active tab exists.

<sup>Written for commit 0d945871649f279847f4289d44bb816f88f3413f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



