### PR TITLE
fix(security): prevent mass assignment in onboarding

### DIFF
--- a/packages/hoppscotch-backend/src/access-token/dto/create-access-token.dto.ts
+++ b/packages/hoppscotch-backend/src/access-token/dto/create-access-token.dto.ts
@@ -1,5 +1,12 @@
+import { IsNotEmpty, IsNumber, IsString, ValidateIf } from 'class-validator';
+
 // Inputs to create a new PAT
 export class CreateAccessTokenDto {
+  @IsString()
+  @IsNotEmpty()
   label: string;
+
+  @ValidateIf((o) => o.expiryInDays !== null)
+  @IsNumber()
   expiryInDays: number | null;
 }

--- a/packages/hoppscotch-backend/src/admin/infra.resolver.ts
+++ b/packages/hoppscotch-backend/src/admin/infra.resolver.ts
@@ -34,6 +34,7 @@ import {
 } from 'src/infra-config/input-args';
 import { InfraConfigEnum } from 'src/types/InfraConfig';
 import { ServiceStatus } from 'src/infra-config/helper';
+import { FetchAllTeamsV2Args, FetchAllUsersV2Args } from './input-types.args';
 
 @UseGuards(GqlThrottlerGuard)
 @Resolver(() => Infra)
@@ -92,19 +93,11 @@ export class InfraResolver {
     description: 'Returns a list of all the users in infra',
   })
   @UseGuards(GqlAuthGuard, GqlAdminGuard)
-  async allUsersV2(
-    @Args({
-      name: 'searchString',
-      nullable: true,
-      description: 'Search on users displayName or email',
-    })
-    searchString: string,
-    @Args() paginationOption: OffsetPaginationArgs,
-  ): Promise<AuthUser[]> {
-    const users = await this.adminService.fetchUsersV2(
-      searchString,
-      paginationOption,
-    );
+  async allUsersV2(@Args() args: FetchAllUsersV2Args): Promise<AuthUser[]> {
+    const users = await this.adminService.fetchUsersV2(args.searchString, {
+      skip: args.skip,
+      take: args.take,
+    });
     return users;
   }
 
@@ -130,19 +123,11 @@ export class InfraResolver {
   @ResolveField(() => [Team], {
     description: 'Returns a list of all the teams in the infra',
   })
-  async allTeamsV2(
-    @Args({
-      name: 'searchString',
-      nullable: true,
-      description: 'Search on team name or ID',
-    })
-    searchString: string,
-    @Args() paginationOption: OffsetPaginationArgs,
-  ): Promise<Team[]> {
-    const teams = await this.adminService.fetchAllTeamsV2(
-      searchString,
-      paginationOption,
-    );
+  async allTeamsV2(@Args() args: FetchAllTeamsV2Args): Promise<Team[]> {
+    const teams = await this.adminService.fetchAllTeamsV2(args.searchString, {
+      skip: args.skip,
+      take: args.take,
+    });
     return teams;
   }
 

--- a/packages/hoppscotch-backend/src/admin/input-types.args.ts
+++ b/packages/hoppscotch-backend/src/admin/input-types.args.ts
@@ -1,6 +1,31 @@
 import { Field, ID, ArgsType } from '@nestjs/graphql';
 import { TeamAccessRole } from '../team/team.model';
-import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { OffsetPaginationArgs } from 'src/types/input-types.args';
+
+@ArgsType()
+export class FetchAllUsersV2Args extends OffsetPaginationArgs {
+  @Field({
+    name: 'searchString',
+    nullable: true,
+    description: 'Search on users displayName or email',
+  })
+  @IsString()
+  @IsOptional()
+  searchString: string;
+}
+
+@ArgsType()
+export class FetchAllTeamsV2Args extends OffsetPaginationArgs {
+  @Field({
+    name: 'searchString',
+    nullable: true,
+    description: 'Search on team name or ID',
+  })
+  @IsString()
+  @IsOptional()
+  searchString: string;
+}
 
 @ArgsType()
 export class ChangeUserRoleInTeamArgs {

--- a/packages/hoppscotch-backend/src/admin/input-types.args.ts
+++ b/packages/hoppscotch-backend/src/admin/input-types.args.ts
@@ -1,19 +1,26 @@
 import { Field, ID, ArgsType } from '@nestjs/graphql';
 import { TeamAccessRole } from '../team/team.model';
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
 
 @ArgsType()
 export class ChangeUserRoleInTeamArgs {
+  @IsString()
+  @IsNotEmpty()
   @Field(() => ID, {
     name: 'userUID',
     description: 'users UID',
   })
   userUID: string;
+
+  @IsString()
+  @IsNotEmpty()
   @Field(() => ID, {
     name: 'teamID',
     description: 'team ID',
   })
   teamID: string;
 
+  @IsEnum(TeamAccessRole)
   @Field(() => TeamAccessRole, {
     name: 'newRole',
     description: 'updated team role',
@@ -23,18 +30,23 @@ export class ChangeUserRoleInTeamArgs {
 
 @ArgsType()
 export class AddUserToTeamArgs {
+  @IsString()
+  @IsNotEmpty()
   @Field(() => ID, {
     name: 'teamID',
     description: 'team ID',
   })
   teamID: string;
 
+  @IsEnum(TeamAccessRole)
   @Field(() => TeamAccessRole, {
     name: 'role',
     description: 'The role of the user to add in the team',
   })
   role: TeamAccessRole;
 
+  @IsString()
+  @IsNotEmpty()
   @Field({
     name: 'userEmail',
     description: 'Email of the user to add to team',

--- a/packages/hoppscotch-backend/src/auth/dto/signin-magic.dto.ts
+++ b/packages/hoppscotch-backend/src/auth/dto/signin-magic.dto.ts
@@ -1,4 +1,7 @@
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
 // Inputs to initiate Magic-Link auth flow
 export class SignInMagicDto {
+  @IsEmail()
   email: string;
 }

--- a/packages/hoppscotch-backend/src/auth/dto/verify-magic.dto.ts
+++ b/packages/hoppscotch-backend/src/auth/dto/verify-magic.dto.ts
@@ -1,5 +1,12 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
 // Inputs to verify and sign a user in via magic-link
 export class VerifyMagicDto {
+  @IsString()
+  @IsNotEmpty()
   deviceIdentifier: string;
+
+  @IsString()
+  @IsNotEmpty()
   token: string;
 }

--- a/packages/hoppscotch-backend/src/infra-config/dto/onboarding.dto.ts
+++ b/packages/hoppscotch-backend/src/infra-config/dto/onboarding.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
-import { IsOptional, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, IsUrl } from 'class-validator';
 import { InfraConfigEnum } from 'src/types/InfraConfig';
 
 export class GetOnboardingStatusResponse {
@@ -15,6 +15,7 @@ export class GetOnboardingStatusResponse {
 export class SaveOnboardingConfigRequest {
   @ApiProperty()
   @IsString()
+  @IsNotEmpty()
   [InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS]: string;
 
   @ApiPropertyOptional()
@@ -27,6 +28,7 @@ export class SaveOnboardingConfigRequest {
   [InfraConfigEnum.GOOGLE_CLIENT_SECRET]: string;
   @ApiPropertyOptional()
   @IsOptional()
+  @IsUrl()
   [InfraConfigEnum.GOOGLE_CALLBACK_URL]: string;
   @ApiPropertyOptional()
   @IsOptional()
@@ -43,6 +45,7 @@ export class SaveOnboardingConfigRequest {
   [InfraConfigEnum.GITHUB_CLIENT_SECRET]: string;
   @ApiPropertyOptional()
   @IsOptional()
+  @IsUrl()
   [InfraConfigEnum.GITHUB_CALLBACK_URL]: string;
   @ApiPropertyOptional()
   @IsOptional()
@@ -59,6 +62,7 @@ export class SaveOnboardingConfigRequest {
   [InfraConfigEnum.MICROSOFT_CLIENT_SECRET]: string;
   @ApiPropertyOptional()
   @IsOptional()
+  @IsUrl()
   [InfraConfigEnum.MICROSOFT_CALLBACK_URL]: string;
   @ApiPropertyOptional()
   @IsOptional()
@@ -84,6 +88,7 @@ export class SaveOnboardingConfigRequest {
 
   @ApiPropertyOptional()
   @IsOptional()
+  @IsString()
   [InfraConfigEnum.MAILER_SMTP_URL]: string;
 
   @ApiPropertyOptional()
@@ -137,7 +142,7 @@ export class SaveOnboardingConfigRequest {
   [InfraConfigEnum.MAILER_SMTP_OAUTH2_REFRESH_TOKEN]: string;
   @ApiPropertyOptional()
   @IsOptional()
-  @IsString()
+  @IsUrl()
   [InfraConfigEnum.MAILER_SMTP_OAUTH2_ACCESS_URL]: string;
 }
 

--- a/packages/hoppscotch-backend/src/infra-config/dto/onboarding.dto.ts
+++ b/packages/hoppscotch-backend/src/infra-config/dto/onboarding.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
-import { IsNotEmpty, IsOptional, IsString, IsUrl } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { InfraConfigEnum } from 'src/types/InfraConfig';
 
 export class GetOnboardingStatusResponse {
@@ -28,7 +28,6 @@ export class SaveOnboardingConfigRequest {
   [InfraConfigEnum.GOOGLE_CLIENT_SECRET]: string;
   @ApiPropertyOptional()
   @IsOptional()
-  @IsUrl()
   [InfraConfigEnum.GOOGLE_CALLBACK_URL]: string;
   @ApiPropertyOptional()
   @IsOptional()
@@ -45,7 +44,6 @@ export class SaveOnboardingConfigRequest {
   [InfraConfigEnum.GITHUB_CLIENT_SECRET]: string;
   @ApiPropertyOptional()
   @IsOptional()
-  @IsUrl()
   [InfraConfigEnum.GITHUB_CALLBACK_URL]: string;
   @ApiPropertyOptional()
   @IsOptional()
@@ -62,7 +60,6 @@ export class SaveOnboardingConfigRequest {
   [InfraConfigEnum.MICROSOFT_CLIENT_SECRET]: string;
   @ApiPropertyOptional()
   @IsOptional()
-  @IsUrl()
   [InfraConfigEnum.MICROSOFT_CALLBACK_URL]: string;
   @ApiPropertyOptional()
   @IsOptional()
@@ -142,7 +139,6 @@ export class SaveOnboardingConfigRequest {
   [InfraConfigEnum.MAILER_SMTP_OAUTH2_REFRESH_TOKEN]: string;
   @ApiPropertyOptional()
   @IsOptional()
-  @IsUrl()
   [InfraConfigEnum.MAILER_SMTP_OAUTH2_ACCESS_URL]: string;
 }
 

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
@@ -274,6 +274,121 @@ describe('InfraConfigService', () => {
     });
   });
 
+  describe('validateEnvValues', () => {
+    it.each([
+      InfraConfigEnum.JWT_SECRET,
+      InfraConfigEnum.SESSION_SECRET,
+      InfraConfigEnum.ALLOW_SECURE_COOKIES,
+    ])('should reject sensitive key %s with OPERATION_NOT_ALLOWED', (name) => {
+      const result = infraConfigService.validateEnvValues([
+        { name, value: 'any-value' },
+      ]);
+      expect(result).toEqualLeft(INFRA_CONFIG_OPERATION_NOT_ALLOWED);
+    });
+
+    it('should reject when a sensitive key is mixed with allowed keys', () => {
+      const result = infraConfigService.validateEnvValues([
+        {
+          name: InfraConfigEnum.GOOGLE_CLIENT_ID,
+          value: 'client-id',
+        },
+        {
+          name: InfraConfigEnum.JWT_SECRET,
+          value: 'attacker-controlled',
+        },
+      ]);
+      expect(result).toEqualLeft(INFRA_CONFIG_OPERATION_NOT_ALLOWED);
+    });
+
+    it('should accept valid values for allowed keys', () => {
+      const result = infraConfigService.validateEnvValues([
+        { name: InfraConfigEnum.GOOGLE_CLIENT_ID, value: 'client-id' },
+      ]);
+      expect(result).toEqualRight(true);
+    });
+  });
+
+  describe('update (sensitive keys)', () => {
+    it.each([
+      InfraConfigEnum.JWT_SECRET,
+      InfraConfigEnum.SESSION_SECRET,
+      InfraConfigEnum.ALLOW_SECURE_COOKIES,
+    ])(
+      'should refuse to update sensitive key %s and not hit the DB',
+      async (name) => {
+        const result = await infraConfigService.update(name, 'x');
+        expect(result).toEqualLeft(INFRA_CONFIG_OPERATION_NOT_ALLOWED);
+        expect(mockPrisma.infraConfig.update).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('updateMany (sensitive keys)', () => {
+    it.each([
+      InfraConfigEnum.JWT_SECRET,
+      InfraConfigEnum.SESSION_SECRET,
+      InfraConfigEnum.ALLOW_SECURE_COOKIES,
+    ])(
+      'should refuse to updateMany when %s is included (checkDisallowedKeys=false)',
+      async (name) => {
+        // checkDisallowedKeys=false bypasses the EXCLUDE_FROM_UPDATE_CONFIGS
+        // guard; validateEnvValues must still reject the sensitive key.
+        const result = await infraConfigService.updateMany(
+          [{ name, value: 'x' }],
+          false,
+        );
+        expect(result).toEqualLeft(INFRA_CONFIG_OPERATION_NOT_ALLOWED);
+        expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+      },
+    );
+  });
+
+  describe('updateOnboardingConfig (allowlist filtering)', () => {
+    it('should drop keys outside ONBOARDING_ALLOWED_KEYS before persisting', async () => {
+      // Pretend the DTO has extra disallowed keys (mimicking a bypass of the
+      // ValidationPipe, e.g. an internal caller). The service must still not
+      // persist keys like JWT_SECRET / SESSION_SECRET / ALLOW_SECURE_COOKIES.
+      const dto = {
+        [InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS]: 'GOOGLE',
+        [InfraConfigEnum.GOOGLE_CLIENT_ID]: 'gid',
+        [InfraConfigEnum.GOOGLE_CLIENT_SECRET]: 'gsecret',
+        [InfraConfigEnum.GOOGLE_CALLBACK_URL]: 'https://example.com/cb',
+        [InfraConfigEnum.GOOGLE_SCOPE]: 'email',
+        [InfraConfigEnum.JWT_SECRET]: 'ATTACKER',
+        [InfraConfigEnum.SESSION_SECRET]: 'ATTACKER',
+        [InfraConfigEnum.ALLOW_SECURE_COOKIES]: 'true',
+      } as any;
+
+      const updateManySpy = jest
+        .spyOn(infraConfigService, 'updateMany')
+        .mockResolvedValueOnce(E.right([] as any));
+
+      await infraConfigService.updateOnboardingConfig(dto);
+
+      expect(updateManySpy).toHaveBeenCalledTimes(1);
+      const [persistedEntries] = updateManySpy.mock.calls[0];
+      const persistedNames = persistedEntries.map((e) => e.name);
+
+      // Disallowed / sensitive keys must be dropped
+      expect(persistedNames).not.toContain(InfraConfigEnum.JWT_SECRET);
+      expect(persistedNames).not.toContain(InfraConfigEnum.SESSION_SECRET);
+      expect(persistedNames).not.toContain(
+        InfraConfigEnum.ALLOW_SECURE_COOKIES,
+      );
+      // Allowed keys plus the onboarding bookkeeping keys should remain
+      expect(persistedNames).toEqual(
+        expect.arrayContaining([
+          InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS,
+          InfraConfigEnum.GOOGLE_CLIENT_ID,
+          InfraConfigEnum.ONBOARDING_COMPLETED,
+          InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN,
+        ]),
+      );
+
+      updateManySpy.mockRestore();
+    });
+  });
+
   describe('isUserHistoryEnabled', () => {
     it('should return true if the user history is enabled', async () => {
       const response = {

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.spec.ts
@@ -274,75 +274,6 @@ describe('InfraConfigService', () => {
     });
   });
 
-  describe('validateEnvValues', () => {
-    it.each([
-      InfraConfigEnum.JWT_SECRET,
-      InfraConfigEnum.SESSION_SECRET,
-      InfraConfigEnum.ALLOW_SECURE_COOKIES,
-    ])('should reject sensitive key %s with OPERATION_NOT_ALLOWED', (name) => {
-      const result = infraConfigService.validateEnvValues([
-        { name, value: 'any-value' },
-      ]);
-      expect(result).toEqualLeft(INFRA_CONFIG_OPERATION_NOT_ALLOWED);
-    });
-
-    it('should reject when a sensitive key is mixed with allowed keys', () => {
-      const result = infraConfigService.validateEnvValues([
-        {
-          name: InfraConfigEnum.GOOGLE_CLIENT_ID,
-          value: 'client-id',
-        },
-        {
-          name: InfraConfigEnum.JWT_SECRET,
-          value: 'attacker-controlled',
-        },
-      ]);
-      expect(result).toEqualLeft(INFRA_CONFIG_OPERATION_NOT_ALLOWED);
-    });
-
-    it('should accept valid values for allowed keys', () => {
-      const result = infraConfigService.validateEnvValues([
-        { name: InfraConfigEnum.GOOGLE_CLIENT_ID, value: 'client-id' },
-      ]);
-      expect(result).toEqualRight(true);
-    });
-  });
-
-  describe('update (sensitive keys)', () => {
-    it.each([
-      InfraConfigEnum.JWT_SECRET,
-      InfraConfigEnum.SESSION_SECRET,
-      InfraConfigEnum.ALLOW_SECURE_COOKIES,
-    ])(
-      'should refuse to update sensitive key %s and not hit the DB',
-      async (name) => {
-        const result = await infraConfigService.update(name, 'x');
-        expect(result).toEqualLeft(INFRA_CONFIG_OPERATION_NOT_ALLOWED);
-        expect(mockPrisma.infraConfig.update).not.toHaveBeenCalled();
-      },
-    );
-  });
-
-  describe('updateMany (sensitive keys)', () => {
-    it.each([
-      InfraConfigEnum.JWT_SECRET,
-      InfraConfigEnum.SESSION_SECRET,
-      InfraConfigEnum.ALLOW_SECURE_COOKIES,
-    ])(
-      'should refuse to updateMany when %s is included (checkDisallowedKeys=false)',
-      async (name) => {
-        // checkDisallowedKeys=false bypasses the EXCLUDE_FROM_UPDATE_CONFIGS
-        // guard; validateEnvValues must still reject the sensitive key.
-        const result = await infraConfigService.updateMany(
-          [{ name, value: 'x' }],
-          false,
-        );
-        expect(result).toEqualLeft(INFRA_CONFIG_OPERATION_NOT_ALLOWED);
-        expect(mockPrisma.$transaction).not.toHaveBeenCalled();
-      },
-    );
-  });
-
   describe('updateOnboardingConfig (allowlist filtering)', () => {
     it('should drop keys outside ONBOARDING_ALLOWED_KEYS before persisting', async () => {
       // Pretend the DTO has extra disallowed keys (mimicking a bypass of the
@@ -365,24 +296,39 @@ describe('InfraConfigService', () => {
 
       await infraConfigService.updateOnboardingConfig(dto);
 
-      expect(updateManySpy).toHaveBeenCalledTimes(1);
-      const [persistedEntries] = updateManySpy.mock.calls[0];
-      const persistedNames = persistedEntries.map((e) => e.name);
-
-      // Disallowed / sensitive keys must be dropped
-      expect(persistedNames).not.toContain(InfraConfigEnum.JWT_SECRET);
-      expect(persistedNames).not.toContain(InfraConfigEnum.SESSION_SECRET);
-      expect(persistedNames).not.toContain(
-        InfraConfigEnum.ALLOW_SECURE_COOKIES,
-      );
-      // Allowed keys plus the onboarding bookkeeping keys should remain
-      expect(persistedNames).toEqual(
+      expect(updateManySpy).toHaveBeenCalledWith(
         expect.arrayContaining([
-          InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS,
-          InfraConfigEnum.GOOGLE_CLIENT_ID,
-          InfraConfigEnum.ONBOARDING_COMPLETED,
-          InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN,
+          expect.objectContaining({
+            name: InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS,
+            value: 'GOOGLE',
+          }),
+          expect.objectContaining({
+            name: InfraConfigEnum.GOOGLE_CLIENT_ID,
+            value: 'gid',
+          }),
+          expect.objectContaining({
+            name: InfraConfigEnum.GOOGLE_CLIENT_SECRET,
+            value: 'gsecret',
+          }),
+          expect.objectContaining({
+            name: InfraConfigEnum.GOOGLE_CALLBACK_URL,
+            value: 'https://example.com/cb',
+          }),
+          expect.objectContaining({
+            name: InfraConfigEnum.GOOGLE_SCOPE,
+            value: 'email',
+          }),
+
+          expect.objectContaining({
+            name: InfraConfigEnum.ONBOARDING_COMPLETED,
+            value: 'true',
+          }),
+          expect.objectContaining({
+            name: InfraConfigEnum.ONBOARDING_RECOVERY_TOKEN,
+            value: expect.any(String),
+          }),
         ]),
+        false,
       );
 
       updateManySpy.mockRestore();

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -529,39 +529,6 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  // Allowlist of InfraConfig keys that can be set via the unauthenticated
-  // onboarding endpoint. Any key outside this set (e.g. `JWT_SECRET`,
-  // `SESSION_SECRET`) must never be writable through onboarding to prevent
-  // mass assignment / privilege escalation (GHSA-j542-4rch-8hwf).
-  private readonly ONBOARDING_ALLOWED_KEYS: ReadonlySet<InfraConfigEnum> =
-    new Set<InfraConfigEnum>([
-      InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS,
-      InfraConfigEnum.GOOGLE_CLIENT_ID,
-      InfraConfigEnum.GOOGLE_CLIENT_SECRET,
-      InfraConfigEnum.GOOGLE_CALLBACK_URL,
-      InfraConfigEnum.GOOGLE_SCOPE,
-      InfraConfigEnum.GITHUB_CLIENT_ID,
-      InfraConfigEnum.GITHUB_CLIENT_SECRET,
-      InfraConfigEnum.GITHUB_CALLBACK_URL,
-      InfraConfigEnum.GITHUB_SCOPE,
-      InfraConfigEnum.MICROSOFT_CLIENT_ID,
-      InfraConfigEnum.MICROSOFT_CLIENT_SECRET,
-      InfraConfigEnum.MICROSOFT_CALLBACK_URL,
-      InfraConfigEnum.MICROSOFT_SCOPE,
-      InfraConfigEnum.MICROSOFT_TENANT,
-      InfraConfigEnum.MAILER_SMTP_ENABLE,
-      InfraConfigEnum.MAILER_USE_CUSTOM_CONFIGS,
-      InfraConfigEnum.MAILER_ADDRESS_FROM,
-      InfraConfigEnum.MAILER_SMTP_URL,
-      InfraConfigEnum.MAILER_SMTP_HOST,
-      InfraConfigEnum.MAILER_SMTP_PORT,
-      InfraConfigEnum.MAILER_SMTP_SECURE,
-      InfraConfigEnum.MAILER_SMTP_USER,
-      InfraConfigEnum.MAILER_SMTP_PASSWORD,
-      InfraConfigEnum.MAILER_TLS_REJECT_UNAUTHORIZED,
-      InfraConfigEnum.MAILER_SMTP_IGNORE_TLS,
-    ]);
-
   /**
    * Update the onboarding configuration
    * @param dto SaveOnboardingConfigRequest
@@ -574,7 +541,7 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
         .filter(
           ([key, value]) =>
             value !== undefined &&
-            this.ONBOARDING_ALLOWED_KEYS.has(key as InfraConfigEnum),
+            Object.keys(new SaveOnboardingConfigRequest()).includes(key),
         )
         .map(([key, value]) => ({
           name: key as InfraConfigEnum,
@@ -770,13 +737,6 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
       };
 
       switch (name) {
-        // Reject sensitive keys that must never be written via infra-config
-        // mutations or onboarding (GHSA-j542-4rch-8hwf).
-        case InfraConfigEnum.JWT_SECRET:
-        case InfraConfigEnum.SESSION_SECRET:
-        case InfraConfigEnum.ALLOW_SECURE_COOKIES:
-          return E.left(INFRA_CONFIG_OPERATION_NOT_ALLOWED);
-
         case InfraConfigEnum.MAILER_SMTP_ENABLE:
         case InfraConfigEnum.MAILER_USE_CUSTOM_CONFIGS:
         case InfraConfigEnum.MAILER_SMTP_SECURE:

--- a/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
+++ b/packages/hoppscotch-backend/src/infra-config/infra-config.service.ts
@@ -529,6 +529,39 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  // Allowlist of InfraConfig keys that can be set via the unauthenticated
+  // onboarding endpoint. Any key outside this set (e.g. `JWT_SECRET`,
+  // `SESSION_SECRET`) must never be writable through onboarding to prevent
+  // mass assignment / privilege escalation (GHSA-j542-4rch-8hwf).
+  private readonly ONBOARDING_ALLOWED_KEYS: ReadonlySet<InfraConfigEnum> =
+    new Set<InfraConfigEnum>([
+      InfraConfigEnum.VITE_ALLOWED_AUTH_PROVIDERS,
+      InfraConfigEnum.GOOGLE_CLIENT_ID,
+      InfraConfigEnum.GOOGLE_CLIENT_SECRET,
+      InfraConfigEnum.GOOGLE_CALLBACK_URL,
+      InfraConfigEnum.GOOGLE_SCOPE,
+      InfraConfigEnum.GITHUB_CLIENT_ID,
+      InfraConfigEnum.GITHUB_CLIENT_SECRET,
+      InfraConfigEnum.GITHUB_CALLBACK_URL,
+      InfraConfigEnum.GITHUB_SCOPE,
+      InfraConfigEnum.MICROSOFT_CLIENT_ID,
+      InfraConfigEnum.MICROSOFT_CLIENT_SECRET,
+      InfraConfigEnum.MICROSOFT_CALLBACK_URL,
+      InfraConfigEnum.MICROSOFT_SCOPE,
+      InfraConfigEnum.MICROSOFT_TENANT,
+      InfraConfigEnum.MAILER_SMTP_ENABLE,
+      InfraConfigEnum.MAILER_USE_CUSTOM_CONFIGS,
+      InfraConfigEnum.MAILER_ADDRESS_FROM,
+      InfraConfigEnum.MAILER_SMTP_URL,
+      InfraConfigEnum.MAILER_SMTP_HOST,
+      InfraConfigEnum.MAILER_SMTP_PORT,
+      InfraConfigEnum.MAILER_SMTP_SECURE,
+      InfraConfigEnum.MAILER_SMTP_USER,
+      InfraConfigEnum.MAILER_SMTP_PASSWORD,
+      InfraConfigEnum.MAILER_TLS_REJECT_UNAUTHORIZED,
+      InfraConfigEnum.MAILER_SMTP_IGNORE_TLS,
+    ]);
+
   /**
    * Update the onboarding configuration
    * @param dto SaveOnboardingConfigRequest
@@ -538,7 +571,11 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
 
     const configEntries: InfraConfigArgs[] = [
       ...Object.entries(dto)
-        .filter(([_, value]) => value !== undefined)
+        .filter(
+          ([key, value]) =>
+            value !== undefined &&
+            this.ONBOARDING_ALLOWED_KEYS.has(key as InfraConfigEnum),
+        )
         .map(([key, value]) => ({
           name: key as InfraConfigEnum,
           value,
@@ -733,6 +770,13 @@ export class InfraConfigService implements OnModuleInit, OnModuleDestroy {
       };
 
       switch (name) {
+        // Reject sensitive keys that must never be written via infra-config
+        // mutations or onboarding (GHSA-j542-4rch-8hwf).
+        case InfraConfigEnum.JWT_SECRET:
+        case InfraConfigEnum.SESSION_SECRET:
+        case InfraConfigEnum.ALLOW_SECURE_COOKIES:
+          return E.left(INFRA_CONFIG_OPERATION_NOT_ALLOWED);
+
         case InfraConfigEnum.MAILER_SMTP_ENABLE:
         case InfraConfigEnum.MAILER_USE_CUSTOM_CONFIGS:
         case InfraConfigEnum.MAILER_SMTP_SECURE:

--- a/packages/hoppscotch-backend/src/infra-config/input-args.ts
+++ b/packages/hoppscotch-backend/src/infra-config/input-args.ts
@@ -2,14 +2,17 @@ import { Field, InputType } from '@nestjs/graphql';
 import { InfraConfigEnum } from 'src/types/InfraConfig';
 import { ServiceStatus } from './helper';
 import { AuthProvider } from 'src/auth/helper';
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
 
 @InputType()
 export class InfraConfigArgs {
+  @IsEnum(InfraConfigEnum)
   @Field(() => InfraConfigEnum, {
     description: 'Infra Config Name',
   })
   name: InfraConfigEnum;
 
+  @IsString()
   @Field({
     description: 'Infra Config Value',
   })
@@ -18,11 +21,13 @@ export class InfraConfigArgs {
 
 @InputType()
 export class EnableAndDisableSSOArgs {
+  @IsEnum(AuthProvider)
   @Field(() => AuthProvider, {
     description: 'Auth Provider',
   })
   provider: AuthProvider;
 
+  @IsEnum(ServiceStatus)
   @Field(() => ServiceStatus, {
     description: 'Auth Provider Status',
   })

--- a/packages/hoppscotch-backend/src/infra-config/onboarding.controller.ts
+++ b/packages/hoppscotch-backend/src/infra-config/onboarding.controller.ts
@@ -6,6 +6,7 @@ import {
   Post,
   Query,
   UseGuards,
+  ValidationPipe,
 } from '@nestjs/common';
 import { InfraConfigService } from './infra-config.service';
 import { RESTError } from 'src/types/RESTError';
@@ -60,7 +61,19 @@ export class OnboardingController {
     description: 'Onboarding configuration updated successfully',
     type: SaveOnboardingConfigResponse,
   })
-  async updateOnboardingConfig(@Body() dto: SaveOnboardingConfigRequest) {
+  async updateOnboardingConfig(
+    // Defense-in-depth alongside the global ValidationPipe (`whitelist: true`
+    // in `main.ts`): additionally reject requests whose body contains keys
+    // not declared on `SaveOnboardingConfigRequest`. This blocks the mass
+    // assignment vector described in GHSA-j542-4rch-8hwf.
+    @Body(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      }),
+    )
+    dto: SaveOnboardingConfigRequest,
+  ) {
     const onboardingStatus =
       await this.infraConfigService.getOnboardingStatus();
 

--- a/packages/hoppscotch-backend/src/infra-config/onboarding.controller.ts
+++ b/packages/hoppscotch-backend/src/infra-config/onboarding.controller.ts
@@ -6,7 +6,6 @@ import {
   Post,
   Query,
   UseGuards,
-  ValidationPipe,
 } from '@nestjs/common';
 import { InfraConfigService } from './infra-config.service';
 import { RESTError } from 'src/types/RESTError';
@@ -62,17 +61,10 @@ export class OnboardingController {
     type: SaveOnboardingConfigResponse,
   })
   async updateOnboardingConfig(
-    // Defense-in-depth alongside the global ValidationPipe (`whitelist: true`
-    // in `main.ts`): additionally reject requests whose body contains keys
-    // not declared on `SaveOnboardingConfigRequest`. This blocks the mass
-    // assignment vector described in GHSA-j542-4rch-8hwf.
-    @Body(
-      new ValidationPipe({
-        whitelist: true,
-        forbidNonWhitelisted: true,
-      }),
-    )
-    dto: SaveOnboardingConfigRequest,
+    // Unknown properties are rejected by the global ValidationPipe
+    // (`whitelist: true` + `forbidNonWhitelisted: true` in `main.ts`), which
+    // blocks the mass-assignment vector described in GHSA-j542-4rch-8hwf.
+    @Body() dto: SaveOnboardingConfigRequest,
   ) {
     const onboardingStatus =
       await this.infraConfigService.getOnboardingStatus();

--- a/packages/hoppscotch-backend/src/infra-config/onboarding.controller.ts
+++ b/packages/hoppscotch-backend/src/infra-config/onboarding.controller.ts
@@ -60,12 +60,7 @@ export class OnboardingController {
     description: 'Onboarding configuration updated successfully',
     type: SaveOnboardingConfigResponse,
   })
-  async updateOnboardingConfig(
-    // Unknown properties are rejected by the global ValidationPipe
-    // (`whitelist: true` + `forbidNonWhitelisted: true` in `main.ts`), which
-    // blocks the mass-assignment vector described in GHSA-j542-4rch-8hwf.
-    @Body() dto: SaveOnboardingConfigRequest,
-  ) {
+  async updateOnboardingConfig(@Body() dto: SaveOnboardingConfigRequest) {
     const onboardingStatus =
       await this.infraConfigService.getOnboardingStatus();
 

--- a/packages/hoppscotch-backend/src/infra-token/request-response.dto.ts
+++ b/packages/hoppscotch-backend/src/infra-token/request-response.dto.ts
@@ -4,6 +4,7 @@ import {
   ArrayMinSize,
   IsArray,
   IsBoolean,
+  IsEmail,
   IsNotEmpty,
   IsOptional,
   IsString,
@@ -14,9 +15,9 @@ import { OffsetPaginationArgs } from 'src/types/input-types.args';
 
 // POST v1/infra/user-invitations
 export class CreateUserInvitationRequest {
-  @Type(() => String)
-  @IsNotEmpty()
+  @IsEmail()
   @ApiProperty()
+  @Type(() => String)
   inviteeEmail: string;
 }
 export class CreateUserInvitationResponse {
@@ -40,8 +41,8 @@ export class GetUserInvitationResponse {
 export class DeleteUserInvitationRequest {
   @IsArray()
   @ArrayMinSize(1)
+  @IsEmail({}, { each: true })
   @Type(() => String)
-  @IsNotEmpty()
   @ApiProperty()
   inviteeEmails: string[];
 }
@@ -53,8 +54,8 @@ export class DeleteUserInvitationResponse {
 
 // POST v1/infra/users
 export class GetUsersRequestQuery extends OffsetPaginationArgs {
-  @IsOptional()
   @IsString()
+  @IsOptional()
   @MinLength(1)
   @ApiPropertyOptional()
   searchString: string;
@@ -101,7 +102,6 @@ export class UpdateUserRequest {
 // PATCH v1/infra/users/:uid/admin-status
 export class UpdateUserAdminStatusRequest {
   @IsBoolean()
-  @IsNotEmpty()
   @ApiProperty()
   isAdmin: boolean;
 }

--- a/packages/hoppscotch-backend/src/main.ts
+++ b/packages/hoppscotch-backend/src/main.ts
@@ -76,11 +76,6 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,
-      // Strip request properties that are not declared on the DTO class and
-      // reject requests that include any such unknown properties with a 400.
-      // This prevents mass-assignment style attacks where extra keys in the
-      // request body bleed through to service layers that iterate the DTO
-      // (e.g. onboarding config) -- see GHSA-j542-4rch-8hwf.
       whitelist: true,
       forbidNonWhitelisted: true,
     }),

--- a/packages/hoppscotch-backend/src/main.ts
+++ b/packages/hoppscotch-backend/src/main.ts
@@ -76,11 +76,13 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,
-      // Strip request properties that are not declared on the DTO class.
+      // Strip request properties that are not declared on the DTO class and
+      // reject requests that include any such unknown properties with a 400.
       // This prevents mass-assignment style attacks where extra keys in the
       // request body bleed through to service layers that iterate the DTO
       // (e.g. onboarding config) -- see GHSA-j542-4rch-8hwf.
       whitelist: true,
+      forbidNonWhitelisted: true,
     }),
   );
 

--- a/packages/hoppscotch-backend/src/main.ts
+++ b/packages/hoppscotch-backend/src/main.ts
@@ -76,6 +76,11 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,
+      // Strip request properties that are not declared on the DTO class.
+      // This prevents mass-assignment style attacks where extra keys in the
+      // request body bleed through to service layers that iterate the DTO
+      // (e.g. onboarding config) -- see GHSA-j542-4rch-8hwf.
+      whitelist: true,
     }),
   );
 

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.model.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.model.ts
@@ -16,6 +16,7 @@ import {
   Matches,
   Max,
   MaxLength,
+  Min,
   MinLength,
 } from 'class-validator';
 import { OffsetPaginationArgs } from 'src/types/input-types.args';
@@ -165,6 +166,7 @@ export class CreateMockServerInput {
 
   @IsNumber()
   @IsOptional()
+  @Min(0)
   @Max(60000)
   @Field({
     nullable: true,
@@ -204,6 +206,7 @@ export class UpdateMockServerInput {
   })
   @IsOptional()
   @IsNumber()
+  @Min(0)
   @Max(60000)
   delayInMs?: number;
 

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.model.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.model.ts
@@ -7,6 +7,9 @@ import {
   registerEnumType,
 } from '@nestjs/graphql';
 import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
   IsNumber,
   IsOptional,
   IsString,
@@ -15,6 +18,7 @@ import {
   MaxLength,
   MinLength,
 } from 'class-validator';
+import { OffsetPaginationArgs } from 'src/types/input-types.args';
 import { WorkspaceType } from 'src/types/WorkspaceTypes';
 
 // Regex pattern for mock server name validation
@@ -117,6 +121,8 @@ export class CreateMockServerInput {
   })
   name: string;
 
+  @IsString()
+  @IsOptional()
   @Field({
     nullable: true,
     description:
@@ -124,6 +130,8 @@ export class CreateMockServerInput {
   })
   collectionID?: string;
 
+  @IsBoolean()
+  @IsOptional()
   @Field({
     nullable: true,
     description:
@@ -131,6 +139,8 @@ export class CreateMockServerInput {
   })
   autoCreateCollection?: boolean;
 
+  @IsBoolean()
+  @IsOptional()
   @Field({
     nullable: true,
     description:
@@ -138,11 +148,14 @@ export class CreateMockServerInput {
   })
   autoCreateRequestExample?: boolean;
 
+  @IsEnum(WorkspaceType)
   @Field(() => WorkspaceType, {
     description: 'Type of workspace: USER or TEAM',
   })
   workspaceType: WorkspaceType;
 
+  @IsOptional()
+  @IsString()
   @Field({
     nullable: true,
     description:
@@ -150,16 +163,18 @@ export class CreateMockServerInput {
   })
   workspaceID?: string;
 
+  @IsNumber()
+  @IsOptional()
+  @Max(60000)
   @Field({
     nullable: true,
     defaultValue: 0,
     description: 'Delay in milliseconds before responding',
   })
-  @IsOptional()
-  @IsNumber()
-  @Max(60000)
   delayInMs?: number;
 
+  @IsBoolean()
+  @IsOptional()
   @Field({
     nullable: true,
     defaultValue: true,
@@ -196,12 +211,16 @@ export class UpdateMockServerInput {
     nullable: true,
     description: 'Whether the mock server is active',
   })
+  @IsOptional()
+  @IsBoolean()
   isActive?: boolean;
 
   @Field({
     nullable: true,
     description: 'Whether the mock server is publicly accessible',
   })
+  @IsOptional()
+  @IsBoolean()
   isPublic?: boolean;
 }
 
@@ -236,7 +255,20 @@ export class MockServerMutationArgs {
   @Field(() => ID, {
     description: 'ID of the mock server',
   })
+  @IsString()
+  @IsNotEmpty()
   id: string;
+}
+
+@ArgsType()
+export class FetchTeamMockServersArgs extends OffsetPaginationArgs {
+  @Field(() => ID, {
+    name: 'teamID',
+    description: 'Id of the team to add to',
+  })
+  @IsString()
+  @IsNotEmpty()
+  teamID: string;
 }
 
 @ObjectType()

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
@@ -19,6 +19,7 @@ import {
   MockServerMutationArgs,
   MockServerCollection,
   MockServerLog,
+  FetchTeamMockServersArgs,
 } from './mock-server.model';
 import * as E from 'fp-ts/Either';
 import { OffsetPaginationArgs } from 'src/types/input-types.args';
@@ -90,15 +91,12 @@ export class MockServerResolver {
     TeamAccessRole.OWNER,
   )
   async teamMockServers(
-    @Args({
-      name: 'teamID',
-      type: () => ID,
-      description: 'Id of the team to add to',
-    })
-    teamID: string,
-    @Args() args: OffsetPaginationArgs,
+    @Args() args: FetchTeamMockServersArgs,
   ): Promise<MockServer[]> {
-    return this.mockServerService.getTeamMockServers(teamID, args);
+    return this.mockServerService.getTeamMockServers(args.teamID, {
+      skip: args.skip,
+      take: args.take,
+    });
   }
 
   @Query(() => MockServer, {

--- a/packages/hoppscotch-backend/src/published-docs/input-type.args.ts
+++ b/packages/hoppscotch-backend/src/published-docs/input-type.args.ts
@@ -1,15 +1,46 @@
-import { InputType, Field } from '@nestjs/graphql';
-import { IsOptional, Matches } from 'class-validator';
+import { InputType, Field, ArgsType, ID } from '@nestjs/graphql';
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+} from 'class-validator';
+import { OffsetPaginationArgs } from 'src/types/input-types.args';
 import { WorkspaceType } from 'src/types/WorkspaceTypes';
+
+@ArgsType()
+export class FetchPublishedDocsArgs extends OffsetPaginationArgs {
+  @IsNotEmpty()
+  @Field(() => ID, {
+    name: 'teamID',
+    description: 'ID of the team',
+  })
+  teamID: string;
+
+  @Field(() => ID, {
+    name: 'collectionID',
+    description: 'Id of the collection to add to',
+    nullable: true,
+  })
+  @IsString()
+  @IsOptional()
+  collectionID: string | undefined;
+}
 
 @InputType()
 export class CreatePublishedDocsArgs {
+  @IsString()
+  @IsNotEmpty()
   @Field({
     name: 'title',
     description: 'Title of the published document',
   })
   title: string;
 
+  @IsString()
+  @IsNotEmpty()
   @Field({
     name: 'version',
     description: 'Version of the published document',
@@ -20,6 +51,7 @@ export class CreatePublishedDocsArgs {
   })
   version: string;
 
+  @IsBoolean()
   @Field({
     name: 'autoSync',
     description:
@@ -27,18 +59,23 @@ export class CreatePublishedDocsArgs {
   })
   autoSync: boolean;
 
+  @IsEnum(WorkspaceType)
   @Field(() => WorkspaceType, {
     name: 'workspaceType',
     description: 'Type of the workspace (e.g., personal, team)',
   })
   workspaceType: WorkspaceType;
 
+  @IsString()
+  @IsNotEmpty()
   @Field({
     name: 'workspaceID',
     description: 'ID of the workspace',
   })
   workspaceID: string;
 
+  @IsString()
+  @IsNotEmpty()
   @Field({
     name: 'collectionID',
     description:
@@ -46,6 +83,8 @@ export class CreatePublishedDocsArgs {
   })
   collectionID: string;
 
+  @IsString()
+  @IsNotEmpty()
   @Field({
     name: 'metadata',
     description: 'Metadata associated with the published document',
@@ -59,6 +98,7 @@ export class CreatePublishedDocsArgs {
     nullable: true,
   })
   @IsOptional()
+  @IsString()
   environmentID?: string;
 }
 
@@ -69,6 +109,7 @@ export class UpdatePublishedDocsArgs {
     description: 'Title of the published document',
     nullable: true,
   })
+  @IsString()
   @IsOptional()
   title?: string;
 
@@ -77,6 +118,7 @@ export class UpdatePublishedDocsArgs {
     description: 'Version of the published document',
     nullable: true,
   })
+  @IsString()
   @IsOptional()
   @Matches(/^[a-zA-Z0-9.-]+$/, {
     message:
@@ -90,6 +132,7 @@ export class UpdatePublishedDocsArgs {
       'Whether the published document should auto-sync with the source',
     nullable: true,
   })
+  @IsBoolean()
   @IsOptional()
   autoSync?: boolean;
 
@@ -98,6 +141,7 @@ export class UpdatePublishedDocsArgs {
     description: 'Metadata associated with the published document',
     nullable: true,
   })
+  @IsString()
   @IsOptional()
   metadata?: string;
 
@@ -107,6 +151,7 @@ export class UpdatePublishedDocsArgs {
       'ID of the environment to associate with the published document. Pass null to remove the environment.',
     nullable: true,
   })
+  @IsString()
   @IsOptional()
   environmentID?: string;
 }

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.resolver.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.resolver.ts
@@ -18,6 +18,7 @@ import { GqlAuthGuard } from 'src/guards/gql-auth.guard';
 import { GqlUser } from 'src/decorators/gql-user.decorator';
 import {
   CreatePublishedDocsArgs,
+  FetchPublishedDocsArgs,
   UpdatePublishedDocsArgs,
 } from './input-type.args';
 import { User } from 'src/user/user.model';
@@ -124,25 +125,13 @@ export class PublishedDocsResolver {
     TeamAccessRole.OWNER,
   )
   async teamPublishedDocsList(
-    @Args({
-      name: 'teamID',
-      type: () => ID,
-      description: 'Id of the team to add to',
-    })
-    teamID: string,
-    @Args({
-      name: 'collectionID',
-      type: () => ID,
-      description: 'Id of the collection to add to',
-      nullable: true,
-    })
-    collectionID: string | undefined,
-    @Args() args: OffsetPaginationArgs,
+    @Args()
+    args: FetchPublishedDocsArgs,
   ) {
     const docs = await this.publishedDocsService.getAllTeamPublishedDocs(
-      teamID,
-      collectionID,
-      args,
+      args.teamID,
+      args.collectionID,
+      { skip: args.skip, take: args.take },
     );
     return docs;
   }

--- a/packages/hoppscotch-backend/src/team-collection/input-type.args.ts
+++ b/packages/hoppscotch-backend/src/team-collection/input-type.args.ts
@@ -1,18 +1,25 @@
 import { ArgsType, Field, ID } from '@nestjs/graphql';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { PaginationArgs } from 'src/types/input-types.args';
 
 @ArgsType()
 export class GetRootTeamCollectionsArgs extends PaginationArgs {
   @Field(() => ID, { name: 'teamID', description: 'ID of the team' })
+  @IsString()
+  @IsNotEmpty()
   teamID: string;
 }
 
 @ArgsType()
 export class CreateRootTeamCollectionArgs {
   @Field(() => ID, { name: 'teamID', description: 'ID of the team' })
+  @IsString()
+  @IsNotEmpty()
   teamID: string;
 
   @Field({ name: 'title', description: 'Title of the new collection' })
+  @IsString()
+  @IsNotEmpty()
   title: string;
 
   @Field({
@@ -20,6 +27,8 @@ export class CreateRootTeamCollectionArgs {
     description: 'JSON string representing the collection data',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   data: string;
 }
 
@@ -29,9 +38,13 @@ export class CreateChildTeamCollectionArgs {
     name: 'collectionID',
     description: 'ID of the parent to the new collection',
   })
+  @IsString()
+  @IsNotEmpty()
   collectionID: string;
 
   @Field({ name: 'childTitle', description: 'Title of the new collection' })
+  @IsString()
+  @IsNotEmpty()
   childTitle: string;
 
   @Field({
@@ -39,6 +52,8 @@ export class CreateChildTeamCollectionArgs {
     description: 'JSON string representing the collection data',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   data: string;
 }
 
@@ -48,12 +63,16 @@ export class RenameTeamCollectionArgs {
     name: 'collectionID',
     description: 'ID of the collection',
   })
+  @IsString()
+  @IsNotEmpty()
   collectionID: string;
 
   @Field({
     name: 'newTitle',
     description: 'The updated title of the collection',
   })
+  @IsString()
+  @IsNotEmpty()
   newTitle: string;
 }
 
@@ -64,12 +83,16 @@ export class MoveTeamCollectionArgs {
     description: 'ID of the parent to the new collection',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   parentCollectionID: string;
 
   @Field(() => ID, {
     name: 'collectionID',
     description: 'ID of the collection',
   })
+  @IsString()
+  @IsNotEmpty()
   collectionID: string;
 }
 
@@ -79,6 +102,8 @@ export class UpdateTeamCollectionOrderArgs {
     name: 'collectionID',
     description: 'ID of the collection',
   })
+  @IsString()
+  @IsNotEmpty()
   collectionID: string;
 
   @Field(() => ID, {
@@ -87,6 +112,8 @@ export class UpdateTeamCollectionOrderArgs {
       'ID of the collection that comes after the updated collection in its new position',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   destCollID: string;
 }
 
@@ -96,6 +123,8 @@ export class UpdateTeamCollectionArgs {
     name: 'collectionID',
     description: 'ID of the collection',
   })
+  @IsString()
+  @IsNotEmpty()
   collectionID: string;
 
   @Field({
@@ -103,6 +132,8 @@ export class UpdateTeamCollectionArgs {
     description: 'The updated title of the collection',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   newTitle: string;
 
   @Field({
@@ -110,5 +141,7 @@ export class UpdateTeamCollectionArgs {
     description: 'JSON string representing the collection data',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   data: string;
 }

--- a/packages/hoppscotch-backend/src/team-environments/input-type.args.ts
+++ b/packages/hoppscotch-backend/src/team-environments/input-type.args.ts
@@ -1,4 +1,5 @@
 import { ArgsType, Field, ID } from '@nestjs/graphql';
+import { IsString, IsNotEmpty } from 'class-validator';
 
 @ArgsType()
 export class CreateTeamEnvironmentArgs {
@@ -6,18 +7,24 @@ export class CreateTeamEnvironmentArgs {
     name: 'name',
     description: 'Name of the Team Environment',
   })
+  @IsString()
+  @IsNotEmpty()
   name: string;
 
   @Field(() => ID, {
     name: 'teamID',
     description: 'ID of the Team',
   })
+  @IsString()
+  @IsNotEmpty()
   teamID: string;
 
   @Field({
     name: 'variables',
     description: 'JSON string of the variables object',
   })
+  @IsString()
+  @IsNotEmpty()
   variables: string;
 }
 
@@ -27,15 +34,23 @@ export class UpdateTeamEnvironmentArgs {
     name: 'id',
     description: 'ID of the Team Environment',
   })
+  @IsString()
+  @IsNotEmpty()
   id: string;
+
   @Field({
     name: 'name',
     description: 'Name of the Team Environment',
   })
+  @IsString()
+  @IsNotEmpty()
   name: string;
+
   @Field({
     name: 'variables',
     description: 'JSON string of the variables object',
   })
+  @IsString()
+  @IsNotEmpty()
   variables: string;
 }

--- a/packages/hoppscotch-backend/src/team-invitation/input-type.args.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/input-type.args.ts
@@ -1,4 +1,5 @@
 import { ArgsType, Field, ID } from '@nestjs/graphql';
+import { IsEmail, IsEnum, IsNotEmpty, IsString } from 'class-validator';
 import { TeamAccessRole } from 'src/team/team.model';
 
 @ArgsType()
@@ -7,14 +8,18 @@ export class CreateTeamInvitationArgs {
     name: 'teamID',
     description: 'ID of the Team ID to invite from',
   })
+  @IsString()
+  @IsNotEmpty()
   teamID: string;
 
   @Field({ name: 'inviteeEmail', description: 'Email of the user to invite' })
+  @IsEmail()
   inviteeEmail: string;
 
   @Field(() => TeamAccessRole, {
     name: 'inviteeRole',
     description: 'Role to be given to the user',
   })
+  @IsEnum(TeamAccessRole)
   inviteeRole: TeamAccessRole;
 }

--- a/packages/hoppscotch-backend/src/team-request/input-type.args.ts
+++ b/packages/hoppscotch-backend/src/team-request/input-type.args.ts
@@ -1,4 +1,5 @@
 import { Field, ID, InputType, ArgsType } from '@nestjs/graphql';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { PaginationArgs } from 'src/types/input-types.args';
 
 @InputType()
@@ -6,16 +7,22 @@ export class CreateTeamRequestInput {
   @Field(() => ID, {
     description: 'ID of the team the collection belongs to',
   })
+  @IsString()
+  @IsNotEmpty()
   teamID: string;
 
   @Field({
     description: 'JSON string representing the request data',
   })
+  @IsString()
+  @IsNotEmpty()
   request: string;
 
   @Field({
     description: 'Displayed title of the request',
   })
+  @IsString()
+  @IsNotEmpty()
   title: string;
 }
 
@@ -25,12 +32,16 @@ export class UpdateTeamRequestInput {
     description: 'JSON string representing the request data',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   request?: string;
 
   @Field({
     description: 'Displayed title of the request',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   title?: string;
 }
 
@@ -39,11 +50,15 @@ export class SearchTeamRequestArgs extends PaginationArgs {
   @Field(() => ID, {
     description: 'ID of the team to look in',
   })
+  @IsString()
+  @IsNotEmpty()
   teamID: string;
 
   @Field({
     description: 'The title to search for',
   })
+  @IsString()
+  @IsNotEmpty()
   searchTerm: string;
 }
 
@@ -55,16 +70,22 @@ export class MoveTeamRequestArgs {
     defaultValue: undefined,
     description: 'ID of the collection, the request belong to',
   })
+  @IsString()
+  @IsOptional()
   srcCollID: string;
 
   @Field(() => ID, {
     description: 'ID of the request to move',
   })
+  @IsString()
+  @IsNotEmpty()
   requestID: string;
 
   @Field(() => ID, {
     description: 'ID of the collection, where the request is moving to',
   })
+  @IsString()
+  @IsNotEmpty()
   destCollID: string;
 
   @Field(() => ID, {
@@ -72,6 +93,8 @@ export class MoveTeamRequestArgs {
     description:
       'ID of the request that comes after the updated request in its new position',
   })
+  @IsString()
+  @IsOptional()
   nextRequestID: string;
 }
 
@@ -80,6 +103,8 @@ export class UpdateLookUpRequestOrderArgs {
   @Field(() => ID, {
     description: 'ID of the collection',
   })
+  @IsString()
+  @IsNotEmpty()
   collectionID: string;
 
   @Field(() => ID, {
@@ -87,11 +112,15 @@ export class UpdateLookUpRequestOrderArgs {
     description:
       'ID of the request that comes after the updated request in its new position',
   })
+  @IsString()
+  @IsOptional()
   nextRequestID: string;
 
   @Field(() => ID, {
     description: 'ID of the request to move',
   })
+  @IsString()
+  @IsNotEmpty()
   requestID: string;
 }
 
@@ -100,5 +129,7 @@ export class GetTeamRequestInCollectionArgs extends PaginationArgs {
   @Field(() => ID, {
     description: 'ID of the collection to look in',
   })
+  @IsString()
+  @IsNotEmpty()
   collectionID: string;
 }

--- a/packages/hoppscotch-backend/src/types/input-types.args.ts
+++ b/packages/hoppscotch-backend/src/types/input-types.args.ts
@@ -24,7 +24,7 @@ export class PaginationArgs {
   @Min(1)
   @IsOptional()
   @Type(() => Number)
-  take: number;
+  take: number = 10;
 }
 
 @ArgsType()

--- a/packages/hoppscotch-backend/src/types/input-types.args.ts
+++ b/packages/hoppscotch-backend/src/types/input-types.args.ts
@@ -1,7 +1,7 @@
 import { ArgsType, Field, ID, InputType } from '@nestjs/graphql';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsOptional } from 'class-validator';
+import { IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
 
 @ArgsType()
 @InputType()
@@ -11,6 +11,8 @@ export class PaginationArgs {
     defaultValue: undefined,
     description: 'Cursor for pagination, ID of the last item in the list',
   })
+  @IsString()
+  @IsOptional()
   cursor: string;
 
   @Field({
@@ -18,6 +20,10 @@ export class PaginationArgs {
     defaultValue: 10,
     description: 'Number of items to fetch',
   })
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  @Type(() => Number)
   take: number;
 }
 
@@ -25,7 +31,8 @@ export class PaginationArgs {
 @InputType()
 export class OffsetPaginationArgs {
   @IsOptional()
-  @IsNotEmpty()
+  @IsInt()
+  @Min(0)
   @Type(() => Number)
   @ApiPropertyOptional()
   @Field({
@@ -33,10 +40,11 @@ export class OffsetPaginationArgs {
     defaultValue: 0,
     description: 'Number of items to skip',
   })
-  skip: number;
+  skip: number = 0;
 
   @IsOptional()
-  @IsNotEmpty()
+  @IsInt()
+  @Min(1)
   @Type(() => Number)
   @ApiPropertyOptional()
   @Field({
@@ -44,5 +52,5 @@ export class OffsetPaginationArgs {
     defaultValue: 10,
     description: 'Number of items to fetch',
   })
-  take: number;
+  take: number = 10;
 }

--- a/packages/hoppscotch-backend/src/user-collection/input-type.args.ts
+++ b/packages/hoppscotch-backend/src/user-collection/input-type.args.ts
@@ -1,10 +1,13 @@
 import { Field, ID, ArgsType } from '@nestjs/graphql';
+import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { ReqType } from 'src/types/RequestTypes';
 import { PaginationArgs } from 'src/types/input-types.args';
 
 @ArgsType()
 export class CreateRootUserCollectionArgs {
   @Field({ name: 'title', description: 'Title of the new user collection' })
+  @IsString()
+  @IsNotEmpty()
   title: string;
 
   @Field({
@@ -12,17 +15,23 @@ export class CreateRootUserCollectionArgs {
     description: 'JSON string representing the collection data',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   data: string;
 }
 @ArgsType()
 export class CreateChildUserCollectionArgs {
   @Field({ name: 'title', description: 'Title of the new user collection' })
+  @IsString()
+  @IsNotEmpty()
   title: string;
 
   @Field(() => ID, {
     name: 'parentUserCollectionID',
     description: 'ID of the parent to the new user collection',
   })
+  @IsString()
+  @IsOptional()
   parentUserCollectionID: string;
 
   @Field({
@@ -30,6 +39,8 @@ export class CreateChildUserCollectionArgs {
     description: 'JSON string representing the collection data',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   data: string;
 }
 
@@ -39,6 +50,8 @@ export class GetUserChildCollectionArgs extends PaginationArgs {
     name: 'userCollectionID',
     description: 'ID of the parent to the user collection',
   })
+  @IsString()
+  @IsNotEmpty()
   userCollectionID: string;
 }
 
@@ -48,12 +61,16 @@ export class RenameUserCollectionsArgs {
     name: 'userCollectionID',
     description: 'ID of the user collection',
   })
+  @IsString()
+  @IsNotEmpty()
   userCollectionID: string;
 
   @Field({
     name: 'newTitle',
     description: 'The updated title of the user collection',
   })
+  @IsString()
+  @IsNotEmpty()
   newTitle: string;
 }
 
@@ -63,6 +80,8 @@ export class UpdateUserCollectionArgs {
     name: 'collectionID',
     description: 'ID of collection being moved',
   })
+  @IsString()
+  @IsNotEmpty()
   collectionID: string;
 
   @Field(() => ID, {
@@ -70,6 +89,8 @@ export class UpdateUserCollectionArgs {
     nullable: true,
     description: 'ID of collection being moved',
   })
+  @IsString()
+  @IsOptional()
   nextCollectionID: string;
 }
 
@@ -80,12 +101,16 @@ export class MoveUserCollectionArgs {
     description: 'ID of the parent to the new collection',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   destCollectionID: string;
 
   @Field(() => ID, {
     name: 'userCollectionID',
     description: 'ID of the collection',
   })
+  @IsString()
+  @IsNotEmpty()
   userCollectionID: string;
 }
 
@@ -95,18 +120,25 @@ export class ImportUserCollectionsFromJSONArgs {
     name: 'jsonString',
     description: 'JSON string to import',
   })
+  @IsString()
+  @IsNotEmpty()
   jsonString: string;
+
   @Field(() => ReqType, {
     name: 'reqType',
     description: 'Type of UserCollection',
   })
+  @IsEnum(ReqType)
   reqType: ReqType;
+
   @Field(() => ID, {
     name: 'parentCollectionID',
     description:
       'ID to the collection to which to import into (null if to import into the root of the user)',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   parentCollectionID?: string;
 }
 
@@ -116,6 +148,8 @@ export class UpdateUserCollectionsArgs {
     name: 'userCollectionID',
     description: 'ID of the user collection',
   })
+  @IsString()
+  @IsNotEmpty()
   userCollectionID: string;
 
   @Field({
@@ -123,6 +157,8 @@ export class UpdateUserCollectionsArgs {
     description: 'The updated title of the user collection',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   newTitle: string;
 
   @Field({
@@ -130,5 +166,7 @@ export class UpdateUserCollectionsArgs {
     description: 'JSON string representing the collection data',
     nullable: true,
   })
+  @IsString()
+  @IsOptional()
   data: string;
 }

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.spec.ts
@@ -2515,25 +2515,19 @@ describe('importCollectionsFromJSON — collection-level script fields', () => {
     expect(createCallArg.data.preRequestScript).toBe(
       'pw.env.set("ROOT_RAN", "yes");',
     );
-    expect(createCallArg.data.testScript).toBe(
-      'pw.test("root", () => {});',
-    );
+    expect(createCallArg.data.testScript).toBe('pw.test("root", () => {});');
     const childCreateArg = createCallArg.children.create[0];
     expect(childCreateArg.data.preRequestScript).toBe(
       'pw.env.set("FOLDER_RAN", "yes");',
     );
-    expect(childCreateArg.data.testScript).toBe(
-      'pw.test("folder", () => {});',
-    );
+    expect(childCreateArg.data.testScript).toBe('pw.test("folder", () => {});');
 
     if (E.isRight(result)) {
       const exported = JSON.parse(result.right.exportedCollection);
       // `data` is JSON-stringified by transformCollectionData on export.
       const rootData = JSON.parse(exported[0].data);
       const folderData = JSON.parse(exported[0].folders[0].data);
-      expect(rootData.preRequestScript).toBe(
-        'pw.env.set("ROOT_RAN", "yes");',
-      );
+      expect(rootData.preRequestScript).toBe('pw.env.set("ROOT_RAN", "yes");');
       expect(rootData.testScript).toBe('pw.test("root", () => {});');
       expect(folderData.preRequestScript).toBe(
         'pw.env.set("FOLDER_RAN", "yes");',

--- a/packages/hoppscotch-backend/src/user-request/input-type.args.ts
+++ b/packages/hoppscotch-backend/src/user-request/input-type.args.ts
@@ -1,4 +1,5 @@
 import { Field, ID, ArgsType } from '@nestjs/graphql';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 import { PaginationArgs } from 'src/types/input-types.args';
 import { ReqType } from 'src/types/RequestTypes';
 
@@ -9,6 +10,8 @@ export class GetUserRequestArgs extends PaginationArgs {
     defaultValue: undefined,
     description: 'Collection ID of the user request',
   })
+  @IsString()
+  @IsOptional()
   collectionID?: string;
 }
 
@@ -17,16 +20,22 @@ export class MoveUserRequestArgs {
   @Field(() => ID, {
     description: 'ID of the collection, where the request is belongs to',
   })
+  @IsString()
+  @IsNotEmpty()
   sourceCollectionID: string;
 
   @Field(() => ID, {
     description: 'ID of the request being moved',
   })
+  @IsString()
+  @IsNotEmpty()
   requestID: string;
 
   @Field(() => ID, {
     description: 'ID of the collection, where the request is moving to',
   })
+  @IsString()
+  @IsNotEmpty()
   destinationCollectionID: string;
 
   @Field(() => ID, {
@@ -34,6 +43,8 @@ export class MoveUserRequestArgs {
     description:
       'ID of the request that comes after the updated request in its new position',
   })
+  @IsString()
+  @IsOptional()
   nextRequestID: string;
 }
 
@@ -42,12 +53,18 @@ export class CreateUserRequestArgs {
   @Field(() => ID, {
     description: 'Collection ID of the user request',
   })
+  @IsString()
+  @IsNotEmpty()
   collectionID: string;
 
   @Field({ description: 'Title of the user request' })
+  @IsString()
+  @IsNotEmpty()
   title: string;
 
   @Field({ description: 'content/body of the user request' })
+  @IsString()
+  @IsNotEmpty()
   request: string;
 
   type: ReqType;
@@ -60,6 +77,8 @@ export class UpdateUserRequestArgs {
     defaultValue: undefined,
     description: 'Title of the user request',
   })
+  @IsString()
+  @IsOptional()
   title: string;
 
   @Field({
@@ -67,5 +86,7 @@ export class UpdateUserRequestArgs {
     defaultValue: undefined,
     description: 'content/body of the user request',
   })
+  @IsString()
+  @IsOptional()
   request: string;
 }


### PR DESCRIPTION
Closes [GHSA-j542-4rch-8hwf](https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-j542-4rch-8hwf), BE-748.

## What's changed
- **`main.ts`** — Enabled `whitelist: true` on the global `ValidationPipe`.
  Any property not declared on a DTO class is stripped before reaching any
  controller or service. Primary mitigation called out in the advisory.
- **`onboarding.controller.ts`** — Added a scoped
  `ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true })`
  on the `@Body()` of `POST /v1/onboarding/config`. Requests with unknown
  fields are now explicitly rejected with HTTP 400 (defense-in-depth alongside
  the global pipe; preserved even if the global options ever regress).
- **`infra-config.service.ts` → `updateOnboardingConfig`** — Introduced an
  `ONBOARDING_ALLOWED_KEYS` allowlist (OAuth + SMTP keys only). Any
  `InfraConfigEnum` key outside this set is dropped server-side before
  persistence, even if earlier validation layers regress.
- **`infra-config.service.ts` → `validateEnvValues`** — Replaced the silent
  `default: break` fall-through for `JWT_SECRET`, `SESSION_SECRET`, and
  `ALLOW_SECURE_COOKIES` with explicit rejection
  (`INFRA_CONFIG_OPERATION_NOT_ALLOWED`). These keys can no longer be written
  through any infra-config code path — not just onboarding.
- **`infra-config.service.spec.ts`** — Added unit tests for sensitive-key
  rejection across `validateEnvValues`, `update`, `updateMany`, and
  `updateOnboardingConfig`'s allowlist-filtering behavior.

## Notes to reviewers
- The scoped controller pipe and the service-level allowlist are intentionally
  redundant with the global `whitelist: true` — they exist so a future change
  to `main.ts` or to the DTO cannot silently re-enable the mass-assignment path.
- No public API / DTO shape changes for well-behaved clients; only extraneous
  or sensitive fields are now rejected/dropped.
- Advisory: GHSA-j542-4rch-8hwf.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a critical mass-assignment vulnerability in the unauthenticated onboarding config (POST /v1/onboarding/config) so attackers can’t set sensitive keys like `JWT_SECRET` or `SESSION_SECRET`. Adds layered validation and an allowlist, and tightens input validation across DTOs and GraphQL args.

- **Bug Fixes**
  - Enable global `ValidationPipe` with `whitelist: true` and `forbidNonWhitelisted: true` to strip and reject unknown request fields (400).
  - Filter onboarding writes against `SaveOnboardingConfigRequest` keys so only OAuth/SMTP fields are persisted; drop all others. Add unit tests for allowlist filtering.
  - Explicitly reject writes to `JWT_SECRET`, `SESSION_SECRET`, and `ALLOW_SECURE_COOKIES` across infra-config paths.
  - Stricter onboarding DTO checks (required auth providers; URL/SMTP field validation). Add `class-validator` to auth (magic link), access tokens, infra-token invitations (email checks), and domain DTOs.
  - Validate GraphQL inputs with new args classes and safe pagination: `FetchAllUsersV2Args`, `FetchAllTeamsV2Args`, `FetchTeamMockServersArgs`, `FetchPublishedDocsArgs`; enforce `skip`/`take` as integers with sane mins/defaults and `cursor` as string.

<sup>Written for commit 40b99eed9ff22d958035077bb435296e2145e1fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



