### PR TITLE
fix(common): align documentation modal height in tauri (#5938)

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/documentation/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/documentation/index.vue
@@ -8,7 +8,7 @@
     @close="hideModal"
   >
     <template #body>
-      <div class="w-full h-[80vh] overflow-hidden">
+      <div class="w-full min-h-0 h-[60vh] overflow-hidden">
         <div class="flex h-full">
           <div class="flex-1 flex">
             <CollectionsDocumentationPreview


### PR DESCRIPTION
 ## Summary

    Fix the documentation modal layout in Tauri by aligning the inner content
  height with the modal body's actual height constraint.

    Previously, the modal body was limited by `HoppSmartModal` to `max-h-
  [60vh]`, while the inner documentation container used a fixed `h-[80vh]`. This
  caused the modal content to be cut off in Tauri/Linux even after scrolling to
  the bottom.

    Closes #5938

    ## Changes

    - replace the inner documentation container height from `h-[80vh]` to `min-
  h-0 h-[60vh]`
    - keep the modal content within the actual available body height
    - preserve the existing modal structure and behavior with a minimal layout-
  only change

    ## Why

    The issue comes from a height mismatch between the modal body and its child
  content.

    By making the inner container respect the same effective height budget as
  the modal body, the documentation view no longer overflows past the visible
  area in Tauri.

    ## Testing

    Validated with:

    - repository pre-commit checks on commit
    - workspace lint
    - workspace typecheck

    ## Files Changed

    - `packages/hoppscotch-
  common/src/components/collections/documentation/index.vue`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the documentation modal overflow in Tauri/Linux by matching the inner container height to the modal body's 60vh limit. Prevents content from being cut off at the bottom. Closes #5938.

- **Bug Fixes**
  - Changed inner container in `packages/hoppscotch-common/src/components/collections/documentation/index.vue` from `h-[80vh]` to `min-h-0 h-[60vh]` to align with `HoppSmartModal`’s `max-h-[60vh]`.

<sup>Written for commit c0b4c5d0e123ccbe7ab6b90bdd413b4b4290d4ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

