### PR TITLE
docs: improve wording and fix minor inconsistencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ _Customized themes are synced with your cloud/local session._
 - Query schema
 - Get query response
 
-🔐 **Authorization:** Allows to identify the end-user.
+🔐 **Authorization:** Allows you to identify the end-user.
 
 - None
 - Basic
@@ -142,7 +142,7 @@ _Customized themes are synced with your cloud/local session._
 
 _Collections are synced with your cloud/local session storage._
 
-📜 **Pre-Request Scripts:** Snippets of code associated with a request that is executed before the request is sent.
+📜 **Pre-Request Scripts:** Snippets of code associated with a request that are executed before the request is sent.
 
 - Set environment variables
 - Include timestamp in the request headers
@@ -237,7 +237,7 @@ Help us to translate Hoppscotch. Please read [`TRANSLATIONS`](TRANSLATIONS.md) f
 - Manage users
 - Manage teams
 
-📦 **Add-ons:** Official add-ons for hoppscotch.
+📦 **Add-ons:** Official add-ons for Hoppscotch.
 
 - **[Hoppscotch CLI](https://github.com/hoppscotch/hoppscotch/tree/main/packages/hoppscotch-cli)** - Command-line interface for Hoppscotch.
 - **[Proxy](https://github.com/hoppscotch/proxyscotch)** - A simple proxy server created for Hoppscotch.


### PR DESCRIPTION
## Description
This PR addresses minor grammatical inconsistencies and capitalization issues in the `README.md` to improve overall readability. 

**Changes made:**
- Fixed grammar in the Authorization section ("Allows to" -> "Allows you to").
- Fixed subject-verb agreement in the Pre-Request Scripts section ("that is executed" -> "that are executed").
- Corrected capitalization of "Hoppscotch" in the Add-ons section.

## Related Issue
Fixes #6277

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/hoppscotch/hoppscotch/blob/main/CONTRIBUTING.md) guide.
- [x] I have verified that these changes are isolated to documentation.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved clarity and consistency in `README.md` by fixing minor grammar and capitalization issues. Makes the Authorization, Pre-Request Scripts, and Add-ons sections easier to read.

- **Bug Fixes**
  - Authorization: “Allows to” → “Allows you to”
  - Pre-Request Scripts: “that is executed” → “that are executed”
  - Add-ons: capitalized “Hoppscotch”

<sup>Written for commit 5daec7798eaba82c97d893a71077e3b359b0059c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

