### PR TITLE
fix: preserve asterisk (*) in URL query params during cURL import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1028,6 +1028,38 @@ data2: {"type":"test2","typeId":"123"}`,
       responses: {},
     }),
   },
+  {
+    command: `curl 'https://api.example.com/search?q=test*&wildcard=*value*'`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://api.example.com/search",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      params: [
+        {
+          active: true,
+          key: "q",
+          value: "test*",
+          description: "",
+        },
+        {
+          active: true,
+          key: "wildcard",
+          value: "*value*",
+          description: "",
+        },
+      ],
+      headers: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
@@ -53,7 +53,7 @@ const parseURL = (urlText: string | number) =>
       u
         .toString()
         .replace(/^'|'$/g, "")
-        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>\s]/g, "")
+        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>*\s]/g, "")
     ),
     O.filter((u) => u.length > 0),
     O.chain((u) =>


### PR DESCRIPTION
## Summary
Fixes #6249

When importing a cURL command, if a URL query parameter contains an asterisk (`*`), the character is silently dropped from the parsed URL and query parameters. URL-encoded asterisks (`%2A`) are also affected since they get decoded before hitting the same filter.

## Root Cause
The URL preprocessing step in `packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts` uses a regex character whitelist to sanitize the URL string. The asterisk (`*`) was not included in this whitelist, so it was stripped during sanitization.

## Changes
- Added `*` to the allowed character set in the URL sanitization regex
- Added a test case covering asterisks in query parameter values

## Test Plan
- [x] Existing curl parser tests pass (53 test files, 713 tests)
- [x] New test verifies `curl 'https://api.example.com/search?q=test*&wildcard=*value*'` correctly preserves asterisks in both parameter values

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `*` in URL query parameters during cURL import, including decoded `%2A`, so query values are parsed correctly instead of losing asterisks.

- **Bug Fixes**
  - Added `*` to the URL sanitization regex in `packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts`.
  - Added a test to verify parameters like `q=test*` and `wildcard=*value*` are preserved.

<sup>Written for commit c1ff3a76240c044adf33fbe9bcd28511fc5a3564. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

