### PR TITLE
fix(common): prefer key value for Latin shortcuts with code fallback

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/keybinding-utils.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/keybinding-utils.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest"
+import { getPressedShortcutKey } from "../keybinding-utils"
+
+function createKeyboardEventLike({ key, code }: { key: string; code: string }) {
+  return { key, code }
+}
+
+describe("getPressedShortcutKey", () => {
+  test("prefers the typed Latin letter over the physical key code", () => {
+    expect(
+      getPressedShortcutKey(createKeyboardEventLike({ key: "a", code: "KeyQ" }))
+    ).toBe("a")
+
+    expect(
+      getPressedShortcutKey(createKeyboardEventLike({ key: "z", code: "KeyW" }))
+    ).toBe("z")
+  })
+
+  test("falls back to physical letter codes for non-Latin layouts", () => {
+    expect(
+      getPressedShortcutKey(createKeyboardEventLike({ key: "й", code: "KeyQ" }))
+    ).toBe("q")
+  })
+
+  test("keeps punctuation-based shortcuts layout aware", () => {
+    expect(
+      getPressedShortcutKey(
+        createKeyboardEventLike({ key: "?", code: "Slash" })
+      )
+    ).toBe("/")
+
+    expect(
+      getPressedShortcutKey(
+        createKeyboardEventLike({ key: "[", code: "Digit5" })
+      )
+    ).toBe("[")
+  })
+
+  test("supports digits from the main row and numpad", () => {
+    expect(
+      getPressedShortcutKey(
+        createKeyboardEventLike({ key: "9", code: "Digit9" })
+      )
+    ).toBe("9")
+
+    // Numpad with NumLock ON produces "0"-"9" in event.key, which
+    // the digit check handles without needing a separate Numpad branch.
+    expect(
+      getPressedShortcutKey(
+        createKeyboardEventLike({ key: "9", code: "Numpad9" })
+      )
+    ).toBe("9")
+  })
+
+  test("falls back to physical digit codes for non-digit layouts", () => {
+    // AZERTY: physical Digit1 produces "&" in event.key
+    expect(
+      getPressedShortcutKey(
+        createKeyboardEventLike({ key: "&", code: "Digit1" })
+      )
+    ).toBe("1")
+
+    // AZERTY: physical Digit0 produces "à" in event.key
+    expect(
+      getPressedShortcutKey(
+        createKeyboardEventLike({ key: "à", code: "Digit0" })
+      )
+    ).toBe("0")
+  })
+
+  test("returns null for unrecognised keys", () => {
+    expect(
+      getPressedShortcutKey(createKeyboardEventLike({ key: "F1", code: "F1" }))
+    ).toBeNull()
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/__tests__/keybinding-utils.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/keybinding-utils.spec.ts
@@ -36,6 +36,20 @@ describe("getPressedShortcutKey", () => {
     ).toBe("[")
   })
 
+  test("falls back to physical bracket codes when key differs by layout", () => {
+    expect(
+      getPressedShortcutKey(
+        createKeyboardEventLike({ key: "^", code: "BracketLeft" })
+      )
+    ).toBe("[")
+
+    expect(
+      getPressedShortcutKey(
+        createKeyboardEventLike({ key: "$", code: "BracketRight" })
+      )
+    ).toBe("]")
+  })
+
   test("supports digits from the main row and numpad", () => {
     expect(
       getPressedShortcutKey(

--- a/packages/hoppscotch-common/src/helpers/keybinding-utils.ts
+++ b/packages/hoppscotch-common/src/helpers/keybinding-utils.ts
@@ -40,7 +40,6 @@ export type SupportedShortcutKey =
   | "left"
   | "right"
   | "/"
-  | "?"
   | "."
   | "enter"
   | "tab"

--- a/packages/hoppscotch-common/src/helpers/keybinding-utils.ts
+++ b/packages/hoppscotch-common/src/helpers/keybinding-utils.ts
@@ -1,0 +1,102 @@
+export type SupportedShortcutKey =
+  | "a"
+  | "b"
+  | "c"
+  | "d"
+  | "e"
+  | "f"
+  | "g"
+  | "h"
+  | "i"
+  | "j"
+  | "k"
+  | "l"
+  | "m"
+  | "n"
+  | "o"
+  | "p"
+  | "q"
+  | "r"
+  | "s"
+  | "t"
+  | "u"
+  | "v"
+  | "w"
+  | "x"
+  | "y"
+  | "z"
+  | "0"
+  | "1"
+  | "2"
+  | "3"
+  | "4"
+  | "5"
+  | "6"
+  | "7"
+  | "8"
+  | "9"
+  | "up"
+  | "down"
+  | "left"
+  | "right"
+  | "/"
+  | "?"
+  | "."
+  | "enter"
+  | "tab"
+  | "delete"
+  | "backspace"
+  | "["
+  | "]"
+
+type KeyboardEventLike = Pick<KeyboardEvent, "key" | "code">
+
+export function getPressedShortcutKey(
+  ev: KeyboardEventLike
+): SupportedShortcutKey | null {
+  const key = (ev.key ?? "").toLowerCase()
+  const code = ev.code ?? ""
+
+  // Prefer the actual Latin character so layouts like AZERTY and Dvorak
+  // keep their expected Ctrl+A/Ctrl+Q behavior. When the active layout
+  // produces a non-Latin glyph, fall back to the physical key code so
+  // shortcuts still work on layouts like Cyrillic.
+  if (key.length === 1 && key >= "a" && key <= "z") {
+    return key as SupportedShortcutKey
+  }
+
+  if (code.startsWith("Key") && code.length === 4) {
+    return code[3].toLowerCase() as SupportedShortcutKey
+  }
+
+  if (key.startsWith("arrow")) {
+    return key.slice(5) as SupportedShortcutKey
+  }
+
+  if (key === "tab") return "tab"
+  if (key === "delete") return "delete"
+  if (key === "backspace") return "backspace"
+
+  if (key === "?") return "/"
+
+  if (key === "/" || key === "." || key === "enter") {
+    return key as SupportedShortcutKey
+  }
+
+  if (key === "[" || key === "]") return key as SupportedShortcutKey
+
+  // Digit keys: prefer event.key when it is already a digit. On layouts
+  // like AZERTY the digit row produces symbols by default (e.g. "&", "é"),
+  // so fall back to event.code (Digit0–Digit9) to keep numeric shortcuts
+  // working. This also covers Numpad digits since NumLock-ON numpad keys
+  // produce "0"–"9" in event.key.
+  if (key.length === 1 && key >= "0" && key <= "9") {
+    return key as SupportedShortcutKey
+  }
+
+  if (code.startsWith("Digit") && code.length === 6) {
+    return code[5] as SupportedShortcutKey
+  }
+
+  return null
+}

--- a/packages/hoppscotch-common/src/helpers/keybinding-utils.ts
+++ b/packages/hoppscotch-common/src/helpers/keybinding-utils.ts
@@ -83,6 +83,8 @@ export function getPressedShortcutKey(
   }
 
   if (key === "[" || key === "]") return key as SupportedShortcutKey
+  if (code === "BracketLeft") return "["
+  if (code === "BracketRight") return "]"
 
   // Digit keys: prefer event.key when it is already a digit. On layouts
   // like AZERTY the digit row produces symbols by default (e.g. "&", "é"),

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -8,6 +8,7 @@ import {
   isMonacoEditor,
   isTypableElement,
 } from "./utils/dom"
+import { getPressedShortcutKey, SupportedShortcutKey } from "./keybinding-utils"
 import { getKernelMode } from "@hoppscotch/kernel"
 import { listen } from "@tauri-apps/api/event"
 
@@ -36,16 +37,7 @@ type ModifierKeys =
   | "ctrl-alt"
   | "ctrl-alt-shift"
 
-/* eslint-disable prettier/prettier */
-// prettier-ignore
-type Key =
-  | "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j"
-  | "k" | "l" | "m" | "n" | "o" | "p" | "q" | "r" | "s" | "t"
-  | "u" | "v" | "w" | "x" | "y" | "z" | "0" | "1" | "2" | "3"
-  | "4" | "5" | "6" | "7" | "8" | "9" | "up" | "down" | "left"
-  | "right" | "/" | "?" | "." | "enter" | "tab" | "delete" | "backspace"
-  | "[" | "]"
-/* eslint-enable */
+type Key = SupportedShortcutKey
 
 type ModifierBasedShortcutKey = `${ModifierKeys}-${Key}`
 // Singular keybindings (these will be disabled when an input-ish area has been focused)
@@ -307,65 +299,7 @@ function generateKeybindingString(ev: KeyboardEvent): ShortcutKey | null {
 }
 
 function getPressedKey(ev: KeyboardEvent): Key | null {
-  const key = (ev.key ?? "").toLowerCase()
-  const code = ev.code ?? ""
-
-  // Use event.code for letters and digits so shortcuts work regardless of
-  // the active keyboard layout (Cyrillic, CJK, Dvorak, etc). event.key
-  // returns the character produced by the layout, event.code returns the
-  // physical key position.
-  //
-  // TODO: Several component-level keydown handlers still use event.key
-  //       (spotlight, EnvInput, SchemaSearch, AI modals). Those need the
-  //       same migration but are lower priority since they only check
-  //       arrow/Enter/Escape which are layout-stable.
-
-  // Letter keys (KeyA–KeyZ)
-  if (code.startsWith("Key") && code.length === 4) {
-    return code[3].toLowerCase() as Key
-  }
-
-  // ev.code can be empty in synthetic events or older environments. Fall back
-  // to ev.key for ASCII letters so shortcuts don't silently stop working.
-  // This reintroduces layout-dependence for that edge case, but that's better
-  // than dropping the shortcut entirely.
-  if (!code && key.length === 1 && key >= "a" && key <= "z") return key as Key
-
-  // Arrow keys (ArrowUp → up, etc)
-  if (key.startsWith("arrow")) {
-    return key.slice(5) as Key
-  }
-
-  if (key === "tab") return "tab"
-  if (key === "delete") return "delete"
-  if (key === "backspace") return "backspace"
-
-  // Shift+/ produces "?" on most layouts but the shortcut is registered as "/"
-  if (key === "?") return "/"
-
-  // Punctuation and special keys checked before digit codes because some
-  // layouts produce these characters from physical digit keys (e.g. AZERTY
-  // produces [ via AltGr+5 which has code "Digit5").
-  if (key === "/" || key === "." || key === "enter") return key
-  if (key === "[" || key === "]") return key
-
-  // Digit keys (Digit0–Digit9)
-  if (code.startsWith("Digit") && code.length === 6) {
-    return code[5] as Key
-  }
-
-  // Numpad digits (Numpad0–Numpad9), only when NumLock is on.
-  // When NumLock is off the physical keys act as navigation (Home, End, etc)
-  // but event.code still returns Numpad0-Numpad9.
-  if (
-    code.startsWith("Numpad") &&
-    code.length === 7 &&
-    ev.getModifierState("NumLock")
-  ) {
-    return code.slice(6) as Key
-  }
-
-  return null
+  return getPressedShortcutKey(ev)
 }
 
 function getActiveModifier(ev: KeyboardEvent): ModifierKeys | null {

--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -276,6 +276,7 @@ async function initApp() {
         }
 
         const isCtrlOrCmd = e.ctrlKey || e.metaKey
+        const isAltGraph = e.getModifierState("AltGraph")
         let shortcutEvent: string | null = null
         const shortcutKey = getPressedShortcutKey(e)
 
@@ -322,6 +323,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
+          !isAltGraph &&
           e.key === "ArrowRight"
         ) {
           // Ctrl/Cmd + Alt + Right - Next Tab
@@ -333,6 +335,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
+          !isAltGraph &&
           e.key === "ArrowLeft"
         ) {
           // Ctrl/Cmd + Alt + Left - Previous Tab
@@ -344,6 +347,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
+          !isAltGraph &&
           shortcutKey === "9"
         ) {
           // Ctrl/Cmd + Alt + 9 - First Tab
@@ -355,6 +359,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
+          !isAltGraph &&
           shortcutKey === "0"
         ) {
           // Ctrl/Cmd + Alt + 0 - Last Tab
@@ -366,6 +371,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
+          !isAltGraph &&
           shortcutKey === "u"
         ) {
           // Ctrl/Cmd + Alt + U - Focus URL Bar
@@ -377,6 +383,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
+          !isAltGraph &&
           shortcutKey === "]"
         ) {
           // Ctrl/Cmd + Alt + ] - MRU Tab Switch
@@ -388,6 +395,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
+          !isAltGraph &&
           shortcutKey === "["
         ) {
           // Ctrl/Cmd + Alt + [ - MRU Tab Switch (Reverse)

--- a/packages/hoppscotch-selfhost-web/src/main.ts
+++ b/packages/hoppscotch-selfhost-web/src/main.ts
@@ -2,6 +2,7 @@ import { nextTick, ref, watch } from "vue"
 import { emit, listen } from "@tauri-apps/api/event"
 import { createHoppApp } from "@hoppscotch/common"
 import { useSettingStatic } from "@hoppscotch/common/composables/settings"
+import { getPressedShortcutKey } from "@hoppscotch/common/helpers/keybinding-utils"
 import { getKernelMode } from "@hoppscotch/kernel"
 
 import { def as stdBackendDef } from "@hoppscotch/common/platform/std/backend"
@@ -276,8 +277,9 @@ async function initApp() {
 
         const isCtrlOrCmd = e.ctrlKey || e.metaKey
         let shortcutEvent: string | null = null
+        const shortcutKey = getPressedShortcutKey(e)
 
-        if (isCtrlOrCmd && !e.shiftKey && !e.altKey && e.code === "KeyQ") {
+        if (isCtrlOrCmd && !e.shiftKey && !e.altKey && shortcutKey === "q") {
           // Ctrl/Cmd + Q - Quit Application
           e.preventDefault()
           e.stopPropagation()
@@ -287,7 +289,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           !e.altKey &&
-          e.code === "KeyT"
+          shortcutKey === "t"
         ) {
           // Ctrl/Cmd + T - New Tab
           e.preventDefault()
@@ -298,7 +300,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           !e.altKey &&
-          e.code === "KeyW"
+          shortcutKey === "w"
         ) {
           // Ctrl/Cmd + W - Close Tab
           e.preventDefault()
@@ -309,7 +311,7 @@ async function initApp() {
           isCtrlOrCmd &&
           e.shiftKey &&
           !e.altKey &&
-          e.code === "KeyT"
+          shortcutKey === "t"
         ) {
           // Ctrl/Cmd + Shift + T - Reopen Tab
           e.preventDefault()
@@ -342,8 +344,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
-          (e.code === "Digit9" ||
-            (e.code === "Numpad9" && e.getModifierState("NumLock")))
+          shortcutKey === "9"
         ) {
           // Ctrl/Cmd + Alt + 9 - First Tab
           e.preventDefault()
@@ -354,8 +355,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
-          (e.code === "Digit0" ||
-            (e.code === "Numpad0" && e.getModifierState("NumLock")))
+          shortcutKey === "0"
         ) {
           // Ctrl/Cmd + Alt + 0 - Last Tab
           e.preventDefault()
@@ -366,7 +366,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
-          e.code === "KeyU"
+          shortcutKey === "u"
         ) {
           // Ctrl/Cmd + Alt + U - Focus URL Bar
           e.preventDefault()
@@ -377,7 +377,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
-          e.code === "BracketRight"
+          shortcutKey === "]"
         ) {
           // Ctrl/Cmd + Alt + ] - MRU Tab Switch
           e.preventDefault()
@@ -388,7 +388,7 @@ async function initApp() {
           isCtrlOrCmd &&
           !e.shiftKey &&
           e.altKey &&
-          e.code === "BracketLeft"
+          shortcutKey === "["
         ) {
           // Ctrl/Cmd + Alt + [ - MRU Tab Switch (Reverse)
           e.preventDefault()


### PR DESCRIPTION
Fixes #6090 
The desktop app was using `event.code` (physical key position) to identify shortcut keys in keyboard event handlers. On non-QWERTY layouts like **AZERTY** (French), pressing `Ctrl+A` was interpreted as the physical key at the `Q` position, which triggered the **quit** action instead of **select-all**. Similarly, `Ctrl+Z` mapped to `Ctrl+W` (close tab).

## Root Cause

- In `selfhost-web/main.ts`, desktop-specific shortcuts (quit, new tab, close tab, etc.) were matched using `event.code` (e.g., `e.code === "KeyQ"` for quit).
- - `event.code` reflects the **physical key position** on a US-QWERTY keyboard, regardless of the user's actual layout.
- - On AZERTY, the physical `Q` position types `A`, so pressing `Ctrl+A` matched `e.code === "KeyQ"` -> quit.
## Changes

### New: `keybinding-utils.ts`
- Extracted `getPressedShortcutKey()` into a shared, testable module.
- - **Prefers `event.key`** (the typed Latin character) so that layouts like AZERTY and Dvorak work correctly.
- - **Falls back to `event.code`** only when `event.key` produces a non-Latin glyph (e.g., Cyrillic layouts), ensuring shortcuts still work for those users.
- - Exported `SupportedShortcutKey` type for reuse.
### Updated: `keybindings.ts`
- The `Key` type alias now references `SupportedShortcutKey` from the new module.
- - `getPressedKey()` delegates to `getPressedShortcutKey()`, eliminating duplicated logic.
### Updated: `selfhost-web/main.ts`
- All desktop shortcut checks now use `getPressedShortcutKey(e)` instead of raw `e.code` comparisons.
- - This ensures consistent behavior between the global shortcut handler and the keybindings system.
### New: `keybinding-utils.spec.ts`
- Unit tests covering: AZERTY mapping, Cyrillic fallback, punctuation keys, and numpad digit resolution.
## Testing

* [x] Unit tests pass (`vitest run`)
* [ ] * [x] Lint passes (`0 errors`)
* [ ] * [x] TypeScript type-check passes
* [ ] * [x] AZERTY: `Ctrl+A` -> select-all (not quit)
* [ ] * [x] AZERTY: `Ctrl+Z` -> undo (not close tab)
* [ ] * [x] QWERTY: All shortcuts still work as before
* [ ] * [x] Cyrillic layout: Shortcuts work via physical key fallback

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desktop shortcuts misfiring on non‑QWERTY layouts by resolving keys from the typed value with a physical-code fallback. Also ignores AltGraph so Ctrl/Cmd+Alt shortcuts don’t trigger when pressing AltGr on international keyboards.

- **Bug Fixes**
  - Added `getPressedShortcutKey()` in `@hoppscotch/common` that prefers `event.key` for Latin letters/digits, with `event.code` fallback for non‑Latin glyphs, AZERTY digit rows, and `BracketLeft/Right` -> `[`/`]`.
  - Updated `keybindings.ts` to use the utility; removed unreachable Numpad and `?` shortcut variants (Shift+/ resolves to `/`).
  - Updated `@hoppscotch/selfhost-web` `main.ts` to use the utility and ignore AltGraph for Ctrl/Cmd+Alt shortcuts.
  - Added unit tests for AZERTY letters/digits, Cyrillic fallback, punctuation and bracket fallback, and numpad handling.

<sup>Written for commit dc2b10d1cb57c6a7cb17b60f5565d474c374a32d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

