### PR TITLE
fix(backend): preserve '=' in cookie values in extractCookieAsKeyValuesFromHeaders

### DIFF
--- a/packages/hoppscotch-backend/src/auth/helper.spec.ts
+++ b/packages/hoppscotch-backend/src/auth/helper.spec.ts
@@ -1,0 +1,140 @@
+import { HttpException } from '@nestjs/common';
+import { IncomingHttpHeaders } from 'http';
+import { COOKIES_NOT_FOUND } from 'src/errors';
+import { extractCookieAsKeyValuesFromHeaders } from './helper';
+
+// RFC 6265 §5.2 says the first '=' in a cookie-pair separates the name from
+// the value, and everything after that first '=' is part of the value.
+// These tests pin down that contract — especially that '=' padding inside
+// JWT and base64-encoded tokens survives a round trip through the parser.
+describe('extractCookieAsKeyValuesFromHeaders', () => {
+  const asHeaders = (cookie: string): IncomingHttpHeaders => ({ cookie });
+
+  describe('basic parsing', () => {
+    it('parses a single cookie', () => {
+      expect(extractCookieAsKeyValuesFromHeaders(asHeaders('a=1'))).toEqual({
+        a: '1',
+      });
+    });
+
+    it('parses multiple cookies separated by "; "', () => {
+      expect(
+        extractCookieAsKeyValuesFromHeaders(asHeaders('a=1; b=2; c=3')),
+      ).toEqual({ a: '1', b: '2', c: '3' });
+    });
+
+    it('trims whitespace around each cookie pair', () => {
+      expect(
+        extractCookieAsKeyValuesFromHeaders(asHeaders('  a=1 ;   b=2  ')),
+      ).toEqual({ a: '1', b: '2' });
+    });
+
+    it('returns an empty value when the cookie ends with "="', () => {
+      // `a=` is legal per RFC 6265 — represents an empty value, not a bare name
+      expect(extractCookieAsKeyValuesFromHeaders(asHeaders('a='))).toEqual({
+        a: '',
+      });
+    });
+  });
+
+  describe('header casing and shape', () => {
+    it('accepts the lowercase "cookie" header', () => {
+      expect(
+        extractCookieAsKeyValuesFromHeaders({ cookie: 'a=1' }),
+      ).toEqual({ a: '1' });
+    });
+
+    it('accepts a capitalized "Cookie" header', () => {
+      expect(
+        extractCookieAsKeyValuesFromHeaders({ Cookie: 'a=1' } as any),
+      ).toEqual({ a: '1' });
+    });
+
+    it('picks the first entry when the cookie header arrives as an array', () => {
+      expect(
+        extractCookieAsKeyValuesFromHeaders({
+          cookie: ['a=1', 'b=2'],
+        }),
+      ).toEqual({ a: '1' });
+    });
+
+    it('throws COOKIES_NOT_FOUND when no cookie header is present', () => {
+      expect(() =>
+        extractCookieAsKeyValuesFromHeaders({} as IncomingHttpHeaders),
+      ).toThrow(HttpException);
+      expect(() =>
+        extractCookieAsKeyValuesFromHeaders({} as IncomingHttpHeaders),
+      ).toThrow(COOKIES_NOT_FOUND);
+    });
+  });
+
+  describe("preserves '=' characters inside cookie values", () => {
+    // This is the bug reported in #6135 — the previous implementation used
+    // `curr.split('=')` with destructuring, which silently dropped everything
+    // after the first '=' inside the value. These cases all contain '='
+    // padding that strict parsers used to mangle.
+
+    it('keeps the trailing "==" on a base64-padded value', () => {
+      const cookieStr = 'token=abc==';
+      expect(
+        extractCookieAsKeyValuesFromHeaders(asHeaders(cookieStr)),
+      ).toEqual({ token: 'abc==' });
+    });
+
+    it('keeps embedded "=" characters inside a JWT-shaped value', () => {
+      // A realistic JWT body — three base64url segments separated by '.',
+      // with padding that includes '=' characters.
+      const jwt =
+        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0==.sig==';
+      const cookieStr = `access_token=${jwt}`;
+      expect(
+        extractCookieAsKeyValuesFromHeaders(asHeaders(cookieStr)),
+      ).toEqual({ access_token: jwt });
+    });
+
+    it('keeps "=" inside each value when multiple cookies are present', () => {
+      const cookieStr =
+        'session=abc=; refresh_token=xyz==; csrf=plain';
+      expect(
+        extractCookieAsKeyValuesFromHeaders(asHeaders(cookieStr)),
+      ).toEqual({
+        session: 'abc=',
+        refresh_token: 'xyz==',
+        csrf: 'plain',
+      });
+    });
+
+    it('handles consecutive "=" characters inside a single value', () => {
+      expect(
+        extractCookieAsKeyValuesFromHeaders(asHeaders('token====')),
+      ).toEqual({ token: '===' });
+    });
+  });
+
+  describe('defensive handling of malformed cookie strings', () => {
+    it('ignores empty segments produced by trailing or duplicate semicolons', () => {
+      // Real-world clients occasionally emit `a=1;; b=2` or trailing `;`.
+      // Empty segments used to produce a stray `{ "": undefined }` entry.
+      expect(
+        extractCookieAsKeyValuesFromHeaders(asHeaders('a=1;; b=2;')),
+      ).toEqual({ a: '1', b: '2' });
+    });
+
+    it('drops nameless cookie segments instead of using an empty key', () => {
+      // A segment that starts with `=` has no name, so there is nothing
+      // useful to index it under. Skip it rather than clobbering the map
+      // with a `""` key.
+      expect(
+        extractCookieAsKeyValuesFromHeaders(asHeaders('=orphan; a=1')),
+      ).toEqual({ a: '1' });
+    });
+
+    it('stores a bare flag cookie with an empty value', () => {
+      // Cookies like `HttpOnly` occasionally appear without an `=value`.
+      // Treat them as present-but-empty so downstream code can detect them.
+      expect(
+        extractCookieAsKeyValuesFromHeaders(asHeaders('flag; a=1')),
+      ).toEqual({ flag: '', a: '1' });
+    });
+  });
+});

--- a/packages/hoppscotch-backend/src/auth/helper.spec.ts
+++ b/packages/hoppscotch-backend/src/auth/helper.spec.ts
@@ -130,8 +130,9 @@ describe('extractCookieAsKeyValuesFromHeaders', () => {
     });
 
     it('stores a bare flag cookie with an empty value', () => {
-      // Cookies like `HttpOnly` occasionally appear without an `=value`.
-      // Treat them as present-but-empty so downstream code can detect them.
+      // Bare cookie names (no `=value`) occasionally appear in `Cookie`
+      // request headers — treat them as present-but-empty so downstream
+      // code can detect them.
       expect(
         extractCookieAsKeyValuesFromHeaders(asHeaders('flag; a=1')),
       ).toEqual({ flag: '', a: '1' });

--- a/packages/hoppscotch-backend/src/auth/helper.ts
+++ b/packages/hoppscotch-backend/src/auth/helper.ts
@@ -149,10 +149,17 @@ export const extractCookieAsKeyValuesFromHeaders = (
   const kv = cookieStr
     .split(';')
     .map((cookie) => cookie.trim())
+    .filter((cookie) => cookie.length > 0)
     .reduce(
       (acc, curr) => {
-        const [key, value] = curr.split('=');
-        acc[key] = value;
+        // Split only on the FIRST '=' — cookie values (JWTs, base64 payloads)
+        // routinely contain '=' padding, and destructuring `curr.split('=')`
+        // into two slots silently drops everything after the first '='.
+        // RFC 6265 §5.2 treats everything after the first '=' as the value.
+        const eqIdx = curr.indexOf('=');
+        const key = eqIdx !== -1 ? curr.slice(0, eqIdx) : curr;
+        const value = eqIdx !== -1 ? curr.slice(eqIdx + 1) : '';
+        if (key) acc[key] = value;
         return acc;
       },
       {} as Record<string, string>,


### PR DESCRIPTION
```
## Summary

- `extractCookieAsKeyValuesFromHeaders` destructured `curr.split('=')` into two slots, silently truncating any cookie value containing `=` padding — JWT access/refresh tokens and base64-encoded payloads end up shorter than the client sent, causing JWT verification to fail and the user to appear unauthenticated
- Split on the first `=` via `indexOf` / `slice` so everything after it is treated as the value (RFC 6265 §5.2, matching the `cookie` npm package the sister parser `subscriptionContextCookieParser` already uses)
- Filter empty segments from trailing / duplicate semicolons so they no longer land in the result map as `{ "": undefined }`
- Skip nameless segments (a cookie-pair starting with `=`) instead of writing them under an empty-string key
- Keep bare flag cookies (no `=` at all) as `{ flag: "" }` so presence-without-value is detectable downstream
- Add `packages/hoppscotch-backend/src/auth/helper.spec.ts` with 14 cases covering single/multi/trimmed parsing, case-variant header keys, array-shape cookie headers, missing-header rejection, base64 padding, JWT-shaped values with embedded `=`, consecutive `=`, and the empty / nameless / bare-flag segment edge cases

## Related Issues

Closes #6135.

Prior PR #6136 was closed by its author because a local tooling error replaced the entire file with unrelated OpenAI Codex CLI content — the cookie-parsing fix itself never landed. The underlying bug is still present on both `main` and `next` (verified via the GitHub contents API).

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added/updated
- [x] Manually verified parser logic against 11 representative inputs via a standalone Node script

The new `helper.spec.ts` is a pure-function test (no NestJS DI / Prisma mocks needed) and follows the same `describe`/`it` layout as `auth.service.spec.ts` next to it.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cookie parsing to preserve '=' in values in `extractCookieAsKeyValuesFromHeaders`, so JWT/base64 tokens are not truncated and auth stays reliable. Also handles malformed segments and keeps flag cookies detectable.

- **Bug Fixes**
  - Split on the first '=' via `indexOf`/`slice` (RFC 6265) to keep full values.
  - Filter empty segments from extra ';' and trim whitespace.
  - Skip nameless segments (starting with '='); keep bare flag cookies (no '=') as empty strings.
  - Added `packages/hoppscotch-backend/src/auth/helper.spec.ts` with 14 cases covering multi-cookie parsing, header casing/array shape, missing-header error (`COOKIES_NOT_FOUND`), and values containing '=' (base64/JWT).

<sup>Written for commit 80fded4f1d57909459dcce4e1c818a6da1a96cf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

