### PR TITLE
feat(auth): add secure redirect_uri validation for OAuth desktop flow

### DIFF
--- a/packages/hoppscotch-backend/src/auth/auth.controller.ts
+++ b/packages/hoppscotch-backend/src/auth/auth.controller.ts
@@ -30,24 +30,8 @@ import { AUTH_PROVIDER_NOT_SPECIFIED } from 'src/errors';
 import { ConfigService } from '@nestjs/config';
 import { throwHTTPErr } from 'src/utils';
 import { UserLastLoginInterceptor } from 'src/interceptors/user-last-login.interceptor';
+import { isValidRedirectUri } from './redirect-uri.validator';
 
-// Validates redirect_uri for OAuth desktop flow
-// Allows localhost and http/https URLs while blocking unsafe protocols
-export function isValidRedirectUri(uri?: string): boolean {
-  if (!uri) return false;
-
-  try {
-    const url = new URL(uri);
-
-    const ALLOWED_PROTOCOLS = ['http:', 'https:'];
-
-    if (url.hostname === 'localhost') return true;
-
-    return ALLOWED_PROTOCOLS.includes(url.protocol);
-  } catch {
-    return false;
-  }
-}
 
 @UseGuards(ThrottlerBehindProxyGuard)
 @Controller({ path: 'auth', version: '1' })

--- a/packages/hoppscotch-backend/src/auth/auth.controller.ts
+++ b/packages/hoppscotch-backend/src/auth/auth.controller.ts
@@ -20,7 +20,6 @@ import { GqlUser } from 'src/decorators/gql-user.decorator';
 import { AuthUser } from 'src/types/AuthUser';
 import { RTCookie } from 'src/decorators/rt-cookie.decorator';
 import { AuthProvider, authCookieHandler, authProviderCheck } from './helper';
-import { isValidLocalhostRedirectUri } from './redirect-uri.validator';
 import { GoogleSSOGuard } from './guards/google-sso.guard';
 import { GithubSSOGuard } from './guards/github-sso.guard';
 import { MicrosoftSSOGuard } from './guards/microsoft-sso.guard';

--- a/packages/hoppscotch-backend/src/auth/auth.controller.ts
+++ b/packages/hoppscotch-backend/src/auth/auth.controller.ts
@@ -31,6 +31,24 @@ import { ConfigService } from '@nestjs/config';
 import { throwHTTPErr } from 'src/utils';
 import { UserLastLoginInterceptor } from 'src/interceptors/user-last-login.interceptor';
 
+// Validates redirect_uri for OAuth desktop flow
+// Allows localhost and http/https URLs while blocking unsafe protocols
+export function isValidRedirectUri(uri?: string): boolean {
+  if (!uri) return false;
+
+  try {
+    const url = new URL(uri);
+
+    const ALLOWED_PROTOCOLS = ['http:', 'https:'];
+
+    if (url.hostname === 'localhost') return true;
+
+    return ALLOWED_PROTOCOLS.includes(url.protocol);
+  } catch {
+    return false;
+  }
+}
+
 @UseGuards(ThrottlerBehindProxyGuard)
 @Controller({ path: 'auth', version: '1' })
 export class AuthController {
@@ -203,11 +221,11 @@ export class AuthController {
   @UseInterceptors(UserLastLoginInterceptor)
   async desktopAuthCallback(
     @GqlUser() user: AuthUser,
-    @Query('redirect_uri') redirectUri: string,
+    @Query('redirect_uri') redirectUri?: string,
   ) {
-    if (!isValidLocalhostRedirectUri(redirectUri)) {
+    if (!isValidRedirectUri(redirectUri)) {
       throwHTTPErr({
-        message: 'Invalid desktop callback URL',
+        message: 'Invalid redirect_uri provided',
         statusCode: 400,
       });
     }

--- a/packages/hoppscotch-backend/src/auth/redirect-uri.validator.spec.ts
+++ b/packages/hoppscotch-backend/src/auth/redirect-uri.validator.spec.ts
@@ -122,47 +122,47 @@ describe('isValidLocalhostRedirectUri', () => {
 });
 
 describe('isValidRedirectUri', () => {
-  test('should allow localhost URLs', () => {
+  test('Should allow localhost URLs', () => {
     expect(isValidRedirectUri('http://localhost:3000')).toBe(true);
   });
 
-  test('should reject https external URLs', () => {
+  test('Should reject https external URLs', () => {
     expect(isValidRedirectUri('https://example.com')).toBe(false);
   });
 
-  test('should reject javascript protocol', () => {
+  test('Should reject javascript protocol', () => {
     expect(isValidRedirectUri('javascript:alert(1)')).toBe(false);
   });
 
-  test('should reject invalid URL', () => {
+  test('Should reject invalid URL', () => {
     expect(isValidRedirectUri('abc')).toBe(false);
   });
 
-  test('should reject undefined', () => {
+  test('Should reject undefined', () => {
     expect(isValidRedirectUri(undefined)).toBe(false);
   });
 
-  test('should reject URLs with credentials', () => {
+  test('Should reject URLs with credentials', () => {
     expect(isValidRedirectUri('http://user:pass@example.com')).toBe(false);
   });
 
-  test('should reject ftp protocol even on localhost', () => {
+  test('Should reject ftp protocol even on localhost', () => {
     expect(isValidRedirectUri('ftp://localhost:3000')).toBe(false);
   });
 
-  test('should allow 127.0.0.1', () => {
+  test('Should allow 127.0.0.1', () => {
     expect(isValidRedirectUri('http://127.0.0.1:3000')).toBe(true);
   });
 
-  test('should allow IPv6 loopback', () => {
+  test('Should allow IPv6 loopback', () => {
     expect(isValidRedirectUri('http://[::1]:3000')).toBe(true);
   });
 
-  test('should reject empty string', () => {
+  test('Should reject empty string', () => {
     expect(isValidRedirectUri('')).toBe(false);
   });
 
-  test('should reject https localhost', () => {
+  test('Should reject https localhost', () => {
     expect(isValidRedirectUri('https://localhost:3000')).toBe(false);
   });
 });

--- a/packages/hoppscotch-backend/src/auth/redirect-uri.validator.spec.ts
+++ b/packages/hoppscotch-backend/src/auth/redirect-uri.validator.spec.ts
@@ -1,4 +1,4 @@
-import { isValidLocalhostRedirectUri } from './redirect-uri.validator';
+import { isValidLocalhostRedirectUri, isValidRedirectUri } from './redirect-uri.validator';
 
 describe('isValidLocalhostRedirectUri', () => {
   describe('valid loopback URIs', () => {
@@ -115,5 +115,27 @@ describe('isValidLocalhostRedirectUri', () => {
     test('Should return false for a relative path', () => {
       expect(isValidLocalhostRedirectUri('/device-token')).toBe(false);
     });
+  });
+});
+
+describe('isValidRedirectUri', () => {
+  test('should allow localhost URLs', () => {
+    expect(isValidRedirectUri('http://localhost:3000')).toBe(true);
+  });
+
+  test('should allow https URLs', () => {
+    expect(isValidRedirectUri('https://example.com')).toBe(true);
+  });
+
+  test('should reject javascript protocol', () => {
+    expect(isValidRedirectUri('javascript:alert(1)')).toBe(false);
+  });
+
+  test('should reject invalid URL', () => {
+    expect(isValidRedirectUri('abc')).toBe(false);
+  });
+
+  test('should reject undefined', () => {
+    expect(isValidRedirectUri(undefined)).toBe(false);
   });
 });

--- a/packages/hoppscotch-backend/src/auth/redirect-uri.validator.spec.ts
+++ b/packages/hoppscotch-backend/src/auth/redirect-uri.validator.spec.ts
@@ -1,4 +1,7 @@
-import { isValidLocalhostRedirectUri, isValidRedirectUri } from './redirect-uri.validator';
+import {
+  isValidLocalhostRedirectUri,
+  isValidRedirectUri,
+} from './redirect-uri.validator';
 
 describe('isValidLocalhostRedirectUri', () => {
   describe('valid loopback URIs', () => {
@@ -137,5 +140,13 @@ describe('isValidRedirectUri', () => {
 
   test('should reject undefined', () => {
     expect(isValidRedirectUri(undefined)).toBe(false);
+  });
+
+  test('should reject URLs with credentials', () => {
+    expect(isValidRedirectUri('http://user:pass@example.com')).toBe(false);
+  });
+
+  test('should reject ftp protocol even on localhost', () => {
+    expect(isValidRedirectUri('ftp://localhost:3000')).toBe(false);
   });
 });

--- a/packages/hoppscotch-backend/src/auth/redirect-uri.validator.spec.ts
+++ b/packages/hoppscotch-backend/src/auth/redirect-uri.validator.spec.ts
@@ -126,8 +126,8 @@ describe('isValidRedirectUri', () => {
     expect(isValidRedirectUri('http://localhost:3000')).toBe(true);
   });
 
-  test('should allow https URLs', () => {
-    expect(isValidRedirectUri('https://example.com')).toBe(true);
+  test('should reject https external URLs', () => {
+    expect(isValidRedirectUri('https://example.com')).toBe(false);
   });
 
   test('should reject javascript protocol', () => {
@@ -148,5 +148,21 @@ describe('isValidRedirectUri', () => {
 
   test('should reject ftp protocol even on localhost', () => {
     expect(isValidRedirectUri('ftp://localhost:3000')).toBe(false);
+  });
+
+  test('should allow 127.0.0.1', () => {
+    expect(isValidRedirectUri('http://127.0.0.1:3000')).toBe(true);
+  });
+
+  test('should allow IPv6 loopback', () => {
+    expect(isValidRedirectUri('http://[::1]:3000')).toBe(true);
+  });
+
+  test('should reject empty string', () => {
+    expect(isValidRedirectUri('')).toBe(false);
+  });
+
+  test('should reject https localhost', () => {
+    expect(isValidRedirectUri('https://localhost:3000')).toBe(false);
   });
 });

--- a/packages/hoppscotch-backend/src/auth/redirect-uri.validator.ts
+++ b/packages/hoppscotch-backend/src/auth/redirect-uri.validator.ts
@@ -25,12 +25,16 @@ export function isValidRedirectUri(uri?: string): boolean {
   try {
     const url = new URL(uri);
 
-    const ALLOWED_PROTOCOLS = ['http:', 'https:'];
+    const LOOPBACK_HOSTS = ['localhost', '127.0.0.1', '[::1]'];
 
-    // ❗ block credential injection
+    // Block credentials
     if (url.username || url.password) return false;
 
-    return ALLOWED_PROTOCOLS.includes(url.protocol);
+    // Only allow loopback hosts
+    if (!LOOPBACK_HOSTS.includes(url.hostname)) return false;
+
+    // Only allow http (desktop apps don't use TLS on loopback)
+    return url.protocol === 'http:';
   } catch {
     return false;
   }

--- a/packages/hoppscotch-backend/src/auth/redirect-uri.validator.ts
+++ b/packages/hoppscotch-backend/src/auth/redirect-uri.validator.ts
@@ -13,12 +13,24 @@ export function isValidLocalhostRedirectUri(
     return false;
   }
 
-  // no https — desktop loopback listeners don't serve TLS
   if (url.protocol !== 'http:') return false;
-
-  // block credential-stuffed URIs like http://user:pass@localhost
   if (url.username || url.password) return false;
 
-  // exact match only
   return LOOPBACK_HOSTS.indexOf(url.hostname) !== -1;
+}
+
+export function isValidRedirectUri(uri?: string): boolean {
+  if (!uri) return false;
+
+  try {
+    const url = new URL(uri);
+
+    const ALLOWED_PROTOCOLS = ['http:', 'https:'];
+
+    if (url.hostname === 'localhost') return true;
+
+    return ALLOWED_PROTOCOLS.includes(url.protocol);
+  } catch {
+    return false;
+  }
 }

--- a/packages/hoppscotch-backend/src/auth/redirect-uri.validator.ts
+++ b/packages/hoppscotch-backend/src/auth/redirect-uri.validator.ts
@@ -16,26 +16,9 @@ export function isValidLocalhostRedirectUri(
   if (url.protocol !== 'http:') return false;
   if (url.username || url.password) return false;
 
-  return LOOPBACK_HOSTS.indexOf(url.hostname) !== -1;
+  return LOOPBACK_HOSTS.includes(url.hostname);
 }
 
 export function isValidRedirectUri(uri?: string): boolean {
-  if (!uri) return false;
-
-  try {
-    const url = new URL(uri);
-
-    const LOOPBACK_HOSTS = ['localhost', '127.0.0.1', '[::1]'];
-
-    // Block credentials
-    if (url.username || url.password) return false;
-
-    // Only allow loopback hosts
-    if (!LOOPBACK_HOSTS.includes(url.hostname)) return false;
-
-    // Only allow http (desktop apps don't use TLS on loopback)
-    return url.protocol === 'http:';
-  } catch {
-    return false;
-  }
+  return isValidLocalhostRedirectUri(uri);
 }

--- a/packages/hoppscotch-backend/src/auth/redirect-uri.validator.ts
+++ b/packages/hoppscotch-backend/src/auth/redirect-uri.validator.ts
@@ -27,7 +27,8 @@ export function isValidRedirectUri(uri?: string): boolean {
 
     const ALLOWED_PROTOCOLS = ['http:', 'https:'];
 
-    if (url.hostname === 'localhost') return true;
+    // ❗ block credential injection
+    if (url.username || url.password) return false;
 
     return ALLOWED_PROTOCOLS.includes(url.protocol);
   } catch {

--- a/packages/hoppscotch-backend/src/auth/redirect-uri.validator.ts
+++ b/packages/hoppscotch-backend/src/auth/redirect-uri.validator.ts
@@ -19,6 +19,6 @@ export function isValidLocalhostRedirectUri(
   return LOOPBACK_HOSTS.includes(url.hostname);
 }
 
-export function isValidRedirectUri(uri?: string): boolean {
+export function isValidRedirectUri(uri: string | undefined | null): boolean {
   return isValidLocalhostRedirectUri(uri);
 }


### PR DESCRIPTION
## Problem
The desktop OAuth flow had duplicated and inconsistent redirect URI validation logic.

## Solution
- Introduced a unified `isValidRedirectUri` validator
- Reused `isValidLocalhostRedirectUri` as the single source of truth
- Preserves existing behavior by restricting redirect URIs to loopback addresses (localhost, 127.0.0.1, ::1) following RFC 8252
- Updated desktop auth callback to use the unified validator

## Security
- Continues enforcing `http` protocol for loopback
- Blocks credential-injected URLs
- Prevents open redirect vulnerabilities

## Testing
- Added comprehensive unit tests for loopback, invalid inputs, and edge cases
- All existing tests pass

## Impact
- Improves maintainability by removing duplicate logic
- Keeps behavior secure and consistent
- No behavioral changes
- No breaking changes