### PR TITLE
Fix(cli): trim and safely resolve environment variable values

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/unit/processVariables.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/processVariables.spec.ts
@@ -1,0 +1,75 @@
+import { Environment } from "@hoppscotch/data";
+import { describe, expect, test, vi } from "vitest";
+
+import { processVariables } from "../../utils/request";
+
+describe("processVariables", () => {
+  const createSecretVariable = (
+    overrides: Partial<Environment["variables"][number]> = {}
+  ) =>
+    ({
+      key: "TEST_SECRET",
+      initialValue: "initial-secret",
+      currentValue: "",
+      secret: true,
+      ...overrides,
+    }) as Environment["variables"][number];
+
+  test("preserves whitespace in currentValue", () => {
+    vi.stubEnv("TEST_SECRET", "  env-secret  ");
+
+    const variable = createSecretVariable({
+      currentValue: "  current-secret  ",
+    });
+
+    expect(processVariables(variable).currentValue).toBe("  current-secret  ");
+
+    vi.unstubAllEnvs();
+  });
+
+  test("preserves whitespace in process.env value", () => {
+    vi.stubEnv("TEST_SECRET", "  env-secret  ");
+
+    const variable = createSecretVariable({
+      currentValue: "",
+    });
+
+    expect(processVariables(variable).currentValue).toBe("  env-secret  ");
+
+    vi.unstubAllEnvs();
+  });
+
+  test("preserves whitespace in initialValue", () => {
+    const variable = createSecretVariable({
+      currentValue: "",
+      initialValue: "  initial-secret  ",
+    });
+
+    expect(processVariables(variable).currentValue).toBe("  initial-secret  ");
+  });
+
+  test("falls back when currentValue contains only whitespace", () => {
+    vi.stubEnv("TEST_SECRET", "  env-secret  ");
+
+    const variable = createSecretVariable({
+      currentValue: "   ",
+    });
+
+    expect(processVariables(variable).currentValue).toBe("  env-secret  ");
+
+    vi.unstubAllEnvs();
+  });
+
+  test("falls back to initialValue when currentValue and env are whitespace", () => {
+    vi.stubEnv("TEST_SECRET", "   ");
+
+    const variable = createSecretVariable({
+      currentValue: "   ",
+      initialValue: "  initial-secret  ",
+    });
+
+    expect(processVariables(variable).currentValue).toBe("  initial-secret  ");
+
+    vi.unstubAllEnvs();
+  });
+});

--- a/packages/hoppscotch-cli/src/__tests__/unit/processVariables.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/processVariables.spec.ts
@@ -40,12 +40,16 @@ describe("processVariables", () => {
   });
 
   test("preserves whitespace in initialValue", () => {
+    vi.stubEnv("TEST_SECRET", "");
+
     const variable = createSecretVariable({
       currentValue: "",
       initialValue: "  initial-secret  ",
     });
 
     expect(processVariables(variable).currentValue).toBe("  initial-secret  ");
+
+    vi.unstubAllEnvs();
   });
 
   test("falls back when currentValue contains only whitespace", () => {

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -39,16 +39,38 @@ import { getTestScriptParams, hasFailedTestCases, testRunner } from "./test";
  * @returns Updated variable with value from system environment
  */
 const processVariables = (variable: Environment["variables"][number]) => {
-  if (variable.secret) {
-    return {
-      ...variable,
-      currentValue:
-        "currentValue" in variable && variable.currentValue !== ""
-          ? variable.currentValue
-          : process.env[variable.key] || variable.initialValue,
-    };
+  const trimIfString = (val: unknown) =>
+    typeof val === "string" ? val.trim() : val;
+
+  // Only process secret variables to avoid changing existing behavior
+  if (!variable.secret) {
+    return variable; 
   }
-  return variable;
+
+  const envValue = trimIfString(process.env[variable.key]);
+
+  const current = trimIfString(
+    "currentValue" in variable ? variable.currentValue : undefined
+  );
+
+  const initial = trimIfString(variable.initialValue);
+
+  let resolvedValue: unknown;
+
+  if (typeof current === "string" && current.length > 0) {
+    resolvedValue = current;
+  } else if (typeof envValue === "string" && envValue.length > 0) {
+    resolvedValue = envValue;
+  } else if (typeof initial === "string" && initial.length > 0) {
+    resolvedValue = initial;
+  } else {
+    resolvedValue = "";
+  }
+
+  return {
+    ...variable,
+    currentValue: resolvedValue,
+  };
 };
 
 /**

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -38,30 +38,28 @@ import { getTestScriptParams, hasFailedTestCases, testRunner } from "./test";
  * @param variable Variable to be processed
  * @returns Updated variable with value from system environment
  */
-const processVariables = (variable: Environment["variables"][number]) => {
-  const trimIfString = (val: unknown) =>
-    typeof val === "string" ? val.trim() : val;
-
-  // Only process secret variables to avoid changing existing behavior
+export const processVariables = (
+  variable: Environment["variables"][number]
+) => {
   if (!variable.secret) {
-    return variable; 
+    return variable;
   }
 
-  const envValue = trimIfString(process.env[variable.key]);
+  const isNonEmptyString = (value: unknown): value is string =>
+    typeof value === "string" && value.trim().length > 0;
 
-  const current = trimIfString(
-    "currentValue" in variable ? variable.currentValue : undefined
-  );
+  const current =
+    "currentValue" in variable ? variable.currentValue : undefined;
+  const envValue = process.env[variable.key];
+  const initial = variable.initialValue;
 
-  const initial = trimIfString(variable.initialValue);
+  let resolvedValue: string;
 
-  let resolvedValue: unknown;
-
-  if (typeof current === "string" && current.length > 0) {
+  if (isNonEmptyString(current)) {
     resolvedValue = current;
-  } else if (typeof envValue === "string" && envValue.length > 0) {
+  } else if (isNonEmptyString(envValue)) {
     resolvedValue = envValue;
-  } else if (typeof initial === "string" && initial.length > 0) {
+  } else if (isNonEmptyString(initial)) {
     resolvedValue = initial;
   } else {
     resolvedValue = "";


### PR DESCRIPTION
### Summary
This PR improves environment variable handling in the CLI by:

- Trimming whitespace from environment values
- Prioritizing currentValue > env > initialValue
- Avoiding unintended empty string overrides
- Ensuring consistent resolution logic

### Why
Previously:
- Values with spaces were not handled properly
- Empty strings could override valid values
- Resolution order was inconsistent

### Scope
- Only affects environment variable resolution
- No changes to CLI behavior outside this logic

### Tests
- Existing tests pass without modification


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI secret environment variable resolution so values keep their whitespace while whitespace-only values no longer override valid ones.

- **Bug Fixes**
  - Resolves secret variables in priority order: current > env > initial.
  - Treats whitespace-only values as empty for fallback but preserves their original whitespace when selected.
  - Leaves non-secret variables unchanged.

<sup>Written for commit 4a09b25ae47f45e018cec0b2b204e3cf4045957b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


