### PR TITLE
fix(common): decode URL-encoded Postman variables during collection import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -504,7 +504,7 @@ const getHoppReqURL = (url: Item["request"]["url"] | null): string => {
     // Postman SDK's toString() URL-encodes path segments, which turns
     // variable syntax {{var}} into %7B%7Bvar%7D%7D. Decode first so
     // replacePMVarTemplating can match the original double-brace pattern.
-    (s) => decodeURIComponent(s),
+    (s) => { try { return decodeURIComponent(s) } catch { return s } },
     S.replace(/\?.+/g, ""),
     replacePMVarTemplating
   )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -504,7 +504,7 @@ const getHoppReqURL = (url: Item["request"]["url"] | null): string => {
     // Postman SDK's toString() URL-encodes path segments, which turns
     // variable syntax {{var}} into %7B%7Bvar%7D%7D. Decode first so
     // replacePMVarTemplating can match the original double-brace pattern.
-    (s) => { try { return decodeURIComponent(s) } catch { return s } },
+    (s) => { try { return decodeURI(s) } catch { return s } },
     S.replace(/\?.+/g, ""),
     replacePMVarTemplating
   )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -501,11 +501,13 @@ const getHoppReqURL = (url: Item["request"]["url"] | null): string => {
   if (!url) return ""
   return pipe(
     url.toString(false),
-    // Postman SDK's toString() URL-encodes path segments, which turns
-    // variable syntax {{var}} into %7B%7Bvar%7D%7D. Decode first so
-    // replacePMVarTemplating can match the original double-brace pattern.
-    (s) => { try { return decodeURI(s) } catch { return s } },
+    // Strip query string before decoding to avoid decoded %3F in path
+    // segments being erroneously removed by the query-strip regex.
     S.replace(/\?.+/g, ""),
+    // Postman SDK's toString() URL-encodes path segments, which turns
+    // variable syntax {{var}} into %7B%7Bvar%7D%7D. Decode after query
+    // removal so replacePMVarTemplating can match double-brace patterns.
+    (s) => { try { return decodeURI(s) } catch { return s } },
     replacePMVarTemplating
   )
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -501,6 +501,10 @@ const getHoppReqURL = (url: Item["request"]["url"] | null): string => {
   if (!url) return ""
   return pipe(
     url.toString(false),
+    // Postman SDK's toString() URL-encodes path segments, which turns
+    // variable syntax {{var}} into %7B%7Bvar%7D%7D. Decode first so
+    // replacePMVarTemplating can match the original double-brace pattern.
+    (s) => decodeURIComponent(s),
     S.replace(/\?.+/g, ""),
     replacePMVarTemplating
   )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -510,7 +510,7 @@ const getHoppReqURL = (url: Item["request"]["url"] | null): string => {
     // Postman SDK's toString() URL-encodes path segments, which turns
     // variable syntax {{var}} into %7B%7Bvar%7D%7D. Decode first so
     // replacePMVarTemplating can match the original double-brace pattern.
-    (s) => { try { return decodeURIComponent(s) } catch { return s } },
+    (s) => { try { return decodeURI(s) } catch { return s } },
     S.replace(/\?.+/g, ""),
     replacePMVarTemplating
   )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -507,6 +507,10 @@ const getHoppReqURL = (url: Item["request"]["url"] | null): string => {
   if (!url) return ""
   return pipe(
     url.toString(false),
+    // Postman SDK's toString() URL-encodes path segments, which turns
+    // variable syntax {{var}} into %7B%7Bvar%7D%7D. Decode first so
+    // replacePMVarTemplating can match the original double-brace pattern.
+    (s) => decodeURIComponent(s),
     S.replace(/\?.+/g, ""),
     replacePMVarTemplating
   )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -507,11 +507,13 @@ const getHoppReqURL = (url: Item["request"]["url"] | null): string => {
   if (!url) return ""
   return pipe(
     url.toString(false),
-    // Postman SDK's toString() URL-encodes path segments, which turns
-    // variable syntax {{var}} into %7B%7Bvar%7D%7D. Decode first so
-    // replacePMVarTemplating can match the original double-brace pattern.
-    (s) => { try { return decodeURI(s) } catch { return s } },
+    // Strip query string before decoding to avoid decoded %3F in path
+    // segments being erroneously removed by the query-strip regex.
     S.replace(/\?.+/g, ""),
+    // Postman SDK's toString() URL-encodes path segments, which turns
+    // variable syntax {{var}} into %7B%7Bvar%7D%7D. Decode after query
+    // removal so replacePMVarTemplating can match double-brace patterns.
+    (s) => { try { return decodeURI(s) } catch { return s } },
     replacePMVarTemplating
   )
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -510,7 +510,7 @@ const getHoppReqURL = (url: Item["request"]["url"] | null): string => {
     // Postman SDK's toString() URL-encodes path segments, which turns
     // variable syntax {{var}} into %7B%7Bvar%7D%7D. Decode first so
     // replacePMVarTemplating can match the original double-brace pattern.
-    (s) => decodeURIComponent(s),
+    (s) => { try { return decodeURIComponent(s) } catch { return s } },
     S.replace(/\?.+/g, ""),
     replacePMVarTemplating
   )


### PR DESCRIPTION
## Summary

Fixes #6140

When importing a Postman v2.1 JSON collection with variable-templated URLs like `{{demo-host}}/a/b/c`, the URL was imported as `%7B%7Bdemo-host%7D%7D/a/b/c` instead of the expected `<<demo-host>>/a/b/c`.

## Root Cause

In `getHoppReqURL()` (`postman.ts`), the Postman SDK's `Url.toString(false)` URL-encodes path segments before `replacePMVarTemplating` runs. This turns `{{` and `}}` into `%7B%7B` and `%7D%7D`, which no longer match the regex pattern in `replacePMVarTemplating`.

## Fix

Add `decodeURIComponent()` before `replacePMVarTemplating` in the `getHoppReqURL` pipeline. This restores the original `{{…}}` pattern so the template replacement works correctly.

## Before / After

| Before | After |
|--------|-------|
| `%7B%7Bdemo-host%7D%7D/a/b/c` | `<<demo-host>>/a/b/c` |


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6140: Postman v2.1 import now decodes URL-encoded variable placeholders so `{{demo-host}}` becomes `<<demo-host>>` instead of `%7B%7Bdemo-host%7D%7D`.

In `getHoppReqURL`, we strip the query string, run `decodeURI` in a try/catch to restore `{{…}}` without decoding reserved characters, then apply templating—preserving path `%3F` and avoiding crashes on malformed URLs.

<sup>Written for commit 22411224561e4ceaac6b2b1ab6915b63c23edfff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6143?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

