### PR TITLE
fix(common): surface GraphQL subscription errors and guard malformed frames

### DIFF
--- a/packages/hoppscotch-common/src/helpers/graphql/__tests__/connection.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/__tests__/connection.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "vitest"
+
+import {
+  decodeSubscriptionFrame,
+  stringifySubscriptionErrorPayload,
+} from "../connection"
+
+describe("decodeSubscriptionFrame", () => {
+  test("rejects non-string frames", () => {
+    const result = decodeSubscriptionFrame(null as unknown as string)
+    expect(result).toEqual({
+      ok: false,
+      reason: "Received an empty or non-string frame",
+    })
+  })
+
+  test("rejects empty-string frames", () => {
+    const result = decodeSubscriptionFrame("")
+    expect(result).toEqual({
+      ok: false,
+      reason: "Received an empty or non-string frame",
+    })
+  })
+
+  test("rejects frames that are not valid JSON", () => {
+    const result = decodeSubscriptionFrame("not-json")
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason.length).toBeGreaterThan(0)
+    }
+  })
+
+  test("rejects JSON that is not an object", () => {
+    const result = decodeSubscriptionFrame('"a bare string"')
+    expect(result).toEqual({
+      ok: false,
+      reason: "Subscription frame is missing a type field",
+    })
+  })
+
+  test("rejects null JSON frames", () => {
+    const result = decodeSubscriptionFrame("null")
+    expect(result).toEqual({
+      ok: false,
+      reason: "Subscription frame is missing a type field",
+    })
+  })
+
+  test("rejects frames without a type field", () => {
+    const result = decodeSubscriptionFrame(JSON.stringify({ id: "1" }))
+    expect(result).toEqual({
+      ok: false,
+      reason: "Subscription frame is missing a type field",
+    })
+  })
+
+  test("accepts a well-formed data frame", () => {
+    const frame = {
+      type: "data",
+      id: "1",
+      payload: { data: { hello: "world" } },
+    }
+    const result = decodeSubscriptionFrame(JSON.stringify(frame))
+    expect(result).toEqual({ ok: true, frame })
+  })
+
+  test("accepts an error frame with a GraphQLError payload", () => {
+    const frame = {
+      type: "error",
+      id: "1",
+      payload: { message: "Unauthorized" },
+    }
+    const result = decodeSubscriptionFrame(JSON.stringify(frame))
+    expect(result).toEqual({ ok: true, frame })
+  })
+})
+
+describe("stringifySubscriptionErrorPayload", () => {
+  test("returns strings unchanged", () => {
+    expect(stringifySubscriptionErrorPayload("auth failed")).toBe("auth failed")
+  })
+
+  test("falls back to 'Unknown error' for null / undefined", () => {
+    expect(stringifySubscriptionErrorPayload(null)).toBe("Unknown error")
+    expect(stringifySubscriptionErrorPayload(undefined)).toBe("Unknown error")
+  })
+
+  test("serialises objects as JSON", () => {
+    expect(
+      stringifySubscriptionErrorPayload({ message: "bad subscription" })
+    ).toBe('{"message":"bad subscription"}')
+  })
+
+  test("serialises GraphQLError-shaped payloads", () => {
+    const payload = {
+      message: "Variable $id is not defined",
+      locations: [{ line: 2, column: 3 }],
+    }
+    const out = stringifySubscriptionErrorPayload(payload)
+    expect(out).toContain("Variable $id is not defined")
+    expect(out).toContain('"line":2')
+  })
+
+  test("falls back to 'Unknown error' when JSON.stringify throws", () => {
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    expect(stringifySubscriptionErrorPayload(circular)).toBe("Unknown error")
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/graphql/__tests__/connection.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/__tests__/connection.spec.ts
@@ -30,24 +30,40 @@ describe("decodeSubscriptionFrame", () => {
     }
   })
 
-  test("rejects JSON that is not an object", () => {
+  test("rejects bare-string JSON with a non-object reason", () => {
     const result = decodeSubscriptionFrame('"a bare string"')
     expect(result).toEqual({
       ok: false,
-      reason: "Subscription frame is missing a type field",
+      reason: "Subscription frame is not a valid object",
     })
   })
 
-  test("rejects null JSON frames", () => {
+  test("rejects null JSON frames with a non-object reason", () => {
     const result = decodeSubscriptionFrame("null")
     expect(result).toEqual({
       ok: false,
-      reason: "Subscription frame is missing a type field",
+      reason: "Subscription frame is not a valid object",
+    })
+  })
+
+  test("rejects JSON arrays with a non-object reason", () => {
+    const result = decodeSubscriptionFrame("[1,2,3]")
+    expect(result).toEqual({
+      ok: false,
+      reason: "Subscription frame is not a valid object",
     })
   })
 
   test("rejects frames without a type field", () => {
     const result = decodeSubscriptionFrame(JSON.stringify({ id: "1" }))
+    expect(result).toEqual({
+      ok: false,
+      reason: "Subscription frame is missing a type field",
+    })
+  })
+
+  test("rejects frames where type is a non-string", () => {
+    const result = decodeSubscriptionFrame(JSON.stringify({ type: 42 }))
     expect(result).toEqual({
       ok: false,
       reason: "Subscription frame is missing a type field",

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -625,7 +625,12 @@ export const runSubscription = (
   const { url, query, operationName } = options
   const wsUrl = url.replace(/^http/, "ws")
 
-  connection.subscriptionState.set(currentTabID.value, "SUBSCRIBING")
+  // Capture the tab that started this subscription so state transitions
+  // fired from async callbacks (onmessage / onclose) always update the
+  // originating tab, even if the user has since switched tabs.
+  const subscriptionTabID = currentTabID.value
+
+  connection.subscriptionState.set(subscriptionTabID, "SUBSCRIBING")
 
   connection.socket = new WebSocket(wsUrl, "graphql-ws")
 
@@ -665,7 +670,7 @@ export const runSubscription = (
     const data = decoded.frame
     switch (data.type) {
       case GQL.CONNECTION_ACK: {
-        connection.subscriptionState.set(currentTabID.value, "SUBSCRIBED")
+        connection.subscriptionState.set(subscriptionTabID, "SUBSCRIBED")
         break
       }
       case GQL.CONNECTION_ERROR:
@@ -686,10 +691,7 @@ export const runSubscription = (
         // transition so the UI does not keep presenting the subscription
         // as live.
         if (data.type === GQL.ERROR) {
-          connection.subscriptionState.set(
-            currentTabID.value,
-            "UNSUBSCRIBED"
-          )
+          connection.subscriptionState.set(subscriptionTabID, "UNSUBSCRIBED")
         }
         break
       }
@@ -715,7 +717,7 @@ export const runSubscription = (
 
   connection.socket.onclose = (event) => {
     console.log("WebSocket is closed now.", event)
-    connection.subscriptionState.set(currentTabID.value, "UNSUBSCRIBED")
+    connection.subscriptionState.set(subscriptionTabID, "UNSUBSCRIBED")
   }
 
   addQueryToHistory(options, "")

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -122,8 +122,11 @@ export function decodeSubscriptionFrame(
     if (
       parsed === null ||
       typeof parsed !== "object" ||
-      typeof (parsed as { type?: unknown }).type !== "string"
+      Array.isArray(parsed)
     ) {
+      return { ok: false, reason: "Subscription frame is not a valid object" }
+    }
+    if (typeof (parsed as { type?: unknown }).type !== "string") {
       return { ok: false, reason: "Subscription frame is missing a type field" }
     }
     return { ok: true, frame: parsed as SubscriptionFrame }
@@ -676,6 +679,17 @@ export const runSubscription = (
                 : "subscription_error",
             message: stringifySubscriptionErrorPayload(data.payload),
           },
+        }
+        // GQL.ERROR terminates this subscription per the
+        // subscriptions-transport-ws protocol — the server will not send
+        // further `data` frames for this id. Mirror `onclose`'s state
+        // transition so the UI does not keep presenting the subscription
+        // as live.
+        if (data.type === GQL.ERROR) {
+          connection.subscriptionState.set(
+            currentTabID.value,
+            "UNSUBSCRIBED"
+          )
         }
         break
       }

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -100,6 +100,51 @@ const GQL = {
   COMPLETE: "complete",
 }
 
+type SubscriptionFrame = {
+  type: string
+  id?: string
+  payload?: unknown
+}
+
+export type SubscriptionFrameDecodeResult =
+  | { ok: true; frame: SubscriptionFrame }
+  | { ok: false; reason: string }
+
+export function decodeSubscriptionFrame(
+  raw: unknown
+): SubscriptionFrameDecodeResult {
+  if (typeof raw !== "string" || raw.length === 0) {
+    return { ok: false, reason: "Received an empty or non-string frame" }
+  }
+
+  try {
+    const parsed = JSON.parse(raw)
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      typeof (parsed as { type?: unknown }).type !== "string"
+    ) {
+      return { ok: false, reason: "Subscription frame is missing a type field" }
+    }
+    return { ok: true, frame: parsed as SubscriptionFrame }
+  } catch (e) {
+    return {
+      ok: false,
+      reason: (e as Error)?.message ?? "Failed to parse subscription frame",
+    }
+  }
+}
+
+export function stringifySubscriptionErrorPayload(payload: unknown): string {
+  if (typeof payload === "string") return payload
+  if (payload === null || payload === undefined) return "Unknown error"
+  try {
+    return JSON.stringify(payload)
+  } catch {
+    return "Unknown error"
+  }
+}
+
 type Connection = {
   state: ConnectionState
   subscriptionState: Map<string, SubscriptionState>
@@ -603,14 +648,35 @@ export const runSubscription = (
   gqlMessageEvent.value = "reset"
 
   connection.socket.onmessage = (event) => {
-    const data = JSON.parse(event.data)
+    const decoded = decodeSubscriptionFrame(event.data)
+    if (!decoded.ok) {
+      gqlMessageEvent.value = {
+        type: "error",
+        error: {
+          type: "malformed_frame",
+          message: decoded.reason,
+        },
+      }
+      return
+    }
+    const data = decoded.frame
     switch (data.type) {
       case GQL.CONNECTION_ACK: {
         connection.subscriptionState.set(currentTabID.value, "SUBSCRIBED")
         break
       }
-      case GQL.CONNECTION_ERROR: {
-        console.error(data.payload)
+      case GQL.CONNECTION_ERROR:
+      case GQL.ERROR: {
+        gqlMessageEvent.value = {
+          type: "error",
+          error: {
+            type:
+              data.type === GQL.CONNECTION_ERROR
+                ? "connection_error"
+                : "subscription_error",
+            message: stringifySubscriptionErrorPayload(data.payload),
+          },
+        }
         break
       }
       case GQL.CONNECTION_KEEP_ALIVE: {

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -665,6 +665,14 @@ export const runSubscription = (
           message: decoded.reason,
         },
       }
+      // A frame we can't decode means the wire format is broken for
+      // this socket; further frames are likely to fail the same way.
+      // Halt message processing by transitioning the originating tab
+      // to UNSUBSCRIBED (mirrors `onclose`) and closing the socket so
+      // the UI doesn't stay stuck in SUBSCRIBING/SUBSCRIBED while a
+      // tight loop of `malformed_frame` errors is emitted.
+      connection.subscriptionState.set(subscriptionTabID, "UNSUBSCRIBED")
+      connection.socket?.close()
       return
     }
     const data = decoded.frame
@@ -685,14 +693,16 @@ export const runSubscription = (
             message: stringifySubscriptionErrorPayload(data.payload),
           },
         }
-        // GQL.ERROR terminates this subscription per the
-        // subscriptions-transport-ws protocol — the server will not send
-        // further `data` frames for this id. Mirror `onclose`'s state
-        // transition so the UI does not keep presenting the subscription
-        // as live.
-        if (data.type === GQL.ERROR) {
-          connection.subscriptionState.set(subscriptionTabID, "UNSUBSCRIBED")
-        }
+        // Both connection-level and subscription-level error frames
+        // are terminal for this active subscription. GQL.ERROR ends
+        // this single subscription per the subscriptions-transport-ws
+        // protocol; GQL.CONNECTION_ERROR ends the whole transport and
+        // the server may take a while to actually close the socket
+        // (or never close it cleanly). Mirror `onclose`'s state
+        // transition immediately in both cases so the UI does not
+        // keep presenting the subscription as live while we wait on
+        // the server.
+        connection.subscriptionState.set(subscriptionTabID, "UNSUBSCRIBED")
         break
       }
       case GQL.CONNECTION_KEEP_ALIVE: {

--- a/packages/hoppscotch-common/src/helpers/graphql/connection.ts
+++ b/packages/hoppscotch-common/src/helpers/graphql/connection.ts
@@ -671,8 +671,13 @@ export const runSubscription = (
       // to UNSUBSCRIBED (mirrors `onclose`) and closing the socket so
       // the UI doesn't stay stuck in SUBSCRIBING/SUBSCRIBED while a
       // tight loop of `malformed_frame` errors is emitted.
+      //
+      // Close the socket that emitted this frame, not
+      // `connection.socket`: the shared reference may already have
+      // been replaced by a newer subscription, and a stale callback
+      // firing here must not disconnect the active one.
       connection.subscriptionState.set(subscriptionTabID, "UNSUBSCRIBED")
-      connection.socket?.close()
+      ;(event.currentTarget as WebSocket | null)?.close()
       return
     }
     const data = decoded.frame


### PR DESCRIPTION
```
## Summary

- `runSubscription`'s WebSocket onmessage handler declared `GQL.ERROR` in the protocol table but never handled it — server-side subscription execution errors (`{"type":"error","payload":{...GraphQLError...}}`) fell through silently and the user had no indication the subscription had failed
- `GQL.CONNECTION_ERROR` only logged to `console.error`, so connection-level failures were invisible to the UI timeline
- `JSON.parse(event.data)` had no guard, so any malformed frame (proxy-injected HTML, binary keep-alive, misconfigured server) threw an uncaught exception out of the message handler

## Changes

- Extract `decodeSubscriptionFrame` and `stringifySubscriptionErrorPayload` pure helpers at the top of `helpers/graphql/connection.ts`
- `decodeSubscriptionFrame` rejects non-string, empty-string, non-JSON, non-object, null, and type-field-less frames, returning a tagged result instead of throwing
- `stringifySubscriptionErrorPayload` returns strings unchanged, falls back to `"Unknown error"` for null / undefined / circular inputs, and JSON-stringifies structured `GraphQLError` payloads
- Route malformed frames, `GQL.ERROR`, and `GQL.CONNECTION_ERROR` through the existing `gqlMessageEvent = { type: "error", error: { type, message } }` surface used by `runGQLOperation` in the same file
- Keep the success / ack / keep-alive / complete arms behaviourally identical

## Related Issues

N/A — code review. The `GQL.ERROR` arm has been missing since the protocol table was introduced; no existing issue tracks this gap. Verified via GitHub search that no open or closed PR addresses any of the three symptoms.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added — `helpers/graphql/__tests__/connection.spec.ts` with 13 vitest cases covering every `decodeSubscriptionFrame` branch (null / empty / non-JSON / bare-string / null JSON / missing-type / valid-data / valid-error) and every `stringifySubscriptionErrorPayload` payload shape (string / null / undefined / object / GraphQLError-shaped / circular reference)
- [x] Manually traced the code path end-to-end against the `subscriptions-transport-ws` spec

## Checklist

- [x] Code follows project style guidelines (error-event shape mirrors `runGQLOperation` in the same file)
- [x] Self-review completed
- [x] Changes are documented (if applicable)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced GraphQL subscription and connection errors in the UI and guarded malformed WebSocket frames. State transitions target the originating tab and end on terminal errors; malformed frames close only the emitting socket to avoid tearing down newer subscriptions.

- **Bug Fixes**
  - Handle `GQL.ERROR` and `GQL.CONNECTION_ERROR` in `runSubscription` and emit `gqlMessageEvent` with `{ type: "error", error: { type, message } }`.
  - On `GQL.ERROR`, `GQL.CONNECTION_ERROR`, and malformed frames, set `subscriptionState` to `UNSUBSCRIBED`; on malformed frames also close only the emitting socket to stop errors without affecting newer connections.
  - Guard frame parsing; malformed or non-JSON frames surface as `malformed_frame` instead of uncaught exceptions.
  - Capture the tab id at subscription start and use it for all `onmessage`/`onclose` transitions to prevent cross-tab state writes.
  - No changes to ack/keep-alive/complete behavior.

- **Refactors**
  - Added `decodeSubscriptionFrame` to safely parse frames and `stringifySubscriptionErrorPayload` to format error payloads.
  - Error payloads: strings pass through; objects are JSON-serialized; null/undefined/circular inputs fall back to "Unknown error".
  - Stricter decode errors: reject non-object/array frames and non-string `type`; separate “not an object” vs “missing type” reasons.

<sup>Written for commit bc151799a70d6fd7325469b1c318969052e988c4. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6179?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

