### PR TITLE
fix(common): resolve history schema mismatch on page reload

### DIFF
--- a/packages/hoppscotch-common/src/newstore/history.ts
+++ b/packages/hoppscotch-common/src/newstore/history.ts
@@ -342,8 +342,9 @@ export function removeDuplicateGraphqlHistoryEntry(id: string) {
 // Listen to completed responses to add to history
 executedResponses$.subscribe((res) => {
   // Spread to auto-capture any future fields, but omit _ref_id and id
-  // since history entries are snapshots and shouldn't carry references
-  const { _ref_id, _id, ...request } = res.req
+  // since history entries are snapshots and shouldn't carry collection/firestore references
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { _ref_id, id, ...request } = res.req
 
   addRESTHistoryEntry(
     makeRESTHistoryEntry({

--- a/packages/hoppscotch-common/src/newstore/history.ts
+++ b/packages/hoppscotch-common/src/newstore/history.ts
@@ -341,23 +341,13 @@ export function removeDuplicateGraphqlHistoryEntry(id: string) {
 
 // Listen to completed responses to add to history
 executedResponses$.subscribe((res) => {
+  // Spread to auto-capture any future fields, but omit _ref_id and id
+  // since history entries are snapshots and shouldn't carry references
+  const { _ref_id, _id, ...request } = res.req
+
   addRESTHistoryEntry(
     makeRESTHistoryEntry({
-      request: {
-        auth: res.req.auth,
-        body: res.req.body,
-        endpoint: res.req.endpoint,
-        headers: res.req.headers,
-        method: res.req.method,
-        name: res.req.name,
-        params: res.req.params,
-        preRequestScript: res.req.preRequestScript,
-        testScript: res.req.testScript,
-        requestVariables: res.req.requestVariables,
-        v: res.req.v,
-        responses: res.req.responses,
-        description: res.req.description,
-      },
+      request,
       responseMeta: {
         duration: res.meta.responseDuration,
         statusCode: res.statusCode,

--- a/packages/hoppscotch-common/src/newstore/history.ts
+++ b/packages/hoppscotch-common/src/newstore/history.ts
@@ -356,6 +356,7 @@ executedResponses$.subscribe((res) => {
         requestVariables: res.req.requestVariables,
         v: res.req.v,
         responses: res.req.responses,
+        description: res.req.description,
       },
       responseMeta: {
         duration: res.meta.responseDuration,

--- a/packages/hoppscotch-selfhost-web/src/platform/history/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/history/desktop/index.ts
@@ -193,35 +193,31 @@ function setupUserHistoryUpdatedSubscription() {
 
   userHistoryUpdated$.subscribe((res) => {
     if (E.isRight(res)) {
-      const { id, reqType } = res.right.userHistoryUpdated
+      const { id, reqType, isStarred } = res.right.userHistoryUpdated
 
       if (reqType == ReqType.Rest) {
-        const updatedRestEntryIndex = restHistoryStore.value.state.findIndex(
+        const existingEntry = restHistoryStore.value.state.find(
           (entry) => entry.id == id
         )
 
-        // Reuse the existing store entry instead of re-parsing the request from the subscription payload.
-        // toggleStar uses deep equality (isEqual) to match entries, and re-parsing could produce
-        // a different object (e.g. migration adding _ref_id or description defaults), causing the match to fail.
-        if (updatedRestEntryIndex != -1) {
+        // Only toggle if the store entry's star doesn't match the server state.
+        // Without this guard, the subscription echo from the same client's own
+        // toggle would cause a second toggle and revert the star.
+        if (existingEntry && existingEntry.star !== isStarred) {
           runDispatchWithOutSyncing(() => {
-            toggleRESTHistoryEntryStar(
-              restHistoryStore.value.state[updatedRestEntryIndex]
-            )
+            toggleRESTHistoryEntryStar(existingEntry)
           })
         }
       }
 
       if (reqType == ReqType.Gql) {
-        const updatedGQLEntryIndex = graphqlHistoryStore.value.state.findIndex(
+        const existingEntry = graphqlHistoryStore.value.state.find(
           (entry) => entry.id == id
         )
 
-        if (updatedGQLEntryIndex != -1) {
+        if (existingEntry && existingEntry.star !== isStarred) {
           runDispatchWithOutSyncing(() => {
-            toggleGraphqlHistoryEntryStar(
-              graphqlHistoryStore.value.state[updatedGQLEntryIndex]
-            )
+            toggleGraphqlHistoryEntryStar(existingEntry)
           })
         }
       }

--- a/packages/hoppscotch-selfhost-web/src/platform/history/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/history/desktop/index.ts
@@ -15,6 +15,7 @@ import {
   deleteGraphqlHistoryEntry,
   clearGraphqlHistory,
 } from "@hoppscotch/common/newstore/history"
+import { translateToNewRequest, translateToGQLRequest } from "@hoppscotch/data"
 import { HistoryPlatformDef } from "@hoppscotch/common/platform/history"
 import {
   getUserHistoryEntries,
@@ -98,7 +99,7 @@ async function loadHistoryEntries() {
 
     const restHistoryEntries: RESTHistoryEntry[] = restEntries.map((entry) => ({
       v: 1,
-      request: JSON.parse(entry.request),
+      request: translateToNewRequest(JSON.parse(entry.request)),
       responseMeta: JSON.parse(entry.responseMetadata),
       star: entry.isStarred,
       updatedOn: new Date(entry.executedOn),
@@ -107,7 +108,7 @@ async function loadHistoryEntries() {
 
     const gqlHistoryEntries: GQLHistoryEntry[] = gqlEntries.map((entry) => ({
       v: 1,
-      request: JSON.parse(entry.request),
+      request: translateToGQLRequest(JSON.parse(entry.request)),
       response: JSON.parse(entry.responseMetadata),
       star: entry.isStarred,
       updatedOn: new Date(entry.executedOn),
@@ -165,7 +166,7 @@ function setupUserHistoryCreatedSubscription() {
             ? addRESTHistoryEntry({
                 v: 1,
                 id,
-                request: JSON.parse(request),
+                request: translateToNewRequest(JSON.parse(request)),
                 responseMeta: JSON.parse(responseMetadata),
                 star: isStarred,
                 updatedOn: new Date(executedOn),
@@ -173,7 +174,7 @@ function setupUserHistoryCreatedSubscription() {
             : addGraphqlHistoryEntry({
                 v: 1,
                 id,
-                request: JSON.parse(request),
+                request: translateToGQLRequest(JSON.parse(request)),
                 response: JSON.parse(responseMetadata),
                 star: isStarred,
                 updatedOn: new Date(executedOn),
@@ -205,7 +206,7 @@ function setupUserHistoryUpdatedSubscription() {
             toggleRESTHistoryEntryStar({
               v: 1,
               id,
-              request: JSON.parse(request),
+              request: translateToNewRequest(JSON.parse(request)),
               responseMeta: JSON.parse(responseMetadata),
               // because the star will be toggled in the store, we need to pass the opposite value
               star: !isStarred,
@@ -225,7 +226,7 @@ function setupUserHistoryUpdatedSubscription() {
             toggleGraphqlHistoryEntryStar({
               v: 1,
               id,
-              request: JSON.parse(request),
+              request: translateToGQLRequest(JSON.parse(request)),
               response: JSON.parse(responseMetadata),
               // because the star will be toggled in the store, we need to pass the opposite value
               star: !isStarred,

--- a/packages/hoppscotch-selfhost-web/src/platform/history/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/history/desktop/index.ts
@@ -193,25 +193,21 @@ function setupUserHistoryUpdatedSubscription() {
 
   userHistoryUpdated$.subscribe((res) => {
     if (E.isRight(res)) {
-      const { id, executedOn, isStarred, request, responseMetadata, reqType } =
-        res.right.userHistoryUpdated
+      const { id, reqType } = res.right.userHistoryUpdated
 
       if (reqType == ReqType.Rest) {
         const updatedRestEntryIndex = restHistoryStore.value.state.findIndex(
           (entry) => entry.id == id
         )
 
+        // Reuse the existing store entry instead of re-parsing the request from the subscription payload.
+        // toggleStar uses deep equality (isEqual) to match entries, and re-parsing could produce
+        // a different object (e.g. migration adding _ref_id or description defaults), causing the match to fail.
         if (updatedRestEntryIndex != -1) {
           runDispatchWithOutSyncing(() => {
-            toggleRESTHistoryEntryStar({
-              v: 1,
-              id,
-              request: translateToNewRequest(JSON.parse(request)),
-              responseMeta: JSON.parse(responseMetadata),
-              // because the star will be toggled in the store, we need to pass the opposite value
-              star: !isStarred,
-              updatedOn: new Date(executedOn),
-            })
+            toggleRESTHistoryEntryStar(
+              restHistoryStore.value.state[updatedRestEntryIndex]
+            )
           })
         }
       }
@@ -223,15 +219,9 @@ function setupUserHistoryUpdatedSubscription() {
 
         if (updatedGQLEntryIndex != -1) {
           runDispatchWithOutSyncing(() => {
-            toggleGraphqlHistoryEntryStar({
-              v: 1,
-              id,
-              request: translateToGQLRequest(JSON.parse(request)),
-              response: JSON.parse(responseMetadata),
-              // because the star will be toggled in the store, we need to pass the opposite value
-              star: !isStarred,
-              updatedOn: new Date(executedOn),
-            })
+            toggleGraphqlHistoryEntryStar(
+              graphqlHistoryStore.value.state[updatedGQLEntryIndex]
+            )
           })
         }
       }

--- a/packages/hoppscotch-selfhost-web/src/platform/history/web/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/history/web/index.ts
@@ -196,25 +196,21 @@ function setupUserHistoryUpdatedSubscription() {
 
   userHistoryUpdated$.subscribe((res) => {
     if (E.isRight(res)) {
-      const { id, executedOn, isStarred, request, responseMetadata, reqType } =
-        res.right.userHistoryUpdated
+      const { id, reqType } = res.right.userHistoryUpdated
 
       if (reqType == ReqType.Rest) {
         const updatedRestEntryIndex = restHistoryStore.value.state.findIndex(
           (entry) => entry.id == id
         )
 
+        // Reuse the existing store entry instead of re-parsing the request from the subscription payload.
+        // toggleStar uses deep equality (isEqual) to match entries, and re-parsing could produce
+        // a different object (e.g. migration adding _ref_id or description defaults), causing the match to fail.
         if (updatedRestEntryIndex != -1) {
           runDispatchWithOutSyncing(() => {
-            toggleRESTHistoryEntryStar({
-              v: 1,
-              id,
-              request: translateToNewRequest(JSON.parse(request)),
-              responseMeta: JSON.parse(responseMetadata),
-              // because the star will be toggled in the store, we need to pass the opposite value
-              star: !isStarred,
-              updatedOn: new Date(executedOn),
-            })
+            toggleRESTHistoryEntryStar(
+              restHistoryStore.value.state[updatedRestEntryIndex]
+            )
           })
         }
       }
@@ -226,15 +222,9 @@ function setupUserHistoryUpdatedSubscription() {
 
         if (updatedGQLEntryIndex != -1) {
           runDispatchWithOutSyncing(() => {
-            toggleGraphqlHistoryEntryStar({
-              v: 1,
-              id,
-              request: translateToGQLRequest(JSON.parse(request)),
-              response: JSON.parse(responseMetadata),
-              // because the star will be toggled in the store, we need to pass the opposite value
-              star: !isStarred,
-              updatedOn: new Date(executedOn),
-            })
+            toggleGraphqlHistoryEntryStar(
+              graphqlHistoryStore.value.state[updatedGQLEntryIndex]
+            )
           })
         }
       }

--- a/packages/hoppscotch-selfhost-web/src/platform/history/web/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/history/web/index.ts
@@ -15,6 +15,7 @@ import {
   deleteGraphqlHistoryEntry,
   clearGraphqlHistory,
 } from "@hoppscotch/common/newstore/history"
+import { translateToNewRequest, translateToGQLRequest } from "@hoppscotch/data"
 import { HistoryPlatformDef } from "@hoppscotch/common/platform/history"
 import {
   getUserHistoryEntries,
@@ -101,7 +102,7 @@ async function loadHistoryEntries() {
 
     const restHistoryEntries: RESTHistoryEntry[] = restEntries.map((entry) => ({
       v: 1,
-      request: JSON.parse(entry.request),
+      request: translateToNewRequest(JSON.parse(entry.request)),
       responseMeta: JSON.parse(entry.responseMetadata),
       star: entry.isStarred,
       updatedOn: new Date(entry.executedOn),
@@ -110,7 +111,7 @@ async function loadHistoryEntries() {
 
     const gqlHistoryEntries: GQLHistoryEntry[] = gqlEntries.map((entry) => ({
       v: 1,
-      request: JSON.parse(entry.request),
+      request: translateToGQLRequest(JSON.parse(entry.request)),
       response: JSON.parse(entry.responseMetadata),
       star: entry.isStarred,
       updatedOn: new Date(entry.executedOn),
@@ -168,7 +169,7 @@ function setupUserHistoryCreatedSubscription() {
             ? addRESTHistoryEntry({
                 v: 1,
                 id,
-                request: JSON.parse(request),
+                request: translateToNewRequest(JSON.parse(request)),
                 responseMeta: JSON.parse(responseMetadata),
                 star: isStarred,
                 updatedOn: new Date(executedOn),
@@ -176,7 +177,7 @@ function setupUserHistoryCreatedSubscription() {
             : addGraphqlHistoryEntry({
                 v: 1,
                 id,
-                request: JSON.parse(request),
+                request: translateToGQLRequest(JSON.parse(request)),
                 response: JSON.parse(responseMetadata),
                 star: isStarred,
                 updatedOn: new Date(executedOn),
@@ -208,7 +209,7 @@ function setupUserHistoryUpdatedSubscription() {
             toggleRESTHistoryEntryStar({
               v: 1,
               id,
-              request: JSON.parse(request),
+              request: translateToNewRequest(JSON.parse(request)),
               responseMeta: JSON.parse(responseMetadata),
               // because the star will be toggled in the store, we need to pass the opposite value
               star: !isStarred,
@@ -228,7 +229,7 @@ function setupUserHistoryUpdatedSubscription() {
             toggleGraphqlHistoryEntryStar({
               v: 1,
               id,
-              request: JSON.parse(request),
+              request: translateToGQLRequest(JSON.parse(request)),
               response: JSON.parse(responseMetadata),
               // because the star will be toggled in the store, we need to pass the opposite value
               star: !isStarred,

--- a/packages/hoppscotch-selfhost-web/src/platform/history/web/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/history/web/index.ts
@@ -196,35 +196,31 @@ function setupUserHistoryUpdatedSubscription() {
 
   userHistoryUpdated$.subscribe((res) => {
     if (E.isRight(res)) {
-      const { id, reqType } = res.right.userHistoryUpdated
+      const { id, reqType, isStarred } = res.right.userHistoryUpdated
 
       if (reqType == ReqType.Rest) {
-        const updatedRestEntryIndex = restHistoryStore.value.state.findIndex(
+        const existingEntry = restHistoryStore.value.state.find(
           (entry) => entry.id == id
         )
 
-        // Reuse the existing store entry instead of re-parsing the request from the subscription payload.
-        // toggleStar uses deep equality (isEqual) to match entries, and re-parsing could produce
-        // a different object (e.g. migration adding _ref_id or description defaults), causing the match to fail.
-        if (updatedRestEntryIndex != -1) {
+        // Only toggle if the store entry's star doesn't match the server state.
+        // Without this guard, the subscription echo from the same client's own
+        // toggle would cause a second toggle and revert the star.
+        if (existingEntry && existingEntry.star !== isStarred) {
           runDispatchWithOutSyncing(() => {
-            toggleRESTHistoryEntryStar(
-              restHistoryStore.value.state[updatedRestEntryIndex]
-            )
+            toggleRESTHistoryEntryStar(existingEntry)
           })
         }
       }
 
       if (reqType == ReqType.Gql) {
-        const updatedGQLEntryIndex = graphqlHistoryStore.value.state.findIndex(
+        const existingEntry = graphqlHistoryStore.value.state.find(
           (entry) => entry.id == id
         )
 
-        if (updatedGQLEntryIndex != -1) {
+        if (existingEntry && existingEntry.star !== isStarred) {
           runDispatchWithOutSyncing(() => {
-            toggleGraphqlHistoryEntryStar(
-              graphqlHistoryStore.value.state[updatedGQLEntryIndex]
-            )
+            toggleGraphqlHistoryEntryStar(existingEntry)
           })
         }
       }


### PR DESCRIPTION


<!-- If this pull request closes an issue, please mention the issue number below -->
Closes FE-1174

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This PR fixes the issue where the app threw restHistory schema mismatch error due to missing field in rest history entry.
Also add translateToNewRequest to history request for parsing request and translate to latest request version while syncing

This pull request improves how request objects are handled and stored in the history feature for both REST and GraphQL entries. The main changes ensure that all request data is properly transformed using dedicated translation functions, leading to more consistent data handling across the application. Additionally, a new `description` field is now included when storing history entries.

Key improvements include:

**Consistent Request Transformation:**

* Replaced direct use of `JSON.parse` for loading and updating REST and GraphQL history entries with the `translateToNewRequest` and `translateToGQLRequest` functions, respectively, in both the desktop and web history platform implementations. This ensures all request objects are consistently normalized before being processed or stored. [[1]](diffhunk://#diff-b59d3c450cfc36aa572554e8562b70ee2f567b0c761936a5dc7dc4a0d3e47774L101-R102) [[2]](diffhunk://#diff-b59d3c450cfc36aa572554e8562b70ee2f567b0c761936a5dc7dc4a0d3e47774L110-R111) [[3]](diffhunk://#diff-b59d3c450cfc36aa572554e8562b70ee2f567b0c761936a5dc7dc4a0d3e47774L168-R177) [[4]](diffhunk://#diff-b59d3c450cfc36aa572554e8562b70ee2f567b0c761936a5dc7dc4a0d3e47774L208-R209) [[5]](diffhunk://#diff-b59d3c450cfc36aa572554e8562b70ee2f567b0c761936a5dc7dc4a0d3e47774L228-R229) [[6]](diffhunk://#diff-8b5ef05e1f865ce6390c503128d882963fc6b4199c974caf7029a8b156f29b13L104-R105) [[7]](diffhunk://#diff-8b5ef05e1f865ce6390c503128d882963fc6b4199c974caf7029a8b156f29b13L113-R114) [[8]](diffhunk://#diff-8b5ef05e1f865ce6390c503128d882963fc6b4199c974caf7029a8b156f29b13L171-R180) [[9]](diffhunk://#diff-8b5ef05e1f865ce6390c503128d882963fc6b4199c974caf7029a8b156f29b13L211-R212) [[10]](diffhunk://#diff-8b5ef05e1f865ce6390c503128d882963fc6b4199c974caf7029a8b156f29b13L231-R232)

* Added imports for `translateToNewRequest` and `translateToGQLRequest` in the corresponding files to support the new transformation logic. [[1]](diffhunk://#diff-b59d3c450cfc36aa572554e8562b70ee2f567b0c761936a5dc7dc4a0d3e47774R18) [[2]](diffhunk://#diff-8b5ef05e1f865ce6390c503128d882963fc6b4199c974caf7029a8b156f29b13R18)

**History Entry Enhancements:**

* Added a `description` field to the stored request object in the history store for improved metadata tracking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FE-1174 by preventing REST history schema mismatches and normalizing requests across REST and GraphQL on desktop and web. Upgrades old entries on load/sync and makes star updates reliable.

- **Bug Fixes**
  - Normalize requests using `translateToNewRequest`/`translateToGQLRequest` on load/create, and only toggle stars when the local state differs, reusing the in-store entry to avoid re-parsing and double-toggles.
  - When adding REST history, store a full request snapshot by spreading fields and excluding `_ref_id` and `id`, preserving new and future fields (like `description`) without references.

<sup>Written for commit 40729c7e627d6ce86fb45fa5ef254eb4a0c89c33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

