### PR TITLE
feat: add ctrl+d shortcut to duplicate line or selection in code editor

### DIFF
--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -201,6 +201,7 @@ declare module 'vue' {
     HttpExampleResponseTab: typeof import('./components/http/example/ResponseTab.vue')['default']
     HttpHeaders: typeof import('./components/http/Headers.vue')['default']
     HttpImportCurl: typeof import('./components/http/ImportCurl.vue')['default']
+    HttpInheritedScriptsModal: typeof import('./components/http/InheritedScriptsModal.vue')['default']
     HttpKeyValue: typeof import('./components/http/KeyValue.vue')['default']
     HttpParameters: typeof import('./components/http/Parameters.vue')['default']
     HttpPreRequestScript: typeof import('./components/http/PreRequestScript.vue')['default']

--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -302,6 +302,34 @@ const stripModulePrefixForDisplay = (value?: string): string | undefined => {
  */
 const MAX_CONTEXT_MENU_CHAR_COUNT = 100_000
 
+const duplicateLineOrSelection = (target: EditorView) => {
+  const { state } = target
+  const changes = state.changeByRange((range) => {
+    if (range.empty) {
+      const line = state.doc.lineAt(range.head)
+      return {
+        changes: { from: line.from, insert: line.text + state.lineBreak },
+        range: EditorSelection.cursor(
+          range.head + line.text.length + state.lineBreak.length
+        ),
+      }
+    } else {
+      const text = state.sliceDoc(range.from, range.to)
+      return {
+        changes: { from: range.to, insert: text },
+        range: EditorSelection.range(range.to, range.to + text.length),
+      }
+    }
+  })
+
+  target.dispatch({
+    ...changes,
+    scrollIntoView: true,
+    userEvent: "input.duplicate",
+  })
+  return true
+}
+
 export function useCodemirror(
   el: Ref<any | null>,
   value: Ref<string | undefined>,
@@ -502,6 +530,12 @@ export function useCodemirror(
           key: "Shift-Tab",
           preventDefault: true,
           run: indentLess,
+        },
+        {
+          key: "Ctrl-d",
+          mac: "Cmd-d",
+          preventDefault: true,
+          run: duplicateLineOrSelection,
         },
       ]),
       Prec.highest(

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -183,6 +183,16 @@ function handleKeyDown(ev: KeyboardEvent) {
 
   // Special handling for Ctrl+D (tab close for web browsers)
   if (binding === "ctrl-d" && boundAction) {
+    const target = ev.target
+    if (
+      isDOMElement(target) &&
+      (isCodeMirrorEditor(target) ||
+        isMonacoEditor(target) ||
+        isTypableElement(target))
+    ) {
+      return
+    }
+
     ev.preventDefault()
     ev.stopPropagation()
     ev.stopImmediatePropagation()


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Ctrl+D (Cmd+D on Mac) to duplicate the current line or the selected text in the code editor. Also ensure the global Ctrl+D handler doesn’t interfere in editors or inputs, so tabs don’t accidentally close while typing.

- **New Features**
  - No selection: duplicates the current line and moves the cursor to the new line.
  - With selection: duplicates the selected text immediately after it and selects the new copy.

- **Bug Fixes**
  - Don’t intercept Ctrl+D when focus is in CodeMirror, Monaco, or other typable elements; let the editor handle duplication.

<sup>Written for commit 774e520951a356742cef218be39a701487c91523. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

