### PR TITLE
feat(common): fall back to initial value in OAuth2 env var resolution

### DIFF
--- a/packages/hoppscotch-common/src/helpers/auth/__tests__/index.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/__tests__/index.spec.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test, vi } from "vitest"
+
+vi.mock("~/modules/dioc", () => ({
+  getService: vi.fn(() => ({
+    currentActiveTab: {
+      value: {
+        document: { type: "example-response" },
+      },
+    },
+  })),
+}))
+
+vi.mock("../../utils/environments", () => ({
+  getCombinedEnvVariables: vi.fn(),
+}))
+
+import { getCombinedEnvVariables } from "../../utils/environments"
+import {
+  replaceTemplateString,
+  replaceTemplateStringsInObjectValues,
+} from "../index"
+
+const mockedGetCombinedEnvVariables = vi.mocked(getCombinedEnvVariables)
+
+describe("replaceTemplateString (OAuth2 env var resolution)", () => {
+  test("uses currentValue when it is set", () => {
+    mockedGetCombinedEnvVariables.mockReturnValue({
+      selected: [
+        {
+          key: "CLIENT_ID",
+          secret: false,
+          initialValue: "fallback-id",
+          currentValue: "real-id",
+        },
+      ],
+      global: [],
+    })
+
+    expect(replaceTemplateString("<<CLIENT_ID>>")).toBe("real-id")
+  })
+
+  test("falls back to initialValue when currentValue is empty", () => {
+    mockedGetCombinedEnvVariables.mockReturnValue({
+      selected: [
+        {
+          key: "CLIENT_ID",
+          secret: false,
+          initialValue: "fallback-id",
+          currentValue: "",
+        },
+      ],
+      global: [],
+    })
+
+    expect(replaceTemplateString("<<CLIENT_ID>>")).toBe("fallback-id")
+  })
+
+  test("falls back to initialValue for secret variables too", () => {
+    mockedGetCombinedEnvVariables.mockReturnValue({
+      selected: [
+        {
+          key: "CLIENT_SECRET",
+          secret: true,
+          initialValue: "fallback-secret",
+          currentValue: "",
+        },
+      ],
+      global: [],
+    })
+
+    expect(replaceTemplateString("<<CLIENT_SECRET>>")).toBe("fallback-secret")
+  })
+
+  test("resolves to empty string when both currentValue and initialValue are empty", () => {
+    mockedGetCombinedEnvVariables.mockReturnValue({
+      selected: [
+        {
+          key: "MISSING",
+          secret: false,
+          initialValue: "",
+          currentValue: "",
+        },
+      ],
+      global: [],
+    })
+
+    expect(replaceTemplateString("<<MISSING>>")).toBe("")
+  })
+
+  test("global variables also honor the fallback", () => {
+    mockedGetCombinedEnvVariables.mockReturnValue({
+      selected: [],
+      global: [
+        {
+          key: "TOKEN_URL",
+          secret: false,
+          initialValue: "https://auth.example.com/token",
+          currentValue: "",
+        },
+      ],
+    })
+
+    expect(replaceTemplateString("<<TOKEN_URL>>")).toBe(
+      "https://auth.example.com/token"
+    )
+  })
+})
+
+describe("replaceTemplateStringsInObjectValues (OAuth2 params)", () => {
+  test("applies the fallback across every string value in the object", () => {
+    mockedGetCombinedEnvVariables.mockReturnValue({
+      selected: [
+        {
+          key: "CLIENT_ID",
+          secret: false,
+          initialValue: "fallback-id",
+          currentValue: "",
+        },
+        {
+          key: "CLIENT_SECRET",
+          secret: true,
+          initialValue: "fallback-secret",
+          currentValue: "",
+        },
+        {
+          key: "SCOPE",
+          secret: false,
+          initialValue: "read",
+          currentValue: "write",
+        },
+      ],
+      global: [],
+    })
+
+    const result = replaceTemplateStringsInObjectValues({
+      clientID: "<<CLIENT_ID>>",
+      clientSecret: "<<CLIENT_SECRET>>",
+      scope: "<<SCOPE>>",
+      isPKCE: true,
+    })
+
+    expect(result).toEqual({
+      clientID: "fallback-id",
+      clientSecret: "fallback-secret",
+      scope: "write",
+      isPKCE: true,
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/auth/__tests__/index.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/__tests__/index.spec.ts
@@ -34,6 +34,7 @@ describe("replaceTemplateString (OAuth2 env var resolution)", () => {
         },
       ],
       global: [],
+      temp: [],
     })
 
     expect(replaceTemplateString("<<CLIENT_ID>>")).toBe("real-id")
@@ -50,6 +51,7 @@ describe("replaceTemplateString (OAuth2 env var resolution)", () => {
         },
       ],
       global: [],
+      temp: [],
     })
 
     expect(replaceTemplateString("<<CLIENT_ID>>")).toBe("fallback-id")
@@ -66,6 +68,7 @@ describe("replaceTemplateString (OAuth2 env var resolution)", () => {
         },
       ],
       global: [],
+      temp: [],
     })
 
     expect(replaceTemplateString("<<CLIENT_SECRET>>")).toBe("fallback-secret")
@@ -82,6 +85,7 @@ describe("replaceTemplateString (OAuth2 env var resolution)", () => {
         },
       ],
       global: [],
+      temp: [],
     })
 
     expect(replaceTemplateString("<<MISSING>>")).toBe("")
@@ -98,6 +102,7 @@ describe("replaceTemplateString (OAuth2 env var resolution)", () => {
           currentValue: "",
         },
       ],
+      temp: [],
     })
 
     expect(replaceTemplateString("<<TOKEN_URL>>")).toBe(
@@ -130,6 +135,7 @@ describe("replaceTemplateStringsInObjectValues (OAuth2 params)", () => {
         },
       ],
       global: [],
+      temp: [],
     })
 
     const result = replaceTemplateStringsInObjectValues({

--- a/packages/hoppscotch-common/src/helpers/auth/index.ts
+++ b/packages/hoppscotch-common/src/helpers/auth/index.ts
@@ -36,7 +36,18 @@ export const replaceTemplateStringsInObjectValues = <
       !requestVariables.some(({ key: reqVarKey }) => reqVarKey === key)
   )
 
-  const envVars = [...selectedEnvVars, ...globalEnvVars, ...requestVariables]
+  // Fall back to initialValue when currentValue is empty so OAuth2 token
+  // generation (the only caller of this helper) resolves variables
+  // consistently with the generic request-run path. Mirrors the
+  // `getTransformedEnvs` transform in RequestRunner.ts from #5162.
+  const envVars = [
+    ...selectedEnvVars,
+    ...globalEnvVars,
+    ...requestVariables,
+  ].map((v) => ({
+    ...v,
+    currentValue: v.currentValue || v.initialValue,
+  }))
 
   const newObj: Partial<T> = {}
 


### PR DESCRIPTION
```
## Summary

Closes #5709.

`replaceTemplateStringsInObjectValues` in `helpers/auth/index.ts` is the helper every OAuth2 grant-type flow uses to unwrap its form values before calling the token / authorization endpoint. Unlike the generic request-run path (`RequestRunner.ts`, updated in #5162 via `getTransformedEnvs`), it passed envVars through to `parseTemplateStringE` without falling back to `initialValue` when `currentValue` was empty, so env vars that showed as resolved in the UI produced empty strings in Generate Token requests and surfaced as form-validation errors from the IdP.

## Changes

- Map each combined env var so `currentValue = currentValue || initialValue` before invoking `parseTemplateStringE`, matching the exact idiom already applied to every other env-var resolution site (`RequestRunner.ts`, `HoppEnvironment.ts`, `helpers/utils/environments.ts`).
- Add `helpers/auth/__tests__/index.spec.ts` covering:
  - `currentValue` preserved when set
  - Fallback to `initialValue` when `currentValue` is empty (selected, global, secret vars all covered)
  - Empty output when both `currentValue` and `initialValue` are empty
  - Object-wide fallback across all string values in a mixed OAuth2 params object

## Verification

Before:

    // <<CLIENT_ID>> where { initialValue: "abc", currentValue: "" }
    parseTemplateStringE("<<CLIENT_ID>>", envVars) // → ""

After:

    // same input
    replaceTemplateString("<<CLIENT_ID>>")         // → "abc"

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added — 6 vitest cases in `helpers/auth/__tests__/index.spec.ts`
- [x] Manually traced the code path end-to-end: `useOAuth2GrantTypes.ts` → `replaceTemplateStringsInObjectValues` → `parseTemplateStringE`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make OAuth2 env var resolution fall back to initial values when current values are empty. This fixes empty fields in Generate Token requests and avoids IdP validation errors.

- **Bug Fixes**
  - In `helpers/auth/index.ts`, default `currentValue` to `initialValue` before parsing, matching `getTransformedEnvs` in `RequestRunner.ts`.
  - Added tests in `helpers/auth/__tests__/index.spec.ts` for current, fallback, empty, and object-wide replacements; updated mocks to include `temp: []` to match the `getCombinedEnvVariables` return shape.

<sup>Written for commit 26079d2eb760e9f90a90981ad70610214edf6680. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

