### PR TITLE
test(cli): add missing unit tests for getColorStatusCode, getMetaData…

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,4 @@
 source_url "https://raw.githubusercontent.com/cachix/devenv/82c0147677e510b247d8b9165c54f73d32dfd899/direnvrc" "sha256-7u4iDd1nZpxL4tCzmPG0dQgC5V+/44Ba+tHkPob1v2k="
 
 use devenv
+feature

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -37,7 +37,7 @@ describe("getters", () => {
 
     test.each(testDurations)(
       "($end.0 s + $end.1 ns) rounded-off to $expected",
-      ({ end, precision, expected }) => {
+      ({ end, precision, expected }: { end: number[]; precision: number; expected: number }) => {
         expect(getDurationInSeconds(end as [number, number], precision)).toBe(
           expected
         );
@@ -228,7 +228,17 @@ describe("getters", () => {
         },
       ];
 
-      test.each(cases)("$description", ({ args, axiosMock, expected }) => {
+      test.each(cases)(
+        "$description",
+        ({
+          args,
+          axiosMock,
+          expected,
+        }: {
+          args: { serverUrl: string; accessToken: string; pathOrId: string; resourceType?: "collection" | "environment" };
+          axiosMock: { code?: string; response?: { status?: number; data?: { reason?: string } } };
+          expected: { code: string; data: string };
+        }) => {
         const { code, response } = axiosMock;
         const axiosErrMessage = code ?? response?.data?.reason;
 

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -516,7 +516,10 @@ describe("getters", () => {
         getResolvedVariables(requestVariables, environmentVariables)
       ).toEqual(expected);
     });
-  });describe("getColorStatusCode", () => {
+    });
+  });
+
+  describe("getColorStatusCode", () => {
     test("returns green-colored string for 2xx status codes", () => {
       const result = getColorStatusCode(200, "OK");
       expect(result).toContain("200 : OK");

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -14,6 +14,9 @@ import {
   getEffectiveFinalMetaData,
   getResolvedVariables,
   getResourceContents,
+  getColorStatusCode,
+  getMetaDataPairs,
+  roundDuration,
 } from "../../utils/getters";
 import * as mutators from "../../utils/mutators";
 
@@ -502,6 +505,125 @@ describe("getters", () => {
       expect(
         getResolvedVariables(requestVariables, environmentVariables)
       ).toEqual(expected);
+    });
+  });describe("getColorStatusCode", () => {
+    test("returns green-colored string for 2xx status codes", () => {
+      const result = getColorStatusCode(200, "OK");
+      expect(result).toContain("200 : OK");
+    });
+
+    test("returns green-colored string for 201 Created", () => {
+      const result = getColorStatusCode(201, "Created");
+      expect(result).toContain("201 : Created");
+    });
+
+    test("returns yellow-colored string for 3xx status codes", () => {
+      const result = getColorStatusCode(301, "Moved Permanently");
+      expect(result).toContain("301 : Moved Permanently");
+    });
+
+    test("returns yellow-colored string for 304 Not Modified", () => {
+      const result = getColorStatusCode(304, "Not Modified");
+      expect(result).toContain("304 : Not Modified");
+    });
+
+    test("returns red-colored string for 4xx status codes", () => {
+      const result = getColorStatusCode(404, "Not Found");
+      expect(result).toContain("404 : Not Found");
+    });
+
+    test("returns red-colored string for 5xx status codes", () => {
+      const result = getColorStatusCode(500, "Internal Server Error");
+      expect(result).toContain("500 : Internal Server Error");
+    });
+
+    test("replaces status 0 with the word 'Error'", () => {
+      const result = getColorStatusCode(0, "Network Error");
+      expect(result).toContain("Error : Network Error");
+    });
+
+    test("accepts status as a string and handles 2xx correctly", () => {
+      const result = getColorStatusCode("200", "OK");
+      expect(result).toContain("200 : OK");
+    });
+
+    test("accepts status as a string and handles 4xx correctly", () => {
+      const result = getColorStatusCode("401", "Unauthorized");
+      expect(result).toContain("401 : Unauthorized");
+    });
+  });
+
+  describe("getMetaDataPairs", () => {
+    test("returns empty object for empty meta-data array", () => {
+      expect(getMetaDataPairs([])).toEqual({});
+    });
+
+    test("returns key-value pairs for active meta-data", () => {
+      const metaData = [
+        { active: true, key: "Content-Type", value: "application/json", description: "" },
+        { active: true, key: "Authorization", value: "Bearer token123", description: "" },
+      ];
+      expect(getMetaDataPairs(metaData)).toEqual({
+        "Content-Type": "application/json",
+        Authorization: "Bearer token123",
+      });
+    });
+
+    test("excludes inactive meta-data entries", () => {
+      const metaData = [
+        { active: true, key: "X-Active", value: "yes", description: "" },
+        { active: false, key: "X-Inactive", value: "no", description: "" },
+      ];
+      expect(getMetaDataPairs(metaData)).toEqual({ "X-Active": "yes" });
+    });
+
+    test("excludes entries with empty keys", () => {
+      const metaData = [
+        { active: true, key: "", value: "ghost", description: "" },
+        { active: true, key: "X-Real", value: "value", description: "" },
+      ];
+      expect(getMetaDataPairs(metaData)).toEqual({ "X-Real": "value" });
+    });
+
+    test("last value wins when duplicate keys exist", () => {
+      const metaData = [
+        { active: true, key: "X-Dup", value: "first", description: "" },
+        { active: true, key: "X-Dup", value: "second", description: "" },
+      ];
+      expect(getMetaDataPairs(metaData)).toEqual({ "X-Dup": "second" });
+    });
+
+    test("excludes entries that are both inactive and have empty keys", () => {
+      const metaData = [
+        { active: false, key: "", value: "nothing", description: "" },
+      ];
+      expect(getMetaDataPairs(metaData)).toEqual({});
+    });
+  });
+
+  describe("roundDuration", () => {
+    test("rounds to default precision of 3 decimal places", () => {
+      expect(roundDuration(3.555555)).toBe(3.556);
+    });
+
+    test("rounds to 1 decimal place when precision is 1", () => {
+      expect(roundDuration(2.678, 1)).toBe(2.7);
+    });
+
+    test("rounds to 2 decimal places when precision is 2", () => {
+      expect(roundDuration(1.234, 2)).toBe(1.23);
+    });
+
+    test("rounds to 4 decimal places when precision is 4", () => {
+      expect(roundDuration(4.77777, 4)).toBe(4.7778);
+    });
+
+    test("returns 0 when duration is 0", () => {
+      expect(roundDuration(0)).toBe(0);
+    });
+
+    test("handles already-rounded values without changing them", () => {
+      expect(roundDuration(1.5, 2)).toBe(1.5);
     });
   });
 });


### PR DESCRIPTION
…Pairs, and roundDuration

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing unit tests for `hoppscotch-cli` getters — `getColorStatusCode`, `getMetaDataPairs`, and `roundDuration` — and tighten type safety in test cases to improve coverage and prevent regressions; includes a minor `.envrc` tweak for local `devenv`.

Tests cover status code formatting (2xx–5xx, 0, string inputs), metadata filtering/duplicates (active-only, empty keys, last wins), and duration rounding (default/custom precision, zero handling, no-op for already rounded values).

<sup>Written for commit 18582662b90edfd76843b764251135936bf5cfce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

