### PR TITLE
fix(backend): prevent request loss in large team collections

### DIFF
--- a/packages/hoppscotch-backend/src/team-request/team-request.service.spec.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.spec.ts
@@ -338,6 +338,19 @@ describe('getRequestsInCollection', () => {
 
     expect(response).resolves.toEqual([teamRequests[1]]);
   });
+
+  test('resolves with an empty array when cursor is provided but cursor item is not found', async () => {
+    mockPrisma.teamRequest.findFirst.mockResolvedValueOnce(null);
+
+    const result = await teamRequestService.getRequestsInCollection(
+      'testcoll',
+      'nonexistent-cursor',
+      10,
+    );
+
+    expect(result).toEqual([]);
+    expect(mockPrisma.teamRequest.findMany).not.toHaveBeenCalled();
+  });
 });
 
 describe('getRequest', () => {

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.spec.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.spec.ts
@@ -328,19 +328,48 @@ describe('getRequestsInCollection', () => {
   });
 
   test('resolves with the correct info for the collection id and a valid cursor', async () => {
+    mockPrisma.teamRequest.findFirst.mockResolvedValue({
+      orderIndex: dbTeamRequests[0].orderIndex,
+    } as DbTeamRequest);
     mockPrisma.teamRequest.findMany.mockResolvedValue([dbTeamRequests[1]]);
 
-    const response = teamRequestService.getRequestsInCollection(
+    const response = await teamRequestService.getRequestsInCollection(
       dbTeamRequests[1].collectionID,
       dbTeamRequests[0].id,
       1,
     );
 
-    expect(response).resolves.toEqual([teamRequests[1]]);
+    expect(response).toEqual([teamRequests[1]]);
+  });
+
+  test('paginates on the orderIndex of the cursor item, scoped to the collection', async () => {
+    mockPrisma.teamRequest.findFirst.mockResolvedValue({
+      orderIndex: dbTeamRequests[0].orderIndex,
+    } as DbTeamRequest);
+    mockPrisma.teamRequest.findMany.mockResolvedValue([dbTeamRequests[1]]);
+
+    await teamRequestService.getRequestsInCollection(
+      teamCollection.id,
+      dbTeamRequests[0].id,
+      1,
+    );
+
+    expect(mockPrisma.teamRequest.findFirst).toHaveBeenCalledWith({
+      where: { id: dbTeamRequests[0].id, collectionID: teamCollection.id },
+      select: { orderIndex: true },
+    });
+    expect(mockPrisma.teamRequest.findMany).toHaveBeenCalledWith({
+      take: 1,
+      where: {
+        collectionID: teamCollection.id,
+        orderIndex: { gt: dbTeamRequests[0].orderIndex },
+      },
+      orderBy: { orderIndex: 'asc' },
+    });
   });
 
   test('resolves with an empty array when cursor is provided but cursor item is not found', async () => {
-    mockPrisma.teamRequest.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.teamRequest.findFirst.mockResolvedValue(null);
 
     const result = await teamRequestService.getRequestsInCollection(
       'testcoll',
@@ -350,6 +379,23 @@ describe('getRequestsInCollection', () => {
 
     expect(result).toEqual([]);
     expect(mockPrisma.teamRequest.findMany).not.toHaveBeenCalled();
+  });
+
+  test('does not look up a cursor item when no cursor is provided', async () => {
+    mockPrisma.teamRequest.findMany.mockResolvedValue(dbTeamRequests);
+
+    await teamRequestService.getRequestsInCollection(
+      teamCollection.id,
+      null,
+      10,
+    );
+
+    expect(mockPrisma.teamRequest.findFirst).not.toHaveBeenCalled();
+    expect(mockPrisma.teamRequest.findMany).toHaveBeenCalledWith({
+      take: 10,
+      where: { collectionID: teamCollection.id },
+      orderBy: { orderIndex: 'asc' },
+    });
   });
 });
 

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -239,7 +239,10 @@ export class TeamRequestService {
 
     if (cursor) {
       const cursorItem = await this.prisma.teamRequest.findFirst({
-        where: { id: cursor },
+      const cursorItem = await this.prisma.teamRequest.findFirst({
+        where: { id: cursor, collectionID },
+        select: { orderIndex: true },
+      });
         select: { orderIndex: true },
       });
 

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -233,26 +233,34 @@ export class TeamRequestService {
     cursor: string,
     take = 10,
   ) {
-    // Using orderIndex-based pagination instead of cursor pagination
-    // to avoid inconsistencies when orderIndex changes (e.g., during reordering)
     let whereClause: Prisma.TeamRequestWhereInput = { collectionID };
 
     if (cursor) {
       const cursorItem = await this.prisma.teamRequest.findFirst({
-      const cursorItem = await this.prisma.teamRequest.findFirst({
         where: { id: cursor, collectionID },
         select: { orderIndex: true },
       });
-        select: { orderIndex: true },
-      });
-
-      if (cursorItem) {
-        whereClause = {
-          collectionID,
-          orderIndex: { gt: cursorItem.orderIndex },
-        };
+  
+      if (!cursorItem) {
+        return [];
       }
+  
+      whereClause = {
+        collectionID,
+        orderIndex: { gt: cursorItem.orderIndex },
+      };
     }
+
+    const dbTeamRequests = await this.prisma.teamRequest.findMany({
+      take,
+      where: whereClause,
+      orderBy: {
+        orderIndex: 'asc',
+      },
+    });
+
+    return dbTeamRequests.map((tr) => this.cast(tr));
+  }
     
     const dbTeamRequests = await this.prisma.teamRequest.findMany({
       take,

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -233,13 +233,27 @@ export class TeamRequestService {
     cursor: string,
     take = 10,
   ) {
+    // Using orderIndex-based pagination instead of cursor pagination
+    // to avoid inconsistencies when orderIndex changes (e.g., during reordering)
+    let whereClause: Prisma.TeamRequestWhereInput = { collectionID };
+
+    if (cursor) {
+      const cursorItem = await this.prisma.teamRequest.findFirst({
+        where: { id: cursor },
+        select: { orderIndex: true },
+      });
+
+      if (cursorItem) {
+        whereClause = {
+          collectionID,
+          orderIndex: { gt: cursorItem.orderIndex },
+        };
+      }
+    }
+    
     const dbTeamRequests = await this.prisma.teamRequest.findMany({
-      cursor: cursor ? { id: cursor } : undefined,
-      take: take,
-      skip: cursor ? 1 : 0,
-      where: {
-        collectionID: collectionID,
-      },
+      take,
+      where: whereClause,
       orderBy: {
         orderIndex: 'asc',
       },

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -234,7 +234,7 @@ export class TeamRequestService {
     take = 10,
   ) {
     let whereClause: Prisma.TeamRequestWhereInput = { collectionID };
-
+  
     if (cursor) {
       const cursorItem = await this.prisma.teamRequest.findFirst({
         where: { id: cursor, collectionID },
@@ -250,7 +250,7 @@ export class TeamRequestService {
         orderIndex: { gt: cursorItem.orderIndex },
       };
     }
-
+  
     const dbTeamRequests = await this.prisma.teamRequest.findMany({
       take,
       where: whereClause,
@@ -258,20 +258,8 @@ export class TeamRequestService {
         orderIndex: 'asc',
       },
     });
-
+  
     return dbTeamRequests.map((tr) => this.cast(tr));
-  }
-    
-    const dbTeamRequests = await this.prisma.teamRequest.findMany({
-      take,
-      where: whereClause,
-      orderBy: {
-        orderIndex: 'asc',
-      },
-    });
-
-    const teamRequests = dbTeamRequests.map((tr) => this.cast(tr));
-    return teamRequests;
   }
 
   /**

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -226,8 +226,15 @@ export class TeamRequestService {
 
   /**
    * Fetch team requests by Collection ID
+   *
+   * Pagination is keyed on `orderIndex` (unique per collection, see the
+   * `TeamRequest_teamID_collectionID_orderIndex_key` constraint) instead of
+   * Prisma's `cursor` + `skip`, so a page never depends on the offset of the
+   * cursor row within the result set.
+   *
    * @param collectionID Collection ID to fetch requests in
-   * @param cursor Cursor for pagination
+   * @param cursor ID of the last request of the previous page. Must belong to
+   * `collectionID`; an unknown cursor resolves to an empty page
    * @param take Take number of requests
    * @returns
    */
@@ -237,23 +244,21 @@ export class TeamRequestService {
     take = 10,
   ) {
     let whereClause: Prisma.TeamRequestWhereInput = { collectionID };
-  
+
     if (cursor) {
       const cursorItem = await this.prisma.teamRequest.findFirst({
         where: { id: cursor, collectionID },
         select: { orderIndex: true },
       });
-  
-      if (!cursorItem) {
-        return [];
-      }
-  
+
+      if (!cursorItem) return [];
+
       whereClause = {
         collectionID,
         orderIndex: { gt: cursorItem.orderIndex },
       };
     }
-  
+
     const dbTeamRequests = await this.prisma.teamRequest.findMany({
       take,
       where: whereClause,
@@ -261,7 +266,7 @@ export class TeamRequestService {
         orderIndex: 'asc',
       },
     });
-  
+
     return dbTeamRequests.map((tr) => this.cast(tr));
   }
 

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -237,7 +237,7 @@ export class TeamRequestService {
     take = 10,
   ) {
     let whereClause: Prisma.TeamRequestWhereInput = { collectionID };
-
+  
     if (cursor) {
       const cursorItem = await this.prisma.teamRequest.findFirst({
         where: { id: cursor, collectionID },
@@ -253,7 +253,7 @@ export class TeamRequestService {
         orderIndex: { gt: cursorItem.orderIndex },
       };
     }
-
+  
     const dbTeamRequests = await this.prisma.teamRequest.findMany({
       take,
       where: whereClause,
@@ -261,20 +261,8 @@ export class TeamRequestService {
         orderIndex: 'asc',
       },
     });
-
+  
     return dbTeamRequests.map((tr) => this.cast(tr));
-  }
-    
-    const dbTeamRequests = await this.prisma.teamRequest.findMany({
-      take,
-      where: whereClause,
-      orderBy: {
-        orderIndex: 'asc',
-      },
-    });
-
-    const teamRequests = dbTeamRequests.map((tr) => this.cast(tr));
-    return teamRequests;
   }
 
   /**

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -236,26 +236,34 @@ export class TeamRequestService {
     cursor: string,
     take = 10,
   ) {
-    // Using orderIndex-based pagination instead of cursor pagination
-    // to avoid inconsistencies when orderIndex changes (e.g., during reordering)
     let whereClause: Prisma.TeamRequestWhereInput = { collectionID };
 
     if (cursor) {
       const cursorItem = await this.prisma.teamRequest.findFirst({
-      const cursorItem = await this.prisma.teamRequest.findFirst({
         where: { id: cursor, collectionID },
         select: { orderIndex: true },
       });
-        select: { orderIndex: true },
-      });
-
-      if (cursorItem) {
-        whereClause = {
-          collectionID,
-          orderIndex: { gt: cursorItem.orderIndex },
-        };
+  
+      if (!cursorItem) {
+        return [];
       }
+  
+      whereClause = {
+        collectionID,
+        orderIndex: { gt: cursorItem.orderIndex },
+      };
     }
+
+    const dbTeamRequests = await this.prisma.teamRequest.findMany({
+      take,
+      where: whereClause,
+      orderBy: {
+        orderIndex: 'asc',
+      },
+    });
+
+    return dbTeamRequests.map((tr) => this.cast(tr));
+  }
     
     const dbTeamRequests = await this.prisma.teamRequest.findMany({
       take,

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -242,7 +242,10 @@ export class TeamRequestService {
 
     if (cursor) {
       const cursorItem = await this.prisma.teamRequest.findFirst({
-        where: { id: cursor },
+      const cursorItem = await this.prisma.teamRequest.findFirst({
+        where: { id: cursor, collectionID },
+        select: { orderIndex: true },
+      });
         select: { orderIndex: true },
       });
 

--- a/packages/hoppscotch-backend/src/team-request/team-request.service.ts
+++ b/packages/hoppscotch-backend/src/team-request/team-request.service.ts
@@ -236,13 +236,27 @@ export class TeamRequestService {
     cursor: string,
     take = 10,
   ) {
+    // Using orderIndex-based pagination instead of cursor pagination
+    // to avoid inconsistencies when orderIndex changes (e.g., during reordering)
+    let whereClause: Prisma.TeamRequestWhereInput = { collectionID };
+
+    if (cursor) {
+      const cursorItem = await this.prisma.teamRequest.findFirst({
+        where: { id: cursor },
+        select: { orderIndex: true },
+      });
+
+      if (cursorItem) {
+        whereClause = {
+          collectionID,
+          orderIndex: { gt: cursorItem.orderIndex },
+        };
+      }
+    }
+    
     const dbTeamRequests = await this.prisma.teamRequest.findMany({
-      cursor: cursor ? { id: cursor } : undefined,
-      take: take,
-      skip: cursor ? 1 : 0,
-      where: {
-        collectionID: collectionID,
-      },
+      take,
+      where: whereClause,
       orderBy: {
         orderIndex: 'asc',
       },


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4767 also seems to fix #2986

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed

Fixes an issue where imported collections in team workspaces were not fully persisted
and appeared to lose requests after refresh.

In affected cases, large collections (e.g. 16 requests) were partially visible immediately
after import, but some requests disappeared after page reload. This was observed in both
desktop and web clients.

The issue was specific to team workspaces and did not affect personal workspaces.

Root cause
Pagination in getRequestsInCollection relied on Prisma cursor-based pagination
(cursor + skip), which becomes unstable when orderIndex changes during operations
like bulk imports or reordering.

This could result in:
- missing requests
- duplicated requests
- inconsistent results after refresh

#### Changes
`team-request.service.ts`

Replaced cursor-based pagination with orderIndex-based pagination:
- Resolve cursor item's orderIndex
- Fetch using orderIndex > cursor.orderIndex
- Remove usage of cursor and skip

This ensures stable and deterministic pagination even when orderIndex changes.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
Minimal and isolated change affecting only getRequestsInCollection.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing or duplicated requests in large team collections by switching to `orderIndex`-based pagination. Also improves environment variable handling and desktop stability, and applies security patches.

- **Bug Fixes**
  - Switched `getRequestsInCollection` to `orderIndex` pagination (`orderIndex > cursor.orderIndex`, `orderBy: asc`) with a single `where` in `packages/hoppscotch-backend/src/team-request/team-request.service.ts`; invalid cursors return an empty page. Added a unit test to cover the missing-cursor case.
  - Unmapped Ctrl+Backspace and Ctrl+Delete to prevent accidental response clearing while editing.
  - Hardened history handling: `responseMeta` parsing now accepts object or string, and REST/GQL history queries support a `take` limit.

- **New Features**
  - Environment variables now resolve with a current→initial fallback at execution time; secret values are masked in previews/autocomplete; per-user `currentValue` stays client-local on wire writes. Replaced `~/helpers/secretVariables` with `~/helpers/clientLocalVariables`.
  - Desktop: added bounded connection timeout used by instance downloads and hid the native Edit menu bar on Linux for new windows.
  - Security: pinned vulnerable transitive dependencies to patched versions (e.g., `xmldom`, `minimatch`, `js-yaml`, `linkify-it`).

<sup>Written for commit 63f2c79c18d16793aa2ff4f58b1e20b971e53eb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





