### PR TITLE
fix: add missing take param to myTeams resolver

### DIFF
--- a/packages/hoppscotch-backend/src/team/team.resolver.ts
+++ b/packages/hoppscotch-backend/src/team/team.resolver.ts
@@ -121,8 +121,16 @@ export class TeamResolver {
       nullable: true,
     })
     cursor?: string,
+    @Args({
+      name: 'take',
+      type: () => Int,
+      description: 'Number of teams to return per page',
+      nullable: true,
+      defaultValue: 10,
+    })
+    take?: number,
   ): Promise<Team[]> {
-    return this.teamService.getTeamsOfUser(user.uid, cursor ?? null);
+    return this.teamService.getTeamsOfUser(user.uid, cursor ?? null, take);
   }
 
   @Query(() => Team, {

--- a/packages/hoppscotch-backend/src/team/team.resolver.ts
+++ b/packages/hoppscotch-backend/src/team/team.resolver.ts
@@ -130,7 +130,7 @@ export class TeamResolver {
     })
     take?: number,
   ): Promise<Team[]> {
-    return this.teamService.getTeamsOfUser(user.uid, cursor ?? null, take);
+    return this.teamService.getTeamsOfUser(user.uid, cursor ?? null, take ?? 10);
   }
 
   @Query(() => Team, {


### PR DESCRIPTION
Fixes #6177

The `myTeams` resolver calls `getTeamsOfUser()` with only 2 args (`uid`, `cursor`) but the service expects a third `take` parameter for pagination.

The `teams` resolver (line 179) already passes `take` correctly. This aligns `myTeams` to match, adding the same `take` GraphQL arg with a default of 10.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pagination in the `myTeams` GraphQL resolver by adding the missing `take` argument (default 10) and guarding against null. The resolver now passes `take` to `getTeamsOfUser`, matching the `teams` resolver.

<sup>Written for commit 52faf534aebe05233c041acd9c57528bc1308d41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

