### PR TITLE
fix: stop secret variable values from leaking to backend 

### DIFF
--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -201,6 +201,7 @@ declare module 'vue' {
     HttpExampleResponseTab: typeof import('./components/http/example/ResponseTab.vue')['default']
     HttpHeaders: typeof import('./components/http/Headers.vue')['default']
     HttpImportCurl: typeof import('./components/http/ImportCurl.vue')['default']
+    HttpInheritedScriptsModal: typeof import('./components/http/InheritedScriptsModal.vue')['default']
     HttpKeyValue: typeof import('./components/http/KeyValue.vue')['default']
     HttpParameters: typeof import('./components/http/Parameters.vue')['default']
     HttpPreRequestScript: typeof import('./components/http/PreRequestScript.vue')['default']

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -35,7 +35,11 @@ import AllCollectionImport from "~/components/importExport/ImportExportSteps/All
 import { useI18n } from "~/composables/i18n"
 import { useToast } from "~/composables/toast"
 import { appendRESTCollections, restCollections$ } from "~/newstore/collections"
-import { populateLocalStoresFromCollectionTree } from "~/helpers/secretVariables"
+import {
+  ensureRefIds,
+  populateLocalStoresFromCollectionTree,
+  stripCollectionTreeForStore,
+} from "~/helpers/secretVariables"
 
 import IconInsomnia from "~icons/hopp/insomnia"
 import IconPostman from "~icons/hopp/postman"
@@ -122,7 +126,9 @@ const handleImportToStore = async (collections: HoppCollection[]) => {
  */
 const importToPersonalWorkspace = (collections: HoppCollection[]) => {
   // Remove old id from the imported collection and folders and transform it to new collection format
-  const sanitizedCollections = collections.map(sanitizeCollection)
+  const sanitizedCollections = collections
+    .map(sanitizeCollection)
+    .map(ensureRefIds)
 
   // Persist any user-supplied secret + currentValue inputs to the local stores
   // BEFORE the wire strip runs (whether via the platform sync path or directly
@@ -142,7 +148,11 @@ const importToPersonalWorkspace = (collections: HoppCollection[]) => {
     )
   }
 
-  appendRESTCollections(sanitizedCollections)
+  // Logged-out / no-platform-sync path: strip raw secret values from the
+  // tree before appending — newstore + localStorage stay clean, the local
+  // secret + currentValue stores (populated above) hold the raw values
+  // keyed by the same `_ref_id`s for UI rehydrate.
+  appendRESTCollections(sanitizedCollections.map(stripCollectionTreeForStore))
   return E.right({ success: true })
 }
 

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -35,6 +35,7 @@ import AllCollectionImport from "~/components/importExport/ImportExportSteps/All
 import { useI18n } from "~/composables/i18n"
 import { useToast } from "~/composables/toast"
 import { appendRESTCollections, restCollections$ } from "~/newstore/collections"
+import { populateLocalStoresFromCollectionTree } from "~/helpers/secretVariables"
 
 import IconInsomnia from "~icons/hopp/insomnia"
 import IconPostman from "~icons/hopp/postman"
@@ -122,6 +123,13 @@ const handleImportToStore = async (collections: HoppCollection[]) => {
 const importToPersonalWorkspace = (collections: HoppCollection[]) => {
   // Remove old id from the imported collection and folders and transform it to new collection format
   const sanitizedCollections = collections.map(sanitizeCollection)
+
+  // Persist any user-supplied secret + currentValue inputs to the local stores
+  // BEFORE the wire strip runs (whether via the platform sync path or directly
+  // via `appendRESTCollections` for logged-out / no-sync workspaces). Without
+  // this, a logged-out import that the user later syncs on login would lose
+  // the secrets when the sync layer strips them on the wire.
+  sanitizedCollections.forEach(populateLocalStoresFromCollectionTree)
 
   if (
     platform.sync.collections.importToPersonalWorkspace &&

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -37,6 +37,7 @@ import { useToast } from "~/composables/toast"
 import { appendRESTCollections, restCollections$ } from "~/newstore/collections"
 import {
   ensureRefIds,
+  flushLocalStoresForCollectionTree,
   populateLocalStoresFromCollectionTree,
   stripCollectionTreeForStore,
 } from "~/helpers/secretVariables"
@@ -151,9 +152,12 @@ const importToPersonalWorkspace = (collections: HoppCollection[]) => {
 }
 
 /**
- * Import collections to teams workspace
- * No need to sanitize the collections before importing to teams workspace because the BE handles this and add the new id to the collection and folders
- * @param collections Collections to import
+ * Import collections to teams workspace. Stamps `_ref_id` and seeds the
+ * device-local secret stores under it; on the team-collection-added
+ * subscription, `TeamCollectionsService.addCollection` migrates entries
+ * from `_ref_id` to the backend-assigned `id`. Wire payload is stripped
+ * of secrets via `transformCollectionForImport`; secrets stay
+ * device-local per the team-isolation model.
  */
 const importToTeamsWorkspace = async (collections: HoppCollection[]) => {
   if (!hasTeamWriteAccess.value || !selectedTeamID.value) {
@@ -162,7 +166,10 @@ const importToTeamsWorkspace = async (collections: HoppCollection[]) => {
     })
   }
 
-  const transformedCollection = collections.map((collection) =>
+  const collectionsWithRefIds = collections.map(ensureRefIds)
+  collectionsWithRefIds.forEach(populateLocalStoresFromCollectionTree)
+
+  const transformedCollection = collectionsWithRefIds.map((collection) =>
     transformCollectionForImport(collection)
   )
 
@@ -171,11 +178,15 @@ const importToTeamsWorkspace = async (collections: HoppCollection[]) => {
     selectedTeamID.value
   )()
 
-  return E.isRight(res)
-    ? E.right({ success: true })
-    : E.left({
-        success: false,
-      })
+  if (E.isLeft(res)) {
+    // Backend rejected the import — flush the just-seeded entries so
+    // they don't linger under `_ref_id`s no team collection will ever
+    // reference. (Success path migrates them via
+    // `TeamCollectionsService.addCollection`.)
+    collectionsWithRefIds.forEach(flushLocalStoresForCollectionTree)
+    return E.left({ success: false })
+  }
+  return E.right({ success: true })
 }
 
 const emit = defineEmits<{

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -130,11 +130,6 @@ const importToPersonalWorkspace = (collections: HoppCollection[]) => {
     .map(sanitizeCollection)
     .map(ensureRefIds)
 
-  // Persist any user-supplied secret + currentValue inputs to the local stores
-  // BEFORE the wire strip runs (whether via the platform sync path or directly
-  // via `appendRESTCollections` for logged-out / no-sync workspaces). Without
-  // this, a logged-out import that the user later syncs on login would lose
-  // the secrets when the sync layer strips them on the wire.
   sanitizedCollections.forEach(populateLocalStoresFromCollectionTree)
 
   if (
@@ -148,10 +143,6 @@ const importToPersonalWorkspace = (collections: HoppCollection[]) => {
     )
   }
 
-  // Logged-out / no-platform-sync path: strip raw secret values from the
-  // tree before appending — newstore + localStorage stay clean, the local
-  // secret + currentValue stores (populated above) hold the raw values
-  // keyed by the same `_ref_id`s for UI rehydrate.
   appendRESTCollections(sanitizedCollections.map(stripCollectionTreeForStore))
   return E.right({ success: true })
 }
@@ -849,10 +840,6 @@ const getCollectionJSON = async () => {
   }
 
   if (props.collectionsType.type === "my-collections") {
-    // Strip secret variable values before stringify — this output is sent
-    // to GitHub gists (third-party storage). Raw secrets must not leave
-    // the device through the export channel. Local secret stores retain
-    // values keyed by `_ref_id` so the user's own session is unaffected.
     const stripped = myCollections.value.map(stripCollectionTreeForStore)
     return E.right(JSON.stringify(stripped, null, 2))
   }

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -37,7 +37,7 @@ import { useToast } from "~/composables/toast"
 import { appendRESTCollections, restCollections$ } from "~/newstore/collections"
 import {
   ensureRefIds,
-  flushLocalStoresForCollectionTree,
+  flushUnmatchedRefIdsFromTree,
   populateLocalStoresFromCollectionTree,
   stripCollectionTreeForStore,
 } from "~/helpers/secretVariables"
@@ -179,11 +179,14 @@ const importToTeamsWorkspace = async (collections: HoppCollection[]) => {
   )()
 
   if (E.isLeft(res)) {
-    // Backend rejected the import — flush the just-seeded entries so
-    // they don't linger under `_ref_id`s no team collection will ever
-    // reference. (Success path migrates them via
-    // `TeamCollectionsService.addCollection`.)
-    collectionsWithRefIds.forEach(flushLocalStoresForCollectionTree)
+    // Backend rejected the import — flush ONLY the `_ref_id`-keyed
+    // entries we just seeded. `flushLocalStoresForCollectionTree`
+    // would also delete by `node.id`, which could be a live backend
+    // `id` from a same-workspace re-import (e.g., the imported file
+    // carries the original team-collection ids) and would wipe the
+    // existing collection's in-memory secrets. Empty `keptRefIds` ⇒
+    // every `_ref_id` in the tree is flushed.
+    flushUnmatchedRefIdsFromTree(collectionsWithRefIds, new Set())
     return E.left({ success: false })
   }
   return E.right({ success: true })

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -849,7 +849,12 @@ const getCollectionJSON = async () => {
   }
 
   if (props.collectionsType.type === "my-collections") {
-    return E.right(JSON.stringify(myCollections.value, null, 2))
+    // Strip secret variable values before stringify — this output is sent
+    // to GitHub gists (third-party storage). Raw secrets must not leave
+    // the device through the export channel. Local secret stores retain
+    // values keyed by `_ref_id` so the user's own session is unaffected.
+    const stripped = myCollections.value.map(stripCollectionTreeForStore)
+    return E.right(JSON.stringify(stripped, null, 2))
   }
 
   return E.left("INVALID_SELECTED_TEAM_OR_INVALID_COLLECTION_TYPE")

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -55,7 +55,10 @@ import { getTeamCollectionJSON } from "~/helpers/backend/helpers"
 
 import { platform } from "~/platform"
 
-import { initializeDownloadFile } from "~/helpers/import-export/export"
+import {
+  initializeDownloadFile,
+  stripRefIdReplacer,
+} from "~/helpers/import-export/export"
 import { gistExporter } from "~/helpers/import-export/export/gist"
 import { myCollectionsExporter } from "~/helpers/import-export/export/myCollections"
 import { teamCollectionsExporter } from "~/helpers/import-export/export/teamCollections"
@@ -841,7 +844,7 @@ const getCollectionJSON = async () => {
 
   if (props.collectionsType.type === "my-collections") {
     const stripped = myCollections.value.map(stripCollectionTreeForStore)
-    return E.right(JSON.stringify(stripped, null, 2))
+    return E.right(JSON.stringify(stripped, stripRefIdReplacer, 2))
   }
 
   return E.left("INVALID_SELECTED_TEAM_OR_INVALID_COLLECTION_TYPE")

--- a/packages/hoppscotch-common/src/components/collections/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/ImportExport.vue
@@ -179,13 +179,11 @@ const importToTeamsWorkspace = async (collections: HoppCollection[]) => {
   )()
 
   if (E.isLeft(res)) {
-    // Backend rejected the import — flush ONLY the `_ref_id`-keyed
-    // entries we just seeded. `flushLocalStoresForCollectionTree`
-    // would also delete by `node.id`, which could be a live backend
-    // `id` from a same-workspace re-import (e.g., the imported file
-    // carries the original team-collection ids) and would wipe the
-    // existing collection's in-memory secrets. Empty `keptRefIds` ⇒
-    // every `_ref_id` in the tree is flushed.
+    // Backend rejected — flush ONLY `_ref_id`-keyed entries we just
+    // seeded. `flushLocalStoresForCollectionTree` would also delete by
+    // `node.id`, which could be a live backend id from a same-workspace
+    // re-import and would wipe existing collections' in-memory secrets.
+    // Empty `keptRefIds` ⇒ every `_ref_id` in the tree is flushed.
     flushUnmatchedRefIdsFromTree(collectionsWithRefIds, new Set())
     return E.left({ success: false })
   }

--- a/packages/hoppscotch-common/src/components/collections/documentation/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/documentation/index.vue
@@ -270,6 +270,7 @@ import {
 
 import { updateTeamCollection } from "~/helpers/backend/mutations/TeamCollection"
 import { updateTeamRequest } from "~/helpers/backend/mutations/TeamRequest"
+import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
 import {
   CollectionDataProps,
   getSingleTeamCollectionJSON,
@@ -735,7 +736,11 @@ const saveCollectionDocumentation = async () => {
     const data: CollectionDataProps = {
       auth: collection.auth || { authType: "inherit", authActive: true },
       headers: collection.headers || [],
-      variables: collection.variables || [],
+      // Strip secrets at the wire boundary — `collection.variables` here
+      // is read off the in-memory team collection, which is normally
+      // already stripped (loaded from backend), but defense-in-depth
+      // guarantees we never leak raw secret values through this path.
+      variables: stripSecretVariableValuesForWire(collection.variables || []),
       description: documentationDescription.value,
       preRequestScript: collection.preRequestScript || "",
       testScript: collection.testScript || "",
@@ -831,7 +836,11 @@ const saveCollectionDocumentationById = async (
       const data: CollectionDataProps = {
         auth: collectionData.auth || { authType: "inherit", authActive: true },
         headers: collectionData.headers || [],
-        variables: collectionData.variables || [],
+        // Strip at the wire boundary — same defense-in-depth rationale
+        // as the `saveCollectionDocumentation` path above.
+        variables: stripSecretVariableValuesForWire(
+          collectionData.variables || []
+        ),
         description: documentation,
         preRequestScript: collectionData.preRequestScript || "",
         testScript: collectionData.testScript || "",

--- a/packages/hoppscotch-common/src/components/collections/documentation/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/documentation/index.vue
@@ -741,6 +741,9 @@ const saveCollectionDocumentation = async () => {
       // already stripped (loaded from backend), but defense-in-depth
       // guarantees we never leak raw secret values through this path.
       variables: stripSecretVariableValuesForWire(collection.variables || []),
+      // Preserve `_ref_id` through the backend round-trip so the local
+      // secret store key survives reload — see `CollectionDataProps`.
+      _ref_id: collection._ref_id,
       description: documentationDescription.value,
       preRequestScript: collection.preRequestScript || "",
       testScript: collection.testScript || "",
@@ -841,6 +844,9 @@ const saveCollectionDocumentationById = async (
         variables: stripSecretVariableValuesForWire(
           collectionData.variables || []
         ),
+        // Preserve `_ref_id` through the backend round-trip so the local
+        // secret store key survives reload — see `CollectionDataProps`.
+        _ref_id: collectionData._ref_id,
         description: documentation,
         preRequestScript: collectionData.preRequestScript || "",
         testScript: collectionData.testScript || "",

--- a/packages/hoppscotch-common/src/components/collections/documentation/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/documentation/index.vue
@@ -736,13 +736,7 @@ const saveCollectionDocumentation = async () => {
     const data: CollectionDataProps = {
       auth: collection.auth || { authType: "inherit", authActive: true },
       headers: collection.headers || [],
-      // Strip secrets at the wire boundary — `collection.variables` here
-      // is read off the in-memory team collection, which is normally
-      // already stripped (loaded from backend), but defense-in-depth
-      // guarantees we never leak raw secret values through this path.
       variables: stripSecretVariableValuesForWire(collection.variables || []),
-      // Preserve `_ref_id` through the backend round-trip so the local
-      // secret store key survives reload — see `CollectionDataProps`.
       _ref_id: collection._ref_id,
       description: documentationDescription.value,
       preRequestScript: collection.preRequestScript || "",
@@ -839,13 +833,9 @@ const saveCollectionDocumentationById = async (
       const data: CollectionDataProps = {
         auth: collectionData.auth || { authType: "inherit", authActive: true },
         headers: collectionData.headers || [],
-        // Strip at the wire boundary — same defense-in-depth rationale
-        // as the `saveCollectionDocumentation` path above.
         variables: stripSecretVariableValuesForWire(
           collectionData.variables || []
         ),
-        // Preserve `_ref_id` through the backend round-trip so the local
-        // secret store key survives reload — see `CollectionDataProps`.
         _ref_id: collectionData._ref_id,
         description: documentation,
         preRequestScript: collectionData.preRequestScript || "",

--- a/packages/hoppscotch-common/src/components/collections/documentation/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/documentation/index.vue
@@ -737,7 +737,6 @@ const saveCollectionDocumentation = async () => {
       auth: collection.auth || { authType: "inherit", authActive: true },
       headers: collection.headers || [],
       variables: stripSecretVariableValuesForWire(collection.variables || []),
-      _ref_id: collection._ref_id,
       description: documentationDescription.value,
       preRequestScript: collection.preRequestScript || "",
       testScript: collection.testScript || "",
@@ -836,7 +835,6 @@ const saveCollectionDocumentationById = async (
         variables: stripSecretVariableValuesForWire(
           collectionData.variables || []
         ),
-        _ref_id: collectionData._ref_id,
         description: documentation,
         preRequestScript: collectionData.preRequestScript || "",
         testScript: collectionData.testScript || "",

--- a/packages/hoppscotch-common/src/components/collections/graphql/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Collection.vue
@@ -250,6 +250,7 @@ import { useService } from "dioc/vue"
 import { computed, ref } from "vue"
 import { Picked } from "~/helpers/types/HoppPicked"
 import { removeGraphqlCollection } from "~/newstore/collections"
+import { flushLocalStoresForCollectionTree } from "~/helpers/secretVariables"
 import { handleTokenValidation } from "~/helpers/handleTokenValidation"
 import { GQLTabService } from "~/services/tab/graphql"
 import IconCheckCircle from "~icons/lucide/check-circle"
@@ -381,6 +382,10 @@ const removeCollection = async () => {
     tab.value.document.saveContext = undefined
     tab.value.document.isDirty = true
   }
+
+  // Cascade-flush local stores for the removed collection and its
+  // descendants. Symmetric to the REST path in `collections/index.vue`.
+  flushLocalStoresForCollectionTree(props.collection)
 
   removeGraphqlCollection(props.collectionIndex, props.collection.id)
   toast.success(`${t("state.deleted")}`)

--- a/packages/hoppscotch-common/src/components/collections/graphql/Collection.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Collection.vue
@@ -383,8 +383,6 @@ const removeCollection = async () => {
     tab.value.document.isDirty = true
   }
 
-  // Cascade-flush local stores for the removed collection and its
-  // descendants. Symmetric to the REST path in `collections/index.vue`.
   flushLocalStoresForCollectionTree(props.collection)
 
   removeGraphqlCollection(props.collectionIndex, props.collection.id)

--- a/packages/hoppscotch-common/src/components/collections/graphql/Folder.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Folder.vue
@@ -235,6 +235,7 @@ import { computed, ref } from "vue"
 import { handleTokenValidation } from "~/helpers/handleTokenValidation"
 import { Picked } from "~/helpers/types/HoppPicked"
 import { removeGraphqlFolder } from "~/newstore/collections"
+import { flushLocalStoresForCollectionTree } from "~/helpers/secretVariables"
 import { GQLTabService } from "~/services/tab/graphql"
 import IconCheckCircle from "~icons/lucide/check-circle"
 import IconCopy from "~icons/lucide/copy"
@@ -344,6 +345,10 @@ const removeFolder = async () => {
     tab.value.document.saveContext = undefined
     tab.value.document.isDirty = true
   }
+
+  // Cascade-flush local stores for the removed folder and its descendants.
+  // Symmetric to the REST path in `collections/index.vue`.
+  flushLocalStoresForCollectionTree(props.folder)
 
   removeGraphqlFolder(props.folderPath, props.folder.id)
   toast.success(t("state.deleted"))

--- a/packages/hoppscotch-common/src/components/collections/graphql/Folder.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/Folder.vue
@@ -346,8 +346,6 @@ const removeFolder = async () => {
     tab.value.document.isDirty = true
   }
 
-  // Cascade-flush local stores for the removed folder and its descendants.
-  // Symmetric to the REST path in `collections/index.vue`.
   flushLocalStoresForCollectionTree(props.folder)
 
   removeGraphqlFolder(props.folderPath, props.folder.id)

--- a/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
@@ -35,6 +35,11 @@ import { gistExporter } from "~/helpers/import-export/export/gist"
 import { computed } from "vue"
 import { hoppGQLImporter } from "~/helpers/import-export/import/hopp"
 import { ReqType } from "~/helpers/backend/graphql"
+import {
+  ensureRefIds,
+  populateLocalStoresFromCollectionTree,
+  stripCollectionTreeForStore,
+} from "~/helpers/secretVariables"
 
 const t = useI18n()
 const toast = useToast()
@@ -233,17 +238,31 @@ const showImportFailedError = () => {
 }
 
 const handleImportToStore = (gqlCollections: HoppCollection[]) => {
+  // Stamp every node with a stable `_ref_id` and persist any user-supplied
+  // secret + currentValue inputs to the local stores BEFORE the wire strip
+  // runs. Same rationale as the REST import: a logged-out import that the
+  // user later syncs on login would otherwise lose secrets when the sync
+  // layer strips them on the wire.
+  const collectionsWithRefIds = gqlCollections.map(ensureRefIds)
+  collectionsWithRefIds.forEach(populateLocalStoresFromCollectionTree)
+
   if (
     platform.sync.collections.importToPersonalWorkspace &&
     currentUser.value
   ) {
     return platform.sync.collections.importToPersonalWorkspace(
-      gqlCollections,
+      collectionsWithRefIds,
       ReqType.Gql
     )
   }
 
-  appendGraphqlCollections(gqlCollections)
+  // Logged-out / no-platform-sync path: strip raw secret values from the
+  // tree before appending — newstore + localStorage stay clean, the local
+  // secret + currentValue stores (populated above) hold the raw values
+  // keyed by the same `_ref_id`s for UI rehydrate.
+  appendGraphqlCollections(
+    collectionsWithRefIds.map(stripCollectionTreeForStore)
+  )
   toast.success(t("state.file_imported"))
 }
 

--- a/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
@@ -196,10 +196,8 @@ const GqlCollectionsGistExporter: ImporterOrExporter = {
     const accessToken = currentUser.value?.accessToken
 
     if (accessToken) {
-      const res = await gistExporter(
-        JSON.stringify(gqlCollections.value),
-        accessToken
-      )
+      const stripped = gqlCollections.value.map(stripCollectionTreeForStore)
+      const res = await gistExporter(JSON.stringify(stripped), accessToken)
 
       if (E.isLeft(res)) {
         toast.error(t("export.failed"))

--- a/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/collections/graphql/ImportExport.vue
@@ -238,11 +238,6 @@ const showImportFailedError = () => {
 }
 
 const handleImportToStore = (gqlCollections: HoppCollection[]) => {
-  // Stamp every node with a stable `_ref_id` and persist any user-supplied
-  // secret + currentValue inputs to the local stores BEFORE the wire strip
-  // runs. Same rationale as the REST import: a logged-out import that the
-  // user later syncs on login would otherwise lose secrets when the sync
-  // layer strips them on the wire.
   const collectionsWithRefIds = gqlCollections.map(ensureRefIds)
   collectionsWithRefIds.forEach(populateLocalStoresFromCollectionTree)
 
@@ -256,10 +251,6 @@ const handleImportToStore = (gqlCollections: HoppCollection[]) => {
     )
   }
 
-  // Logged-out / no-platform-sync path: strip raw secret values from the
-  // tree before appending — newstore + localStorage stay clean, the local
-  // secret + currentValue stores (populated above) hold the raw values
-  // keyed by the same `_ref_id`s for UI rehydrate.
   appendGraphqlCollections(
     collectionsWithRefIds.map(stripCollectionTreeForStore)
   )

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -399,6 +399,7 @@ import { CurrentValueService } from "~/services/current-environment-value.servic
 import { TeamCollectionsService } from "~/services/team-collection.service"
 import { SortOptions } from "~/helpers/backend/graphql"
 import { CurrentSortValuesService } from "~/services/current-sort.service"
+import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
 
 const t = useI18n()
 const toast = useToast()
@@ -3239,6 +3240,26 @@ const getCurrentValue = (
   )?.currentValue
 }
 
+/**
+ * Restore both `initialValue` and `currentValue` for a secret variable from
+ * the local secret store. Both fields are blanked at the wire boundary
+ * before the variable is sent to the backend, so when the user reopens the
+ * Properties modal we re-populate from `secretEnvironmentService`.
+ * Returns null for non-secret variables (callers fall back to existing
+ * current-value lookup) or when the slot has no entry in the secret store.
+ */
+const getSecretValues = (
+  isSecret: boolean,
+  varIndex: number,
+  collectionID: string
+): { value: string; initialValue: string } | null => {
+  if (!isSecret) return null
+  return secretEnvironmentService.getSecretEnvironmentVariableValue(
+    collectionID,
+    varIndex
+  )
+}
+
 const editProperties = async (payload: {
   collectionIndex: string
   collection: HoppCollection | TeamCollection
@@ -3276,14 +3297,15 @@ const editProperties = async (payload: {
     const collectionVariables = pipe(
       (collection as HoppCollection).variables ?? [],
       A.mapWithIndex((index, e) => {
+        const storeID = (collection as HoppCollection)._ref_id ?? collectionId!
+        const stored = getSecretValues(e.secret, index, storeID)
         return {
           ...e,
           currentValue:
-            getCurrentValue(
-              e.secret,
-              index,
-              (collection as HoppCollection)._ref_id ?? collectionId!
-            ) ?? e.currentValue,
+            stored?.value ??
+            getCurrentValue(e.secret, index, storeID) ??
+            e.currentValue,
+          initialValue: stored?.initialValue ?? e.initialValue,
         }
       })
     )
@@ -3337,10 +3359,14 @@ const editProperties = async (payload: {
       const collectionVariables = pipe(
         (data.variables ?? []) as HoppCollectionVariable[],
         A.mapWithIndex((index, e) => {
+          const stored = getSecretValues(e.secret, index, collectionId!)
           return {
             ...e,
             currentValue:
-              getCurrentValue(e.secret, index, collectionId!) ?? e.currentValue,
+              stored?.value ??
+              getCurrentValue(e.secret, index, collectionId!) ??
+              e.currentValue,
+            initialValue: stored?.initialValue ?? e.initialValue,
           }
         })
       )
@@ -3403,6 +3429,7 @@ const setCollectionProperties = (newCollection: {
           ? O.some({
               key: e.key,
               value: e.currentValue,
+              initialValue: e.initialValue,
               varIndex: i,
             })
           : O.none
@@ -3433,14 +3460,12 @@ const setCollectionProperties = (newCollection: {
       nonSecretVariables
     )
 
-    //set current value and secret values to empty string
-    collection.variables = pipe(
-      filteredVariables,
-      A.map((e) => ({
-        ...e,
-        currentValue: "",
-      }))
-    )
+    // Strip values that must not leave the client: secret variables get
+    // both `initialValue` and `currentValue` cleared (the secrets are
+    // already saved into `secretEnvironmentService` above), and non-secret
+    // variables keep their `initialValue` but have `currentValue` cleared
+    // because `currentValue` is per-user/per-session state.
+    collection.variables = stripSecretVariableValuesForWire(filteredVariables)
   }
 
   if (collectionsType.value.type === "my-collections") {

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -3482,7 +3482,12 @@ const setCollectionProperties = (newCollection: {
         authActive: true,
       },
       headers: collection.headers ?? [],
-      variables: collection.variables ?? [],
+      // `collection.variables` is set by the strip a few lines up when
+      // `collection.variables` was non-empty, but the early-return for
+      // the empty case bypasses that — strip again here defensively so
+      // every wire-boundary call to `updateTeamCollection` is uniformly
+      // safe.
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
       testScript: collection.testScript ?? "",

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -401,6 +401,7 @@ import { SortOptions } from "~/helpers/backend/graphql"
 import { CurrentSortValuesService } from "~/services/current-sort.service"
 import {
   flushLocalStoresForCollectionTree,
+  stripCollectionTreeForStore,
   stripSecretVariableValuesForWire,
 } from "~/helpers/secretVariables"
 
@@ -3140,7 +3141,11 @@ const initializeDownloadCollection = async (
  */
 const exportData = async (collection: HoppCollection | TeamCollection) => {
   if (collectionsType.value.type === "my-collections") {
-    const collectionJSON = JSON.stringify(collection, stripRefIdReplacer, 2)
+    const collectionJSON = JSON.stringify(
+      stripCollectionTreeForStore(collection as HoppCollection),
+      stripRefIdReplacer,
+      2
+    )
 
     // Strip `export {};\n` from `testScript` and `preRequestScript` fields
     const cleanedCollectionJSON =
@@ -3164,7 +3169,7 @@ const exportData = async (collection: HoppCollection | TeamCollection) => {
         async (coll) => {
           const hoppColl = teamCollToHoppRESTColl(coll)
           const collectionJSONString = JSON.stringify(
-            hoppColl,
+            stripCollectionTreeForStore(hoppColl),
             stripRefIdReplacer,
             2
           )
@@ -3461,8 +3466,7 @@ const setCollectionProperties = (newCollection: {
         authActive: true,
       },
       headers: collection.headers ?? [],
-      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
-      _ref_id: collection._ref_id,
+      variables: collection.variables ?? [],
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
       testScript: collection.testScript ?? "",

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -3450,15 +3450,15 @@ const setCollectionProperties = (newCollection: {
       )
     )
 
-    secretEnvironmentService.addSecretEnvironment(
-      collection._ref_id ?? collectionId!,
-      secretVariables
-    )
+    // Mirror the read-side keying in `editProperties`.
+    const storeKey =
+      collectionsType.value.type === "team-collections"
+        ? collectionId!
+        : (collection._ref_id ?? collectionId!)
 
-    currentEnvironmentValueService.addEnvironment(
-      collection._ref_id ?? collectionId!,
-      nonSecretVariables
-    )
+    secretEnvironmentService.addSecretEnvironment(storeKey, secretVariables)
+
+    currentEnvironmentValueService.addEnvironment(storeKey, nonSecretVariables)
 
     collection.variables = stripSecretVariableValuesForWire(filteredVariables)
   }

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -1996,9 +1996,6 @@ const onRemoveCollection = async () => {
     toast.success(t("state.deleted"))
     displayConfirmModal(false)
 
-    // Cascade-flush local stores for the removed collection and ALL its
-    // descendant folders. A single-level delete would orphan child-folder
-    // entries keyed by their own `_ref_id`s.
     if (collectionToRemove) {
       flushLocalStoresForCollectionTree(collectionToRemove)
     }
@@ -2018,12 +2015,7 @@ const onRemoveCollection = async () => {
     removeTeamCollectionOrFolder(collectionID).then(() => {
       resetTeamRequestsContext()
 
-      // Single-level flush is sufficient here: team collection IDs are
-      // globally-unique backend UUIDs, so descendant entries that survive
-      // a parent delete won't be re-aliased by a future entity. They do
-      // accumulate as a slow leak; a cascade walk would need the team
-      // subtree snapshotted before delete, which `team-collection.service`
-      // doesn't expose today. Worth a follow-up; not a security gap.
+      // Single-level flush — team UUIDs are globally unique, no aliasing.
       if (collectionID) {
         secretEnvironmentService.deleteSecretEnvironment(collectionID)
         currentEnvironmentValueService.deleteEnvironment(collectionID)
@@ -2077,10 +2069,6 @@ const onRemoveFolder = async () => {
     toast.success(t("state.deleted"))
     displayConfirmModal(false)
 
-    // Cascade-flush local stores for the removed folder and ALL its
-    // descendant folders. The personal-workspace local store is keyed by
-    // `_ref_id`, so a single-level flush by `folderToRemove.id` would
-    // both miss descendants and likely use the wrong key.
     if (folderToRemove) {
       flushLocalStoresForCollectionTree(folderToRemove)
     }
@@ -2100,8 +2088,6 @@ const onRemoveFolder = async () => {
     removeTeamCollectionOrFolder(collectionID).then(() => {
       resetTeamRequestsContext()
 
-      // Single-level flush — see note in `onRemoveCollection` for why
-      // descendants aren't cascaded for team workspaces today.
       if (collectionID) {
         secretEnvironmentService.deleteSecretEnvironment(collectionID)
         currentEnvironmentValueService.deleteEnvironment(collectionID)
@@ -3454,11 +3440,6 @@ const setCollectionProperties = (newCollection: {
       nonSecretVariables
     )
 
-    // Strip values that must not leave the client: secret variables get
-    // both `initialValue` and `currentValue` cleared (the secrets are
-    // already saved into `secretEnvironmentService` above), and non-secret
-    // variables keep their `initialValue` but have `currentValue` cleared
-    // because `currentValue` is per-user/per-session state.
     collection.variables = stripSecretVariableValuesForWire(filteredVariables)
   }
 
@@ -3480,15 +3461,7 @@ const setCollectionProperties = (newCollection: {
         authActive: true,
       },
       headers: collection.headers ?? [],
-      // `collection.variables` is set by the strip a few lines up when
-      // `collection.variables` was non-empty, but the early-return for
-      // the empty case bypasses that — strip again here defensively so
-      // every wire-boundary call to `updateTeamCollection` is uniformly
-      // safe.
       variables: stripSecretVariableValuesForWire(collection.variables ?? []),
-      // Round-trip `_ref_id` through the backend `data` blob so the local
-      // secret store key stays stable across reloads — same rationale as
-      // the personal-collection writers in `platform/collections/.../sync.ts`.
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -401,6 +401,7 @@ import { SortOptions } from "~/helpers/backend/graphql"
 import { CurrentSortValuesService } from "~/services/current-sort.service"
 import {
   flushLocalStoresForCollectionTree,
+  flushLocalStoresForTeamCollectionTree,
   stripCollectionTreeForStore,
   stripSecretVariableValuesForWire,
 } from "~/helpers/secretVariables"
@@ -2013,11 +2014,20 @@ const onRemoveCollection = async () => {
       emit("select", null)
     }
 
+    // Capture the subtree BEFORE the mutation so the
+    // team-collection-removed subscription can't drop it from FE state
+    // before we flush nested entries.
+    const subtreeSnapshot =
+      teamCollectionService.findCollectionByID(collectionID)
+
     removeTeamCollectionOrFolder(collectionID).then(() => {
       resetTeamRequestsContext()
 
-      // Single-level flush — team UUIDs are globally unique, no aliasing.
-      if (collectionID) {
+      if (subtreeSnapshot) {
+        flushLocalStoresForTeamCollectionTree(subtreeSnapshot)
+      } else if (collectionID) {
+        // Snapshot miss (already removed from tree). Flush at least the
+        // top-level id so the secret service doesn't leak this entry.
         secretEnvironmentService.deleteSecretEnvironment(collectionID)
         currentEnvironmentValueService.deleteEnvironment(collectionID)
       }
@@ -2086,10 +2096,15 @@ const onRemoveFolder = async () => {
       emit("select", null)
     }
 
+    const subtreeSnapshot =
+      teamCollectionService.findCollectionByID(collectionID)
+
     removeTeamCollectionOrFolder(collectionID).then(() => {
       resetTeamRequestsContext()
 
-      if (collectionID) {
+      if (subtreeSnapshot) {
+        flushLocalStoresForTeamCollectionTree(subtreeSnapshot)
+      } else if (collectionID) {
         secretEnvironmentService.deleteSecretEnvironment(collectionID)
         currentEnvironmentValueService.deleteEnvironment(collectionID)
       }

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -399,7 +399,10 @@ import { CurrentValueService } from "~/services/current-environment-value.servic
 import { TeamCollectionsService } from "~/services/team-collection.service"
 import { SortOptions } from "~/helpers/backend/graphql"
 import { CurrentSortValuesService } from "~/services/current-sort.service"
-import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
+import {
+  flushLocalStoresForCollectionTree,
+  stripSecretVariableValuesForWire,
+} from "~/helpers/secretVariables"
 
 const t = useI18n()
 const toast = useToast()
@@ -1993,15 +1996,11 @@ const onRemoveCollection = async () => {
     toast.success(t("state.deleted"))
     displayConfirmModal(false)
 
-    // delete the secret collection variables
-    // and current collection variables value if the collection is removed
+    // Cascade-flush local stores for the removed collection and ALL its
+    // descendant folders. A single-level delete would orphan child-folder
+    // entries keyed by their own `_ref_id`s.
     if (collectionToRemove) {
-      secretEnvironmentService.deleteSecretEnvironment(
-        collectionToRemove._ref_id ?? `${collectionIndex}`
-      )
-      currentEnvironmentValueService.deleteEnvironment(
-        collectionToRemove._ref_id ?? `${collectionIndex}`
-      )
+      flushLocalStoresForCollectionTree(collectionToRemove)
     }
   } else if (hasTeamWriteAccess.value) {
     const collectionID = editingCollectionID.value
@@ -2019,8 +2018,12 @@ const onRemoveCollection = async () => {
     removeTeamCollectionOrFolder(collectionID).then(() => {
       resetTeamRequestsContext()
 
-      // delete the secret collection variables
-      // and current collection variables value if the collection is removed
+      // Single-level flush is sufficient here: team collection IDs are
+      // globally-unique backend UUIDs, so descendant entries that survive
+      // a parent delete won't be re-aliased by a future entity. They do
+      // accumulate as a slow leak; a cascade walk would need the team
+      // subtree snapshotted before delete, which `team-collection.service`
+      // doesn't expose today. Worth a follow-up; not a security gap.
       if (collectionID) {
         secretEnvironmentService.deleteSecretEnvironment(collectionID)
         currentEnvironmentValueService.deleteEnvironment(collectionID)
@@ -2054,8 +2057,6 @@ const onRemoveFolder = async () => {
       emit("select", null)
     }
 
-    const folderIndex = pathToLastIndex(folderPath)
-
     const folderToRemove = folderPath
       ? navigateToFolderWithIndexPath(
           restCollectionStore.value.state,
@@ -2076,15 +2077,12 @@ const onRemoveFolder = async () => {
     toast.success(t("state.deleted"))
     displayConfirmModal(false)
 
-    // delete the secret collection variables
-    // and current collection variables value if the collection is removed
+    // Cascade-flush local stores for the removed folder and ALL its
+    // descendant folders. The personal-workspace local store is keyed by
+    // `_ref_id`, so a single-level flush by `folderToRemove.id` would
+    // both miss descendants and likely use the wrong key.
     if (folderToRemove) {
-      secretEnvironmentService.deleteSecretEnvironment(
-        folderToRemove.id ?? `${folderIndex}`
-      )
-      currentEnvironmentValueService.deleteEnvironment(
-        folderToRemove.id ?? `${folderIndex}`
-      )
+      flushLocalStoresForCollectionTree(folderToRemove)
     }
   } else if (hasTeamWriteAccess.value) {
     const collectionID = editingCollectionID.value
@@ -2102,8 +2100,8 @@ const onRemoveFolder = async () => {
     removeTeamCollectionOrFolder(collectionID).then(() => {
       resetTeamRequestsContext()
 
-      // delete the secret collection variables
-      // and current collection variables value if the collection is removed
+      // Single-level flush — see note in `onRemoveCollection` for why
+      // descendants aren't cascaded for team workspaces today.
       if (collectionID) {
         secretEnvironmentService.deleteSecretEnvironment(collectionID)
         currentEnvironmentValueService.deleteEnvironment(collectionID)

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -399,6 +399,7 @@ import { CurrentValueService } from "~/services/current-environment-value.servic
 import { TeamCollectionsService } from "~/services/team-collection.service"
 import { SortOptions } from "~/helpers/backend/graphql"
 import { CurrentSortValuesService } from "~/services/current-sort.service"
+import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
 
 const t = useI18n()
 const toast = useToast()
@@ -3235,6 +3236,26 @@ const getCurrentValue = (
   )?.currentValue
 }
 
+/**
+ * Restore both `initialValue` and `currentValue` for a secret variable from
+ * the local secret store. Both fields are blanked at the wire boundary
+ * before the variable is sent to the backend, so when the user reopens the
+ * Properties modal we re-populate from `secretEnvironmentService`.
+ * Returns null for non-secret variables (callers fall back to existing
+ * current-value lookup) or when the slot has no entry in the secret store.
+ */
+const getSecretValues = (
+  isSecret: boolean,
+  varIndex: number,
+  collectionID: string
+): { value: string; initialValue: string } | null => {
+  if (!isSecret) return null
+  return secretEnvironmentService.getSecretEnvironmentVariableValue(
+    collectionID,
+    varIndex
+  )
+}
+
 const editProperties = async (payload: {
   collectionIndex: string
   collection: HoppCollection | TeamCollection
@@ -3272,14 +3293,15 @@ const editProperties = async (payload: {
     const collectionVariables = pipe(
       (collection as HoppCollection).variables ?? [],
       A.mapWithIndex((index, e) => {
+        const storeID = (collection as HoppCollection)._ref_id ?? collectionId!
+        const stored = getSecretValues(e.secret, index, storeID)
         return {
           ...e,
           currentValue:
-            getCurrentValue(
-              e.secret,
-              index,
-              (collection as HoppCollection)._ref_id ?? collectionId!
-            ) ?? e.currentValue,
+            stored?.value ??
+            getCurrentValue(e.secret, index, storeID) ??
+            e.currentValue,
+          initialValue: stored?.initialValue ?? e.initialValue,
         }
       })
     )
@@ -3333,10 +3355,14 @@ const editProperties = async (payload: {
       const collectionVariables = pipe(
         (data.variables ?? []) as HoppCollectionVariable[],
         A.mapWithIndex((index, e) => {
+          const stored = getSecretValues(e.secret, index, collectionId!)
           return {
             ...e,
             currentValue:
-              getCurrentValue(e.secret, index, collectionId!) ?? e.currentValue,
+              stored?.value ??
+              getCurrentValue(e.secret, index, collectionId!) ??
+              e.currentValue,
+            initialValue: stored?.initialValue ?? e.initialValue,
           }
         })
       )
@@ -3399,6 +3425,7 @@ const setCollectionProperties = (newCollection: {
           ? O.some({
               key: e.key,
               value: e.currentValue,
+              initialValue: e.initialValue,
               varIndex: i,
             })
           : O.none
@@ -3429,14 +3456,12 @@ const setCollectionProperties = (newCollection: {
       nonSecretVariables
     )
 
-    //set current value and secret values to empty string
-    collection.variables = pipe(
-      filteredVariables,
-      A.map((e) => ({
-        ...e,
-        currentValue: "",
-      }))
-    )
+    // Strip values that must not leave the client: secret variables get
+    // both `initialValue` and `currentValue` cleared (the secrets are
+    // already saved into `secretEnvironmentService` above), and non-secret
+    // variables keep their `initialValue` but have `currentValue` cleared
+    // because `currentValue` is per-user/per-session state.
+    collection.variables = stripSecretVariableValuesForWire(filteredVariables)
   }
 
   if (collectionsType.value.type === "my-collections") {

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -3476,7 +3476,7 @@ const setCollectionProperties = (newCollection: {
     })
     toast.success(t("collection.properties_updated"))
   } else if (hasTeamWriteAccess.value && collectionId) {
-    const data = {
+    const data: CollectionDataProps = {
       auth: collection.auth ?? {
         authType: "inherit",
         authActive: true,
@@ -3488,6 +3488,10 @@ const setCollectionProperties = (newCollection: {
       // every wire-boundary call to `updateTeamCollection` is uniformly
       // safe.
       variables: stripSecretVariableValuesForWire(collection.variables ?? []),
+      // Round-trip `_ref_id` through the backend `data` blob so the local
+      // secret store key stays stable across reloads — same rationale as
+      // the personal-collection writers in `platform/collections/.../sync.ts`.
+      _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
       testScript: collection.testScript ?? "",

--- a/packages/hoppscotch-common/src/components/environments/Add.vue
+++ b/packages/hoppscotch-common/src/components/environments/Add.vue
@@ -79,6 +79,7 @@ import { useToast } from "~/composables/toast"
 import { GQLError } from "~/helpers/backend/GQLClient"
 import { updateTeamEnvironment } from "~/helpers/backend/mutations/TeamEnvironment"
 import { getEnvActionErrorMessage } from "~/helpers/error-messages"
+import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
 import {
   setGlobalEnvVariables,
   updateEnvironment,
@@ -205,7 +206,12 @@ const addEnvironment = async () => {
 
     await pipe(
       updateTeamEnvironment(
-        JSON.stringify(newVariables),
+        // Strip at the wire boundary — `newVariables` is built from the
+        // existing in-memory team env (already stripped on load) plus a
+        // freshly-added non-secret entry, but the strip here makes the
+        // wire-boundary safety independent of how `newVariables` is
+        // constructed upstream.
+        JSON.stringify(stripSecretVariableValuesForWire(newVariables)),
         scope.value.environment.id,
         scope.value.environment.environment.name
       ),

--- a/packages/hoppscotch-common/src/components/environments/Add.vue
+++ b/packages/hoppscotch-common/src/components/environments/Add.vue
@@ -206,11 +206,6 @@ const addEnvironment = async () => {
 
     await pipe(
       updateTeamEnvironment(
-        // Strip at the wire boundary — `newVariables` is built from the
-        // existing in-memory team env (already stripped on load) plus a
-        // freshly-added non-secret entry, but the strip here makes the
-        // wire-boundary safety independent of how `newVariables` is
-        // constructed upstream.
         JSON.stringify(stripSecretVariableValuesForWire(newVariables)),
         scope.value.environment.id,
         scope.value.environment.environment.name

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup lang="ts">
-import { Environment, NonSecretEnvironment } from "@hoppscotch/data"
+import { Environment } from "@hoppscotch/data"
 import {
   populateLocalStoresFromVariables,
   stripSecretVariableValuesForWire,
@@ -28,8 +28,12 @@ import {
   addGlobalEnvVariable,
   appendEnvironments,
   environments$,
+  getGlobalVariables,
 } from "~/newstore/environments"
 
+import { useService } from "dioc/vue"
+import { CurrentValueService } from "~/services/current-environment-value.service"
+import { SecretEnvironmentService } from "~/services/secret-environment.service"
 import { GQLError } from "~/helpers/backend/GQLClient"
 import { CreateTeamEnvironmentMutation } from "~/helpers/backend/graphql"
 import { createTeamEnvironment } from "~/helpers/backend/mutations/TeamEnvironment"
@@ -59,6 +63,9 @@ const props = defineProps<{
 }>()
 
 const myEnvironments = useReadonlyStream(environments$, [])
+
+const currentEnvironmentValueService = useService(CurrentValueService)
+const secretEnvironmentService = useService(SecretEnvironmentService)
 
 const currentUser = useReadonlyStream(
   platform.auth.getCurrentUserStream(),
@@ -362,30 +369,72 @@ const showImportFailedError = () => {
 
 const handleImportToStore = async (
   environments: Environment[],
-  globalEnvs: NonSecretEnvironment[] = []
+  globalEnvs: Environment[] = []
 ) => {
   // Pre-populate local stores with imported secret + currentValue inputs
   // BEFORE anything (raw or sync) reaches the newstore. This way, even if
   // the user is offline, sync is disabled, or the app quits before sync
   // completes, the secret values survive — they're keyed locally and the
   // newstore is never written with raw secrets.
-  globalEnvs.forEach(({ variables }) => {
-    populateLocalStoresFromVariables("Global", variables)
-  })
+  //
+  // Non-global envs are keyed by their own backend id (one map entry per
+  // env), so a per-env replace is safe.
   environments.forEach((env) => {
     populateLocalStoresFromVariables(env.id, env.variables)
   })
 
-  // Add global envs to the store with values stripped — the secret + per-
-  // user `currentValue` inputs we just persisted locally re-hydrate via
-  // `getCurrentValue` / `getInitialValue` in the env Details modal.
-  globalEnvs.forEach(({ variables }) => {
-    stripSecretVariableValuesForWire(variables).forEach(
+  // Globals all share the single `"Global"` key in the local stores, so we
+  // must MERGE the imported entries with whatever's already there. A naive
+  // `populateLocalStoresFromVariables("Global", ...)` per base env would
+  // (a) wipe pre-existing entries on each call (Map.set replace), and
+  // (b) misalign `varIndex` against the newstore when more than one base
+  // env is imported (only the last call's indices would match).
+  //
+  // Hydrate the existing globals from the local stores (where the raw
+  // secret + currentValue values live), concat the imported tail, then
+  // call the helper once on the full array — its index-based replace then
+  // matches the newstore order exactly.
+  if (globalEnvs.length > 0) {
+    const importedGlobals = globalEnvs.flatMap(({ variables }) => variables)
+
+    const existingHydrated: Environment["variables"] = getGlobalVariables().map(
+      (v, i) => {
+        if (v.secret) {
+          const stored = secretEnvironmentService.getSecretEnvironmentVariable(
+            "Global",
+            i
+          )
+          return {
+            ...v,
+            initialValue: stored?.initialValue ?? "",
+            currentValue: stored?.value ?? "",
+          }
+        }
+        const stored = currentEnvironmentValueService.getEnvironmentVariable(
+          "Global",
+          i
+        )
+        return {
+          ...v,
+          currentValue: stored?.currentValue ?? v.currentValue,
+        }
+      }
+    )
+
+    populateLocalStoresFromVariables("Global", [
+      ...existingHydrated,
+      ...importedGlobals,
+    ])
+
+    // Append the stripped imported globals to the newstore. Order matches
+    // the hydrated existing entries above so the local-store `varIndex`
+    // aligns with the newstore array position.
+    stripSecretVariableValuesForWire(importedGlobals).forEach(
       ({ key, initialValue, currentValue, secret }) => {
         addGlobalEnvVariable({ key, initialValue, currentValue, secret })
       }
     )
-  })
+  }
 
   if (props.environmentType === "MY_ENV") {
     // Strip wire payload before adding to newstore so raw secret values

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -364,15 +364,38 @@ const handleImportToStore = async (
   environments: Environment[],
   globalEnvs: NonSecretEnvironment[] = []
 ) => {
-  // Add global envs to the store
+  // Pre-populate local stores with imported secret + currentValue inputs
+  // BEFORE anything (raw or sync) reaches the newstore. This way, even if
+  // the user is offline, sync is disabled, or the app quits before sync
+  // completes, the secret values survive — they're keyed locally and the
+  // newstore is never written with raw secrets.
   globalEnvs.forEach(({ variables }) => {
-    variables.forEach(({ key, initialValue, currentValue, secret }) => {
-      addGlobalEnvVariable({ key, initialValue, currentValue, secret })
-    })
+    populateLocalStoresFromVariables("Global", variables)
+  })
+  environments.forEach((env) => {
+    populateLocalStoresFromVariables(env.id, env.variables)
+  })
+
+  // Add global envs to the store with values stripped — the secret + per-
+  // user `currentValue` inputs we just persisted locally re-hydrate via
+  // `getCurrentValue` / `getInitialValue` in the env Details modal.
+  globalEnvs.forEach(({ variables }) => {
+    stripSecretVariableValuesForWire(variables).forEach(
+      ({ key, initialValue, currentValue, secret }) => {
+        addGlobalEnvVariable({ key, initialValue, currentValue, secret })
+      }
+    )
   })
 
   if (props.environmentType === "MY_ENV") {
-    appendEnvironments(environments)
+    // Strip wire payload before adding to newstore so raw secret values
+    // never sit in newstore / localStorage where a later subscription or
+    // sync could persist them. UI re-hydrates from the local stores above.
+    const strippedEnvironments = environments.map((env) => ({
+      ...env,
+      variables: stripSecretVariableValuesForWire(env.variables),
+    }))
+    appendEnvironments(strippedEnvironments)
     toast.success(t("state.file_imported"))
   } else {
     await importToTeams(environments)

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -371,17 +371,14 @@ const handleImportToStore = async (
   environments: Environment[],
   globalEnvs: Environment[] = []
 ) => {
-  // Pre-populate local stores with imported secret + currentValue inputs
-  // BEFORE anything (raw or sync) reaches the newstore. This way, even if
-  // the user is offline, sync is disabled, or the app quits before sync
-  // completes, the secret values survive — they're keyed locally and the
-  // newstore is never written with raw secrets.
-  //
-  // Non-global envs are keyed by their own backend id (one map entry per
-  // env), so a per-env replace is safe.
-  environments.forEach((env) => {
-    populateLocalStoresFromVariables(env.id, env.variables)
-  })
+  // Per-env pre-populate is intentionally NOT done here for every env.
+  // It happens inside the MY_ENV branch below, where the temp UUID assigned
+  // at import time has a defined remap path via `updateSecretEnvironmentID`
+  // / `updateEnvironmentID` in the sync handler once the backend create
+  // resolves. The TEAMS branch goes through `importToTeams`, which
+  // populates per-env with the real backend ID returned from
+  // `createTeamEnvironment` — pre-populating under the throwaway temp
+  // UUID would orphan a map entry that nothing later reaps.
 
   // Globals all share the single `"Global"` key in the local stores, so we
   // must MERGE the imported entries with whatever's already there. A naive
@@ -437,6 +434,16 @@ const handleImportToStore = async (
   }
 
   if (props.environmentType === "MY_ENV") {
+    // Pre-populate local stores under the temp UUID assigned at import
+    // time. The sync handler (`appendEnvironments` in
+    // `selfhost-web/.../environments/web/sync.ts`) remaps each entry to
+    // the real backend ID via `updateSecretEnvironmentID` /
+    // `updateEnvironmentID` once `createUserEnvironment` resolves, so the
+    // raw values survive the wire-strip and end up keyed correctly.
+    environments.forEach((env) => {
+      populateLocalStoresFromVariables(env.id, env.variables)
+    })
+
     // Strip wire payload before adding to newstore so raw secret values
     // never sit in newstore / localStorage where a later subscription or
     // sync could persist them. UI re-hydrates from the local stores above.

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -10,6 +10,10 @@
 
 <script setup lang="ts">
 import { Environment, NonSecretEnvironment } from "@hoppscotch/data"
+import {
+  populateLocalStoresFromVariables,
+  stripSecretVariableValuesForWire,
+} from "~/helpers/secretVariables"
 import * as E from "fp-ts/Either"
 import { ref } from "vue"
 
@@ -382,7 +386,7 @@ const importToTeams = async (content: Environment[]) => {
 
   for (const [, env] of content.entries()) {
     const res = createTeamEnvironment(
-      JSON.stringify(env.variables),
+      JSON.stringify(stripSecretVariableValuesForWire(env.variables)),
       props.teamId as string,
       env.name
     )()
@@ -391,6 +395,20 @@ const importToTeams = async (content: Environment[]) => {
   }
 
   const res = await Promise.all(envImportPromises)
+
+  // Persist the imported secret + currentValue inputs to the local stores,
+  // re-keyed to each new backend env ID. Pairs with the wire-strip above:
+  // the team's DB row stays clean while this device retains the values the
+  // user just imported. Non-conforming clients elsewhere on the team see
+  // empty values, matching the per-user-per-device security model.
+  res.forEach((entry, index) => {
+    if (E.isRight(entry)) {
+      populateLocalStoresFromVariables(
+        entry.right.createTeamEnvironment.id,
+        content[index].variables
+      )
+    }
+  })
 
   const failedImports = res.some((r) => E.isLeft(r))
 

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup lang="ts">
-import { Environment } from "@hoppscotch/data"
+import { Environment, generateUniqueRefId } from "@hoppscotch/data"
 import {
   populateLocalStoresFromVariables,
   stripSecretVariableValuesForWire,
@@ -434,20 +434,25 @@ const handleImportToStore = async (
   }
 
   if (props.environmentType === "MY_ENV") {
-    // Pre-populate local stores under the temp UUID assigned at import
-    // time. The sync handler (`appendEnvironments` in
-    // `selfhost-web/.../environments/web/sync.ts`) remaps each entry to
-    // the real backend ID via `updateSecretEnvironmentID` /
-    // `updateEnvironmentID` once `createUserEnvironment` resolves, so the
-    // raw values survive the wire-strip and end up keyed correctly.
-    environments.forEach((env) => {
+    // Stamp a temp id onto envs that arrive without one (locally-created,
+    // never-synced envs export with `id: ""`). `populateLocalStoresFromVariables`
+    // early-returns on empty entityId, so without this every secret would
+    // silently drop. The same id flows into `strippedEnvironments` so the
+    // sync handler's `tempId = environments[envId].id` capture finds the
+    // local-store entry and remaps it to the real backend id.
+    const envsWithIds = environments.map((env) => ({
+      ...env,
+      id: env.id || generateUniqueRefId("env"),
+    }))
+
+    envsWithIds.forEach((env) => {
       populateLocalStoresFromVariables(env.id, env.variables)
     })
 
     // Strip wire payload before adding to newstore so raw secret values
     // never sit in newstore / localStorage where a later subscription or
     // sync could persist them. UI re-hydrates from the local stores above.
-    const strippedEnvironments = environments.map((env) => ({
+    const strippedEnvironments = envsWithIds.map((env) => ({
       ...env,
       variables: stripSecretVariableValuesForWire(env.variables),
     }))

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -12,7 +12,7 @@
 import { Environment, generateUniqueRefId } from "@hoppscotch/data"
 import {
   populateLocalStoresFromVariables,
-  promoteSecretInitialValueForImport,
+  promoteInitialValueForImport,
   stripSecretVariableValuesForWire,
 } from "~/helpers/secretVariables"
 import * as E from "fp-ts/Either"
@@ -414,7 +414,7 @@ const handleImportToStore = async (
     // cleared per the rehydration semantic.
     populateLocalStoresFromVariables("Global", [
       ...existingHydrated,
-      ...promoteSecretInitialValueForImport(importedGlobals),
+      ...promoteInitialValueForImport(importedGlobals),
     ])
 
     // Append stripped imports; varIndex aligns with the hydrated entries.
@@ -440,7 +440,7 @@ const handleImportToStore = async (
     envsWithIds.forEach((env) => {
       populateLocalStoresFromVariables(
         env.id,
-        promoteSecretInitialValueForImport(env.variables)
+        promoteInitialValueForImport(env.variables)
       )
     })
 
@@ -478,7 +478,7 @@ const importToTeams = async (content: Environment[]) => {
     if (E.isRight(entry)) {
       populateLocalStoresFromVariables(
         entry.right.createTeamEnvironment.id,
-        promoteSecretInitialValueForImport(content[index].variables)
+        promoteInitialValueForImport(content[index].variables)
       )
     }
   })

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -371,26 +371,9 @@ const handleImportToStore = async (
   environments: Environment[],
   globalEnvs: Environment[] = []
 ) => {
-  // Per-env pre-populate is intentionally NOT done here for every env.
-  // It happens inside the MY_ENV branch below, where the temp UUID assigned
-  // at import time has a defined remap path via `updateSecretEnvironmentID`
-  // / `updateEnvironmentID` in the sync handler once the backend create
-  // resolves. The TEAMS branch goes through `importToTeams`, which
-  // populates per-env with the real backend ID returned from
-  // `createTeamEnvironment` — pre-populating under the throwaway temp
-  // UUID would orphan a map entry that nothing later reaps.
-
-  // Globals all share the single `"Global"` key in the local stores, so we
-  // must MERGE the imported entries with whatever's already there. A naive
-  // `populateLocalStoresFromVariables("Global", ...)` per base env would
-  // (a) wipe pre-existing entries on each call (Map.set replace), and
-  // (b) misalign `varIndex` against the newstore when more than one base
-  // env is imported (only the last call's indices would match).
-  //
-  // Hydrate the existing globals from the local stores (where the raw
-  // secret + currentValue values live), concat the imported tail, then
-  // call the helper once on the full array — its index-based replace then
-  // matches the newstore order exactly.
+  // Per-env populate happens inside MY_ENV / TEAMS branches below, each
+  // keyed appropriately. Globals share the single `"Global"` key and must
+  // merge with existing entries — hydrate, concat, populate once.
   if (globalEnvs.length > 0) {
     const importedGlobals = globalEnvs.flatMap(({ variables }) => variables)
 
@@ -423,9 +406,7 @@ const handleImportToStore = async (
       ...importedGlobals,
     ])
 
-    // Append the stripped imported globals to the newstore. Order matches
-    // the hydrated existing entries above so the local-store `varIndex`
-    // aligns with the newstore array position.
+    // Append stripped imports; varIndex aligns with the hydrated entries.
     stripSecretVariableValuesForWire(importedGlobals).forEach(
       ({ key, initialValue, currentValue, secret }) => {
         addGlobalEnvVariable({ key, initialValue, currentValue, secret })
@@ -434,12 +415,9 @@ const handleImportToStore = async (
   }
 
   if (props.environmentType === "MY_ENV") {
-    // Stamp a temp id onto envs that arrive without one (locally-created,
-    // never-synced envs export with `id: ""`). `populateLocalStoresFromVariables`
-    // early-returns on empty entityId, so without this every secret would
-    // silently drop. The same id flows into `strippedEnvironments` so the
-    // sync handler's `tempId = environments[envId].id` capture finds the
-    // local-store entry and remaps it to the real backend id.
+    // Stamp a temp id when missing — `populateLocalStoresFromVariables`
+    // early-returns on empty. The id flows into `strippedEnvironments`
+    // so the sync handler can remap it to the real backend id.
     const envsWithIds = environments.map((env) => ({
       ...env,
       id: env.id || generateUniqueRefId("env"),
@@ -449,9 +427,6 @@ const handleImportToStore = async (
       populateLocalStoresFromVariables(env.id, env.variables)
     })
 
-    // Strip wire payload before adding to newstore so raw secret values
-    // never sit in newstore / localStorage where a later subscription or
-    // sync could persist them. UI re-hydrates from the local stores above.
     const strippedEnvironments = envsWithIds.map((env) => ({
       ...env,
       variables: stripSecretVariableValuesForWire(env.variables),
@@ -480,11 +455,8 @@ const importToTeams = async (content: Environment[]) => {
 
   const res = await Promise.all(envImportPromises)
 
-  // Persist the imported secret + currentValue inputs to the local stores,
-  // re-keyed to each new backend env ID. Pairs with the wire-strip above:
-  // the team's DB row stays clean while this device retains the values the
-  // user just imported. Non-conforming clients elsewhere on the team see
-  // empty values, matching the per-user-per-device security model.
+  // Populate local stores keyed by the new backend env ID — this device
+  // retains the raw values; the team DB row stays clean.
   res.forEach((entry, index) => {
     if (E.isRight(entry)) {
       populateLocalStoresFromVariables(

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -12,6 +12,7 @@
 import { Environment, generateUniqueRefId } from "@hoppscotch/data"
 import {
   populateLocalStoresFromVariables,
+  promoteSecretInitialValueForImport,
   stripSecretVariableValuesForWire,
 } from "~/helpers/secretVariables"
 import * as E from "fp-ts/Either"
@@ -406,9 +407,14 @@ const handleImportToStore = async (
     // concat) running with no awaits in between — a future refactor that
     // introduces one between the snapshot and this call would silently
     // drop any global added meanwhile.
+    //
+    // Promote on the IMPORTED slice only (not `existingHydrated`) so a
+    // legacy export shape (`initialValue` set, `currentValue: ""`) lands
+    // its secrets correctly, while user-cleared existing globals stay
+    // cleared per the rehydration semantic.
     populateLocalStoresFromVariables("Global", [
       ...existingHydrated,
-      ...importedGlobals,
+      ...promoteSecretInitialValueForImport(importedGlobals),
     ])
 
     // Append stripped imports; varIndex aligns with the hydrated entries.
@@ -432,7 +438,10 @@ const handleImportToStore = async (
     }))
 
     envsWithIds.forEach((env) => {
-      populateLocalStoresFromVariables(env.id, env.variables)
+      populateLocalStoresFromVariables(
+        env.id,
+        promoteSecretInitialValueForImport(env.variables)
+      )
     })
 
     const strippedEnvironments = envsWithIds.map((env) => ({
@@ -469,7 +478,7 @@ const importToTeams = async (content: Environment[]) => {
     if (E.isRight(entry)) {
       populateLocalStoresFromVariables(
         entry.right.createTeamEnvironment.id,
-        content[index].variables
+        promoteSecretInitialValueForImport(content[index].variables)
       )
     }
   })

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -415,12 +415,15 @@ const handleImportToStore = async (
   }
 
   if (props.environmentType === "MY_ENV") {
-    // Stamp a temp id when missing — `populateLocalStoresFromVariables`
-    // early-returns on empty. The id flows into `strippedEnvironments`
-    // so the sync handler can remap it to the real backend id.
+    // Always stamp a fresh temp id, even if the export carried one —
+    // re-using the exported `id` would land the populate on a store
+    // entry already owned by the original environment (then the sync
+    // remap would migrate that entry away, blanking the original's
+    // secrets). A fresh id guarantees no collision with anything in
+    // the store before the sync handler creates the new backend row.
     const envsWithIds = environments.map((env) => ({
       ...env,
-      id: env.id || generateUniqueRefId("env"),
+      id: generateUniqueRefId("env"),
     }))
 
     envsWithIds.forEach((env) => {

--- a/packages/hoppscotch-common/src/components/environments/ImportExport.vue
+++ b/packages/hoppscotch-common/src/components/environments/ImportExport.vue
@@ -401,6 +401,11 @@ const handleImportToStore = async (
       }
     )
 
+    // `populateLocalStoresFromVariables` is a full replace for `"Global"`.
+    // Relies on the sync path above (`getGlobalVariables()` → hydrate →
+    // concat) running with no awaits in between — a future refactor that
+    // introduces one between the snapshot and this call would silently
+    // drop any global added meanwhile.
     populateLocalStoresFromVariables("Global", [
       ...existingHydrated,
       ...importedGlobals,

--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -694,7 +694,11 @@ const envQuickPeekActions = ref<TippyComponent | null>(null)
 const globalVals = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
 
 const globalEnvs = computed(() => {
-  return globalVals.value.variables.map((variable, index) => ({
+  // The default value passed to `useReadonlyStream` here is `{}`, so
+  // `globalVals.value.variables` is legitimately undefined for the brief
+  // window before the stream emits. It can also be undefined if the
+  // backend schema returned a non-wrapper shape; defend against both.
+  return (globalVals.value?.variables ?? []).map((variable, index) => ({
     ...variable,
     currentValue:
       currentEnvironmentValueService.getEnvironmentVariableValue(

--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -691,9 +691,6 @@ onMounted(() => {
 const envSelectorActions = ref<TippyComponent | null>(null)
 const envQuickPeekActions = ref<TippyComponent | null>(null)
 
-// Initialize with a structurally complete empty wrapper, not `{}`. Casting
-// `{}` to `GlobalEnvironment` would lie about presence of `variables` and
-// crash any downstream `.map` access before the stream emits.
 const globalVals = useReadonlyStream(globalEnv$, {
   v: 2,
   variables: [],

--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -691,13 +691,15 @@ onMounted(() => {
 const envSelectorActions = ref<TippyComponent | null>(null)
 const envQuickPeekActions = ref<TippyComponent | null>(null)
 
-const globalVals = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
+// Initialize with a structurally complete empty wrapper, not `{}`. Casting
+// `{}` to `GlobalEnvironment` would lie about presence of `variables` and
+// crash any downstream `.map` access before the stream emits.
+const globalVals = useReadonlyStream(globalEnv$, {
+  v: 2,
+  variables: [],
+} as GlobalEnvironment)
 
 const globalEnvs = computed(() => {
-  // The default value passed to `useReadonlyStream` here is `{}`, so
-  // `globalVals.value.variables` is legitimately undefined for the brief
-  // window before the stream emits. It can also be undefined if the
-  // backend schema returned a non-wrapper shape; defend against both.
   return (globalVals.value?.variables ?? []).map((variable, index) => ({
     ...variable,
     currentValue:

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -57,6 +57,7 @@
 <script setup lang="ts">
 import { useReadonlyStream, useStream } from "@composables/stream"
 import { Environment, GlobalEnvironment } from "@hoppscotch/data"
+import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
 import { useService } from "dioc/vue"
 import * as TE from "fp-ts/TaskEither"
 import { pipe } from "fp-ts/function"
@@ -265,7 +266,9 @@ const duplicateGlobalEnvironment = async () => {
 
     await pipe(
       createTeamEnvironment(
-        JSON.stringify(globalEnvironment.value.variables),
+        JSON.stringify(
+          stripSecretVariableValuesForWire(globalEnvironment.value.variables)
+        ),
         workspace.value.teamID,
         `Global - ${t("action.duplicate")}`
       ),
@@ -276,6 +279,9 @@ const duplicateGlobalEnvironment = async () => {
           toast.error(t(getEnvActionErrorMessage(err)))
         },
         () => {
+          // Secret variable values are intentionally NOT copied to the
+          // duplicated environment — duplicates start fresh on secrets per
+          // the per-entity secret model.
           toast.success(t("environment.duplicated"))
         }
       )

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -102,7 +102,13 @@ const environmentType = ref<EnvironmentsChooseType>({
   selectedTeam: undefined,
 })
 
-const globalEnv = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
+// Initialize with a structurally complete empty wrapper so every consumer
+// of `globalEnv` (and the `globalEnvironment` computed below) sees a valid
+// `variables` array unconditionally — `{}` would lie about the type.
+const globalEnv = useReadonlyStream(globalEnv$, {
+  v: 2,
+  variables: [],
+} as GlobalEnvironment)
 
 const globalEnvironment = computed<Environment>(() => ({
   v: 2 as const,

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -77,12 +77,16 @@ import TeamEnvironmentAdapter from "~/helpers/teams/TeamEnvironmentAdapter"
 import {
   createEnvironment,
   deleteEnvironment,
+  environmentsStore,
   getGlobalVariables,
   getSelectedEnvironmentIndex,
   globalEnv$,
   selectedEnvironmentIndex$,
   setSelectedEnvironmentIndex,
 } from "~/newstore/environments"
+import { getService } from "~/modules/dioc"
+import { SecretEnvironmentService } from "~/services/secret-environment.service"
+import { CurrentValueService } from "~/services/current-environment-value.service"
 import { useLocalState } from "~/newstore/localstate"
 import { platform } from "~/platform"
 import { TeamWorkspace, WorkspaceService } from "~/services/workspace.service"
@@ -303,23 +307,40 @@ const duplicateGlobalEnvironment = async () => {
   toast.success(`${t("environment.duplicated")}`)
 }
 
+const secretEnvironmentService = getService(SecretEnvironmentService)
+const currentEnvironmentValueService = getService(CurrentValueService)
+
 const removeSelectedEnvironment = () => {
   const selectedEnvIndex = getSelectedEnvironmentIndex()
   if (selectedEnvIndex?.type === "NO_ENV_SELECTED") return
 
   if (selectedEnvIndex?.type === "MY_ENV") {
-    deleteEnvironment(selectedEnvIndex.index)
+    // Pass the env id — selfhost sync handler bails on `envID === undefined`
+    // and the backend row would otherwise leak. Also flush local stores so
+    // the secret service doesn't accumulate orphans.
+    const envID =
+      environmentsStore.value.environments[selectedEnvIndex.index]?.id
+    deleteEnvironment(selectedEnvIndex.index, envID)
+    if (envID) {
+      secretEnvironmentService.deleteSecretEnvironment(envID)
+      currentEnvironmentValueService.deleteEnvironment(envID)
+    }
     toast.success(`${t("state.deleted")}`)
   }
 
   if (selectedEnvIndex?.type === "TEAM_ENV") {
+    const teamEnvID = selectedEnvIndex.teamEnvID
     pipe(
-      deleteTeamEnvironment(selectedEnvIndex.teamEnvID),
+      deleteTeamEnvironment(teamEnvID),
       TE.match(
         (err: GQLError<string>) => {
           console.error(err)
         },
         () => {
+          // Same lifecycle hygiene as MY_ENV — flush after backend
+          // success so the secret service doesn't retain the entry.
+          secretEnvironmentService.deleteSecretEnvironment(teamEnvID)
+          currentEnvironmentValueService.deleteEnvironment(teamEnvID)
           toast.success(`${t("team_environment.deleted")}`)
         }
       )

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -102,9 +102,6 @@ const environmentType = ref<EnvironmentsChooseType>({
   selectedTeam: undefined,
 })
 
-// Initialize with a structurally complete empty wrapper so every consumer
-// of `globalEnv` (and the `globalEnvironment` computed below) sees a valid
-// `variables` array unconditionally — `{}` would lie about the type.
 const globalEnv = useReadonlyStream(globalEnv$, {
   v: 2,
   variables: [],

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -315,19 +315,13 @@ const removeSelectedEnvironment = () => {
   if (selectedEnvIndex?.type === "NO_ENV_SELECTED") return
 
   if (selectedEnvIndex?.type === "MY_ENV") {
-    // Local-store flush only — DON'T pass `envID` to the dispatcher.
-    // The store entry's `id` is the temp `uniqueID()` during the ~100-500ms
-    // window between `createEnvironment` dispatch and the backend create
-    // resolving. Passing it would make the sync handler call
-    // `deleteUserEnvironment(tempId)` → 404 → meanwhile the create
-    // resolves and the backend row persists as an orphan. Letting the
-    // sync handler bail on `envID === undefined` keeps the backend row
-    // (pre-existing debt; recoverable manually) and avoids the spurious
-    // bad request. The secret-store flush below still works because
-    // entries are keyed by whatever `id` the env had at write time.
+    // Pass envID so the selfhost sync handler can call the backend delete
+    // for already-synced envs. The handler internally guards against the
+    // create-window race (`pendingTempEnvIds` set in `sync.ts`) so a temp
+    // `uniqueID()` here won't 404; only real backend ids reach the wire.
     const envID =
       environmentsStore.value.environments[selectedEnvIndex.index]?.id
-    deleteEnvironment(selectedEnvIndex.index)
+    deleteEnvironment(selectedEnvIndex.index, envID)
     if (envID) {
       secretEnvironmentService.deleteSecretEnvironment(envID)
       currentEnvironmentValueService.deleteEnvironment(envID)

--- a/packages/hoppscotch-common/src/components/environments/index.vue
+++ b/packages/hoppscotch-common/src/components/environments/index.vue
@@ -315,12 +315,19 @@ const removeSelectedEnvironment = () => {
   if (selectedEnvIndex?.type === "NO_ENV_SELECTED") return
 
   if (selectedEnvIndex?.type === "MY_ENV") {
-    // Pass the env id — selfhost sync handler bails on `envID === undefined`
-    // and the backend row would otherwise leak. Also flush local stores so
-    // the secret service doesn't accumulate orphans.
+    // Local-store flush only — DON'T pass `envID` to the dispatcher.
+    // The store entry's `id` is the temp `uniqueID()` during the ~100-500ms
+    // window between `createEnvironment` dispatch and the backend create
+    // resolving. Passing it would make the sync handler call
+    // `deleteUserEnvironment(tempId)` → 404 → meanwhile the create
+    // resolves and the backend row persists as an orphan. Letting the
+    // sync handler bail on `envID === undefined` keeps the backend row
+    // (pre-existing debt; recoverable manually) and avoids the spurious
+    // bad request. The secret-store flush below still works because
+    // entries are keyed by whatever `id` the env had at write time.
     const envID =
       environmentsStore.value.environments[selectedEnvIndex.index]?.id
-    deleteEnvironment(selectedEnvIndex.index, envID)
+    deleteEnvironment(selectedEnvIndex.index)
     if (envID) {
       secretEnvironmentService.deleteSecretEnvironment(envID)
       currentEnvironmentValueService.deleteEnvironment(envID)

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -571,28 +571,22 @@ const saveEnvironment = () => {
     )
   )
 
-  if (secretVariables.length > 0) {
-    if (editingID.value) {
-      secretEnvironmentService.addSecretEnvironment(
-        editingID.value,
-        secretVariables
-      )
-    } else if (props.editingEnvironmentIndex === "Global") {
-      secretEnvironmentService.addSecretEnvironment("Global", secretVariables)
-    }
-  }
-  if (nonSecretVariables.length > 0) {
-    if (editingID.value) {
-      currentEnvironmentValueService.addEnvironment(
-        editingID.value,
-        nonSecretVariables
-      )
-    } else if (props.editingEnvironmentIndex === "Global") {
-      currentEnvironmentValueService.addEnvironment(
-        "Global",
-        nonSecretVariables
-      )
-    }
+  // Always write to both stores (even when an array is empty) so a save
+  // that removes secrets/non-secrets clears the prior entries instead of
+  // leaving stale values keyed by old `varIndex` slots — `addSecretEnvironment`
+  // / `addEnvironment` are `Map.set` replacements, not merges.
+  if (editingID.value) {
+    secretEnvironmentService.addSecretEnvironment(
+      editingID.value,
+      secretVariables
+    )
+    currentEnvironmentValueService.addEnvironment(
+      editingID.value,
+      nonSecretVariables
+    )
+  } else if (props.editingEnvironmentIndex === "Global") {
+    secretEnvironmentService.addSecretEnvironment("Global", secretVariables)
+    currentEnvironmentValueService.addEnvironment("Global", nonSecretVariables)
   }
 
   const variables = stripSecretVariableValuesForWire(filteredVariables)

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -241,6 +241,7 @@ import * as E from "fp-ts/Either"
 import * as O from "fp-ts/Option"
 import { flow, pipe } from "fp-ts/function"
 import { ComputedRef, computed, ref, watch } from "vue"
+import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
 import { uniqueID } from "~/helpers/utils/uniqueID"
 import {
   createEnvironment,
@@ -594,15 +595,7 @@ const saveEnvironment = () => {
     }
   }
 
-  const variables = pipe(
-    filteredVariables,
-    A.map((e) => ({
-      key: e.key,
-      secret: e.secret,
-      initialValue: e.secret ? "" : e.initialValue,
-      currentValue: "",
-    }))
-  )
+  const variables = stripSecretVariableValuesForWire(filteredVariables)
 
   const environmentUpdated: Environment = {
     v: 2,

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -362,9 +362,6 @@ const clearIcon = refAutoReset<typeof IconTrash2 | typeof IconDone>(
   1000
 )
 
-// Initialize with a structurally complete empty wrapper, not `{}`. Casting
-// `{}` to `GlobalEnvironment` would lie about presence of `variables` and
-// crash any downstream `.map` / `.findIndex` access before the stream emits.
 const globalEnv = useReadonlyStream(globalEnv$, {
   v: 2,
   variables: [],

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -362,7 +362,13 @@ const clearIcon = refAutoReset<typeof IconTrash2 | typeof IconDone>(
   1000
 )
 
-const globalEnv = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
+// Initialize with a structurally complete empty wrapper, not `{}`. Casting
+// `{}` to `GlobalEnvironment` would lie about presence of `variables` and
+// crash any downstream `.map` / `.findIndex` access before the stream emits.
+const globalEnv = useReadonlyStream(globalEnv$, {
+  v: 2,
+  variables: [],
+} as GlobalEnvironment)
 
 type SelectedEnv = "variables" | "secret"
 

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -254,6 +254,7 @@ import {
   updateTeamEnvironment,
 } from "~/helpers/backend/mutations/TeamEnvironment"
 import { GQLError } from "~/helpers/backend/GQLClient"
+import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
 import { TeamEnvironment } from "~/helpers/teams/TeamEnvironment"
 import { useColorMode } from "~/composables/theming"
 import { platform } from "~/platform"
@@ -551,15 +552,7 @@ const saveEnvironment = async () => {
     )
   )
 
-  const variables = pipe(
-    filteredVariables,
-    A.map((e) => ({
-      key: e.key,
-      secret: e.secret,
-      initialValue: e.secret ? "" : e.initialValue,
-      currentValue: "",
-    }))
-  )
+  const variables = stripSecretVariableValuesForWire(filteredVariables)
 
   const environmentUpdated: Environment = {
     v: 2,

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -354,7 +354,13 @@ const vars = ref<EnvironmentVariable[]>([
 const secretEnvironmentService = useService(SecretEnvironmentService)
 const currentEnvironmentValueService = useService(CurrentValueService)
 
-const globalEnv = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
+// Initialize with a structurally complete empty wrapper, not `{}`. Casting
+// `{}` to `GlobalEnvironment` would lie about presence of `variables` and
+// crash any downstream `.map` / `.findIndex` access before the stream emits.
+const globalEnv = useReadonlyStream(globalEnv$, {
+  v: 2,
+  variables: [],
+} as GlobalEnvironment)
 
 const secretVars = computed(() =>
   pipe(

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -354,9 +354,6 @@ const vars = ref<EnvironmentVariable[]>([
 const secretEnvironmentService = useService(SecretEnvironmentService)
 const currentEnvironmentValueService = useService(CurrentValueService)
 
-// Initialize with a structurally complete empty wrapper, not `{}`. Casting
-// `{}` to `GlobalEnvironment` would lie about presence of `variables` and
-// crash any downstream `.map` / `.findIndex` access before the stream emits.
 const globalEnv = useReadonlyStream(globalEnv$, {
   v: 2,
   variables: [],

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -608,26 +608,24 @@ const saveEnvironment = async () => {
       return
     }
 
-    if (editingID.value) {
-      secretEnvironmentService.addSecretEnvironment(
-        editingID.value,
-        secretVariables
-      )
-
-      currentEnvironmentValueService.addEnvironment(
-        editingID.value,
-        nonSecretVariables
-      )
-
-      // If the user is a viewer, we don't need to update the environment in BE
-      // just update the secret environment and current environment in the local storage
-      if (props.isViewer) {
-        hideModal()
-        toast.success(`${t("environment.updated")}`)
+    // Viewers don't sync to backend — update local stores immediately
+    // and exit. For non-viewers, defer the store writes to the backend
+    // success callback (mirrors the "new" branch above) so local state
+    // stays in sync with the persisted payload if the mutation fails.
+    if (props.isViewer) {
+      if (editingID.value) {
+        secretEnvironmentService.addSecretEnvironment(
+          editingID.value,
+          secretVariables
+        )
+        currentEnvironmentValueService.addEnvironment(
+          editingID.value,
+          nonSecretVariables
+        )
       }
-    }
-
-    if (!props.isViewer) {
+      hideModal()
+      toast.success(`${t("environment.updated")}`)
+    } else {
       await pipe(
         updateTeamEnvironment(
           JSON.stringify(environmentUpdated.variables),
@@ -641,6 +639,16 @@ const saveEnvironment = async () => {
             isLoading.value = false
           },
           () => {
+            if (editingID.value) {
+              secretEnvironmentService.addSecretEnvironment(
+                editingID.value,
+                secretVariables
+              )
+              currentEnvironmentValueService.addEnvironment(
+                editingID.value,
+                nonSecretVariables
+              )
+            }
             hideModal()
             toast.success(`${t("environment.updated")}`)
 

--- a/packages/hoppscotch-common/src/components/http/TestResult.vue
+++ b/packages/hoppscotch-common/src/components/http/TestResult.vue
@@ -314,7 +314,13 @@ const selectedEnvironmentIndex = useStream(
   setSelectedEnvironmentIndex
 )
 
-const globalEnvVars = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
+// Initialize with a structurally complete empty wrapper, not `{}`. Casting
+// `{}` to `GlobalEnvironment` would lie about presence of `variables` and
+// crash any downstream `.map` / `.findIndex` access before the stream emits.
+const globalEnvVars = useReadonlyStream(globalEnv$, {
+  v: 2,
+  variables: [],
+} as GlobalEnvironment)
 
 const noEnvSelected = computed(
   () => selectedEnvironmentIndex.value.type === "NO_ENV_SELECTED"

--- a/packages/hoppscotch-common/src/components/http/TestResult.vue
+++ b/packages/hoppscotch-common/src/components/http/TestResult.vue
@@ -314,9 +314,6 @@ const selectedEnvironmentIndex = useStream(
   setSelectedEnvironmentIndex
 )
 
-// Initialize with a structurally complete empty wrapper, not `{}`. Casting
-// `{}` to `GlobalEnvironment` would lie about presence of `variables` and
-// crash any downstream `.map` / `.findIndex` access before the stream emits.
 const globalEnvVars = useReadonlyStream(globalEnv$, {
   v: 2,
   variables: [],

--- a/packages/hoppscotch-common/src/components/http/test/TestResult.vue
+++ b/packages/hoppscotch-common/src/components/http/test/TestResult.vue
@@ -276,9 +276,6 @@ const selectedEnvironmentIndex = useStream(
   setSelectedEnvironmentIndex
 )
 
-// Initialize with a structurally complete empty wrapper, not `{}`. Casting
-// `{}` to `GlobalEnvironment` would lie about presence of `variables` and
-// crash any downstream `.map` / `.findIndex` access before the stream emits.
 const globalEnvVars = useReadonlyStream(globalEnv$, {
   v: 2,
   variables: [],

--- a/packages/hoppscotch-common/src/components/http/test/TestResult.vue
+++ b/packages/hoppscotch-common/src/components/http/test/TestResult.vue
@@ -276,7 +276,13 @@ const selectedEnvironmentIndex = useStream(
   setSelectedEnvironmentIndex
 )
 
-const globalEnvVars = useReadonlyStream(globalEnv$, {} as GlobalEnvironment)
+// Initialize with a structurally complete empty wrapper, not `{}`. Casting
+// `{}` to `GlobalEnvironment` would lie about presence of `variables` and
+// crash any downstream `.map` / `.findIndex` access before the stream emits.
+const globalEnvVars = useReadonlyStream(globalEnv$, {
+  v: 2,
+  variables: [],
+} as GlobalEnvironment)
 
 const noEnvSelected = computed(
   () => selectedEnvironmentIndex.value.type === "NO_ENV_SELECTED"

--- a/packages/hoppscotch-common/src/composables/useMockServer.ts
+++ b/packages/hoppscotch-common/src/composables/useMockServer.ts
@@ -30,6 +30,7 @@ import {
   loadMockServers,
 } from "~/newstore/mockServers"
 import { CurrentValueService } from "~/services/current-environment-value.service"
+import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
 import { TeamCollectionsService } from "~/services/team-collection.service"
 import { WorkspaceService } from "~/services/workspace.service"
 
@@ -281,7 +282,13 @@ export function useMockServer() {
 
         await pipe(
           updateTeamEnvironment(
-            JSON.stringify(normalizedVariables),
+            // Strip at the wire boundary — `normalizedVariables` carries
+            // through whatever the team env already had plus a non-secret
+            // mockUrl override; defense-in-depth protects against any
+            // upstream change that could let a raw secret slip through.
+            JSON.stringify(
+              stripSecretVariableValuesForWire(normalizedVariables)
+            ),
             existingEnv.id,
             existingEnv.environment.name
           ),
@@ -323,7 +330,15 @@ export function useMockServer() {
         ]
 
         await pipe(
-          createTeamEnvironment(JSON.stringify(variables), teamID, envName),
+          createTeamEnvironment(
+            // Strip at the wire boundary — `variables` is a hardcoded
+            // single non-secret entry today, but every other call to
+            // `createTeamEnvironment` strips here, so this stays
+            // uniform with the rest of the codebase.
+            JSON.stringify(stripSecretVariableValuesForWire(variables)),
+            teamID,
+            envName
+          ),
           TE.match(
             (error) => {
               console.error("Failed to create team environment:", error)

--- a/packages/hoppscotch-common/src/composables/useMockServer.ts
+++ b/packages/hoppscotch-common/src/composables/useMockServer.ts
@@ -282,10 +282,6 @@ export function useMockServer() {
 
         await pipe(
           updateTeamEnvironment(
-            // Strip at the wire boundary — `normalizedVariables` carries
-            // through whatever the team env already had plus a non-secret
-            // mockUrl override; defense-in-depth protects against any
-            // upstream change that could let a raw secret slip through.
             JSON.stringify(
               stripSecretVariableValuesForWire(normalizedVariables)
             ),
@@ -331,10 +327,6 @@ export function useMockServer() {
 
         await pipe(
           createTeamEnvironment(
-            // Strip at the wire boundary — `variables` is a hardcoded
-            // single non-secret entry today, but every other call to
-            // `createTeamEnvironment` strips here, so this stays
-            // uniform with the rest of the codebase.
             JSON.stringify(stripSecretVariableValuesForWire(variables)),
             teamID,
             envName

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -255,12 +255,16 @@ const updateEnvironments = (
         currentValue: e.currentValue ?? "",
       })
 
-      // For non-secret variables, preserve both initialValue and currentValue
+      // `currentValue` is per-user/per-session by Hoppscotch convention and
+      // is never persisted server-side. The actual value lives in the local
+      // `currentEnvironmentValueService` (populated above); the wire payload
+      // gets it cleared so test-script env updates can't leak per-user state
+      // into the team backend.
       return {
         key: e.key,
         secret: e.secret ?? false,
         initialValue: e.initialValue ?? "",
-        currentValue: e.currentValue ?? "",
+        currentValue: "",
       }
     })
   )
@@ -637,6 +641,7 @@ export function runRESTRequest$(
                 combinedResult,
                 initialEnvironmentIndex,
                 initialEnvName,
+                initialEnvsForComparison,
                 initialEnvID
               )
             }
@@ -699,97 +704,82 @@ function updateEnvsAfterTestScript(
   runResult: E.Right<SandboxTestResult>,
   initialEnvironmentIndex: SelectedEnvironmentIndex,
   initialEnvName: string,
+  initialEnvsForComparison: TestResult["envs"],
   initialEnvID?: string
 ) {
-  const globalEnvVariables = updateEnvironments(
-    runResult.right.envs.global,
-    "global"
+  // Gate each writeback on whether its own scope actually changed. The outer
+  // `hasEnvironmentChanges` guard is an OR across both scopes, so without
+  // these per-scope checks a script that touched only the selected env would
+  // still trigger an `updateUserEnvironment` round-trip for the unchanged
+  // globals (and the same happens the other way for TEAM_ENV).
+  const globalChanged = hasScopeChanges(
+    initialEnvsForComparison.global,
+    runResult.right.envs.global
+  )
+  const selectedChanged = hasScopeChanges(
+    initialEnvsForComparison.selected,
+    runResult.right.envs.selected
   )
 
-  setGlobalEnvVariables({
-    v: 2,
-    variables: globalEnvVariables,
-  })
+  if (globalChanged) {
+    const globalEnvVariables = updateEnvironments(
+      runResult.right.envs.global,
+      "global"
+    )
 
-  const selectedEnvVariables = updateEnvironments(
-    cloneDeep(runResult.right.envs.selected),
-    "selected",
-    initialEnvID
-  )
-
-  if (initialEnvironmentIndex.type === "MY_ENV") {
-    const env = getEnvironment({
-      type: "MY_ENV",
-      index: initialEnvironmentIndex.index,
-    })
-    updateEnvironment(initialEnvironmentIndex.index, {
-      name: env.name,
+    setGlobalEnvVariables({
       v: 2,
-      id: "id" in env ? env.id : "",
-      variables: selectedEnvVariables,
+      variables: globalEnvVariables,
     })
-  } else if (initialEnvironmentIndex.type === "TEAM_ENV") {
-    // Use the initial environment name to avoid issues when environment changes during request execution
-    // adding a fallback to current environment name just in case so it's not null
-    const envName = initialEnvName ?? getCurrentEnvironment().name
-    pipe(
-      updateTeamEnvironment(
-        JSON.stringify(selectedEnvVariables),
-        initialEnvironmentIndex.teamEnvID,
-        envName
-      )
-    )()
+  }
+
+  if (selectedChanged) {
+    const selectedEnvVariables = updateEnvironments(
+      cloneDeep(runResult.right.envs.selected),
+      "selected",
+      initialEnvID
+    )
+
+    if (initialEnvironmentIndex.type === "MY_ENV") {
+      const env = getEnvironment({
+        type: "MY_ENV",
+        index: initialEnvironmentIndex.index,
+      })
+      updateEnvironment(initialEnvironmentIndex.index, {
+        name: env.name,
+        v: 2,
+        id: "id" in env ? env.id : "",
+        variables: selectedEnvVariables,
+      })
+    } else if (initialEnvironmentIndex.type === "TEAM_ENV") {
+      // Use the initial environment name to avoid issues when environment changes during request execution
+      // adding a fallback to current environment name just in case so it's not null
+      const envName = initialEnvName ?? getCurrentEnvironment().name
+      pipe(
+        updateTeamEnvironment(
+          JSON.stringify(selectedEnvVariables),
+          initialEnvironmentIndex.teamEnvID,
+          envName
+        )
+      )()
+    }
   }
 }
 
-/**
- * Checks if there are any changes between two environment states by comparing
- * the initial environment state with the final environment state.
- * @param initialEnvs The environment state at the start
- * @param finalEnvs The environment state after changes
- * @returns true if there are any environment changes, false otherwise
- */
+const hasScopeChanges = (
+  initial: Environment["variables"],
+  final: Environment["variables"]
+): boolean =>
+  getAddedEnvVariables(initial, final).length > 0 ||
+  getRemovedEnvVariables(initial, final).length > 0 ||
+  getUpdatedEnvVariables(initial, final).length > 0
+
 const hasEnvironmentChanges = (
   initialEnvs: TestResult["envs"],
   finalEnvs: TestResult["envs"]
-): boolean => {
-  // Check global environment changes
-  const globalAdditions = getAddedEnvVariables(
-    initialEnvs.global,
-    finalEnvs.global
-  )
-  const globalDeletions = getRemovedEnvVariables(
-    initialEnvs.global,
-    finalEnvs.global
-  )
-  const globalUpdations = getUpdatedEnvVariables(
-    initialEnvs.global,
-    finalEnvs.global
-  )
-
-  // Check selected environment changes
-  const selectedAdditions = getAddedEnvVariables(
-    initialEnvs.selected,
-    finalEnvs.selected
-  )
-  const selectedDeletions = getRemovedEnvVariables(
-    initialEnvs.selected,
-    finalEnvs.selected
-  )
-  const selectedUpdations = getUpdatedEnvVariables(
-    initialEnvs.selected,
-    finalEnvs.selected
-  )
-
-  return (
-    globalAdditions.length > 0 ||
-    globalDeletions.length > 0 ||
-    globalUpdations.length > 0 ||
-    selectedAdditions.length > 0 ||
-    selectedDeletions.length > 0 ||
-    selectedUpdations.length > 0
-  )
-}
+): boolean =>
+  hasScopeChanges(initialEnvs.global, finalEnvs.global) ||
+  hasScopeChanges(initialEnvs.selected, finalEnvs.selected)
 
 const getCookieJarEntries = () => {
   // Exclusive to the Desktop App
@@ -940,6 +930,7 @@ export async function runTestRunnerRequest(
                   postRequestScriptResult,
                   initialEnvironmentIndex,
                   initialEnvName,
+                  initialEnvsForComparison,
                   initialEnvID
                 )
               }

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -236,11 +236,14 @@ const updateEnvironments = (
           initialValue: e.initialValue ?? "",
         })
 
-        // For secret variables, keep the initialValue but clear currentValue for storage
+        // Secret values stay client-side only (they were saved into the
+        // local secret service above). Both `initialValue` and
+        // `currentValue` are cleared on the wire payload so the secret
+        // never leaves the device.
         return {
           key: e.key,
           secret: e.secret,
-          initialValue: e.initialValue ?? "",
+          initialValue: "",
           currentValue: "",
         }
       }

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -135,7 +135,16 @@ export const captureInitialEnvironmentState = (): InitialEnvironmentState => {
   // Capture the initial environment name
   const initialEnvName = getCurrentEnvironment().name
 
-  // Capture the initial script environment state (the environment passed to scripts)
+  // Capture the initial script environment state (the environment passed to scripts).
+  //
+  // INVARIANT: `getCombinedEnvVariables()` hydrates secret variables from
+  // `SecretEnvironmentService` into their resolved values, and the sandbox
+  // receives the same fully-resolved values. Both sides of the post-script
+  // `hasScopeChanges` comparison therefore use the same representation —
+  // a script that merely *reads* a secret variable doesn't appear changed.
+  // If a future change desyncs these two sources (e.g. comparing stripped
+  // vs hydrated values), `hasScopeChanges` would emit false positives and
+  // trigger spurious `updateUserEnvironment` writes.
   const initialEnvs = getCombinedEnvVariables()
   const initialEnvsForComparison: TestResult["envs"] = {
     global: initialEnvs.global,

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -54,7 +54,6 @@ import {
 } from "~/services/secret-environment.service"
 import { HoppTab } from "~/services/tab"
 import { updateTeamEnvironment } from "./backend/mutations/TeamEnvironment"
-import { stripSecretVariableValuesForWire } from "./secretVariables"
 import { createRESTNetworkRequestStream } from "./network"
 import { HoppRequestDocument } from "./rest/document"
 import {
@@ -761,11 +760,10 @@ function updateEnvsAfterTestScript(
       // Use the initial environment name to avoid issues when environment changes during request execution
       // adding a fallback to current environment name just in case so it's not null
       const envName = initialEnvName ?? getCurrentEnvironment().name
+      // `updateEnvironments` above already returns wire-shaped variables
       pipe(
         updateTeamEnvironment(
-          JSON.stringify(
-            stripSecretVariableValuesForWire(selectedEnvVariables)
-          ),
+          JSON.stringify(selectedEnvVariables),
           initialEnvironmentIndex.teamEnvID,
           envName
         )

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -54,6 +54,7 @@ import {
 } from "~/services/secret-environment.service"
 import { HoppTab } from "~/services/tab"
 import { updateTeamEnvironment } from "./backend/mutations/TeamEnvironment"
+import { stripSecretVariableValuesForWire } from "./secretVariables"
 import { createRESTNetworkRequestStream } from "./network"
 import { HoppRequestDocument } from "./rest/document"
 import {
@@ -760,7 +761,13 @@ function updateEnvsAfterTestScript(
       const envName = initialEnvName ?? getCurrentEnvironment().name
       pipe(
         updateTeamEnvironment(
-          JSON.stringify(selectedEnvVariables),
+          // Strip at the wire boundary — `selectedEnvVariables` already
+          // comes back stripped from `updateEnvironments` above, but
+          // every other team-env mutation in this codebase strips here
+          // too. Keeps the wire-boundary contract uniform.
+          JSON.stringify(
+            stripSecretVariableValuesForWire(selectedEnvVariables)
+          ),
           initialEnvironmentIndex.teamEnvID,
           envName
         )

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -135,16 +135,9 @@ export const captureInitialEnvironmentState = (): InitialEnvironmentState => {
   // Capture the initial environment name
   const initialEnvName = getCurrentEnvironment().name
 
-  // Capture the initial script environment state (the environment passed to scripts).
-  //
-  // INVARIANT: `getCombinedEnvVariables()` hydrates secret variables from
-  // `SecretEnvironmentService` into their resolved values, and the sandbox
-  // receives the same fully-resolved values. Both sides of the post-script
-  // `hasScopeChanges` comparison therefore use the same representation —
-  // a script that merely *reads* a secret variable doesn't appear changed.
-  // If a future change desyncs these two sources (e.g. comparing stripped
-  // vs hydrated values), `hasScopeChanges` would emit false positives and
-  // trigger spurious `updateUserEnvironment` writes.
+  // Snapshot for the post-script diff. Both this and the sandbox receive
+  // secret-hydrated values from `getCombinedEnvVariables`, so reading a
+  // secret doesn't show up as a change in `hasScopeChanges`.
   const initialEnvs = getCombinedEnvVariables()
   const initialEnvsForComparison: TestResult["envs"] = {
     global: initialEnvs.global,
@@ -770,10 +763,6 @@ function updateEnvsAfterTestScript(
       const envName = initialEnvName ?? getCurrentEnvironment().name
       pipe(
         updateTeamEnvironment(
-          // Strip at the wire boundary — `selectedEnvVariables` already
-          // comes back stripped from `updateEnvironments` above, but
-          // every other team-env mutation in this codebase strips here
-          // too. Keeps the wire-boundary contract uniform.
           JSON.stringify(
             stripSecretVariableValuesForWire(selectedEnvVariables)
           ),

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -239,11 +239,14 @@ const updateEnvironments = (
           initialValue: e.initialValue ?? "",
         })
 
-        // For secret variables, keep the initialValue but clear currentValue for storage
+        // Secret values stay client-side only (they were saved into the
+        // local secret service above). Both `initialValue` and
+        // `currentValue` are cleared on the wire payload so the secret
+        // never leaves the device.
         return {
           key: e.key,
           secret: e.secret,
-          initialValue: e.initialValue ?? "",
+          initialValue: "",
           currentValue: "",
         }
       }

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -258,12 +258,16 @@ const updateEnvironments = (
         currentValue: e.currentValue ?? "",
       })
 
-      // For non-secret variables, preserve both initialValue and currentValue
+      // `currentValue` is per-user/per-session by Hoppscotch convention and
+      // is never persisted server-side. The actual value lives in the local
+      // `currentEnvironmentValueService` (populated above); the wire payload
+      // gets it cleared so test-script env updates can't leak per-user state
+      // into the team backend.
       return {
         key: e.key,
         secret: e.secret ?? false,
         initialValue: e.initialValue ?? "",
-        currentValue: e.currentValue ?? "",
+        currentValue: "",
       }
     })
   )
@@ -640,6 +644,7 @@ export function runRESTRequest$(
                 combinedResult,
                 initialEnvironmentIndex,
                 initialEnvName,
+                initialEnvsForComparison,
                 initialEnvID
               )
             }
@@ -702,97 +707,82 @@ function updateEnvsAfterTestScript(
   runResult: E.Right<SandboxTestResult>,
   initialEnvironmentIndex: SelectedEnvironmentIndex,
   initialEnvName: string,
+  initialEnvsForComparison: TestResult["envs"],
   initialEnvID?: string
 ) {
-  const globalEnvVariables = updateEnvironments(
-    runResult.right.envs.global,
-    "global"
+  // Gate each writeback on whether its own scope actually changed. The outer
+  // `hasEnvironmentChanges` guard is an OR across both scopes, so without
+  // these per-scope checks a script that touched only the selected env would
+  // still trigger an `updateUserEnvironment` round-trip for the unchanged
+  // globals (and the same happens the other way for TEAM_ENV).
+  const globalChanged = hasScopeChanges(
+    initialEnvsForComparison.global,
+    runResult.right.envs.global
+  )
+  const selectedChanged = hasScopeChanges(
+    initialEnvsForComparison.selected,
+    runResult.right.envs.selected
   )
 
-  setGlobalEnvVariables({
-    v: 2,
-    variables: globalEnvVariables,
-  })
+  if (globalChanged) {
+    const globalEnvVariables = updateEnvironments(
+      runResult.right.envs.global,
+      "global"
+    )
 
-  const selectedEnvVariables = updateEnvironments(
-    cloneDeep(runResult.right.envs.selected),
-    "selected",
-    initialEnvID
-  )
-
-  if (initialEnvironmentIndex.type === "MY_ENV") {
-    const env = getEnvironment({
-      type: "MY_ENV",
-      index: initialEnvironmentIndex.index,
-    })
-    updateEnvironment(initialEnvironmentIndex.index, {
-      name: env.name,
+    setGlobalEnvVariables({
       v: 2,
-      id: "id" in env ? env.id : "",
-      variables: selectedEnvVariables,
+      variables: globalEnvVariables,
     })
-  } else if (initialEnvironmentIndex.type === "TEAM_ENV") {
-    // Use the initial environment name to avoid issues when environment changes during request execution
-    // adding a fallback to current environment name just in case so it's not null
-    const envName = initialEnvName ?? getCurrentEnvironment().name
-    pipe(
-      updateTeamEnvironment(
-        JSON.stringify(selectedEnvVariables),
-        initialEnvironmentIndex.teamEnvID,
-        envName
-      )
-    )()
+  }
+
+  if (selectedChanged) {
+    const selectedEnvVariables = updateEnvironments(
+      cloneDeep(runResult.right.envs.selected),
+      "selected",
+      initialEnvID
+    )
+
+    if (initialEnvironmentIndex.type === "MY_ENV") {
+      const env = getEnvironment({
+        type: "MY_ENV",
+        index: initialEnvironmentIndex.index,
+      })
+      updateEnvironment(initialEnvironmentIndex.index, {
+        name: env.name,
+        v: 2,
+        id: "id" in env ? env.id : "",
+        variables: selectedEnvVariables,
+      })
+    } else if (initialEnvironmentIndex.type === "TEAM_ENV") {
+      // Use the initial environment name to avoid issues when environment changes during request execution
+      // adding a fallback to current environment name just in case so it's not null
+      const envName = initialEnvName ?? getCurrentEnvironment().name
+      pipe(
+        updateTeamEnvironment(
+          JSON.stringify(selectedEnvVariables),
+          initialEnvironmentIndex.teamEnvID,
+          envName
+        )
+      )()
+    }
   }
 }
 
-/**
- * Checks if there are any changes between two environment states by comparing
- * the initial environment state with the final environment state.
- * @param initialEnvs The environment state at the start
- * @param finalEnvs The environment state after changes
- * @returns true if there are any environment changes, false otherwise
- */
+const hasScopeChanges = (
+  initial: Environment["variables"],
+  final: Environment["variables"]
+): boolean =>
+  getAddedEnvVariables(initial, final).length > 0 ||
+  getRemovedEnvVariables(initial, final).length > 0 ||
+  getUpdatedEnvVariables(initial, final).length > 0
+
 const hasEnvironmentChanges = (
   initialEnvs: TestResult["envs"],
   finalEnvs: TestResult["envs"]
-): boolean => {
-  // Check global environment changes
-  const globalAdditions = getAddedEnvVariables(
-    initialEnvs.global,
-    finalEnvs.global
-  )
-  const globalDeletions = getRemovedEnvVariables(
-    initialEnvs.global,
-    finalEnvs.global
-  )
-  const globalUpdations = getUpdatedEnvVariables(
-    initialEnvs.global,
-    finalEnvs.global
-  )
-
-  // Check selected environment changes
-  const selectedAdditions = getAddedEnvVariables(
-    initialEnvs.selected,
-    finalEnvs.selected
-  )
-  const selectedDeletions = getRemovedEnvVariables(
-    initialEnvs.selected,
-    finalEnvs.selected
-  )
-  const selectedUpdations = getUpdatedEnvVariables(
-    initialEnvs.selected,
-    finalEnvs.selected
-  )
-
-  return (
-    globalAdditions.length > 0 ||
-    globalDeletions.length > 0 ||
-    globalUpdations.length > 0 ||
-    selectedAdditions.length > 0 ||
-    selectedDeletions.length > 0 ||
-    selectedUpdations.length > 0
-  )
-}
+): boolean =>
+  hasScopeChanges(initialEnvs.global, finalEnvs.global) ||
+  hasScopeChanges(initialEnvs.selected, finalEnvs.selected)
 
 const getCookieJarEntries = () => {
   // Exclusive to the Desktop App
@@ -943,6 +933,7 @@ export async function runTestRunnerRequest(
                   postRequestScriptResult,
                   initialEnvironmentIndex,
                   initialEnvName,
+                  initialEnvsForComparison,
                   initialEnvID
                 )
               }

--- a/packages/hoppscotch-common/src/helpers/__tests__/globalEnvShape.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/globalEnvShape.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { coerceGlobalEnvironment } from "../globalEnvShape"
+
+describe("coerceGlobalEnvironment", () => {
+  it("passes through a valid v2 wrapper unchanged", () => {
+    const wrapper = {
+      v: 2 as const,
+      variables: [
+        { key: "k", initialValue: "i", currentValue: "c", secret: false },
+      ],
+    }
+
+    expect(coerceGlobalEnvironment(wrapper)).toBe(wrapper)
+  })
+
+  it("wraps a bare variables array (legacy / older-backend shape)", () => {
+    const bareArray = [
+      { key: "k", initialValue: "i", currentValue: "c", secret: false },
+    ]
+
+    expect(coerceGlobalEnvironment(bareArray)).toEqual({
+      v: 2,
+      variables: bareArray,
+    })
+  })
+
+  it("returns an empty wrapper for null", () => {
+    expect(coerceGlobalEnvironment(null)).toEqual({ v: 2, variables: [] })
+  })
+
+  it("returns an empty wrapper for undefined", () => {
+    expect(coerceGlobalEnvironment(undefined)).toEqual({ v: 2, variables: [] })
+  })
+
+  it("returns an empty wrapper for an object with non-array variables", () => {
+    expect(
+      coerceGlobalEnvironment({ v: 2, variables: "not-an-array" })
+    ).toEqual({ v: 2, variables: [] })
+  })
+
+  it("returns an empty wrapper for an object missing variables", () => {
+    expect(coerceGlobalEnvironment({ v: 2 })).toEqual({ v: 2, variables: [] })
+  })
+
+  it("returns an empty wrapper for a primitive", () => {
+    expect(coerceGlobalEnvironment("string")).toEqual({
+      v: 2,
+      variables: [],
+    })
+    expect(coerceGlobalEnvironment(42)).toEqual({ v: 2, variables: [] })
+  })
+
+  it("preserves an empty variables array (does not collapse to a fresh wrapper)", () => {
+    const wrapper = { v: 2 as const, variables: [] }
+    // Identity check: when the input is already a valid wrapper we want
+    // to pass it through, not re-allocate, so downstream `===` checks /
+    // distinctUntilChanged comparisons stay stable.
+    expect(coerceGlobalEnvironment(wrapper)).toBe(wrapper)
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/__tests__/globalEnvShape.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/globalEnvShape.spec.ts
@@ -42,6 +42,30 @@ describe("coerceGlobalEnvironment", () => {
     expect(coerceGlobalEnvironment({ v: 2 })).toEqual({ v: 2, variables: [] })
   })
 
+  it("rebuilds with v:2 when an object has a variables array but missing v", () => {
+    const variables = [
+      { key: "k", initialValue: "i", currentValue: "c", secret: false },
+    ]
+    expect(coerceGlobalEnvironment({ variables })).toEqual({
+      v: 2,
+      variables,
+    })
+  })
+
+  it("rebuilds with v:2 when an object has a variables array but a non-2 v", () => {
+    const variables = [
+      { key: "k", initialValue: "i", currentValue: "c", secret: false },
+    ]
+    expect(coerceGlobalEnvironment({ v: 1, variables })).toEqual({
+      v: 2,
+      variables,
+    })
+    expect(coerceGlobalEnvironment({ v: "2", variables })).toEqual({
+      v: 2,
+      variables,
+    })
+  })
+
   it("returns an empty wrapper for a primitive", () => {
     expect(coerceGlobalEnvironment("string")).toEqual({
       v: 2,

--- a/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
@@ -5,8 +5,10 @@ import { getService } from "~/modules/dioc"
 import { CurrentValueService } from "~/services/current-environment-value.service"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
 import {
+  indexCollectionsByRefId,
   populateLocalStoresFromCollectionTree,
   populateLocalStoresFromVariables,
+  repopulateLoadedCollectionTree,
   stripSecretVariableValuesForWire,
 } from "../secretVariables"
 
@@ -344,5 +346,140 @@ describe("populateLocalStoresFromCollectionTree", () => {
 
     expect(secretService.getSecretEnvironment("child-1")).toBeDefined()
     expect(secretService.getSecretEnvironment("placeholder")).toBeUndefined()
+  })
+})
+
+describe("indexCollectionsByRefId + repopulateLoadedCollectionTree", () => {
+  let secretService: SecretEnvironmentService
+  let currentValueService: CurrentValueService
+
+  beforeEach(() => {
+    secretService = getService(SecretEnvironmentService)
+    currentValueService = getService(CurrentValueService)
+    secretService.secretEnvironments.clear()
+    currentValueService.environments.clear()
+  })
+
+  const buildCollection = (
+    refId: string,
+    variables: HoppCollection["variables"],
+    folders: HoppCollection[] = []
+  ): HoppCollection => ({
+    v: 12,
+    name: `coll-${refId}`,
+    _ref_id: refId,
+    folders,
+    requests: [],
+    auth: { authType: "inherit", authActive: true },
+    headers: [],
+    variables,
+    description: null,
+    preRequestScript: "",
+    testScript: "",
+  })
+
+  // The key invariant: if the backend reorders the loaded tree, the
+  // repopulate logic must still pair each loaded node with its original
+  // by `_ref_id` rather than by array index. Otherwise secrets would
+  // re-key onto the wrong collection.
+  it("re-keys secrets by ref-id when the loaded tree is reordered", () => {
+    const originalA = buildCollection("ref-a", [
+      { key: "a-tok", initialValue: "ai", currentValue: "ac", secret: true },
+    ])
+    const originalB = buildCollection("ref-b", [
+      { key: "b-tok", initialValue: "bi", currentValue: "bc", secret: true },
+    ])
+
+    const originalsByRefId = new Map<string, HoppCollection>()
+    indexCollectionsByRefId([originalA, originalB], originalsByRefId)
+
+    // Backend round-trip: same ref-ids preserved via `data._ref_id`,
+    // but order is reversed. Variables on the loaded tree are stripped
+    // (initialValue: "" for secrets, currentValue: "" everywhere).
+    const stripped = (refId: string, key: string) =>
+      buildCollection(refId, [
+        { key, initialValue: "", currentValue: "", secret: true },
+      ])
+    const loadedReordered = [
+      stripped("ref-b", "b-tok"),
+      stripped("ref-a", "a-tok"),
+    ]
+
+    loadedReordered.forEach((c) =>
+      repopulateLoadedCollectionTree(c, originalsByRefId)
+    )
+
+    expect(secretService.getSecretEnvironment("ref-a")).toEqual([
+      { key: "a-tok", value: "ac", initialValue: "ai", varIndex: 0 },
+    ])
+    expect(secretService.getSecretEnvironment("ref-b")).toEqual([
+      { key: "b-tok", value: "bc", initialValue: "bi", varIndex: 0 },
+    ])
+  })
+
+  it("indexes nested folders into the same flat map", () => {
+    const grandchild = buildCollection("gc", [])
+    const child = buildCollection("child", [], [grandchild])
+    const root = buildCollection("root", [], [child])
+
+    const map = new Map<string, HoppCollection>()
+    indexCollectionsByRefId([root], map)
+
+    expect([...map.keys()].sort()).toEqual(["child", "gc", "root"])
+    expect(map.get("gc")).toBe(grandchild)
+  })
+
+  it("skips loaded nodes whose ref-id is absent from the original index", () => {
+    const original = buildCollection("ref-a", [
+      { key: "a-tok", initialValue: "ai", currentValue: "ac", secret: true },
+    ])
+    const map = new Map<string, HoppCollection>()
+    indexCollectionsByRefId([original], map)
+
+    // Backend dropped the ref-id round-trip on this node — the loaded
+    // tree carries a fresh ref-id that the original index doesn't know.
+    const orphanLoaded = buildCollection("ref-a-fresh", [
+      { key: "a-tok", initialValue: "", currentValue: "", secret: true },
+    ])
+
+    repopulateLoadedCollectionTree(orphanLoaded, map)
+
+    // Nothing was populated for the unknown ref-id, and the original's
+    // ref-id is also untouched (no spurious cross-population).
+    expect(secretService.getSecretEnvironment("ref-a-fresh")).toBeUndefined()
+    expect(secretService.getSecretEnvironment("ref-a")).toBeUndefined()
+  })
+
+  it("recurses through nested folders and re-keys each by its own ref-id", () => {
+    const childOriginal = buildCollection("child", [
+      { key: "ck", initialValue: "ci", currentValue: "cc", secret: true },
+    ])
+    const rootOriginal = buildCollection(
+      "root",
+      [{ key: "rk", initialValue: "ri", currentValue: "rc", secret: true }],
+      [childOriginal]
+    )
+
+    const map = new Map<string, HoppCollection>()
+    indexCollectionsByRefId([rootOriginal], map)
+
+    // Loaded tree from backend: same ref-ids, stripped variables.
+    const childLoaded = buildCollection("child", [
+      { key: "ck", initialValue: "", currentValue: "", secret: true },
+    ])
+    const rootLoaded = buildCollection(
+      "root",
+      [{ key: "rk", initialValue: "", currentValue: "", secret: true }],
+      [childLoaded]
+    )
+
+    repopulateLoadedCollectionTree(rootLoaded, map)
+
+    expect(secretService.getSecretEnvironment("root")).toEqual([
+      { key: "rk", value: "rc", initialValue: "ri", varIndex: 0 },
+    ])
+    expect(secretService.getSecretEnvironment("child")).toEqual([
+      { key: "ck", value: "cc", initialValue: "ci", varIndex: 0 },
+    ])
   })
 })

--- a/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
@@ -1,0 +1,348 @@
+import { HoppCollection } from "@hoppscotch/data"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { getService } from "~/modules/dioc"
+import { CurrentValueService } from "~/services/current-environment-value.service"
+import { SecretEnvironmentService } from "~/services/secret-environment.service"
+import {
+  populateLocalStoresFromCollectionTree,
+  populateLocalStoresFromVariables,
+  stripSecretVariableValuesForWire,
+} from "../secretVariables"
+
+const ENTITY_ID = "entity-1"
+
+describe("stripSecretVariableValuesForWire", () => {
+  it("clears both initialValue and currentValue for secret variables", () => {
+    const result = stripSecretVariableValuesForWire([
+      {
+        key: "token",
+        initialValue: "should-be-stripped",
+        currentValue: "should-be-stripped",
+        secret: true,
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        key: "token",
+        initialValue: "",
+        currentValue: "",
+        secret: true,
+      },
+    ])
+  })
+
+  it("keeps initialValue but clears currentValue for non-secret variables", () => {
+    const result = stripSecretVariableValuesForWire([
+      {
+        key: "host",
+        initialValue: "https://api.example.com",
+        currentValue: "https://staging.example.com",
+        secret: false,
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        key: "host",
+        initialValue: "https://api.example.com",
+        currentValue: "",
+        secret: false,
+      },
+    ])
+  })
+
+  it("preserves extra fields on each variable (forward-compatible with future schemas)", () => {
+    const input = [
+      {
+        key: "x",
+        initialValue: "v",
+        currentValue: "v",
+        secret: false,
+        // hypothetical future field
+        description: "the X variable",
+      },
+    ]
+
+    const [out] = stripSecretVariableValuesForWire(input)
+    expect(out.description).toBe("the X variable")
+  })
+
+  it("returns an empty array for empty input", () => {
+    expect(stripSecretVariableValuesForWire([])).toEqual([])
+  })
+})
+
+describe("populateLocalStoresFromVariables", () => {
+  let secretService: SecretEnvironmentService
+  let currentValueService: CurrentValueService
+
+  beforeEach(() => {
+    secretService = getService(SecretEnvironmentService)
+    currentValueService = getService(CurrentValueService)
+    secretService.secretEnvironments.delete(ENTITY_ID)
+    currentValueService.environments.delete(ENTITY_ID)
+  })
+
+  it("writes secret variables to SecretEnvironmentService", () => {
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      {
+        key: "token",
+        initialValue: "init-secret",
+        currentValue: "current-secret",
+        secret: true,
+      },
+    ])
+
+    expect(secretService.getSecretEnvironment(ENTITY_ID)).toEqual([
+      {
+        key: "token",
+        value: "current-secret",
+        initialValue: "init-secret",
+        varIndex: 0,
+      },
+    ])
+  })
+
+  it("writes non-secret currentValue entries to CurrentValueService", () => {
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      {
+        key: "host",
+        initialValue: "https://api.example.com",
+        currentValue: "https://staging.example.com",
+        secret: false,
+      },
+    ])
+
+    expect(currentValueService.getEnvironment(ENTITY_ID)).toEqual([
+      {
+        key: "host",
+        currentValue: "https://staging.example.com",
+        varIndex: 0,
+        isSecret: false,
+      },
+    ])
+  })
+
+  it("preserves the variable index for mixed secret + non-secret entries", () => {
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      {
+        key: "host",
+        initialValue: "init-host",
+        currentValue: "cur-host",
+        secret: false,
+      },
+      {
+        key: "token",
+        initialValue: "init-token",
+        currentValue: "cur-token",
+        secret: true,
+      },
+      {
+        key: "version",
+        initialValue: "v1",
+        currentValue: "v2",
+        secret: false,
+      },
+    ])
+
+    expect(secretService.getSecretEnvironment(ENTITY_ID)).toEqual([
+      {
+        key: "token",
+        value: "cur-token",
+        initialValue: "init-token",
+        varIndex: 1,
+      },
+    ])
+    expect(currentValueService.getEnvironment(ENTITY_ID)).toEqual([
+      {
+        key: "host",
+        currentValue: "cur-host",
+        varIndex: 0,
+        isSecret: false,
+      },
+      {
+        key: "version",
+        currentValue: "v2",
+        varIndex: 2,
+        isSecret: false,
+      },
+    ])
+  })
+
+  it("is a no-op when entityId is empty", () => {
+    populateLocalStoresFromVariables("", [
+      {
+        key: "token",
+        initialValue: "init",
+        currentValue: "cur",
+        secret: true,
+      },
+    ])
+
+    expect(secretService.getSecretEnvironment("")).toBeUndefined()
+  })
+
+  it("writes empty arrays to both stores when variables is empty (clears stale)", () => {
+    // First populate with secrets + non-secrets
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      { key: "s", initialValue: "v", currentValue: "v", secret: true },
+      { key: "n", initialValue: "v", currentValue: "v", secret: false },
+    ])
+
+    // Re-populate with empty variables — should wipe both stores
+    populateLocalStoresFromVariables(ENTITY_ID, [])
+
+    expect(secretService.getSecretEnvironment(ENTITY_ID)).toEqual([])
+    expect(currentValueService.getEnvironment(ENTITY_ID)).toEqual([])
+  })
+
+  it("writes empty array to CurrentValueService when all entries are secret", () => {
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      {
+        key: "a",
+        initialValue: "a",
+        currentValue: "a",
+        secret: true,
+      },
+    ])
+
+    expect(currentValueService.getEnvironment(ENTITY_ID)).toEqual([])
+  })
+
+  it("writes empty array to SecretEnvironmentService when no entries are secret", () => {
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      {
+        key: "a",
+        initialValue: "a",
+        currentValue: "a",
+        secret: false,
+      },
+    ])
+
+    expect(secretService.getSecretEnvironment(ENTITY_ID)).toEqual([])
+  })
+
+  it("re-populating with fewer secrets clears the previous secret entries", () => {
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      { key: "old1", initialValue: "1", currentValue: "1", secret: true },
+      { key: "old2", initialValue: "2", currentValue: "2", secret: true },
+    ])
+
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      { key: "new", initialValue: "3", currentValue: "3", secret: true },
+    ])
+
+    expect(secretService.getSecretEnvironment(ENTITY_ID)).toEqual([
+      {
+        key: "new",
+        value: "3",
+        initialValue: "3",
+        varIndex: 0,
+      },
+    ])
+  })
+})
+
+describe("populateLocalStoresFromCollectionTree", () => {
+  let secretService: SecretEnvironmentService
+  let currentValueService: CurrentValueService
+
+  beforeEach(() => {
+    secretService = getService(SecretEnvironmentService)
+    currentValueService = getService(CurrentValueService)
+    secretService.secretEnvironments.clear()
+    currentValueService.environments.clear()
+  })
+
+  const buildCollection = (
+    refId: string,
+    variables: HoppCollection["variables"],
+    folders: HoppCollection[] = []
+  ): HoppCollection => ({
+    v: 12,
+    name: `coll-${refId}`,
+    _ref_id: refId,
+    folders,
+    requests: [],
+    auth: { authType: "inherit", authActive: true },
+    headers: [],
+    variables,
+    description: null,
+    preRequestScript: "",
+    testScript: "",
+  })
+
+  it("populates the secret store for the root collection", () => {
+    populateLocalStoresFromCollectionTree(
+      buildCollection("root", [
+        { key: "tok", initialValue: "init", currentValue: "cur", secret: true },
+      ])
+    )
+
+    expect(secretService.getSecretEnvironment("root")).toEqual([
+      {
+        key: "tok",
+        value: "cur",
+        initialValue: "init",
+        varIndex: 0,
+      },
+    ])
+  })
+
+  it("recurses into nested folders, populating each by its own _ref_id", () => {
+    const child = buildCollection("child-1", [
+      {
+        key: "child-tok",
+        initialValue: "ci",
+        currentValue: "cc",
+        secret: true,
+      },
+    ])
+    const grandchild = buildCollection("gc-1", [
+      { key: "gc-tok", initialValue: "gi", currentValue: "gc", secret: true },
+    ])
+    child.folders = [grandchild]
+
+    populateLocalStoresFromCollectionTree(
+      buildCollection(
+        "root",
+        [
+          {
+            key: "r-tok",
+            initialValue: "ri",
+            currentValue: "rc",
+            secret: true,
+          },
+        ],
+        [child]
+      )
+    )
+
+    expect(secretService.getSecretEnvironment("root")).toBeDefined()
+    expect(secretService.getSecretEnvironment("child-1")).toBeDefined()
+    expect(secretService.getSecretEnvironment("gc-1")).toEqual([
+      {
+        key: "gc-tok",
+        value: "gc",
+        initialValue: "gi",
+        varIndex: 0,
+      },
+    ])
+  })
+
+  it("skips a node that has no _ref_id but still recurses into its folders", () => {
+    const child = buildCollection("child-1", [
+      { key: "tok", initialValue: "i", currentValue: "c", secret: true },
+    ])
+
+    const root = buildCollection("placeholder", [], [child])
+    delete (root as Partial<HoppCollection>)._ref_id
+
+    populateLocalStoresFromCollectionTree(root)
+
+    expect(secretService.getSecretEnvironment("child-1")).toBeDefined()
+    expect(secretService.getSecretEnvironment("placeholder")).toBeUndefined()
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
@@ -127,6 +127,54 @@ describe("populateLocalStoresFromVariables", () => {
     ])
   })
 
+  it("falls back to initialValue when non-secret currentValue is empty (re-import of own JSON export)", () => {
+    // Hoppscotch's env JSON export blanks `currentValue` for ALL variables.
+    // On re-import, a non-secret variable's currentValue should fall back
+    // to the persisted `initialValue` so the user's runtime UI doesn't
+    // show blank fields after re-importing their own export.
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      {
+        key: "host",
+        initialValue: "https://api.example.com",
+        currentValue: "",
+        secret: false,
+      },
+    ])
+
+    expect(currentValueService.getEnvironment(ENTITY_ID)).toEqual([
+      {
+        key: "host",
+        currentValue: "https://api.example.com",
+        varIndex: 0,
+        isSecret: false,
+      },
+    ])
+  })
+
+  it("does NOT fall back to initialValue for secrets (security posture)", () => {
+    // Stripped secret payloads have both fields empty, but a JSON export
+    // can carry `initialValue` even when `currentValue` is empty. We
+    // intentionally do NOT recover the secret value from `initialValue`
+    // for `secret: true` entries — secrets must be re-entered per device.
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      {
+        key: "token",
+        initialValue: "leaked-from-export",
+        currentValue: "",
+        secret: true,
+      },
+    ])
+
+    expect(secretService.getSecretEnvironment(ENTITY_ID)).toEqual([
+      {
+        key: "token",
+        value: "",
+        initialValue: "leaked-from-export",
+        varIndex: 0,
+      },
+    ])
+  })
+
   it("preserves the variable index for mixed secret + non-secret entries", () => {
     populateLocalStoresFromVariables(ENTITY_ID, [
       {

--- a/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
@@ -172,18 +172,15 @@ describe("populateLocalStoresFromVariables", () => {
     ])
   })
 
-  it("falls back to initialValue for secrets when currentValue is empty", () => {
-    // Hoppscotch JSON exports strip **both** `initialValue` and `currentValue`
-    // for secrets, so a fully-stripped wire payload lands with both as `""`.
-    // The fallback to `initialValue` is primarily useful for Postman imports
-    // (which carry the secret in `value`/`initialValue`) and for any legacy
-    // export format that only blanked `currentValue`. When both are empty the
-    // fallback is a no-op — the secret stays blank, which is intentional for
-    // round-tripping a stripped export.
+  it("preserves an explicit empty currentValue for secrets", () => {
+    // An explicit `""` is a deliberate clear and must not be resurrected
+    // from `initialValue` — otherwise rehydrating an existing global where
+    // the user cleared `currentValue` while keeping `initialValue` would
+    // silently restore the old secret on the next import/merge.
     populateLocalStoresFromVariables(ENTITY_ID, [
       {
         key: "token",
-        initialValue: "exported-secret",
+        initialValue: "old-secret",
         currentValue: "",
         secret: true,
       },
@@ -192,8 +189,31 @@ describe("populateLocalStoresFromVariables", () => {
     expect(secretService.getSecretEnvironment(ENTITY_ID)).toEqual([
       {
         key: "token",
-        value: "exported-secret",
-        initialValue: "exported-secret",
+        value: "",
+        initialValue: "old-secret",
+        varIndex: 0,
+      },
+    ])
+  })
+
+  it("falls back to initialValue for secrets when currentValue is absent", () => {
+    // Nullish (missing) `currentValue` — distinct from an explicit clear —
+    // falls through to `initialValue`. Covers the legacy `hoppEnv` import
+    // shape where only `initialValue` is present on the entry.
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      {
+        key: "token",
+        initialValue: "imported-secret",
+        currentValue: undefined as unknown as string,
+        secret: true,
+      },
+    ])
+
+    expect(secretService.getSecretEnvironment(ENTITY_ID)).toEqual([
+      {
+        key: "token",
+        value: "imported-secret",
+        initialValue: "imported-secret",
         varIndex: 0,
       },
     ])
@@ -418,6 +438,31 @@ describe("populateLocalStoresFromCollectionTree", () => {
 
     expect(secretService.getSecretEnvironment("child-1")).toBeDefined()
     expect(secretService.getSecretEnvironment("placeholder")).toBeUndefined()
+  })
+
+  it("promotes initialValue to value for foreign-import secrets (Postman/Insomnia)", () => {
+    // `postman.ts` and `insomnia/insomniaColl.ts` set `currentValue: ""` while
+    // putting the secret in `initialValue`. The collection-tree populate must
+    // promote so the imported secret survives in the secret service.
+    populateLocalStoresFromCollectionTree(
+      buildCollection("postman-style", [
+        {
+          key: "api_key",
+          initialValue: "pm-secret",
+          currentValue: "",
+          secret: true,
+        },
+      ])
+    )
+
+    expect(secretService.getSecretEnvironment("postman-style")).toEqual([
+      {
+        key: "api_key",
+        value: "pm-secret",
+        initialValue: "pm-secret",
+        varIndex: 0,
+      },
+    ])
   })
 })
 

--- a/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
@@ -127,16 +127,37 @@ describe("populateLocalStoresFromVariables", () => {
     ])
   })
 
-  it("falls back to initialValue when non-secret currentValue is empty (re-import of own JSON export)", () => {
-    // Hoppscotch's env JSON export blanks `currentValue` for ALL variables.
-    // On re-import, a non-secret variable's currentValue should fall back
-    // to the persisted `initialValue` so the user's runtime UI doesn't
-    // show blank fields after re-importing their own export.
+  it("preserves an explicit empty currentValue for non-secrets", () => {
+    // `""` is a meaningful "user cleared this" value — must NOT fall
+    // through to `initialValue`. Only nullish (missing) currentValue
+    // triggers the fallback.
     populateLocalStoresFromVariables(ENTITY_ID, [
       {
         key: "host",
         initialValue: "https://api.example.com",
         currentValue: "",
+        secret: false,
+      },
+    ])
+
+    expect(currentValueService.getEnvironment(ENTITY_ID)).toEqual([
+      {
+        key: "host",
+        currentValue: "",
+        varIndex: 0,
+        isSecret: false,
+      },
+    ])
+  })
+
+  it("falls back to initialValue when non-secret currentValue is absent", () => {
+    // Missing (undefined) currentValue — not an explicit clear — falls
+    // through to `initialValue`.
+    populateLocalStoresFromVariables(ENTITY_ID, [
+      {
+        key: "host",
+        initialValue: "https://api.example.com",
+        currentValue: undefined as unknown as string,
         secret: false,
       },
     ])

--- a/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
@@ -173,11 +173,13 @@ describe("populateLocalStoresFromVariables", () => {
   })
 
   it("falls back to initialValue for secrets when currentValue is empty", () => {
-    // A JSON export preserves the secret's `initialValue` (export blanks
-    // only `currentValue`). On re-import the live `value` falls back to
-    // `initialValue` so the secret surfaces in the UI without manual
-    // re-entry. Both fields are empty for a fully-stripped wire payload,
-    // so this fallback is safe for legitimate stripped paths too.
+    // Hoppscotch JSON exports strip **both** `initialValue` and `currentValue`
+    // for secrets, so a fully-stripped wire payload lands with both as `""`.
+    // The fallback to `initialValue` is primarily useful for Postman imports
+    // (which carry the secret in `value`/`initialValue`) and for any legacy
+    // export format that only blanked `currentValue`. When both are empty the
+    // fallback is a no-op — the secret stays blank, which is intentional for
+    // round-tripping a stripped export.
     populateLocalStoresFromVariables(ENTITY_ID, [
       {
         key: "token",

--- a/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
@@ -5,6 +5,8 @@ import { getService } from "~/modules/dioc"
 import { CurrentValueService } from "~/services/current-environment-value.service"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
 import {
+  flushLocalStoresForTeamCollectionTree,
+  flushUnmatchedRefIdsFromTree,
   indexCollectionsByRefId,
   populateLocalStoresFromCollectionTree,
   populateLocalStoresFromVariables,
@@ -598,5 +600,174 @@ describe("indexCollectionsByRefId + repopulateLoadedCollectionTree", () => {
     expect(secretService.getSecretEnvironment("child")).toEqual([
       { key: "ck", value: "cc", initialValue: "ci", varIndex: 0 },
     ])
+  })
+
+  it("promotes foreign-import secrets when re-seeding after backend round-trip", () => {
+    // Selfhost-web personal-workspace flow: user imports a Postman collection,
+    // backend round-trip succeeds, then `repopulateLoadedCollectionTree` re-seeds
+    // local stores from the pre-strip original. The original still carries the
+    // Postman convention (`currentValue: ""` + `initialValue: "X"` for secrets),
+    // so the re-seed must promote — otherwise the round-trip would overwrite
+    // the secret service entry that the earlier collection-tree populate set.
+    const original = buildCollection("ref-pm", [
+      {
+        key: "api_key",
+        initialValue: "pm-secret",
+        currentValue: "",
+        secret: true,
+      },
+    ])
+
+    const map = new Map<string, HoppCollection>()
+    indexCollectionsByRefId([original], map)
+
+    const loaded = buildCollection("ref-pm", [
+      { key: "api_key", initialValue: "", currentValue: "", secret: true },
+    ])
+
+    repopulateLoadedCollectionTree(loaded, map)
+
+    expect(secretService.getSecretEnvironment("ref-pm")).toEqual([
+      {
+        key: "api_key",
+        value: "pm-secret",
+        initialValue: "pm-secret",
+        varIndex: 0,
+      },
+    ])
+  })
+})
+
+describe("flushUnmatchedRefIdsFromTree", () => {
+  let secretService: SecretEnvironmentService
+  let currentValueService: CurrentValueService
+
+  beforeEach(() => {
+    secretService = getService(SecretEnvironmentService)
+    currentValueService = getService(CurrentValueService)
+    secretService.secretEnvironments.clear()
+    currentValueService.environments.clear()
+  })
+
+  const buildCollection = (
+    refId: string,
+    variables: HoppCollection["variables"],
+    folders: HoppCollection[] = []
+  ): HoppCollection => ({
+    v: 12,
+    name: `coll-${refId}`,
+    _ref_id: refId,
+    folders,
+    requests: [],
+    auth: { authType: "inherit", authActive: true },
+    headers: [],
+    variables,
+    description: null,
+    preRequestScript: "",
+    testScript: "",
+  })
+
+  it("deletes entries whose `_ref_id` is not in the kept set", () => {
+    secretService.addSecretEnvironment("ref-orphan", [
+      { key: "k", value: "v", initialValue: "v", varIndex: 0 },
+    ])
+    currentValueService.addEnvironment("ref-orphan", [
+      { key: "k", currentValue: "v", varIndex: 0, isSecret: false },
+    ])
+
+    flushUnmatchedRefIdsFromTree([buildCollection("ref-orphan", [])], new Set())
+
+    expect(secretService.getSecretEnvironment("ref-orphan")).toBeUndefined()
+    expect(currentValueService.getEnvironment("ref-orphan")).toBeUndefined()
+  })
+
+  it("keeps entries whose `_ref_id` is in the kept set", () => {
+    secretService.addSecretEnvironment("ref-kept", [
+      { key: "k", value: "v", initialValue: "v", varIndex: 0 },
+    ])
+
+    flushUnmatchedRefIdsFromTree(
+      [buildCollection("ref-kept", [])],
+      new Set(["ref-kept"])
+    )
+
+    expect(secretService.getSecretEnvironment("ref-kept")).toBeDefined()
+  })
+
+  it("recurses into folders, flushing each unmatched descendant", () => {
+    secretService.addSecretEnvironment("ref-root", [
+      { key: "k", value: "v", initialValue: "v", varIndex: 0 },
+    ])
+    secretService.addSecretEnvironment("ref-child", [
+      { key: "k", value: "v", initialValue: "v", varIndex: 0 },
+    ])
+    secretService.addSecretEnvironment("ref-kept", [
+      { key: "k", value: "v", initialValue: "v", varIndex: 0 },
+    ])
+
+    const child = buildCollection("ref-child", [])
+    const root = buildCollection("ref-root", [], [child])
+    const kept = buildCollection("ref-kept", [])
+
+    flushUnmatchedRefIdsFromTree([root, kept], new Set(["ref-kept"]))
+
+    expect(secretService.getSecretEnvironment("ref-root")).toBeUndefined()
+    expect(secretService.getSecretEnvironment("ref-child")).toBeUndefined()
+    expect(secretService.getSecretEnvironment("ref-kept")).toBeDefined()
+  })
+})
+
+describe("flushLocalStoresForTeamCollectionTree", () => {
+  let secretService: SecretEnvironmentService
+  let currentValueService: CurrentValueService
+
+  beforeEach(() => {
+    secretService = getService(SecretEnvironmentService)
+    currentValueService = getService(CurrentValueService)
+    secretService.secretEnvironments.clear()
+    currentValueService.environments.clear()
+  })
+
+  it("deletes the top-level entry by team backend `id`", () => {
+    secretService.addSecretEnvironment("team-coll-1", [
+      { key: "k", value: "v", initialValue: "v", varIndex: 0 },
+    ])
+    currentValueService.addEnvironment("team-coll-1", [
+      { key: "k", currentValue: "v", varIndex: 0, isSecret: false },
+    ])
+
+    flushLocalStoresForTeamCollectionTree({
+      id: "team-coll-1",
+      children: null,
+    })
+
+    expect(secretService.getSecretEnvironment("team-coll-1")).toBeUndefined()
+    expect(currentValueService.getEnvironment("team-coll-1")).toBeUndefined()
+  })
+
+  it("recurses into `children` and flushes every descendant", () => {
+    secretService.addSecretEnvironment("root", [
+      { key: "k", value: "v", initialValue: "v", varIndex: 0 },
+    ])
+    secretService.addSecretEnvironment("child-1", [
+      { key: "k", value: "v", initialValue: "v", varIndex: 0 },
+    ])
+    secretService.addSecretEnvironment("grandchild", [
+      { key: "k", value: "v", initialValue: "v", varIndex: 0 },
+    ])
+
+    flushLocalStoresForTeamCollectionTree({
+      id: "root",
+      children: [
+        {
+          id: "child-1",
+          children: [{ id: "grandchild", children: null }],
+        },
+      ],
+    })
+
+    expect(secretService.getSecretEnvironment("root")).toBeUndefined()
+    expect(secretService.getSecretEnvironment("child-1")).toBeUndefined()
+    expect(secretService.getSecretEnvironment("grandchild")).toBeUndefined()
   })
 })

--- a/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/secretVariables.spec.ts
@@ -172,15 +172,16 @@ describe("populateLocalStoresFromVariables", () => {
     ])
   })
 
-  it("does NOT fall back to initialValue for secrets (security posture)", () => {
-    // Stripped secret payloads have both fields empty, but a JSON export
-    // can carry `initialValue` even when `currentValue` is empty. We
-    // intentionally do NOT recover the secret value from `initialValue`
-    // for `secret: true` entries — secrets must be re-entered per device.
+  it("falls back to initialValue for secrets when currentValue is empty", () => {
+    // A JSON export preserves the secret's `initialValue` (export blanks
+    // only `currentValue`). On re-import the live `value` falls back to
+    // `initialValue` so the secret surfaces in the UI without manual
+    // re-entry. Both fields are empty for a fully-stripped wire payload,
+    // so this fallback is safe for legitimate stripped paths too.
     populateLocalStoresFromVariables(ENTITY_ID, [
       {
         key: "token",
-        initialValue: "leaked-from-export",
+        initialValue: "exported-secret",
         currentValue: "",
         secret: true,
       },
@@ -189,8 +190,8 @@ describe("populateLocalStoresFromVariables", () => {
     expect(secretService.getSecretEnvironment(ENTITY_ID)).toEqual([
       {
         key: "token",
-        value: "",
-        initialValue: "leaked-from-export",
+        value: "exported-secret",
+        initialValue: "exported-secret",
         varIndex: 0,
       },
     ])

--- a/packages/hoppscotch-common/src/helpers/backend/helpers.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/helpers.ts
@@ -42,6 +42,11 @@ export type CollectionDataProps = {
   description: string | null
   preRequestScript: string
   testScript: string
+  // Stable client-side ref for local secret/currentValue stores. Lives
+  // inside `data` so it survives the backend round-trip — the wire's
+  // top-level `_ref_id` is dropped, only `data._ref_id` is echoed back.
+  // Optional because legacy / non-synced rows may not carry one.
+  _ref_id?: string
 }
 
 export const BACKEND_PAGE_SIZE = 10

--- a/packages/hoppscotch-common/src/helpers/backend/helpers.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/helpers.ts
@@ -43,10 +43,8 @@ export type CollectionDataProps = {
   description: string | null
   preRequestScript: string
   testScript: string
-  // Stable client-side ref for local secret/currentValue stores. Lives
-  // inside `data` so it survives the backend round-trip — the wire's
-  // top-level `_ref_id` is dropped, only `data._ref_id` is echoed back.
-  // Optional because legacy / non-synced rows may not carry one.
+  // Personal-collection writers only: stable local-store key,
+  // round-tripped via `data._ref_id`. Team paths don't use it.
   _ref_id?: string
 }
 
@@ -384,6 +382,10 @@ export const getSingleTeamCollectionJSON = async (
   }
 
   return E.right(
-    JSON.stringify(stripCollectionTreeForStore(result.right), null, 2)
+    JSON.stringify(
+      stripCollectionTreeForStore(result.right),
+      stripRefIdReplacer,
+      2
+    )
   )
 }

--- a/packages/hoppscotch-common/src/helpers/backend/helpers.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/helpers.ts
@@ -18,6 +18,7 @@ import { getI18n } from "~/modules/i18n"
 import { TeamCollection } from "../teams/TeamCollection"
 import { TeamRequest } from "../teams/TeamRequest"
 import { GQLError, runGQLQuery } from "./GQLClient"
+import { stripCollectionTreeForStore } from "~/helpers/secretVariables"
 import {
   ExportAsJsonDocument,
   ExportCollectionToJsonDocument,
@@ -323,7 +324,10 @@ export const getTeamCollectionJSON = async (teamID: string) => {
     return E.left(t("error.no_collections_to_export"))
   }
 
-  const hoppCollections = collections.map(teamCollectionJSONToHoppRESTColl)
+  // Strip secret variable values before stringify.
+  const hoppCollections = collections
+    .map(teamCollectionJSONToHoppRESTColl)
+    .map(stripCollectionTreeForStore)
   return E.right(JSON.stringify(hoppCollections, stripRefIdReplacer, 2))
 }
 
@@ -378,5 +382,9 @@ export const getSingleTeamCollectionJSON = async (
     return E.left(errorMsg)
   }
 
-  return E.right(JSON.stringify(result.right, null, 2))
+  // Strip secret variable values before stringify — same reasoning as
+  // `getTeamCollectionJSON` above. The exported JSON is user-shareable.
+  return E.right(
+    JSON.stringify(stripCollectionTreeForStore(result.right), null, 2)
+  )
 }

--- a/packages/hoppscotch-common/src/helpers/backend/helpers.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/helpers.ts
@@ -43,8 +43,11 @@ export type CollectionDataProps = {
   description: string | null
   preRequestScript: string
   testScript: string
-  // Personal-collection writers only: stable local-store key,
-  // round-tripped via `data._ref_id`. Team paths don't use it.
+  // Stable local-store key, round-tripped via `data._ref_id`. The wire
+  // payload is opaque to the backend, which just echoes it back; the FE
+  // uses it to pair populated secret-store entries to the backend `id`
+  // (personal) or to migrate from `_ref_id` to backend `id` (team
+  // collection import).
   _ref_id?: string
 }
 

--- a/packages/hoppscotch-common/src/helpers/backend/helpers.ts
+++ b/packages/hoppscotch-common/src/helpers/backend/helpers.ts
@@ -274,6 +274,8 @@ export const teamCollToHoppRESTColl = (
           headers: [],
           variables: [],
           description: null,
+          preRequestScript: "",
+          testScript: "",
         }
 
   const {
@@ -324,7 +326,6 @@ export const getTeamCollectionJSON = async (teamID: string) => {
     return E.left(t("error.no_collections_to_export"))
   }
 
-  // Strip secret variable values before stringify.
   const hoppCollections = collections
     .map(teamCollectionJSONToHoppRESTColl)
     .map(stripCollectionTreeForStore)
@@ -382,8 +383,6 @@ export const getSingleTeamCollectionJSON = async (
     return E.left(errorMsg)
   }
 
-  // Strip secret variable values before stringify — same reasoning as
-  // `getTeamCollectionJSON` above. The exported JSON is user-shareable.
   return E.right(
     JSON.stringify(stripCollectionTreeForStore(result.right), null, 2)
   )

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -312,6 +312,9 @@ export function transformCollectionForImport(
     auth: collection.auth,
     headers: collection.headers,
     variables: stripSecretVariableValuesForWire(collection.variables ?? []),
+    // Preserve `_ref_id` through the backend round-trip so the local
+    // secret store key survives reload — see `CollectionDataProps`.
+    _ref_id: collection._ref_id,
     description: collection.description,
     preRequestScript: collection.preRequestScript ?? "",
     testScript: collection.testScript ?? "",

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -299,6 +299,7 @@ export function getFoldersByPath(
 /**
  * Transforms a collection to the format expected by team or personal collections.
  * BE expects CollectionFolder format with a data field containing auth, headers, variables, and description.
+ *
  * @param collection The collection to transform
  * @returns The transformed collection
  */

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -8,6 +8,7 @@ import { RESTTabService } from "~/services/tab/rest"
 import { GQLTabService } from "~/services/tab/graphql"
 import { TeamCollectionsService } from "~/services/team-collection.service"
 import { cascadeParentCollectionForProperties } from "~/newstore/collections"
+import { stripSecretVariableValuesForWire } from "../secretVariables"
 import { CollectionDataProps } from "../backend/helpers"
 import { CollectionFolder } from "../backend/queries/PublishedDocs"
 
@@ -309,7 +310,7 @@ export function transformCollectionForImport(
   const data: CollectionDataProps = {
     auth: collection.auth,
     headers: collection.headers,
-    variables: collection.variables,
+    variables: stripSecretVariableValuesForWire(collection.variables ?? []),
     description: collection.description,
     preRequestScript: collection.preRequestScript ?? "",
     testScript: collection.testScript ?? "",

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -312,7 +312,6 @@ export function transformCollectionForImport(
     auth: collection.auth,
     headers: collection.headers,
     variables: stripSecretVariableValuesForWire(collection.variables ?? []),
-    _ref_id: collection._ref_id,
     description: collection.description,
     preRequestScript: collection.preRequestScript ?? "",
     testScript: collection.testScript ?? "",

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -312,8 +312,6 @@ export function transformCollectionForImport(
     auth: collection.auth,
     headers: collection.headers,
     variables: stripSecretVariableValuesForWire(collection.variables ?? []),
-    // Preserve `_ref_id` through the backend round-trip so the local
-    // secret store key survives reload — see `CollectionDataProps`.
     _ref_id: collection._ref_id,
     description: collection.description,
     preRequestScript: collection.preRequestScript ?? "",

--- a/packages/hoppscotch-common/src/helpers/collection/collection.ts
+++ b/packages/hoppscotch-common/src/helpers/collection/collection.ts
@@ -312,6 +312,10 @@ export function transformCollectionForImport(
     auth: collection.auth,
     headers: collection.headers,
     variables: stripSecretVariableValuesForWire(collection.variables ?? []),
+    // Round-trip the local-store key so the team-collection-added handler
+    // (`TeamCollectionsService.addCollection`) can migrate the importer's
+    // secret entries from this `_ref_id` to the backend-assigned `id`.
+    _ref_id: collection._ref_id,
     description: collection.description,
     preRequestScript: collection.preRequestScript ?? "",
     testScript: collection.testScript ?? "",

--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -40,6 +40,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -151,6 +152,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -170,6 +172,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -196,6 +199,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -228,6 +232,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -260,6 +265,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -292,6 +298,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -324,6 +331,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -354,6 +362,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -387,6 +396,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -422,6 +432,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -493,6 +504,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -523,6 +535,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -588,6 +601,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -637,6 +651,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -688,6 +703,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -704,6 +720,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -730,6 +747,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -749,6 +767,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -775,6 +794,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -794,6 +814,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -820,6 +841,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -844,6 +866,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -866,6 +889,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -889,6 +913,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -911,6 +936,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -944,6 +970,7 @@ const samples = [
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -978,6 +1005,7 @@ data2: {"type":"test2","typeId":"123"}`,
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
   {
@@ -1026,6 +1054,7 @@ data2: {"type":"test2","typeId":"123"}`,
       testScript: "",
       requestVariables: [],
       responses: {},
+      description: null,
     }),
   },
 ]

--- a/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
@@ -244,5 +244,6 @@ export const parseCurlCommand = (curlCommand: string) => {
     body: finalBody,
     requestVariables: defaultRESTReq.requestVariables,
     responses: {},
+    description: defaultRESTReq.description,
   })
 }

--- a/packages/hoppscotch-common/src/helpers/globalEnvShape.ts
+++ b/packages/hoppscotch-common/src/helpers/globalEnvShape.ts
@@ -1,0 +1,32 @@
+import type { GlobalEnvironment } from "@hoppscotch/data"
+
+/**
+ * Coerce any incoming value to a valid v2 `GlobalEnvironment` wrapper
+ * (`{ v: 2, variables: [...] }`).
+ *
+ * Three shapes can reach the store dispatcher in the wild:
+ *   - the wrapper itself (current FE schema)
+ *   - a bare variables array (older backends, or schema drift between
+ *     instances on a self-hosted deployment)
+ *   - a malformed / nullish value (corrupt persistence, race, future bug)
+ *
+ * Backend changes can't be guaranteed across self-hosted instances, so
+ * the FE must absorb all three. This helper keeps that coercion pure
+ * and unit-testable, separate from the dispatcher's side effects.
+ */
+export const coerceGlobalEnvironment = (
+  entries: unknown
+): GlobalEnvironment => {
+  if (Array.isArray(entries)) {
+    return { v: 2, variables: entries }
+  }
+  if (
+    entries &&
+    typeof entries === "object" &&
+    "variables" in entries &&
+    Array.isArray((entries as { variables: unknown }).variables)
+  ) {
+    return entries as GlobalEnvironment
+  }
+  return { v: 2, variables: [] }
+}

--- a/packages/hoppscotch-common/src/helpers/globalEnvShape.ts
+++ b/packages/hoppscotch-common/src/helpers/globalEnvShape.ts
@@ -1,8 +1,11 @@
-import type { GlobalEnvironment } from "@hoppscotch/data"
+import {
+  GLOBAL_ENV_LATEST_VERSION,
+  type GlobalEnvironment,
+} from "@hoppscotch/data"
 
 /**
- * Coerce any incoming value to a valid v2 `GlobalEnvironment` wrapper
- * (`{ v: 2, variables: [...] }`).
+ * Coerce any incoming value to a valid latest-version `GlobalEnvironment`
+ * wrapper (`{ v: GLOBAL_ENV_LATEST_VERSION, variables: [...] }`).
  *
  * Three shapes can reach the store dispatcher in the wild:
  *   - the wrapper itself (current FE schema)
@@ -13,12 +16,22 @@ import type { GlobalEnvironment } from "@hoppscotch/data"
  * Backend changes can't be guaranteed across self-hosted instances, so
  * the FE must absorb all three. This helper keeps that coercion pure
  * and unit-testable, separate from the dispatcher's side effects.
+ *
+ * Version handling: when the input has a recognized current `v` we pass
+ * the wrapper through unchanged so downstream identity checks
+ * (`distinctUntilChanged`) stay stable. When `v` is missing, wrong, or
+ * non-numeric we rebuild with the latest version — schema migration
+ * across versions is verzod's responsibility on the load path, not
+ * this dispatcher boundary.
  */
 export const coerceGlobalEnvironment = (
   entries: unknown
 ): GlobalEnvironment => {
   if (Array.isArray(entries)) {
-    return { v: 2, variables: entries }
+    return {
+      v: GLOBAL_ENV_LATEST_VERSION,
+      variables: entries,
+    } as GlobalEnvironment
   }
   if (
     entries &&
@@ -26,7 +39,20 @@ export const coerceGlobalEnvironment = (
     "variables" in entries &&
     Array.isArray((entries as { variables: unknown }).variables)
   ) {
-    return entries as GlobalEnvironment
+    const wrapper = entries as {
+      v?: unknown
+      variables: GlobalEnvironment["variables"]
+    }
+    if (wrapper.v === GLOBAL_ENV_LATEST_VERSION) {
+      return wrapper as GlobalEnvironment
+    }
+    return {
+      v: GLOBAL_ENV_LATEST_VERSION,
+      variables: wrapper.variables,
+    } as GlobalEnvironment
   }
-  return { v: 2, variables: [] }
+  return {
+    v: GLOBAL_ENV_LATEST_VERSION,
+    variables: [],
+  } as GlobalEnvironment
 }

--- a/packages/hoppscotch-common/src/helpers/globalEnvShape.ts
+++ b/packages/hoppscotch-common/src/helpers/globalEnvShape.ts
@@ -4,25 +4,11 @@ import {
 } from "@hoppscotch/data"
 
 /**
- * Coerce any incoming value to a valid latest-version `GlobalEnvironment`
- * wrapper (`{ v: GLOBAL_ENV_LATEST_VERSION, variables: [...] }`).
- *
- * Three shapes can reach the store dispatcher in the wild:
- *   - the wrapper itself (current FE schema)
- *   - a bare variables array (older backends, or schema drift between
- *     instances on a self-hosted deployment)
- *   - a malformed / nullish value (corrupt persistence, race, future bug)
- *
- * Backend changes can't be guaranteed across self-hosted instances, so
- * the FE must absorb all three. This helper keeps that coercion pure
- * and unit-testable, separate from the dispatcher's side effects.
- *
- * Version handling: when the input has a recognized current `v` we pass
- * the wrapper through unchanged so downstream identity checks
- * (`distinctUntilChanged`) stay stable. When `v` is missing, wrong, or
- * non-numeric we rebuild with the latest version — schema migration
- * across versions is verzod's responsibility on the load path, not
- * this dispatcher boundary.
+ * Coerce any value to a valid latest-version `GlobalEnvironment` wrapper.
+ * Accepts the wrapper itself, a bare variables array (legacy/older
+ * backends), or malformed input. Passes the wrapper through identity-
+ * preserving when `v` already matches; schema migration is verzod's job
+ * on the load path, not this dispatcher boundary.
  */
 export const coerceGlobalEnvironment = (
   entries: unknown

--- a/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
@@ -29,13 +29,8 @@ const getEnvironmentJSON = (
 }
 
 // Apply necessary transformations prior to environment exports.
-//
 // Strips `initialValue` for `secret: true` variables AND clears
-// `currentValue` for all variables. Matches the wire-strip convention
-// used at every backend mutation boundary — the exported JSON is a
-// shareable file (downloaded, committed, gisted) and must not carry
-// plaintext secrets. Users must re-enter secrets on each device per the
-// "secrets never leave the source device" security posture.
+// `currentValue` for all variables.
 export const transformEnvironmentVariables = ({
   id,
   v,

--- a/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/environment.ts
@@ -3,6 +3,7 @@ import * as E from "fp-ts/Either"
 import { cloneDeep } from "lodash-es"
 
 import { TeamEnvironment } from "~/helpers/teams/TeamEnvironment"
+import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
 import { initializeDownloadFile } from "."
 
 const getEnvironmentJSON = (
@@ -27,7 +28,14 @@ const getEnvironmentJSON = (
     : undefined
 }
 
-// Apply necessary transformations prior to environment exports
+// Apply necessary transformations prior to environment exports.
+//
+// Strips `initialValue` for `secret: true` variables AND clears
+// `currentValue` for all variables. Matches the wire-strip convention
+// used at every backend mutation boundary — the exported JSON is a
+// shareable file (downloaded, committed, gisted) and must not carry
+// plaintext secrets. Users must re-enter secrets on each device per the
+// "secrets never leave the source device" security posture.
 export const transformEnvironmentVariables = ({
   id,
   v,
@@ -38,18 +46,7 @@ export const transformEnvironmentVariables = ({
     id,
     v,
     name,
-    variables: variables.map((variable) => {
-      const { key, secret, initialValue } = variable
-
-      // Eliminate `currentValue` field for secret environment variables and currentValue
-
-      return {
-        key,
-        secret,
-        initialValue,
-        currentValue: variable.secret ? "" : (variable.currentValue ?? ""),
-      }
-    }),
+    variables: stripSecretVariableValuesForWire(variables),
   }
 }
 

--- a/packages/hoppscotch-common/src/helpers/import-export/export/environments.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/environments.ts
@@ -1,5 +1,13 @@
 import { Environment } from "@hoppscotch/data"
+import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
 
 export const environmentsExporter = (myEnvironments: Environment[]) => {
-  return JSON.stringify(myEnvironments, null, 2)
+  // Strip secret values from every env's variables before stringify. The
+  // exported JSON is a shareable file — raw secrets must not travel with
+  // it. Local secret store retains values for the user's own session.
+  const stripped = myEnvironments.map((env) => ({
+    ...env,
+    variables: stripSecretVariableValuesForWire(env.variables),
+  }))
+  return JSON.stringify(stripped, null, 2)
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/export/environments.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/environments.ts
@@ -2,9 +2,6 @@ import { Environment } from "@hoppscotch/data"
 import { stripSecretVariableValuesForWire } from "~/helpers/secretVariables"
 
 export const environmentsExporter = (myEnvironments: Environment[]) => {
-  // Strip secret values from every env's variables before stringify. The
-  // exported JSON is a shareable file — raw secrets must not travel with
-  // it. Local secret store retains values for the user's own session.
   const stripped = myEnvironments.map((env) => ({
     ...env,
     variables: stripSecretVariableValuesForWire(env.variables),

--- a/packages/hoppscotch-common/src/helpers/import-export/export/gqlCollections.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/gqlCollections.ts
@@ -1,6 +1,8 @@
 import { HoppCollection } from "@hoppscotch/data"
 import { stripRefIdReplacer } from "."
+import { stripCollectionTreeForStore } from "~/helpers/secretVariables"
 
 export const gqlCollectionsExporter = (gqlCollections: HoppCollection[]) => {
-  return JSON.stringify(gqlCollections, stripRefIdReplacer, 2)
+  const stripped = gqlCollections.map(stripCollectionTreeForStore)
+  return JSON.stringify(stripped, stripRefIdReplacer, 2)
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/export/myCollections.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/myCollections.ts
@@ -3,10 +3,6 @@ import { stripRefIdReplacer } from "."
 import { stripCollectionTreeForStore } from "~/helpers/secretVariables"
 
 export const myCollectionsExporter = (myCollections: HoppCollection[]) => {
-  // Strip secret variable values from the tree BEFORE stringify. The
-  // exported JSON is a file the user may share, commit, or upload — raw
-  // secrets must not travel with it. The local secret store retains the
-  // values keyed by `_ref_id` for the user's own device.
   const stripped = myCollections.map(stripCollectionTreeForStore)
   return JSON.stringify(stripped, stripRefIdReplacer, 2)
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/export/myCollections.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/export/myCollections.ts
@@ -1,6 +1,12 @@
 import { HoppCollection } from "@hoppscotch/data"
 import { stripRefIdReplacer } from "."
+import { stripCollectionTreeForStore } from "~/helpers/secretVariables"
 
 export const myCollectionsExporter = (myCollections: HoppCollection[]) => {
-  return JSON.stringify(myCollections, stripRefIdReplacer, 2)
+  // Strip secret variable values from the tree BEFORE stringify. The
+  // exported JSON is a file the user may share, commit, or upload — raw
+  // secrets must not travel with it. The local secret store retains the
+  // values keyed by `_ref_id` for the user's own device.
+  const stripped = myCollections.map(stripCollectionTreeForStore)
+  return JSON.stringify(stripped, stripRefIdReplacer, 2)
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/postmanEnv.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/postmanEnv.spec.ts
@@ -1,0 +1,104 @@
+import * as E from "fp-ts/Either"
+import { describe, expect, it } from "vitest"
+
+import { postmanEnvImporter } from "../postmanEnv"
+
+const runImport = async (envs: object[]) => {
+  const result = await postmanEnvImporter([JSON.stringify(envs)])()
+  if (E.isLeft(result)) throw new Error(`importer failed: ${result.left}`)
+  return result.right
+}
+
+describe("postmanEnvImporter — secret flag handling", () => {
+  it('recognizes the legacy `type: "secret"` shape (older Postman exports)', async () => {
+    const [env] = await runImport([
+      {
+        name: "Legacy",
+        values: [
+          {
+            key: "API_KEY",
+            value: "old-secret-value",
+            type: "secret",
+            enabled: true,
+          },
+          {
+            key: "URL",
+            value: "https://example.com",
+            type: "default",
+            enabled: true,
+          },
+        ],
+      },
+    ])
+
+    expect(env.variables).toEqual([
+      expect.objectContaining({ key: "API_KEY", secret: true }),
+      expect.objectContaining({ key: "URL", secret: false }),
+    ])
+  })
+
+  it('recognizes the Postman 12+ `secret: true` boolean (with `type: "default"`)', async () => {
+    const [env] = await runImport([
+      {
+        name: "PET_STORE",
+        values: [
+          {
+            key: "baseUrl-secret",
+            value: "",
+            type: "default",
+            enabled: true,
+            secret: true,
+          },
+          {
+            key: "baseUrl-not-secret",
+            value: "baseUrl-not-secret",
+            type: "default",
+            enabled: true,
+          },
+        ],
+      },
+    ])
+
+    expect(env.variables).toEqual([
+      expect.objectContaining({ key: "baseUrl-secret", secret: true }),
+      expect.objectContaining({ key: "baseUrl-not-secret", secret: false }),
+    ])
+  })
+
+  it("treats a variable as secret when EITHER signal is present", async () => {
+    const [env] = await runImport([
+      {
+        name: "Mixed",
+        values: [
+          // Both signals — still secret
+          {
+            key: "BOTH",
+            value: "x",
+            type: "secret",
+            secret: true,
+            enabled: true,
+          },
+          // Only legacy
+          { key: "LEGACY", value: "x", type: "secret", enabled: true },
+          // Only new
+          {
+            key: "NEW",
+            value: "x",
+            type: "default",
+            secret: true,
+            enabled: true,
+          },
+          // Neither — not secret
+          { key: "PLAIN", value: "x", type: "default", enabled: true },
+        ],
+      },
+    ])
+
+    expect(env.variables.map((v) => [v.key, v.secret])).toEqual([
+      ["BOTH", true],
+      ["LEGACY", true],
+      ["NEW", true],
+      ["PLAIN", false],
+    ])
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -121,11 +121,19 @@ const getHoppCollVariables = (
         variable.key.length > 0
     ),
     A.map((variable) => {
+      // Postman 12+ flags secret variables via a top-level `secret: true`
+      // boolean while keeping `type` as `"default"`. Older exports used
+      // `type: "secret"`. Honor both — the postman-collection SDK doesn't
+      // surface the new flag in its types, so read it off the raw object.
+      const isSecret =
+        variable.type === "secret" ||
+        (variable as { secret?: boolean }).secret === true
+
       return <HoppCollectionVariable>{
         key: replacePMVarTemplating(variable.key ?? ""),
         initialValue: replacePMVarTemplating(variable.value ?? ""),
         currentValue: "",
-        secret: variable.type === "secret",
+        secret: isSecret,
       }
     })
   )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -121,10 +121,8 @@ const getHoppCollVariables = (
         variable.key.length > 0
     ),
     A.map((variable) => {
-      // Postman 12+ flags secret variables via a top-level `secret: true`
-      // boolean while keeping `type` as `"default"`. Older exports used
-      // `type: "secret"`. Honor both — the postman-collection SDK doesn't
-      // surface the new flag in its types, so read it off the raw object.
+      // Postman 12+ uses `secret: true`; older exports use `type: "secret"`.
+      // The SDK's types don't surface the new flag, so read it off raw.
       const isSecret =
         variable.type === "secret" ||
         (variable as { secret?: boolean }).secret === true

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
@@ -15,6 +15,10 @@ const postmanEnvSchema = z.object({
       key: z.string(),
       value: z.string(),
       type: z.string(),
+      // Postman 12+ moved the secret flag onto a separate boolean field while
+      // leaving `type` as `"default"`. Older exports use `type: "secret"`.
+      // Accept both shapes so both formats import correctly.
+      secret: z.boolean().optional(),
     })
   ),
 })
@@ -49,17 +53,19 @@ export const postmanEnvImporter = (contents: string[]) => {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)
   }
 
-  // Convert `values` to `variables` to match the format expected by the system
+  // Convert `values` to `variables` to match the format expected by the system.
+  // A variable is treated as secret when EITHER the legacy `type: "secret"` or
+  // the Postman 12+ top-level `secret: true` flag is set.
   const environments: Environment[] = validationResult.data.map(
     ({ name, values }) => ({
       id: uniqueID(),
       v: EnvironmentSchemaVersion,
       name,
-      variables: values.map(({ key, value, type }) => ({
+      variables: values.map(({ key, value, type, secret }) => ({
         key,
         initialValue: replacePMVarTemplating(value),
         currentValue: replacePMVarTemplating(value),
-        secret: type === "secret",
+        secret: type === "secret" || secret === true,
       })),
     })
   )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postmanEnv.ts
@@ -15,9 +15,7 @@ const postmanEnvSchema = z.object({
       key: z.string(),
       value: z.string(),
       type: z.string(),
-      // Postman 12+ moved the secret flag onto a separate boolean field while
-      // leaving `type` as `"default"`. Older exports use `type: "secret"`.
-      // Accept both shapes so both formats import correctly.
+      // Postman 12+ uses `secret: true`; older exports use `type: "secret"`.
       secret: z.boolean().optional(),
     })
   ),
@@ -53,9 +51,7 @@ export const postmanEnvImporter = (contents: string[]) => {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)
   }
 
-  // Convert `values` to `variables` to match the format expected by the system.
-  // A variable is treated as secret when EITHER the legacy `type: "secret"` or
-  // the Postman 12+ top-level `secret: true` flag is set.
+  // Treat as secret on legacy `type: "secret"` OR Postman 12+ `secret: true`.
   const environments: Environment[] = validationResult.data.map(
     ({ name, values }) => ({
       id: uniqueID(),

--- a/packages/hoppscotch-common/src/helpers/mockServer/exampleCollection.ts
+++ b/packages/hoppscotch-common/src/helpers/mockServer/exampleCollection.ts
@@ -88,6 +88,7 @@ export function createExamplePetStoreCollection(
           ],
         },
       },
+      description: null,
     }),
 
     // GET - Get a single pet by ID
@@ -137,6 +138,7 @@ export function createExamplePetStoreCollection(
           ],
         },
       },
+      description: null,
     }),
 
     // POST - Create a new pet
@@ -213,6 +215,7 @@ export function createExamplePetStoreCollection(
           ],
         },
       },
+      description: null,
     }),
 
     // PUT - Update an existing pet
@@ -283,6 +286,7 @@ export function createExamplePetStoreCollection(
           ],
         },
       },
+      description: null,
     }),
 
     // DELETE - Delete a pet
@@ -311,6 +315,7 @@ export function createExamplePetStoreCollection(
           headers: [],
         },
       },
+      description: null,
     }),
   ]
 

--- a/packages/hoppscotch-common/src/helpers/mockServer/exampleMockCollection.ts
+++ b/packages/hoppscotch-common/src/helpers/mockServer/exampleMockCollection.ts
@@ -4,6 +4,7 @@ import * as E from "fp-ts/Either"
 import {
   HoppRESTRequest,
   RESTReqSchemaVersion,
+  generateUniqueRefId,
   makeCollection,
 } from "@hoppscotch/data"
 import { createNewRootCollection } from "~/helpers/backend/mutations/TeamCollection"
@@ -72,6 +73,7 @@ export function getExampleMockRequests(): HoppRESTRequest[] {
       auth: oauthAuth,
       requestVariables: [],
       responses: {},
+      description: "",
     },
     // updatePet request
     {
@@ -90,6 +92,7 @@ export function getExampleMockRequests(): HoppRESTRequest[] {
       auth: oauthAuth,
       requestVariables: [],
       responses: {},
+      description: "",
     },
     // findByStatus request
     {
@@ -115,6 +118,7 @@ export function getExampleMockRequests(): HoppRESTRequest[] {
       auth: oauthAuth,
       requestVariables: [],
       responses: {},
+      description: "",
     },
     // getPetById request
     {
@@ -139,6 +143,7 @@ export function getExampleMockRequests(): HoppRESTRequest[] {
       },
       requestVariables: [],
       responses: {},
+      description: "",
     },
     // updatePetWithForm request
     {
@@ -157,6 +162,7 @@ export function getExampleMockRequests(): HoppRESTRequest[] {
       auth: oauthAuth,
       requestVariables: [],
       responses: {},
+      description: "",
     },
     // deletePet request
     {
@@ -182,6 +188,7 @@ export function getExampleMockRequests(): HoppRESTRequest[] {
       auth: oauthAuth,
       requestVariables: [],
       responses: {},
+      description: "",
     },
   ]
 
@@ -249,7 +256,9 @@ export async function createMockCollectionForTeam(
 export async function createMockCollectionForPersonal(
   collectionName: string
 ): Promise<E.Either<string, { id: string; name: string }>> {
-  // Prepare collection data
+  // Prepare collection data. Stamp a `_ref_id` so the collection has a
+  // stable client-side key once round-tripped through the backend `data`
+  // blob — matches every other personal-collection writer in the codebase.
   const data = {
     auth: {
       authType: "inherit" as const,
@@ -257,6 +266,10 @@ export async function createMockCollectionForPersonal(
     },
     headers: [],
     variables: [],
+    _ref_id: generateUniqueRefId("coll"),
+    description: null,
+    preRequestScript: "",
+    testScript: "",
   }
 
   // Create the root collection using GraphQL mutation

--- a/packages/hoppscotch-common/src/helpers/mockServer/exampleMockCollection.ts
+++ b/packages/hoppscotch-common/src/helpers/mockServer/exampleMockCollection.ts
@@ -256,9 +256,6 @@ export async function createMockCollectionForTeam(
 export async function createMockCollectionForPersonal(
   collectionName: string
 ): Promise<E.Either<string, { id: string; name: string }>> {
-  // Prepare collection data. Stamp a `_ref_id` so the collection has a
-  // stable client-side key once round-tripped through the backend `data`
-  // blob — matches every other personal-collection writer in the codebase.
   const data = {
     auth: {
       authType: "inherit" as const,

--- a/packages/hoppscotch-common/src/helpers/rest/default.ts
+++ b/packages/hoppscotch-common/src/helpers/rest/default.ts
@@ -19,4 +19,5 @@ export const getDefaultRESTRequest = (): HoppRESTRequest => ({
   },
   requestVariables: [],
   responses: {},
+  description: "",
 })

--- a/packages/hoppscotch-common/src/helpers/rest/default.ts
+++ b/packages/hoppscotch-common/src/helpers/rest/default.ts
@@ -19,5 +19,5 @@ export const getDefaultRESTRequest = (): HoppRESTRequest => ({
   },
   requestVariables: [],
   responses: {},
-  description: "",
+  description: null,
 })

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -1,0 +1,96 @@
+import { getService } from "../modules/dioc"
+import { CurrentValueService } from "../services/current-environment-value.service"
+import { SecretEnvironmentService } from "../services/secret-environment.service"
+
+/**
+ * Structural shape shared by Hoppscotch's collection variables and
+ * environment variables. Both carry a `secret` flag; both are persisted
+ * server-side via JSON blobs.
+ */
+type SecretCapableVariable = {
+  key: string
+  initialValue: string
+  currentValue: string
+  secret: boolean
+}
+
+/**
+ * Strip the values of secret variables before sending them to the backend.
+ * Used at the wire boundary for both collection variables and environment
+ * variables. The user's actual secret values stay in the local secret store
+ * (see `secretEnvironmentService`); only the slot — `key` and `secret: true`
+ * — survives onto the wire so the UI can still render it.
+ *
+ * `currentValue` is also cleared on all (non-secret) variables to match the
+ * existing Hoppscotch convention that `currentValue` is per-user/per-session
+ * state and never persisted server-side.
+ *
+ */
+export const stripSecretVariableValuesForWire = <
+  T extends SecretCapableVariable,
+>(
+  variables: T[]
+): T[] =>
+  variables.map((v) => ({
+    ...v,
+    initialValue: v.secret ? "" : v.initialValue,
+    currentValue: "",
+  }))
+
+/**
+ * Populate the local secret store and current-value store from a variables
+ * array, keyed by the entity's local ID. Mirrors what `setCollectionProperties`
+ * and `saveEnvironment` do on UI-edit save: extract `secret: true` entries to
+ * `secretEnvironmentService`, extract `currentValue` for non-secret entries to
+ * `currentEnvironmentValueService`.
+ *
+ * Required for any code path that ingests user-authored variables WITHOUT
+ * going through the UI save flow — imports, duplicates, restore-from-file —
+ * because the wire-strip removes the values from the payload that round-trips
+ * through the backend, so without this hook the user loses them on next
+ * `setRESTCollections` / `replaceEnvironments` from a backend fetch.
+ *
+ * No-ops for empty inputs so callers can apply it unconditionally.
+ */
+export const populateLocalStoresFromVariables = (
+  entityId: string,
+  variables: readonly SecretCapableVariable[]
+) => {
+  if (!entityId || variables.length === 0) return
+
+  const secretEnvironmentService = getService(SecretEnvironmentService)
+  const currentEnvironmentValueService = getService(CurrentValueService)
+
+  const secrets = variables.flatMap((v, index) =>
+    v.secret
+      ? [
+          {
+            key: v.key,
+            value: v.currentValue ?? "",
+            initialValue: v.initialValue ?? "",
+            varIndex: index,
+          },
+        ]
+      : []
+  )
+
+  const nonSecrets = variables.flatMap((v, index) =>
+    !v.secret
+      ? [
+          {
+            key: v.key,
+            currentValue: v.currentValue ?? "",
+            varIndex: index,
+            isSecret: false as const,
+          },
+        ]
+      : []
+  )
+
+  if (secrets.length > 0) {
+    secretEnvironmentService.addSecretEnvironment(entityId, secrets)
+  }
+  if (nonSecrets.length > 0) {
+    currentEnvironmentValueService.addEnvironment(entityId, nonSecrets)
+  }
+}

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -161,3 +161,49 @@ export const stripCollectionTreeForStore = (
   variables: stripSecretVariableValuesForWire(collection.variables ?? []),
   folders: (collection.folders ?? []).map(stripCollectionTreeForStore),
 })
+
+/**
+ * Build a flat `_ref_id → collection` index across an entire collection
+ * tree (root + nested folders). Used post-import to pair backend-returned
+ * collections with their pre-walked originals by stable ref-id rather
+ * than by array position, since the backend is free to reorder.
+ *
+ * Mutates `out` in place (avoids allocating an intermediate per call,
+ * since the caller typically wants a single map for the whole tree).
+ */
+export const indexCollectionsByRefId = (
+  collections: HoppCollection[],
+  out: Map<string, HoppCollection>
+) => {
+  collections.forEach((c) => {
+    if (c._ref_id) out.set(c._ref_id, c)
+    if (c.folders?.length) indexCollectionsByRefId(c.folders, out)
+  })
+}
+
+/**
+ * Walk a backend-loaded collection tree and re-populate the local secret +
+ * currentValue stores from the matching original (pre-walked) tree. Pairs
+ * each loaded node to its original by `_ref_id` (looked up in the flat map
+ * built by `indexCollectionsByRefId`). Skips nodes without a `_ref_id`
+ * (matches the prior index-based path's behavior for missing keys).
+ *
+ * Why ref-id, not array index: the backend may reorder collections during
+ * a bulk import. An index-based pairing would re-key secrets onto the
+ * wrong collection. `_ref_id` round-trips through `data._ref_id` so the
+ * lookup is stable.
+ */
+export const repopulateLoadedCollectionTree = (
+  loaded: HoppCollection,
+  originalsByRefId: Map<string, HoppCollection>
+) => {
+  if (loaded._ref_id) {
+    const original = originalsByRefId.get(loaded._ref_id)
+    if (original) {
+      populateLocalStoresFromVariables(loaded._ref_id, original.variables ?? [])
+    }
+  }
+  ;(loaded.folders ?? []).forEach((loadedFolder) => {
+    repopulateLoadedCollectionTree(loadedFolder, originalsByRefId)
+  })
+}

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -131,10 +131,21 @@ export const populateLocalStoresFromCollectionTree = (
 
 /**
  * Walk a collection tree assigning a fresh `_ref_id` to any node that lacks
- * one. Returns a deep-cloned tree (input is not mutated). Used at every
- * import entry point before the wire strip / local-store populate runs, so
- * the secret values are addressable by ref-id no matter which downstream
- * branch (backend success, backend failure, logged-out append) executes.
+ * one. Returns a new tree with fresh node objects and new `folders` arrays
+ * at every level — but `variables`, `requests`, `auth`, `headers`, etc.
+ * still reference the original input arrays/objects (NOT a deep clone).
+ *
+ * This shallow-per-node behavior is enough for the import pipeline: the
+ * downstream `stripSecretVariableValuesForWire` reallocates each node's
+ * `variables` array, and `populateLocalStoresFromCollectionTree` is
+ * read-only. Callers that intend to mutate non-folder fields after
+ * stamping ref-ids must clone those fields themselves; this helper does
+ * not protect against shared aliasing into the original graph.
+ *
+ * Used at every import entry point before the wire strip / local-store
+ * populate runs, so secret values are addressable by ref-id no matter
+ * which downstream branch (backend success, backend failure, logged-out
+ * append) executes.
  */
 export const ensureRefIds = (collection: HoppCollection): HoppCollection => ({
   ...collection,
@@ -144,14 +155,22 @@ export const ensureRefIds = (collection: HoppCollection): HoppCollection => ({
 
 /**
  * Recursive variant of `stripSecretVariableValuesForWire` for a collection
- * tree. Returns a deep-cloned tree with every node's `variables` array
- * stripped (secret values blanked, non-secret `currentValue` cleared).
+ * tree. Returns a new tree with fresh node objects, fresh `variables`
+ * arrays (every variable replaced via the strip), and fresh `folders`
+ * arrays at every level — but `requests`, `auth`, `headers`, and the
+ * script/description fields still reference the original input objects
+ * (NOT a deep clone).
+ *
+ * This is sufficient for the strip's purpose (no raw secret values
+ * land in newstore / localStorage / future sync payloads, since secrets
+ * live only inside `variables` and that's the field we reallocate).
+ * Callers that intend to mutate non-`variables` fields on the returned
+ * tree must clone those fields themselves.
  *
  * Used wherever an imported tree is appended directly to newstore (the
  * logged-out / no-platform-sync branch and the platform fallback when the
- * backend bulk-import fails) so raw secrets don't sit in newstore /
- * localStorage / future sync payloads. The local secret + currentValue
- * stores must already be populated (via `populateLocalStoresFromCollectionTree`
+ * backend bulk-import fails). The local secret + currentValue stores
+ * must already be populated (via `populateLocalStoresFromCollectionTree`
  * keyed by the same `_ref_id`s) so the UI can rehydrate values on read.
  */
 export const stripCollectionTreeForStore = (

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -1,4 +1,4 @@
-import type { HoppCollection } from "@hoppscotch/data"
+import { generateUniqueRefId, type HoppCollection } from "@hoppscotch/data"
 
 import { getService } from "../modules/dioc"
 import { CurrentValueService } from "../services/current-environment-value.service"
@@ -55,6 +55,16 @@ export const stripSecretVariableValuesForWire = <
  * Always writes to both stores when the entityId is non-empty (even when one
  * side has zero entries) so a re-import or re-save with fewer/no secrets
  * clears any stale entries from a previous version of the same entity.
+ *
+ * IMPORTANT — pre-stripped inputs: if `variables` already comes from a
+ * stripped source (a Hoppscotch JSON export, or a backend row reload), each
+ * `secret: true` entry will have `currentValue: ""` and `initialValue: ""`.
+ * Calling this with such inputs persists `""` as the secret value, and the
+ * UI shows blank fields after re-import. That matches the security posture
+ * (secrets never leave the source device, so reimporting can't recover
+ * them — users must re-enter them on each new device), but callers that
+ * expect values to survive re-import are misusing this helper. Pass the
+ * RAW user-authored variables here, before any wire-strip runs.
  */
 export const populateLocalStoresFromVariables = (
   entityId: string,
@@ -118,3 +128,36 @@ export const populateLocalStoresFromCollectionTree = (
   }
   ;(collection.folders ?? []).forEach(populateLocalStoresFromCollectionTree)
 }
+
+/**
+ * Walk a collection tree assigning a fresh `_ref_id` to any node that lacks
+ * one. Returns a deep-cloned tree (input is not mutated). Used at every
+ * import entry point before the wire strip / local-store populate runs, so
+ * the secret values are addressable by ref-id no matter which downstream
+ * branch (backend success, backend failure, logged-out append) executes.
+ */
+export const ensureRefIds = (collection: HoppCollection): HoppCollection => ({
+  ...collection,
+  _ref_id: collection._ref_id ?? generateUniqueRefId("coll"),
+  folders: (collection.folders ?? []).map(ensureRefIds),
+})
+
+/**
+ * Recursive variant of `stripSecretVariableValuesForWire` for a collection
+ * tree. Returns a deep-cloned tree with every node's `variables` array
+ * stripped (secret values blanked, non-secret `currentValue` cleared).
+ *
+ * Used wherever an imported tree is appended directly to newstore (the
+ * logged-out / no-platform-sync branch and the platform fallback when the
+ * backend bulk-import fails) so raw secrets don't sit in newstore /
+ * localStorage / future sync payloads. The local secret + currentValue
+ * stores must already be populated (via `populateLocalStoresFromCollectionTree`
+ * keyed by the same `_ref_id`s) so the UI can rehydrate values on read.
+ */
+export const stripCollectionTreeForStore = (
+  collection: HoppCollection
+): HoppCollection => ({
+  ...collection,
+  variables: stripSecretVariableValuesForWire(collection.variables ?? []),
+  folders: (collection.folders ?? []).map(stripCollectionTreeForStore),
+})

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -1,3 +1,5 @@
+import type { HoppCollection } from "@hoppscotch/data"
+
 import { getService } from "../modules/dioc"
 import { CurrentValueService } from "../services/current-environment-value.service"
 import { SecretEnvironmentService } from "../services/secret-environment.service"
@@ -50,13 +52,15 @@ export const stripSecretVariableValuesForWire = <
  * through the backend, so without this hook the user loses them on next
  * `setRESTCollections` / `replaceEnvironments` from a backend fetch.
  *
- * No-ops for empty inputs so callers can apply it unconditionally.
+ * Always writes to both stores when the entityId is non-empty (even when one
+ * side has zero entries) so a re-import or re-save with fewer/no secrets
+ * clears any stale entries from a previous version of the same entity.
  */
 export const populateLocalStoresFromVariables = (
   entityId: string,
   variables: readonly SecretCapableVariable[]
 ) => {
-  if (!entityId || variables.length === 0) return
+  if (!entityId) return
 
   const secretEnvironmentService = getService(SecretEnvironmentService)
   const currentEnvironmentValueService = getService(CurrentValueService)
@@ -87,10 +91,30 @@ export const populateLocalStoresFromVariables = (
       : []
   )
 
-  if (secrets.length > 0) {
-    secretEnvironmentService.addSecretEnvironment(entityId, secrets)
+  secretEnvironmentService.addSecretEnvironment(entityId, secrets)
+  currentEnvironmentValueService.addEnvironment(entityId, nonSecrets)
+}
+
+/**
+ * Recursive variant of `populateLocalStoresFromVariables` for a HoppCollection
+ * tree (collection + nested folders). Walks the tree and populates the local
+ * stores for every node that has a `_ref_id`.
+ *
+ * Used at import-time entry points BEFORE the wire strip runs, so that even
+ * the logged-out / no-platform-sync branch (which skips
+ * `translateToPersonalCollectionFormat`) preserves user-supplied secret +
+ * currentValue inputs in the local stores. On subsequent login + sync, the
+ * wire payload is stripped but the secret store still has the values keyed
+ * by the same `_ref_id` that round-trips through the backend `data` blob.
+ */
+export const populateLocalStoresFromCollectionTree = (
+  collection: HoppCollection
+) => {
+  if (collection._ref_id) {
+    populateLocalStoresFromVariables(
+      collection._ref_id,
+      collection.variables ?? []
+    )
   }
-  if (nonSecrets.length > 0) {
-    currentEnvironmentValueService.addEnvironment(entityId, nonSecrets)
-  }
+  ;(collection.folders ?? []).forEach(populateLocalStoresFromCollectionTree)
 }

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -233,3 +233,35 @@ export const repopulateLoadedCollectionTree = (
     repopulateLoadedCollectionTree(loadedFolder, originalsByRefId)
   })
 }
+
+/**
+ * Walk a collection tree and flush every node's entries from both local
+ * stores. Called when a collection or folder is deleted — without this,
+ * descendant secret + currentValue entries (keyed by each node's `_ref_id`
+ * for personal workspaces, `id` for team workspaces) orphan in memory and
+ * a future entity that happens to land on the same key would surface
+ * stale data.
+ *
+ * Flushes by BOTH `_ref_id` and `id` when present — services no-op on
+ * missing keys, so this safely covers personal (keyed by `_ref_id`) and
+ * team (keyed by backend `id`) workspaces with one helper.
+ */
+export const flushLocalStoresForCollectionTree = (
+  collection: HoppCollection
+) => {
+  const secretEnvironmentService = getService(SecretEnvironmentService)
+  const currentEnvironmentValueService = getService(CurrentValueService)
+
+  const walk = (node: HoppCollection) => {
+    if (node._ref_id) {
+      secretEnvironmentService.deleteSecretEnvironment(node._ref_id)
+      currentEnvironmentValueService.deleteEnvironment(node._ref_id)
+    }
+    if (node.id) {
+      secretEnvironmentService.deleteSecretEnvironment(node.id)
+      currentEnvironmentValueService.deleteEnvironment(node.id)
+    }
+    ;(node.folders ?? []).forEach(walk)
+  }
+  walk(collection)
+}

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -32,6 +32,22 @@ export const stripSecretVariableValuesForWire = <
  *
  * IMPORTANT: pass RAW (pre-strip) inputs. A stripped variable has empty
  * `initialValue` / `currentValue` and will persist as blank.
+ *
+ * ─── `??` vs `||` — read before "fixing" this ───
+ * Both branches below use `??` so an explicit `""` is preserved. This is
+ * the correct semantic for the REHYDRATION path (`""` means "user
+ * deliberately cleared" — must not be resurrected from `initialValue`).
+ *
+ * For the IMPORT path, `""` means "stripped on wire" and the real value
+ * lives in `initialValue`. That gap is bridged at the import-site
+ * boundary by `promoteInitialValueForImport` (called from
+ * `populateLocalStoresFromCollectionTree`, `repopulateLoadedCollectionTree`,
+ * and the env-import callers in `environments/ImportExport.vue`).
+ *
+ * Do not switch these to `||` — that re-introduces the rehydration
+ * regression for both secrets and non-secrets. If a new import path
+ * silently stores blanks, the fix is to route it through
+ * `promoteInitialValueForImport` upstream, not to change this function.
  */
 export const populateLocalStoresFromVariables = (
   entityId: string,
@@ -47,14 +63,6 @@ export const populateLocalStoresFromVariables = (
       ? [
           {
             key: v.key,
-            // `??` (not `||`) so an explicit `""` is preserved across
-            // both calling contexts: in rehydration it means "user
-            // deliberately cleared"; in import it means "importer didn't
-            // supply a value." Fallback to `initialValue` only fires for
-            // nullish `currentValue` (legacy `hoppEnv` shape).
-            // Postman/Insomnia collection imports promote
-            // `initialValue` → `currentValue` upstream via
-            // `promoteSecretInitialValueForImport`.
             value: v.currentValue ?? v.initialValue ?? "",
             initialValue: v.initialValue ?? "",
             varIndex: index,
@@ -68,9 +76,6 @@ export const populateLocalStoresFromVariables = (
       ? [
           {
             key: v.key,
-            // Fall back to `initialValue` ONLY when `currentValue` is
-            // absent — `""` is a meaningful "user cleared this" value
-            // and must be preserved.
             currentValue: v.currentValue ?? v.initialValue ?? "",
             varIndex: index,
             isSecret: false as const,
@@ -84,19 +89,22 @@ export const populateLocalStoresFromVariables = (
 }
 
 /**
- * Foreign-import convention normalizer: `postman.ts`,
- * `insomnia/insomniaColl.ts`, and legacy Hoppscotch env exports put the
- * secret in `initialValue` with `currentValue: ""` (so the wire payload
- * stays clean). Promote so the secret service stores the imported value.
+ * Foreign-import convention normalizer for BOTH secret and non-secret
+ * variables. The wire strip blanks `currentValue` for everything and (for
+ * secrets) `initialValue`; non-secret `initialValue` is preserved. So a
+ * Hoppscotch / Postman / Insomnia exported file lands with
+ * `currentValue: ""` and (for non-secrets) `initialValue: "value"`. Promote
+ * so the local stores see the imported value.
+ *
  * The global-env rehydration path bypasses this step intentionally — there
  * `""` means "user deliberately cleared," not "value lives in initialValue."
  * Idempotent — promoted entries are unchanged on a second pass.
  */
-export const promoteSecretInitialValueForImport = (
+export const promoteInitialValueForImport = (
   variables: readonly SecretCapableVariable[]
 ): SecretCapableVariable[] =>
   variables.map((v) =>
-    v.secret && !v.currentValue && v.initialValue
+    !v.currentValue && v.initialValue
       ? { ...v, currentValue: v.initialValue }
       : v
   )
@@ -107,7 +115,7 @@ export const populateLocalStoresFromCollectionTree = (
   if (collection._ref_id) {
     populateLocalStoresFromVariables(
       collection._ref_id,
-      promoteSecretInitialValueForImport(collection.variables ?? [])
+      promoteInitialValueForImport(collection.variables ?? [])
     )
   } else {
     // All current callers run `ensureRefIds` upstream so this should be
@@ -166,7 +174,7 @@ export const repopulateLoadedCollectionTree = (
       // still carries the secret in `initialValue` with `currentValue: ""`.
       populateLocalStoresFromVariables(
         loaded._ref_id,
-        promoteSecretInitialValueForImport(original.variables ?? [])
+        promoteInitialValueForImport(original.variables ?? [])
       )
     }
   }

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -47,7 +47,12 @@ export const populateLocalStoresFromVariables = (
       ? [
           {
             key: v.key,
-            value: v.currentValue ?? "",
+            // Fall back to `initialValue` when `currentValue` is empty —
+            // a fresh JSON-import carries the secret in `initialValue`
+            // with `currentValue` blanked by the wire/export strip.
+            // Without the fallback the UI would render blank immediately
+            // after import even though the value was in the file.
+            value: v.currentValue || v.initialValue || "",
             initialValue: v.initialValue ?? "",
             varIndex: index,
           },

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -118,9 +118,15 @@ export const populateLocalStoresFromCollectionTree = (
       promoteInitialValueForImport(collection.variables ?? [])
     )
   } else {
-    // All current callers run `ensureRefIds` upstream so this should be
-    // unreachable; the warn exists so a future caller that skips it is
-    // debuggable instead of silently dropping secret values.
+    // All current callers of THIS function run `ensureRefIds` upstream
+    // so this should be unreachable; the warn exists so a future caller
+    // that skips it is debuggable instead of silently dropping secrets.
+    // Scope note: the equivalent "missing ref-id" case on the
+    // backstop-repopulate path is NOT covered here —
+    // `repopulateLoadedCollectionTree` calls `populateLocalStoresFromVariables`
+    // directly and bypasses this branch. That gap is covered by the
+    // `unpairedCount` warning in
+    // `selfhost-web/.../web/import.ts:importToPersonalWorkspace`.
     console.warn(
       "[populateLocalStoresFromCollectionTree] collection has no `_ref_id`; secret values will not be persisted locally",
       collection.name

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -93,7 +93,14 @@ export const populateLocalStoresFromVariables = (
       ? [
           {
             key: v.key,
-            currentValue: v.currentValue ?? "",
+            // Fall back to `initialValue` when `currentValue` is empty.
+            // Hoppscotch's own JSON export blanks `currentValue` for ALL
+            // variables (per the runtime/persisted split), so without this
+            // a re-import of the user's own export would show blank
+            // current-value fields. Limited to non-secrets — secrets stay
+            // strict so the "can't recover from re-import" security claim
+            // in the JSDoc above continues to hold for `secret: true`.
+            currentValue: v.currentValue || v.initialValue || "",
             varIndex: index,
             isSecret: false as const,
           },

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -54,7 +54,7 @@ export const populateLocalStoresFromVariables = (
             // nullish `currentValue` (legacy `hoppEnv` shape).
             // Postman/Insomnia collection imports promote
             // `initialValue` → `currentValue` upstream via
-            // `promoteSecretInitialValueForCollection`.
+            // `promoteSecretInitialValueForImport`.
             value: v.currentValue ?? v.initialValue ?? "",
             initialValue: v.initialValue ?? "",
             varIndex: index,
@@ -84,15 +84,15 @@ export const populateLocalStoresFromVariables = (
 }
 
 /**
- * Foreign-collection-import convention: `postman.ts` and
- * `insomnia/insomniaColl.ts` put the secret in `initialValue` with
- * `currentValue: ""` (so the wire payload stays clean). Promote so the secret
- * service stores the imported value. Env importers set both fields and call
- * `populateLocalStoresFromVariables` directly — they bypass this step, as
- * does the global-env rehydration path (which must preserve user clears).
+ * Foreign-import convention normalizer: `postman.ts`,
+ * `insomnia/insomniaColl.ts`, and legacy Hoppscotch env exports put the
+ * secret in `initialValue` with `currentValue: ""` (so the wire payload
+ * stays clean). Promote so the secret service stores the imported value.
+ * The global-env rehydration path bypasses this step intentionally — there
+ * `""` means "user deliberately cleared," not "value lives in initialValue."
  * Idempotent — promoted entries are unchanged on a second pass.
  */
-const promoteSecretInitialValueForCollection = (
+export const promoteSecretInitialValueForImport = (
   variables: readonly SecretCapableVariable[]
 ): SecretCapableVariable[] =>
   variables.map((v) =>
@@ -107,7 +107,7 @@ export const populateLocalStoresFromCollectionTree = (
   if (collection._ref_id) {
     populateLocalStoresFromVariables(
       collection._ref_id,
-      promoteSecretInitialValueForCollection(collection.variables ?? [])
+      promoteSecretInitialValueForImport(collection.variables ?? [])
     )
   } else {
     // All current callers run `ensureRefIds` upstream so this should be
@@ -166,7 +166,7 @@ export const repopulateLoadedCollectionTree = (
       // still carries the secret in `initialValue` with `currentValue: ""`.
       populateLocalStoresFromVariables(
         loaded._ref_id,
-        promoteSecretInitialValueForCollection(original.variables ?? [])
+        promoteSecretInitialValueForImport(original.variables ?? [])
       )
     }
   }

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -4,11 +4,7 @@ import { getService } from "../modules/dioc"
 import { CurrentValueService } from "../services/current-environment-value.service"
 import { SecretEnvironmentService } from "../services/secret-environment.service"
 
-/**
- * Structural shape shared by Hoppscotch's collection variables and
- * environment variables. Both carry a `secret` flag; both are persisted
- * server-side via JSON blobs.
- */
+/** Shape shared by collection and environment variables. */
 type SecretCapableVariable = {
   key: string
   initialValue: string
@@ -17,16 +13,8 @@ type SecretCapableVariable = {
 }
 
 /**
- * Strip the values of secret variables before sending them to the backend.
- * Used at the wire boundary for both collection variables and environment
- * variables. The user's actual secret values stay in the local secret store
- * (see `secretEnvironmentService`); only the slot — `key` and `secret: true`
- * — survives onto the wire so the UI can still render it.
- *
- * `currentValue` is also cleared on all (non-secret) variables to match the
- * existing Hoppscotch convention that `currentValue` is per-user/per-session
- * state and never persisted server-side.
- *
+ * Clear `initialValue` for secrets and `currentValue` for all variables
+ * before the wire write. Raw values live only in the local secret store.
  */
 export const stripSecretVariableValuesForWire = <
   T extends SecretCapableVariable,
@@ -40,31 +28,10 @@ export const stripSecretVariableValuesForWire = <
   }))
 
 /**
- * Populate the local secret store and current-value store from a variables
- * array, keyed by the entity's local ID. Mirrors what `setCollectionProperties`
- * and `saveEnvironment` do on UI-edit save: extract `secret: true` entries to
- * `secretEnvironmentService`, extract `currentValue` for non-secret entries to
- * `currentEnvironmentValueService`.
+ * Seed the local secret + currentValue stores from raw variables.
  *
- * Required for any code path that ingests user-authored variables WITHOUT
- * going through the UI save flow — imports, duplicates, restore-from-file —
- * because the wire-strip removes the values from the payload that round-trips
- * through the backend, so without this hook the user loses them on next
- * `setRESTCollections` / `replaceEnvironments` from a backend fetch.
- *
- * Always writes to both stores when the entityId is non-empty (even when one
- * side has zero entries) so a re-import or re-save with fewer/no secrets
- * clears any stale entries from a previous version of the same entity.
- *
- * IMPORTANT — pre-stripped inputs: if `variables` already comes from a
- * stripped source (a Hoppscotch JSON export, or a backend row reload), each
- * `secret: true` entry will have `currentValue: ""` and `initialValue: ""`.
- * Calling this with such inputs persists `""` as the secret value, and the
- * UI shows blank fields after re-import. That matches the security posture
- * (secrets never leave the source device, so reimporting can't recover
- * them — users must re-enter them on each new device), but callers that
- * expect values to survive re-import are misusing this helper. Pass the
- * RAW user-authored variables here, before any wire-strip runs.
+ * IMPORTANT: pass RAW (pre-strip) inputs. A stripped variable has empty
+ * `initialValue` / `currentValue` and will persist as blank.
  */
 export const populateLocalStoresFromVariables = (
   entityId: string,
@@ -93,13 +60,8 @@ export const populateLocalStoresFromVariables = (
       ? [
           {
             key: v.key,
-            // Fall back to `initialValue` when `currentValue` is empty.
-            // Hoppscotch's own JSON export blanks `currentValue` for ALL
-            // variables (per the runtime/persisted split), so without this
-            // a re-import of the user's own export would show blank
-            // current-value fields. Limited to non-secrets — secrets stay
-            // strict so the "can't recover from re-import" security claim
-            // in the JSDoc above continues to hold for `secret: true`.
+            // Fall back to `initialValue` — Hoppscotch's own JSON export
+            // blanks `currentValue` on every variable. Secrets stay strict.
             currentValue: v.currentValue || v.initialValue || "",
             varIndex: index,
             isSecret: false as const,
@@ -112,18 +74,6 @@ export const populateLocalStoresFromVariables = (
   currentEnvironmentValueService.addEnvironment(entityId, nonSecrets)
 }
 
-/**
- * Recursive variant of `populateLocalStoresFromVariables` for a HoppCollection
- * tree (collection + nested folders). Walks the tree and populates the local
- * stores for every node that has a `_ref_id`.
- *
- * Used at import-time entry points BEFORE the wire strip runs, so that even
- * the logged-out / no-platform-sync branch (which skips
- * `translateToPersonalCollectionFormat`) preserves user-supplied secret +
- * currentValue inputs in the local stores. On subsequent login + sync, the
- * wire payload is stripped but the secret store still has the values keyed
- * by the same `_ref_id` that round-trips through the backend `data` blob.
- */
 export const populateLocalStoresFromCollectionTree = (
   collection: HoppCollection
 ) => {
@@ -136,50 +86,14 @@ export const populateLocalStoresFromCollectionTree = (
   ;(collection.folders ?? []).forEach(populateLocalStoresFromCollectionTree)
 }
 
-/**
- * Walk a collection tree assigning a fresh `_ref_id` to any node that lacks
- * one. Returns a new tree with fresh node objects and new `folders` arrays
- * at every level — but `variables`, `requests`, `auth`, `headers`, etc.
- * still reference the original input arrays/objects (NOT a deep clone).
- *
- * This shallow-per-node behavior is enough for the import pipeline: the
- * downstream `stripSecretVariableValuesForWire` reallocates each node's
- * `variables` array, and `populateLocalStoresFromCollectionTree` is
- * read-only. Callers that intend to mutate non-folder fields after
- * stamping ref-ids must clone those fields themselves; this helper does
- * not protect against shared aliasing into the original graph.
- *
- * Used at every import entry point before the wire strip / local-store
- * populate runs, so secret values are addressable by ref-id no matter
- * which downstream branch (backend success, backend failure, logged-out
- * append) executes.
- */
+/** Fresh node objects + `folders` arrays; other fields alias the input. */
 export const ensureRefIds = (collection: HoppCollection): HoppCollection => ({
   ...collection,
   _ref_id: collection._ref_id ?? generateUniqueRefId("coll"),
   folders: (collection.folders ?? []).map(ensureRefIds),
 })
 
-/**
- * Recursive variant of `stripSecretVariableValuesForWire` for a collection
- * tree. Returns a new tree with fresh node objects, fresh `variables`
- * arrays (every variable replaced via the strip), and fresh `folders`
- * arrays at every level — but `requests`, `auth`, `headers`, and the
- * script/description fields still reference the original input objects
- * (NOT a deep clone).
- *
- * This is sufficient for the strip's purpose (no raw secret values
- * land in newstore / localStorage / future sync payloads, since secrets
- * live only inside `variables` and that's the field we reallocate).
- * Callers that intend to mutate non-`variables` fields on the returned
- * tree must clone those fields themselves.
- *
- * Used wherever an imported tree is appended directly to newstore (the
- * logged-out / no-platform-sync branch and the platform fallback when the
- * backend bulk-import fails). The local secret + currentValue stores
- * must already be populated (via `populateLocalStoresFromCollectionTree`
- * keyed by the same `_ref_id`s) so the UI can rehydrate values on read.
- */
+/** Reallocates `variables` and `folders`; other fields alias the input. */
 export const stripCollectionTreeForStore = (
   collection: HoppCollection
 ): HoppCollection => ({
@@ -188,15 +102,7 @@ export const stripCollectionTreeForStore = (
   folders: (collection.folders ?? []).map(stripCollectionTreeForStore),
 })
 
-/**
- * Build a flat `_ref_id → collection` index across an entire collection
- * tree (root + nested folders). Used post-import to pair backend-returned
- * collections with their pre-walked originals by stable ref-id rather
- * than by array position, since the backend is free to reorder.
- *
- * Mutates `out` in place (avoids allocating an intermediate per call,
- * since the caller typically wants a single map for the whole tree).
- */
+/** Flat `_ref_id → collection` index across a tree. Mutates `out`. */
 export const indexCollectionsByRefId = (
   collections: HoppCollection[],
   out: Map<string, HoppCollection>
@@ -208,16 +114,8 @@ export const indexCollectionsByRefId = (
 }
 
 /**
- * Walk a backend-loaded collection tree and re-populate the local secret +
- * currentValue stores from the matching original (pre-walked) tree. Pairs
- * each loaded node to its original by `_ref_id` (looked up in the flat map
- * built by `indexCollectionsByRefId`). Skips nodes without a `_ref_id`
- * (matches the prior index-based path's behavior for missing keys).
- *
- * Why ref-id, not array index: the backend may reorder collections during
- * a bulk import. An index-based pairing would re-key secrets onto the
- * wrong collection. `_ref_id` round-trips through `data._ref_id` so the
- * lookup is stable.
+ * Re-seed local stores after bulk-import using `_ref_id` (round-tripped
+ * via `data._ref_id`) instead of array index — backend may reorder.
  */
 export const repopulateLoadedCollectionTree = (
   loaded: HoppCollection,
@@ -235,16 +133,8 @@ export const repopulateLoadedCollectionTree = (
 }
 
 /**
- * Walk a collection tree and flush every node's entries from both local
- * stores. Called when a collection or folder is deleted — without this,
- * descendant secret + currentValue entries (keyed by each node's `_ref_id`
- * for personal workspaces, `id` for team workspaces) orphan in memory and
- * a future entity that happens to land on the same key would surface
- * stale data.
- *
- * Flushes by BOTH `_ref_id` and `id` when present — services no-op on
- * missing keys, so this safely covers personal (keyed by `_ref_id`) and
- * team (keyed by backend `id`) workspaces with one helper.
+ * Flush every node's local-store entries on delete. Flushes by both
+ * `_ref_id` (personal) and `id` (team); services no-op on missing keys.
  */
 export const flushLocalStoresForCollectionTree = (
   collection: HoppCollection

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -47,12 +47,15 @@ export const populateLocalStoresFromVariables = (
       ? [
           {
             key: v.key,
-            // `||` is intentional: an explicit `""` currentValue means
-            // the secret was stripped on export; fall through to
-            // `initialValue` so a Postman/JSON import where the value
-            // lives there isn't silently blank. Non-secrets use `??`
-            // below to preserve deliberate clears.
-            value: v.currentValue || v.initialValue || "",
+            // Symmetric with non-secrets below: `??` (not `||`) so an
+            // explicit `""` currentValue is preserved — a deliberate
+            // user clear must not be resurrected from `initialValue` on
+            // rehydration. Fallback only kicks in when `currentValue` is
+            // nullish (e.g. legacy `hoppEnv` import without the field).
+            // Confirmed importers (Postman/Insomnia/hopp v2 migration)
+            // already set both fields, so the fallback never fires for
+            // them anyway.
+            value: v.currentValue ?? v.initialValue ?? "",
             initialValue: v.initialValue ?? "",
             varIndex: index,
           },
@@ -84,10 +87,20 @@ export const populateLocalStoresFromCollectionTree = (
   collection: HoppCollection
 ) => {
   if (collection._ref_id) {
-    populateLocalStoresFromVariables(
-      collection._ref_id,
-      collection.variables ?? []
+    // Foreign-collection-import convention: `postman.ts` and
+    // `insomnia/insomniaColl.ts` put the secret in `initialValue` with
+    // `currentValue: ""` (so the wire payload stays clean). Promote here so
+    // the secret service stores the imported value. Env importers
+    // (`postmanEnv`, `insomniaEnv`) set both fields and call
+    // `populateLocalStoresFromVariables` directly, so they bypass this step
+    // — and the global-env rehydration path (which must preserve user-clears)
+    // does too.
+    const normalized = (collection.variables ?? []).map((v) =>
+      v.secret && !v.currentValue && v.initialValue
+        ? { ...v, currentValue: v.initialValue }
+        : v
     )
+    populateLocalStoresFromVariables(collection._ref_id, normalized)
   }
   ;(collection.folders ?? []).forEach(populateLocalStoresFromCollectionTree)
 }

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -83,24 +83,32 @@ export const populateLocalStoresFromVariables = (
   currentEnvironmentValueService.addEnvironment(entityId, nonSecrets)
 }
 
+/**
+ * Foreign-collection-import convention: `postman.ts` and
+ * `insomnia/insomniaColl.ts` put the secret in `initialValue` with
+ * `currentValue: ""` (so the wire payload stays clean). Promote so the secret
+ * service stores the imported value. Env importers set both fields and call
+ * `populateLocalStoresFromVariables` directly — they bypass this step, as
+ * does the global-env rehydration path (which must preserve user clears).
+ * Idempotent — promoted entries are unchanged on a second pass.
+ */
+const promoteSecretInitialValueForCollection = (
+  variables: readonly SecretCapableVariable[]
+): SecretCapableVariable[] =>
+  variables.map((v) =>
+    v.secret && !v.currentValue && v.initialValue
+      ? { ...v, currentValue: v.initialValue }
+      : v
+  )
+
 export const populateLocalStoresFromCollectionTree = (
   collection: HoppCollection
 ) => {
   if (collection._ref_id) {
-    // Foreign-collection-import convention: `postman.ts` and
-    // `insomnia/insomniaColl.ts` put the secret in `initialValue` with
-    // `currentValue: ""` (so the wire payload stays clean). Promote here so
-    // the secret service stores the imported value. Env importers
-    // (`postmanEnv`, `insomniaEnv`) set both fields and call
-    // `populateLocalStoresFromVariables` directly, so they bypass this step
-    // — and the global-env rehydration path (which must preserve user-clears)
-    // does too.
-    const normalized = (collection.variables ?? []).map((v) =>
-      v.secret && !v.currentValue && v.initialValue
-        ? { ...v, currentValue: v.initialValue }
-        : v
+    populateLocalStoresFromVariables(
+      collection._ref_id,
+      promoteSecretInitialValueForCollection(collection.variables ?? [])
     )
-    populateLocalStoresFromVariables(collection._ref_id, normalized)
   }
   ;(collection.folders ?? []).forEach(populateLocalStoresFromCollectionTree)
 }
@@ -143,7 +151,13 @@ export const repopulateLoadedCollectionTree = (
   if (loaded._ref_id) {
     const original = originalsByRefId.get(loaded._ref_id)
     if (original) {
-      populateLocalStoresFromVariables(loaded._ref_id, original.variables ?? [])
+      // Same promote as `populateLocalStoresFromCollectionTree` — `original`
+      // is the pre-strip input tree, which for Postman/Insomnia imports
+      // still carries the secret in `initialValue` with `currentValue: ""`.
+      populateLocalStoresFromVariables(
+        loaded._ref_id,
+        promoteSecretInitialValueForCollection(original.variables ?? [])
+      )
     }
   }
   ;(loaded.folders ?? []).forEach((loadedFolder) => {
@@ -171,6 +185,59 @@ export const flushLocalStoresForCollectionTree = (
       currentEnvironmentValueService.deleteEnvironment(node.id)
     }
     ;(node.folders ?? []).forEach(walk)
+  }
+  walk(collection)
+}
+
+/**
+ * Flush local-store entries keyed by `_ref_id`s in `tree` that aren't
+ * present in `keptRefIds`. Used after `repopulateLoadedCollectionTree`
+ * to clean up orphans on old SH backends that drop the `data._ref_id`
+ * round-trip — upstream populate seeded entries under originals' refIds
+ * that the loaded tree (with fresh UUIDs) can't reach.
+ */
+export const flushUnmatchedRefIdsFromTree = (
+  tree: HoppCollection[],
+  keptRefIds: ReadonlySet<string>
+) => {
+  const secretEnvironmentService = getService(SecretEnvironmentService)
+  const currentEnvironmentValueService = getService(CurrentValueService)
+
+  const walk = (nodes: HoppCollection[]) => {
+    nodes.forEach((node) => {
+      if (node._ref_id && !keptRefIds.has(node._ref_id)) {
+        secretEnvironmentService.deleteSecretEnvironment(node._ref_id)
+        currentEnvironmentValueService.deleteEnvironment(node._ref_id)
+      }
+      walk(node.folders ?? [])
+    })
+  }
+  walk(tree)
+}
+
+/**
+ * Recursive flush for a team-collection subtree. Walks `children` (not
+ * `folders` — different shape from `HoppCollection`) and deletes each
+ * descendant's secret/current entries by backend `id`. Without this,
+ * deleting a team collection leaves nested folders' secrets orphaned in
+ * the secret service.
+ */
+export const flushLocalStoresForTeamCollectionTree = (collection: {
+  id: string
+  children: { id: string; children: unknown }[] | null | undefined
+}) => {
+  const secretEnvironmentService = getService(SecretEnvironmentService)
+  const currentEnvironmentValueService = getService(CurrentValueService)
+
+  const walk = (node: {
+    id: string
+    children: { id: string; children: unknown }[] | null | undefined
+  }) => {
+    secretEnvironmentService.deleteSecretEnvironment(node.id)
+    currentEnvironmentValueService.deleteEnvironment(node.id)
+    ;(node.children ?? []).forEach(
+      walk as (n: { id: string; children: unknown }) => void
+    )
   }
   walk(collection)
 }

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -47,14 +47,14 @@ export const populateLocalStoresFromVariables = (
       ? [
           {
             key: v.key,
-            // Symmetric with non-secrets below: `??` (not `||`) so an
-            // explicit `""` currentValue is preserved — a deliberate
-            // user clear must not be resurrected from `initialValue` on
-            // rehydration. Fallback only kicks in when `currentValue` is
-            // nullish (e.g. legacy `hoppEnv` import without the field).
-            // Confirmed importers (Postman/Insomnia/hopp v2 migration)
-            // already set both fields, so the fallback never fires for
-            // them anyway.
+            // `??` (not `||`) so an explicit `""` is preserved across
+            // both calling contexts: in rehydration it means "user
+            // deliberately cleared"; in import it means "importer didn't
+            // supply a value." Fallback to `initialValue` only fires for
+            // nullish `currentValue` (legacy `hoppEnv` shape).
+            // Postman/Insomnia collection imports promote
+            // `initialValue` → `currentValue` upstream via
+            // `promoteSecretInitialValueForCollection`.
             value: v.currentValue ?? v.initialValue ?? "",
             initialValue: v.initialValue ?? "",
             varIndex: index,
@@ -151,6 +151,8 @@ export const indexCollectionsByRefId = (
 /**
  * Re-seed local stores after bulk-import using `_ref_id` (round-tripped
  * via `data._ref_id`) instead of array index — backend may reorder.
+ * Assumes the backend preserves `data._ref_id` at EVERY level (root +
+ * nested folders); unpaired nodes fall through to `flushUnmatchedRefIdsFromTree`.
  */
 export const repopulateLoadedCollectionTree = (
   loaded: HoppCollection,

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -47,11 +47,11 @@ export const populateLocalStoresFromVariables = (
       ? [
           {
             key: v.key,
-            // Fall back to `initialValue` when `currentValue` is empty —
-            // a fresh JSON-import carries the secret in `initialValue`
-            // with `currentValue` blanked by the wire/export strip.
-            // Without the fallback the UI would render blank immediately
-            // after import even though the value was in the file.
+            // `||` is intentional: an explicit `""` currentValue means
+            // the secret was stripped on export; fall through to
+            // `initialValue` so a Postman/JSON import where the value
+            // lives there isn't silently blank. Non-secrets use `??`
+            // below to preserve deliberate clears.
             value: v.currentValue || v.initialValue || "",
             initialValue: v.initialValue ?? "",
             varIndex: index,

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -109,6 +109,14 @@ export const populateLocalStoresFromCollectionTree = (
       collection._ref_id,
       promoteSecretInitialValueForCollection(collection.variables ?? [])
     )
+  } else {
+    // All current callers run `ensureRefIds` upstream so this should be
+    // unreachable; the warn exists so a future caller that skips it is
+    // debuggable instead of silently dropping secret values.
+    console.warn(
+      "[populateLocalStoresFromCollectionTree] collection has no `_ref_id`; secret values will not be persisted locally",
+      collection.name
+    )
   }
   ;(collection.folders ?? []).forEach(populateLocalStoresFromCollectionTree)
 }
@@ -222,22 +230,21 @@ export const flushUnmatchedRefIdsFromTree = (
  * deleting a team collection leaves nested folders' secrets orphaned in
  * the secret service.
  */
-export const flushLocalStoresForTeamCollectionTree = (collection: {
+type TeamCollectionNode = {
   id: string
-  children: { id: string; children: unknown }[] | null | undefined
-}) => {
+  children: TeamCollectionNode[] | null | undefined
+}
+
+export const flushLocalStoresForTeamCollectionTree = (
+  collection: TeamCollectionNode
+) => {
   const secretEnvironmentService = getService(SecretEnvironmentService)
   const currentEnvironmentValueService = getService(CurrentValueService)
 
-  const walk = (node: {
-    id: string
-    children: { id: string; children: unknown }[] | null | undefined
-  }) => {
+  const walk = (node: TeamCollectionNode) => {
     secretEnvironmentService.deleteSecretEnvironment(node.id)
     currentEnvironmentValueService.deleteEnvironment(node.id)
-    ;(node.children ?? []).forEach(
-      walk as (n: { id: string; children: unknown }) => void
-    )
+    ;(node.children ?? []).forEach(walk)
   }
   walk(collection)
 }

--- a/packages/hoppscotch-common/src/helpers/secretVariables.ts
+++ b/packages/hoppscotch-common/src/helpers/secretVariables.ts
@@ -60,9 +60,10 @@ export const populateLocalStoresFromVariables = (
       ? [
           {
             key: v.key,
-            // Fall back to `initialValue` — Hoppscotch's own JSON export
-            // blanks `currentValue` on every variable. Secrets stay strict.
-            currentValue: v.currentValue || v.initialValue || "",
+            // Fall back to `initialValue` ONLY when `currentValue` is
+            // absent — `""` is a meaningful "user cleared this" value
+            // and must be preserved.
+            currentValue: v.currentValue ?? v.initialValue ?? "",
             varIndex: index,
             isSecret: false as const,
           },

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -1155,13 +1155,28 @@ const gqlCollectionDispatchers = defineDispatchers({
     if (collection) {
       const name = `${collection.name} - ${t("action.duplicate")}`
 
-      const duplicatedCollection = {
+      // Re-stamp `_ref_id` recursively so the duplicate doesn't alias the
+      // original's local secret-store entries — sharing a `_ref_id` would
+      // mean editing secrets on the duplicate mutates the source. Mirrors
+      // the REST `duplicateCollection` dispatcher above.
+      function recursiveChangeRefIdToAvoidConflicts(
+        coll: HoppCollection
+      ): HoppCollection {
+        const next = {
+          ...coll,
+          _ref_id: generateUniqueRefId("coll"),
+        }
+        next.folders = next.folders.map(recursiveChangeRefIdToAvoidConflicts)
+        return next
+      }
+
+      const duplicatedCollection = recursiveChangeRefIdToAvoidConflicts({
         ...cloneDeep(collection),
         name,
         ...(collection.id
           ? { id: `${collection.id}-duplicate-collection` }
           : {}),
-      }
+      })
 
       if (isRootCollection) {
         newState.push(duplicatedCollection)

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -695,7 +695,7 @@ const restCollectionDispatchers = defineDispatchers({
           _ref_id: generateUniqueRefId("coll"),
         }
 
-        newCollection.folders = newCollection.folders.map((folder) =>
+        newCollection.folders = (newCollection.folders ?? []).map((folder) =>
           recursiveChangeRefIdToAvoidConflicts(folder)
         )
 
@@ -1166,7 +1166,9 @@ const gqlCollectionDispatchers = defineDispatchers({
           ...coll,
           _ref_id: generateUniqueRefId("coll"),
         }
-        next.folders = next.folders.map(recursiveChangeRefIdToAvoidConflicts)
+        next.folders = (next.folders ?? []).map(
+          recursiveChangeRefIdToAvoidConflicts
+        )
         return next
       }
 

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -309,8 +309,20 @@ const dispatchers = defineDispatchers({
     }
   },
   setGlobalVariables(_, { entries }: { entries: GlobalEnvironment }) {
+    // Defensive normalization at the wire-into-store boundary. The
+    // dispatcher payload type says `GlobalEnvironment` (`{ v, variables }`)
+    // but TS dispatchers are erased to `any` at runtime, and a malformed
+    // value from a backend schema change, persistence-layer corruption, or
+    // a future caller would otherwise corrupt `state.globals` and crash
+    // every consumer of `globalEnv.variables.map(...)` downstream. Coerce
+    // to a valid v2 wrapper here so the store invariant always holds.
+    const safeEntries: GlobalEnvironment = Array.isArray(entries)
+      ? { v: 2, variables: entries }
+      : entries && Array.isArray(entries.variables)
+        ? entries
+        : { v: 2, variables: [] }
     return {
-      globals: entries,
+      globals: safeEntries,
     }
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -469,8 +481,7 @@ export const aggregateEnvs$: Observable<AggregateEnvironment[]> = combineLatest(
         })
       }
     })
-
-    globalEnv.variables.forEach((variable) => {
+    ;(globalEnv?.variables ?? []).forEach((variable) => {
       const { key, secret } = variable
       const currentValue =
         "currentValue" in variable ? variable.currentValue : ""
@@ -663,8 +674,7 @@ export const aggregateEnvsWithCurrentValue$: Observable<
           sourceEnv: selectedEnv.name,
         })
       })
-
-      globalEnv.variables.map((x, index) => {
+      ;(globalEnv?.variables ?? []).map((x, index) => {
         let currentValue = x.currentValue
         let initialValue = x.initialValue
         if (x.secret) {
@@ -749,7 +759,11 @@ export function getLegacyGlobalEnvironment(): Environment | null {
 }
 
 export function getGlobalVariables(): GlobalEnvironmentVariable[] {
-  return environmentsStore.value.globals.variables.map(
+  // Defensive `?? []` — the dispatcher normalizes `state.globals` to a
+  // valid wrapper, but if state somehow ended up corrupt (e.g. before
+  // a normalization fix shipped), we'd rather return an empty list than
+  // crash every consumer of this function.
+  return (environmentsStore.value.globals?.variables ?? []).map(
     (env: GlobalEnvironmentVariable) => {
       if (env.key && "currentValue" in env && !("secret" in env)) {
         return {

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -14,6 +14,7 @@ import DispatchingStore, {
 } from "~/newstore/DispatchingStore"
 import { CurrentValueService } from "~/services/current-environment-value.service"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
+import { coerceGlobalEnvironment } from "~/helpers/globalEnvShape"
 
 export type SelectedEnvironmentIndex =
   | { type: "NO_ENV_SELECTED" }
@@ -309,20 +310,13 @@ const dispatchers = defineDispatchers({
     }
   },
   setGlobalVariables(_, { entries }: { entries: GlobalEnvironment }) {
-    // Defensive normalization at the wire-into-store boundary. The
-    // dispatcher payload type says `GlobalEnvironment` (`{ v, variables }`)
-    // but TS dispatchers are erased to `any` at runtime, and a malformed
-    // value from a backend schema change, persistence-layer corruption, or
-    // a future caller would otherwise corrupt `state.globals` and crash
-    // every consumer of `globalEnv.variables.map(...)` downstream. Coerce
-    // to a valid v2 wrapper here so the store invariant always holds.
-    const safeEntries: GlobalEnvironment = Array.isArray(entries)
-      ? { v: 2, variables: entries }
-      : entries && Array.isArray(entries.variables)
-        ? entries
-        : { v: 2, variables: [] }
+    // Defensive normalization at the wire-into-store boundary. TS
+    // dispatchers are erased to `any` at runtime, and a malformed value
+    // from a backend schema change, persistence-layer corruption, or a
+    // future caller would otherwise corrupt `state.globals` and crash
+    // every consumer of `globalEnv.variables.map(...)` downstream.
     return {
-      globals: safeEntries,
+      globals: coerceGlobalEnvironment(entries),
     }
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -589,7 +583,12 @@ export function getAggregateEnvsWithCurrentValue() {
             currentEnv.id,
             index
           ) ?? currentValue,
-        initialValue: x.initialValue ?? initialValue,
+        // For stripped secret vars `x.initialValue` is `""` (non-nullish),
+        // so `x.initialValue ?? initialValue` would pin the empty string
+        // and bypass the secret-store hydration above. The local
+        // `initialValue` already encodes both branches: secret-store value
+        // for secrets, raw `x.initialValue` for non-secrets.
+        initialValue,
         secret: x.secret,
         sourceEnv: currentEnv.name,
       }
@@ -617,7 +616,7 @@ export function getAggregateEnvsWithCurrentValue() {
             "Global",
             index
           ) ?? currentValue,
-        initialValue: x.initialValue ?? initialValue,
+        initialValue,
         secret: x.secret,
         sourceEnv: "Global",
       }
@@ -669,7 +668,10 @@ export const aggregateEnvsWithCurrentValue$: Observable<
               selectedEnv.id,
               index
             ) ?? currentValue,
-          initialValue: x.initialValue ?? initialValue,
+          // See note on `aggregateEnvs$` above — `x.initialValue` is `""`
+          // for stripped secrets so `??` would discard the secret-store
+          // hydration. The local `initialValue` is already correct.
+          initialValue,
           secret: x.secret,
           sourceEnv: selectedEnv.name,
         })
@@ -697,7 +699,7 @@ export const aggregateEnvsWithCurrentValue$: Observable<
               "Global",
               index
             ) ?? currentValue,
-          initialValue: x.initialValue ?? initialValue,
+          initialValue,
           secret: x.secret,
           sourceEnv: "Global",
         })

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -310,11 +310,8 @@ const dispatchers = defineDispatchers({
     }
   },
   setGlobalVariables(_, { entries }: { entries: GlobalEnvironment }) {
-    // Defensive normalization at the wire-into-store boundary. TS
-    // dispatchers are erased to `any` at runtime, and a malformed value
-    // from a backend schema change, persistence-layer corruption, or a
-    // future caller would otherwise corrupt `state.globals` and crash
-    // every consumer of `globalEnv.variables.map(...)` downstream.
+    // Coerce at the wire-into-store boundary — TS dispatchers are erased
+    // at runtime; a malformed value would corrupt `state.globals`.
     return {
       globals: coerceGlobalEnvironment(entries),
     }
@@ -583,11 +580,8 @@ export function getAggregateEnvsWithCurrentValue() {
             currentEnv.id,
             index
           ) ?? currentValue,
-        // For stripped secret vars `x.initialValue` is `""` (non-nullish),
-        // so `x.initialValue ?? initialValue` would pin the empty string
-        // and bypass the secret-store hydration above. The local
-        // `initialValue` already encodes both branches: secret-store value
-        // for secrets, raw `x.initialValue` for non-secrets.
+        // Use the local resolved value — `x.initialValue ?? initialValue`
+        // would pin `""` for stripped secrets and skip the store hydration.
         initialValue,
         secret: x.secret,
         sourceEnv: currentEnv.name,
@@ -668,9 +662,7 @@ export const aggregateEnvsWithCurrentValue$: Observable<
               selectedEnv.id,
               index
             ) ?? currentValue,
-          // See note on `aggregateEnvs$` above — `x.initialValue` is `""`
-          // for stripped secrets so `??` would discard the secret-store
-          // hydration. The local `initialValue` is already correct.
+          // Use the local resolved value — see note on `aggregateEnvs$`.
           initialValue,
           secret: x.secret,
           sourceEnv: selectedEnv.name,

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -645,7 +645,7 @@ export const aggregateEnvsWithCurrentValue$: Observable<
         })
       })
 
-      selectedEnv?.variables.map((x, index) => {
+      selectedEnv?.variables.forEach((x, index) => {
         let currentValue = x.currentValue
         let initialValue = x.initialValue
         if (x.secret) {
@@ -676,7 +676,7 @@ export const aggregateEnvsWithCurrentValue$: Observable<
           sourceEnv: selectedEnv.name,
         })
       })
-      ;(globalEnv?.variables ?? []).map((x, index) => {
+      ;(globalEnv?.variables ?? []).forEach((x, index) => {
         let currentValue = x.currentValue
         let initialValue = x.initialValue
         if (x.secret) {

--- a/packages/hoppscotch-common/src/pages/import.vue
+++ b/packages/hoppscotch-common/src/pages/import.vue
@@ -14,6 +14,11 @@ import * as E from "fp-ts/Either"
 import { pipe } from "fp-ts/function"
 import { HoppCollection } from "@hoppscotch/data"
 import { appendRESTCollections } from "~/newstore/collections"
+import {
+  ensureRefIds,
+  populateLocalStoresFromCollectionTree,
+  stripCollectionTreeForStore,
+} from "~/helpers/secretVariables"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
 import { IMPORTER_INVALID_FILE_FORMAT } from "~/helpers/import-export/import"
@@ -111,7 +116,14 @@ const handleImportFailure = (error: ImportCollectionsError) => {
 }
 
 const handleImportSuccess = (collections: HoppCollection[]) => {
-  appendRESTCollections(collections)
+  // Mirror the modal-import path: stamp `_ref_id`s, persist any raw
+  // secret values to the local secret store, then append the stripped
+  // tree to newstore so localStorage / future syncs stay clean.
+  const withRefIds = collections.map(ensureRefIds)
+
+  withRefIds.forEach(populateLocalStoresFromCollectionTree)
+  appendRESTCollections(withRefIds.map(stripCollectionTreeForStore))
+
   toast.success(t("import.import_from_url_success").toString())
 }
 

--- a/packages/hoppscotch-common/src/services/current-environment-value.service.ts
+++ b/packages/hoppscotch-common/src/services/current-environment-value.service.ts
@@ -128,10 +128,17 @@ export class CurrentValueService extends Service {
    * Used while syncing with the server.
    * @param oldID old ID of the environment
    * @param newID new ID of the environment
+   *
+   * Skip the `set` when there's nothing to migrate — otherwise an empty
+   * array would be written under `newID` and silently clobber any entry
+   * a prior operation already keyed there. The `delete(oldID)` still
+   * runs unconditionally to clean up regardless.
    */
   public updateEnvironmentID(oldID: string, newID: string) {
     const vars = this.getEnvironment(oldID)
-    this.environments.set(newID, vars || [])
+    if (vars !== undefined) {
+      this.environments.set(newID, vars)
+    }
     this.environments.delete(oldID)
   }
 

--- a/packages/hoppscotch-common/src/services/current-environment-value.service.ts
+++ b/packages/hoppscotch-common/src/services/current-environment-value.service.ts
@@ -124,15 +124,8 @@ export class CurrentValueService extends Service {
   }
 
   /**
-   * Used to update the ID of a environment.
-   * Used while syncing with the server.
-   * @param oldID old ID of the environment
-   * @param newID new ID of the environment
-   *
-   * Skip the `set` when there's nothing to migrate — otherwise an empty
-   * array would be written under `newID` and silently clobber any entry
-   * a prior operation already keyed there. The `delete(oldID)` still
-   * runs unconditionally to clean up regardless.
+   * Migrate entries from `oldID` to `newID`. Skips the `set` when nothing
+   * exists under `oldID` so a no-op migrate doesn't clobber `newID`.
    */
   public updateEnvironmentID(oldID: string, newID: string) {
     const vars = this.getEnvironment(oldID)

--- a/packages/hoppscotch-common/src/services/current-environment-value.service.ts
+++ b/packages/hoppscotch-common/src/services/current-environment-value.service.ts
@@ -128,6 +128,9 @@ export class CurrentValueService extends Service {
    * exists under `oldID` so a no-op migrate doesn't clobber `newID`.
    */
   public updateEnvironmentID(oldID: string, newID: string) {
+    // No-op when keys match — otherwise the get→set→delete sequence would
+    // erase the just-written entry.
+    if (oldID === newID) return
     const vars = this.getEnvironment(oldID)
     if (vars !== undefined) {
       this.environments.set(newID, vars)

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -119,10 +119,17 @@ export class SecretEnvironmentService extends Service {
    * Used while syncing with the server.
    * @param oldID old ID of the environment
    * @param newID new ID of the environment
+   *
+   * Skip the `set` when there's nothing to migrate — otherwise an empty
+   * array would be written under `newID` and silently clobber any entry
+   * a prior operation already keyed there. The `delete(oldID)` still
+   * runs unconditionally to clean up regardless.
    */
   public updateSecretEnvironmentID(oldID: string, newID: string) {
     const secretVars = this.getSecretEnvironment(oldID)
-    this.secretEnvironments.set(newID, secretVars || [])
+    if (secretVars !== undefined) {
+      this.secretEnvironments.set(newID, secretVars)
+    }
     this.secretEnvironments.delete(oldID)
   }
 

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -115,15 +115,8 @@ export class SecretEnvironmentService extends Service {
   }
 
   /**
-   * Used to update the ID of a secret environment.
-   * Used while syncing with the server.
-   * @param oldID old ID of the environment
-   * @param newID new ID of the environment
-   *
-   * Skip the `set` when there's nothing to migrate — otherwise an empty
-   * array would be written under `newID` and silently clobber any entry
-   * a prior operation already keyed there. The `delete(oldID)` still
-   * runs unconditionally to clean up regardless.
+   * Migrate entries from `oldID` to `newID`. Skips the `set` when nothing
+   * exists under `oldID` so a no-op migrate doesn't clobber `newID`.
    */
   public updateSecretEnvironmentID(oldID: string, newID: string) {
     const secretVars = this.getSecretEnvironment(oldID)

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -119,9 +119,8 @@ export class SecretEnvironmentService extends Service {
    * exists under `oldID` so a no-op migrate doesn't clobber `newID`.
    */
   public updateSecretEnvironmentID(oldID: string, newID: string) {
-    // No-op when keys match — otherwise the get→set→delete sequence would
-    // erase the just-written entry. Also short-circuits the spurious
-    // `delete` call when nothing exists under `oldID`.
+    // No-op when keys match — without this guard the get→set→delete
+    // sequence would erase the just-written entry for `oldID === newID`.
     if (oldID === newID) return
     const secretVars = this.getSecretEnvironment(oldID)
     if (secretVars !== undefined) {

--- a/packages/hoppscotch-common/src/services/secret-environment.service.ts
+++ b/packages/hoppscotch-common/src/services/secret-environment.service.ts
@@ -119,6 +119,10 @@ export class SecretEnvironmentService extends Service {
    * exists under `oldID` so a no-op migrate doesn't clobber `newID`.
    */
   public updateSecretEnvironmentID(oldID: string, newID: string) {
+    // No-op when keys match — otherwise the get→set→delete sequence would
+    // erase the just-written entry. Also short-circuits the spurious
+    // `delete` call when nothing exists under `oldID`.
+    if (oldID === newID) return
     const secretVars = this.getSecretEnvironment(oldID)
     if (secretVars !== undefined) {
       this.secretEnvironments.set(newID, secretVars)

--- a/packages/hoppscotch-common/src/services/team-collection.service.ts
+++ b/packages/hoppscotch-common/src/services/team-collection.service.ts
@@ -310,6 +310,10 @@ export class TeamCollectionsService extends Service<void> {
     this.collections.value = [...tree]
   }
 
+  // Relies on the backend preserving `data._ref_id` at every level —
+  // each nested folder's `teamCollectionAdded` event must carry its own
+  // `data._ref_id` for migration to fire. A backend that drops nested
+  // `data` would leave per-folder entries orphaned under `_ref_id`.
   private migrateImportedSecretEntries(collection: TeamCollection) {
     if (!collection.data) return
     try {

--- a/packages/hoppscotch-common/src/services/team-collection.service.ts
+++ b/packages/hoppscotch-common/src/services/team-collection.service.ts
@@ -174,6 +174,16 @@ export class TeamCollectionsService extends Service<void> {
   }
 
   /**
+   * Look up a `TeamCollection` subtree by backend `id` in the current tree.
+   * Useful before a delete mutation so callers can capture the subtree for
+   * recursive cleanup (e.g. flushing nested secret-store entries) without
+   * racing the delete subscription.
+   */
+  public findCollectionByID(id: string): TeamCollection | null {
+    return findCollInTree(this.collections.value, id)
+  }
+
+  /**
    * Watches for loading collections and updates inherited properties once loading is done
    */
   private collectionLoadingWatcher() {
@@ -288,10 +298,36 @@ export class TeamCollectionsService extends Service<void> {
       }
     }
 
+    // Migrate device-local secret entries seeded by `importToTeamsWorkspace`
+    // under the importer-stamped `_ref_id` to the backend-assigned `id`.
+    // No-op on devices that didn't seed (migration helpers skip when
+    // nothing exists under the old key).
+    this.migrateImportedSecretEntries(collection)
+
     // Add to entity ids set
     this.entityIDs.add(`collection-${collection.id}`)
 
     this.collections.value = [...tree]
+  }
+
+  private migrateImportedSecretEntries(collection: TeamCollection) {
+    if (!collection.data) return
+    try {
+      const parsed = JSON.parse(collection.data) as { _ref_id?: unknown }
+      if (typeof parsed._ref_id !== "string" || !parsed._ref_id) return
+      this.secretEnvironmentService.updateSecretEnvironmentID(
+        parsed._ref_id,
+        collection.id
+      )
+      this.currentEnvironmentValueService.updateEnvironmentID(
+        parsed._ref_id,
+        collection.id
+      )
+    } catch {
+      // Malformed `data` — skip migration; the secret service stays
+      // keyed by `_ref_id` and the imported secrets aren't accessible
+      // via the team `id`. Rare; only happens on a malformed backend.
+    }
   }
 
   /**

--- a/packages/hoppscotch-data/src/global-environment/index.ts
+++ b/packages/hoppscotch-data/src/global-environment/index.ts
@@ -10,8 +10,10 @@ const versionedObject = z.object({
   v: z.number(),
 })
 
+export const GLOBAL_ENV_LATEST_VERSION = 2 as const
+
 export const GlobalEnvironment = createVersionedEntity({
-  latestVersion: 2,
+  latestVersion: GLOBAL_ENV_LATEST_VERSION,
   versionMap: {
     0: V0_VERSION,
     1: V1_VERSION,

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/gqlCollections.sync.ts
@@ -14,6 +14,8 @@ import {
   HoppRESTRequest,
 } from "@hoppscotch/data"
 
+import { stripSecretVariableValuesForWire } from "@hoppscotch/common/helpers/secretVariables"
+
 import { getSyncInitFunction, type StoreSyncDefinitionOf } from "@app/lib/sync"
 
 import { createMapper } from "@app/lib/sync/mapper"
@@ -43,7 +45,7 @@ const transformCollectionForBackend = (collection: HoppCollection): any => {
       authActive: true,
     },
     headers: collection.headers ?? [],
-    variables: collection.variables ?? [],
+    variables: stripSecretVariableValuesForWire(collection.variables ?? []),
     _ref_id: collection._ref_id,
     description: collection.description ?? null,
     preRequestScript: collection.preRequestScript ?? "",
@@ -80,7 +82,7 @@ const recursivelySyncCollections = async (
         authActive: true,
       },
       headers: collection.headers ?? [],
-      variables: collection.variables ?? [],
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -134,7 +136,7 @@ const recursivelySyncCollections = async (
         authActive: true,
       },
       headers: collection.headers ?? [],
-      variables: collection.variables ?? [],
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -287,7 +289,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const data = {
       auth: collection.auth,
       headers: collection.headers,
-      variables: collection.variables,
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -336,7 +338,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const data = {
       auth: folder.auth,
       headers: folder.headers,
-      variables: folder.variables,
+      variables: stripSecretVariableValuesForWire(folder.variables ?? []),
       _ref_id: folder._ref_id,
       description: folder.description ?? null,
       preRequestScript: folder.preRequestScript ?? "",

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/sync.ts
@@ -15,6 +15,8 @@ import {
   HoppRESTRequest,
 } from "@hoppscotch/data"
 
+import { stripSecretVariableValuesForWire } from "@hoppscotch/common/helpers/secretVariables"
+
 import { getSyncInitFunction, StoreSyncDefinitionOf } from "@app/lib/sync"
 import { createMapper } from "@app/lib/sync/mapper"
 import {
@@ -45,7 +47,7 @@ const transformCollectionForBackend = (collection: HoppCollection): any => {
       authActive: true,
     },
     headers: collection.headers ?? [],
-    variables: collection.variables ?? [],
+    variables: stripSecretVariableValuesForWire(collection.variables ?? []),
     _ref_id: collection._ref_id,
     description: collection.description ?? null,
     preRequestScript: collection.preRequestScript ?? "",
@@ -82,7 +84,7 @@ const recursivelySyncCollections = async (
         authActive: true,
       },
       headers: collection.headers ?? [],
-      variables: collection.variables ?? [],
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -131,7 +133,7 @@ const recursivelySyncCollections = async (
         authActive: true,
       },
       headers: collection.headers ?? [],
-      variables: collection.variables ?? [],
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -280,7 +282,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const data = {
       auth: collection.auth,
       headers: collection.headers,
-      variables: collection.variables,
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -365,7 +367,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const data = {
       auth: folder.auth,
       headers: folder.headers,
-      variables: folder.variables,
+      variables: stripSecretVariableValuesForWire(folder.variables ?? []),
       _ref_id: folder._ref_id,
       description: folder.description ?? null,
       preRequestScript: folder.preRequestScript ?? "",

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/gqlCollections.sync.ts
@@ -270,7 +270,10 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const lastCreatedCollectionIndex =
       graphqlCollectionStore.value.state.length - 1
 
-    recursivelySyncCollections(collection, `${lastCreatedCollectionIndex}`)
+    await recursivelySyncCollections(
+      collection,
+      `${lastCreatedCollectionIndex}`
+    )
   },
   async removeCollection({ collectionID }) {
     if (collectionID) {

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/gqlCollections.sync.ts
@@ -14,6 +14,8 @@ import {
   HoppRESTRequest,
 } from "@hoppscotch/data"
 
+import { stripSecretVariableValuesForWire } from "@hoppscotch/common/helpers/secretVariables"
+
 import { getSyncInitFunction, type StoreSyncDefinitionOf } from "@app/lib/sync"
 
 import { createMapper } from "@app/lib/sync/mapper"
@@ -43,7 +45,7 @@ const transformCollectionForBackend = (collection: HoppCollection): any => {
       authActive: true,
     },
     headers: collection.headers ?? [],
-    variables: collection.variables ?? [],
+    variables: stripSecretVariableValuesForWire(collection.variables ?? []),
     _ref_id: collection._ref_id,
     description: collection.description ?? null,
     preRequestScript: collection.preRequestScript ?? "",
@@ -80,7 +82,7 @@ const recursivelySyncCollections = async (
         authActive: true,
       },
       headers: collection.headers ?? [],
-      variables: collection.variables ?? [],
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -134,7 +136,7 @@ const recursivelySyncCollections = async (
         authActive: true,
       },
       headers: collection.headers ?? [],
-      variables: collection.variables ?? [],
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -268,10 +270,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const lastCreatedCollectionIndex =
       graphqlCollectionStore.value.state.length - 1
 
-    await recursivelySyncCollections(
-      collection,
-      `${lastCreatedCollectionIndex}`
-    )
+    recursivelySyncCollections(collection, `${lastCreatedCollectionIndex}`)
   },
   async removeCollection({ collectionID }) {
     if (collectionID) {
@@ -287,7 +286,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const data = {
       auth: collection.auth,
       headers: collection.headers,
-      variables: collection.variables,
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -336,7 +335,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const data = {
       auth: folder.auth,
       headers: folder.headers,
-      variables: folder.variables,
+      variables: stripSecretVariableValuesForWire(folder.variables ?? []),
       _ref_id: folder._ref_id,
       description: folder.description ?? null,
       preRequestScript: folder.preRequestScript ?? "",

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -3,8 +3,11 @@ import {
   appendGraphqlCollections,
   appendRESTCollections,
 } from "@hoppscotch/common/newstore/collections"
-import { CollectionDataProps } from "@hoppscotch/common/helpers/backend/helpers"
 import { HoppCollection } from "@hoppscotch/data"
+import {
+  populateLocalStoresFromVariables,
+  stripSecretVariableValuesForWire,
+} from "@hoppscotch/common/helpers/secretVariables"
 import * as E from "fp-ts/Either"
 import {
   exportedCollectionToHoppCollection,
@@ -61,14 +64,23 @@ export const appendCollectionsToStore = (
 }
 
 export function translateToPersonalCollectionFormat(x: HoppCollection) {
+  // Save the user's secret + currentValue inputs into the local stores BEFORE
+  // they're stripped from the wire payload. Without this, the user loses
+  // their imported secrets on the next backend round-trip (the synced row
+  // overwrites local newstore via `setRESTCollections`).
+  if (x._ref_id) {
+    populateLocalStoresFromVariables(x._ref_id, x.variables ?? [])
+  }
+
   const folders: HoppCollection[] = (x.folders ?? []).map(
     translateToPersonalCollectionFormat
   )
 
-  const data: CollectionDataProps = {
+  const data = {
     auth: x.auth,
     headers: x.headers,
-    variables: x.variables,
+    variables: stripSecretVariableValuesForWire(x.variables ?? []),
+    _ref_id: x._ref_id,
     description: x.description,
     preRequestScript: x.preRequestScript ?? "",
     testScript: x.testScript ?? "",

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -5,7 +5,10 @@ import {
 } from "@hoppscotch/common/newstore/collections"
 import { generateUniqueRefId, HoppCollection } from "@hoppscotch/data"
 import {
+  ensureRefIds,
+  populateLocalStoresFromCollectionTree,
   populateLocalStoresFromVariables,
+  stripCollectionTreeForStore,
   stripSecretVariableValuesForWire,
 } from "@hoppscotch/common/helpers/secretVariables"
 import * as E from "fp-ts/Either"
@@ -24,8 +27,17 @@ export const importToPersonalWorkspace = async (
   collections: HoppCollection[],
   reqType: ReqType
 ) => {
+  // Stamp every node with a stable `_ref_id` and populate local stores
+  // BEFORE the wire-strip runs. This way the secret values are
+  // addressable by ref-id whether we end up taking the backend-success
+  // path or the local-fallback path below — the orphaned-secrets bug
+  // (local store keyed under temp ref-ids that the fallback's
+  // collections didn't carry) is impossible by construction.
+  const collectionsWithRefIds = collections.map(ensureRefIds)
+  collectionsWithRefIds.forEach(populateLocalStoresFromCollectionTree)
+
   try {
-    const transformedCollection = collections.map((collection) =>
+    const transformedCollection = collectionsWithRefIds.map((collection) =>
       translateToPersonalCollectionFormat(collection)
     )
 
@@ -42,16 +54,16 @@ export const importToPersonalWorkspace = async (
           : "GQL"
       )
 
-      // Defensive re-populate: pair the post-load collections (which carry
-      // the backend-assigned IDs and whatever `_ref_id` survived the
-      // round-trip) with the originals (which retain raw secret values),
-      // walked in parallel by index. If `data._ref_id` round-tripped
-      // cleanly the keys match the translate-time populate (idempotent
-      // replace); if for any reason the round-trip dropped or rewrote
-      // `_ref_id`, this re-keys the local secret store under the loaded
-      // collection's actual `_ref_id` so the read path finds it.
+      // Defensive re-populate: pair the post-load collections (which
+      // carry the backend-assigned IDs and whatever `_ref_id` survived
+      // the round-trip) with the originals (which retain raw secret
+      // values), walked in parallel by index. If `data._ref_id`
+      // round-tripped cleanly the keys match the pre-walk populate
+      // (idempotent replace); if for any reason the round-trip dropped
+      // or rewrote `_ref_id`, this re-keys the local secret store
+      // under the loaded collection's actual `_ref_id`.
       loaded.forEach((loadedColl, i) => {
-        const original = collections[i]
+        const original = collectionsWithRefIds[i]
         if (original) {
           repopulateLoadedCollectionTree(loadedColl, original)
         }
@@ -59,11 +71,19 @@ export const importToPersonalWorkspace = async (
 
       return E.right({ success: true })
     }
-    // Backend import failed, fall back to local storage
-    return appendCollectionsToStore(collections, reqType)
+    // Backend import failed — append a stripped tree to newstore so raw
+    // secret values don't sit in the store / localStorage / future sync
+    // payloads. Raw values remain in the local secret + currentValue
+    // stores, keyed by the same `_ref_id`s populated above.
+    return appendCollectionsToStore(
+      collectionsWithRefIds.map(stripCollectionTreeForStore),
+      reqType
+    )
   } catch {
-    // On any error, fall back to local storage
-    return appendCollectionsToStore(collections, reqType)
+    return appendCollectionsToStore(
+      collectionsWithRefIds.map(stripCollectionTreeForStore),
+      reqType
+    )
   }
 }
 

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -35,12 +35,28 @@ export const importToPersonalWorkspace = async (
     )
 
     if (E.isRight(res)) {
-      await loadImportedUserCollections(
+      const loaded = await loadImportedUserCollections(
         res.right.importUserCollectionsFromJSON.exportedCollection,
         res.right.importUserCollectionsFromJSON.collectionType === "REST"
           ? "REST"
           : "GQL"
       )
+
+      // Defensive re-populate: pair the post-load collections (which carry
+      // the backend-assigned IDs and whatever `_ref_id` survived the
+      // round-trip) with the originals (which retain raw secret values),
+      // walked in parallel by index. If `data._ref_id` round-tripped
+      // cleanly the keys match the translate-time populate (idempotent
+      // replace); if for any reason the round-trip dropped or rewrote
+      // `_ref_id`, this re-keys the local secret store under the loaded
+      // collection's actual `_ref_id` so the read path finds it.
+      loaded.forEach((loadedColl, i) => {
+        const original = collections[i]
+        if (original) {
+          repopulateLoadedCollectionTree(loadedColl, original)
+        }
+      })
+
       return E.right({ success: true })
     }
     // Backend import failed, fall back to local storage
@@ -49,6 +65,21 @@ export const importToPersonalWorkspace = async (
     // On any error, fall back to local storage
     return appendCollectionsToStore(collections, reqType)
   }
+}
+
+const repopulateLoadedCollectionTree = (
+  loaded: HoppCollection,
+  original: HoppCollection
+) => {
+  if (loaded._ref_id) {
+    populateLocalStoresFromVariables(loaded._ref_id, original.variables ?? [])
+  }
+  ;(loaded.folders ?? []).forEach((loadedFolder, i) => {
+    const originalFolder = original.folders?.[i]
+    if (originalFolder) {
+      repopulateLoadedCollectionTree(loadedFolder, originalFolder)
+    }
+  })
 }
 
 export const appendCollectionsToStore = (
@@ -104,31 +135,28 @@ export function translateToPersonalCollectionFormat(x: HoppCollection) {
 export async function loadImportedUserCollections(
   collectionsJSONString: string,
   collectionType: "REST" | "GQL"
-) {
+): Promise<HoppCollection[]> {
   const importedCollections = (
     JSON.parse(collectionsJSONString) as Array<
       ExportedUserCollectionGQL | ExportedUserCollectionREST
     >
   ).map((collection) => ({ v: 1, ...collection }))
+
+  const hoppCollections = importedCollections.map(
+    (collection) =>
+      exportedCollectionToHoppCollection(
+        collection,
+        collectionType
+      ) as HoppCollection
+  )
+
   runDispatchWithOutSyncing(() => {
-    collectionType === "REST"
-      ? appendRESTCollections(
-          importedCollections.map(
-            (collection) =>
-              exportedCollectionToHoppCollection(
-                collection,
-                "REST"
-              ) as HoppCollection
-          )
-        )
-      : appendGraphqlCollections(
-          importedCollections.map(
-            (collection) =>
-              exportedCollectionToHoppCollection(
-                collection,
-                "GQL"
-              ) as HoppCollection
-          )
-        )
+    if (collectionType === "REST") {
+      appendRESTCollections(hoppCollections)
+    } else {
+      appendGraphqlCollections(hoppCollections)
+    }
   })
+
+  return hoppCollections
 }

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -3,7 +3,7 @@ import {
   appendGraphqlCollections,
   appendRESTCollections,
 } from "@hoppscotch/common/newstore/collections"
-import { HoppCollection } from "@hoppscotch/data"
+import { generateUniqueRefId, HoppCollection } from "@hoppscotch/data"
 import {
   populateLocalStoresFromVariables,
   stripSecretVariableValuesForWire,
@@ -64,13 +64,16 @@ export const appendCollectionsToStore = (
 }
 
 export function translateToPersonalCollectionFormat(x: HoppCollection) {
+  // Generate a `_ref_id` if missing — collections from local/non-synced
+  // workspaces may arrive without one, and we need a stable key for the
+  // local secret store both before and after the backend round-trip.
+  const refId = x._ref_id ?? generateUniqueRefId("coll")
+
   // Save the user's secret + currentValue inputs into the local stores BEFORE
   // they're stripped from the wire payload. Without this, the user loses
   // their imported secrets on the next backend round-trip (the synced row
   // overwrites local newstore via `setRESTCollections`).
-  if (x._ref_id) {
-    populateLocalStoresFromVariables(x._ref_id, x.variables ?? [])
-  }
+  populateLocalStoresFromVariables(refId, x.variables ?? [])
 
   const folders: HoppCollection[] = (x.folders ?? []).map(
     translateToPersonalCollectionFormat
@@ -80,12 +83,15 @@ export function translateToPersonalCollectionFormat(x: HoppCollection) {
     auth: x.auth,
     headers: x.headers,
     variables: stripSecretVariableValuesForWire(x.variables ?? []),
-    _ref_id: x._ref_id,
+    _ref_id: refId,
     description: x.description,
     preRequestScript: x.preRequestScript ?? "",
     testScript: x.testScript ?? "",
   }
 
+  // `_ref_id` lives inside `data` (which the backend persists and echoes
+  // back); the top-level field on the wire is ignored, so we don't write it
+  // here.
   const obj = {
     ...x,
     folders,

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -6,7 +6,8 @@ import {
 import { generateUniqueRefId, HoppCollection } from "@hoppscotch/data"
 import {
   ensureRefIds,
-  populateLocalStoresFromVariables,
+  indexCollectionsByRefId,
+  repopulateLoadedCollectionTree,
   stripCollectionTreeForStore,
   stripSecretVariableValuesForWire,
 } from "@hoppscotch/common/helpers/secretVariables"
@@ -88,34 +89,6 @@ export const importToPersonalWorkspace = async (
       reqType
     )
   }
-}
-
-// Builds a `_ref_id → original collection` index across the whole tree
-// so the post-load re-populate can pair by stable ref-id instead of by
-// array position (the backend can reorder).
-const indexCollectionsByRefId = (
-  collections: HoppCollection[],
-  out: Map<string, HoppCollection>
-) => {
-  collections.forEach((c) => {
-    if (c._ref_id) out.set(c._ref_id, c)
-    if (c.folders?.length) indexCollectionsByRefId(c.folders, out)
-  })
-}
-
-const repopulateLoadedCollectionTree = (
-  loaded: HoppCollection,
-  originalsByRefId: Map<string, HoppCollection>
-) => {
-  if (loaded._ref_id) {
-    const original = originalsByRefId.get(loaded._ref_id)
-    if (original) {
-      populateLocalStoresFromVariables(loaded._ref_id, original.variables ?? [])
-    }
-  }
-  ;(loaded.folders ?? []).forEach((loadedFolder) => {
-    repopulateLoadedCollectionTree(loadedFolder, originalsByRefId)
-  })
 }
 
 export const appendCollectionsToStore = (

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -6,11 +6,11 @@ import {
 import { generateUniqueRefId, HoppCollection } from "@hoppscotch/data"
 import {
   ensureRefIds,
-  populateLocalStoresFromCollectionTree,
   populateLocalStoresFromVariables,
   stripCollectionTreeForStore,
   stripSecretVariableValuesForWire,
 } from "@hoppscotch/common/helpers/secretVariables"
+import { CollectionDataProps } from "@hoppscotch/common/helpers/backend/helpers"
 import * as E from "fp-ts/Either"
 import {
   exportedCollectionToHoppCollection,
@@ -27,14 +27,17 @@ export const importToPersonalWorkspace = async (
   collections: HoppCollection[],
   reqType: ReqType
 ) => {
-  // Stamp every node with a stable `_ref_id` and populate local stores
-  // BEFORE the wire-strip runs. This way the secret values are
-  // addressable by ref-id whether we end up taking the backend-success
-  // path or the local-fallback path below — the orphaned-secrets bug
-  // (local store keyed under temp ref-ids that the fallback's
-  // collections didn't carry) is impossible by construction.
+  // CONTRACT: the caller (`components/collections/ImportExport.vue`) is
+  // expected to have already run `ensureRefIds` + `populateLocalStores
+  // FromCollectionTree` over the input. We re-stamp ref-ids here as a
+  // defensive idempotent backstop, but we DO NOT re-populate — the
+  // raw secret/currentValue values aren't on the input variables array
+  // at any later point in this function (the strip runs inside
+  // `translateToPersonalCollectionFormat`), so a populate here would
+  // either duplicate work or, if a future callsite forgets to populate
+  // upstream, silently lose the values. Keeping the populate at exactly
+  // one well-defined point avoids the implicit-ordering trap.
   const collectionsWithRefIds = collections.map(ensureRefIds)
-  collectionsWithRefIds.forEach(populateLocalStoresFromCollectionTree)
 
   try {
     const transformedCollection = collectionsWithRefIds.map((collection) =>
@@ -54,19 +57,19 @@ export const importToPersonalWorkspace = async (
           : "GQL"
       )
 
-      // Defensive re-populate: pair the post-load collections (which
-      // carry the backend-assigned IDs and whatever `_ref_id` survived
-      // the round-trip) with the originals (which retain raw secret
-      // values), walked in parallel by index. If `data._ref_id`
-      // round-tripped cleanly the keys match the pre-walk populate
-      // (idempotent replace); if for any reason the round-trip dropped
-      // or rewrote `_ref_id`, this re-keys the local secret store
-      // under the loaded collection's actual `_ref_id`.
-      loaded.forEach((loadedColl, i) => {
-        const original = collectionsWithRefIds[i]
-        if (original) {
-          repopulateLoadedCollectionTree(loadedColl, original)
-        }
+      // Defensive re-populate: pair post-load collections with their
+      // originals by `_ref_id` (not array index). The backend may
+      // reorder collections during bulk import; matching by index
+      // would re-key the wrong secret-store entry to the wrong
+      // collection's variables. Pre-walk stamps `_ref_id` and the
+      // `data._ref_id` blob round-trips it, so the pairing is stable
+      // by ref-id. If a node's `_ref_id` is missing (backend dropped
+      // it) the lookup returns no original and populate is skipped —
+      // matching the prior behavior of the index-based path.
+      const originalsByRefId = new Map<string, HoppCollection>()
+      indexCollectionsByRefId(collectionsWithRefIds, originalsByRefId)
+      loaded.forEach((loadedColl) => {
+        repopulateLoadedCollectionTree(loadedColl, originalsByRefId)
       })
 
       return E.right({ success: true })
@@ -87,18 +90,31 @@ export const importToPersonalWorkspace = async (
   }
 }
 
+// Builds a `_ref_id → original collection` index across the whole tree
+// so the post-load re-populate can pair by stable ref-id instead of by
+// array position (the backend can reorder).
+const indexCollectionsByRefId = (
+  collections: HoppCollection[],
+  out: Map<string, HoppCollection>
+) => {
+  collections.forEach((c) => {
+    if (c._ref_id) out.set(c._ref_id, c)
+    if (c.folders?.length) indexCollectionsByRefId(c.folders, out)
+  })
+}
+
 const repopulateLoadedCollectionTree = (
   loaded: HoppCollection,
-  original: HoppCollection
+  originalsByRefId: Map<string, HoppCollection>
 ) => {
   if (loaded._ref_id) {
-    populateLocalStoresFromVariables(loaded._ref_id, original.variables ?? [])
-  }
-  ;(loaded.folders ?? []).forEach((loadedFolder, i) => {
-    const originalFolder = original.folders?.[i]
-    if (originalFolder) {
-      repopulateLoadedCollectionTree(loadedFolder, originalFolder)
+    const original = originalsByRefId.get(loaded._ref_id)
+    if (original) {
+      populateLocalStoresFromVariables(loaded._ref_id, original.variables ?? [])
     }
+  }
+  ;(loaded.folders ?? []).forEach((loadedFolder) => {
+    repopulateLoadedCollectionTree(loadedFolder, originalsByRefId)
   })
 }
 
@@ -118,24 +134,30 @@ export function translateToPersonalCollectionFormat(x: HoppCollection) {
   // Generate a `_ref_id` if missing — collections from local/non-synced
   // workspaces may arrive without one, and we need a stable key for the
   // local secret store both before and after the backend round-trip.
+  //
+  // CONTRACT: this function does NOT populate the local secret /
+  // currentValue stores. The caller MUST do that upstream before
+  // invoking translate (see `components/collections/ImportExport.vue:
+  // importToPersonalWorkspace` which calls
+  // `populateLocalStoresFromCollectionTree` over the pre-walked tree).
+  // Doing it here would duplicate the populate that the caller already
+  // ran — and invite "implicit-ordering" hazards if the caller's data
+  // ever differs from `x.variables` after the strip below.
   const refId = x._ref_id ?? generateUniqueRefId("coll")
-
-  // Save the user's secret + currentValue inputs into the local stores BEFORE
-  // they're stripped from the wire payload. Without this, the user loses
-  // their imported secrets on the next backend round-trip (the synced row
-  // overwrites local newstore via `setRESTCollections`).
-  populateLocalStoresFromVariables(refId, x.variables ?? [])
 
   const folders: HoppCollection[] = (x.folders ?? []).map(
     translateToPersonalCollectionFormat
   )
 
-  const data = {
+  const data: CollectionDataProps = {
     auth: x.auth,
     headers: x.headers,
     variables: stripSecretVariableValuesForWire(x.variables ?? []),
+    // Lives inside `data` so it round-trips the backend — the top-level
+    // `_ref_id` on the wire is dropped, only `data._ref_id` is echoed
+    // back. Without it, the local secret store keys orphan on next load.
     _ref_id: refId,
-    description: x.description,
+    description: x.description ?? null,
     preRequestScript: x.preRequestScript ?? "",
     testScript: x.testScript ?? "",
   }

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -156,6 +156,11 @@ export function translateToPersonalCollectionFormat(x: HoppCollection) {
 
   return {
     ...x,
+    // Override the spread's top-level `variables` with the stripped copy
+    // — without this, the raw secret values would still travel in the
+    // HTTP body even though the backend only reads `data.variables`.
+    // Reuses `data.variables` so we don't strip twice.
+    variables: data.variables,
     folders,
     data,
   }

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -24,8 +24,10 @@ import { runDispatchWithOutSyncing } from "@app/lib/sync"
 /**
  * Platform-specific import for selfhost-web. Caller (`components/collections/
  * ImportExport.vue`) must have run `ensureRefIds` + `populateLocalStoresFromCollectionTree`
- * upstream — we re-stamp ref-ids defensively but do NOT re-populate (raw values
- * aren't on the variables array by the time the strip runs).
+ * upstream — we re-stamp ref-ids defensively. We never populate from the
+ * stripped wire payload (raw values are gone by then), but on backend
+ * success we re-seed local stores from the original (pre-strip) tree
+ * paired to the loaded tree by `_ref_id` via `repopulateLoadedCollectionTree`.
  */
 export const importToPersonalWorkspace = async (
   collections: HoppCollection[],

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -171,6 +171,10 @@ export async function loadImportedUserCollections(
     >
   ).map((collection) => ({ v: 1, ...collection }))
 
+  // NOTE: backend-returned objects whose variables have already been stripped
+  // (initialValue/currentValue cleared for secrets). Returned so callers can
+  // pair them back to originals by `_ref_id` for repopulation — do NOT pass
+  // these as the source of secret values.
   const hoppCollections = importedCollections.map(
     (collection) =>
       exportedCollectionToHoppCollection(

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -156,6 +156,12 @@ export function translateToPersonalCollectionFormat(x: HoppCollection) {
 
   return {
     ...x,
+    // Carry the resolved `refId` at top level too (not just inside `data`)
+    // so the post-translation object is internally consistent even when
+    // `x._ref_id` was missing on the input. Wire-irrelevant — backend
+    // only reads `data._ref_id` — but matches the invariant other code
+    // expects of a `HoppCollection`.
+    _ref_id: refId,
     // Override the spread's top-level `variables` with the stripped copy
     // — without this, the raw secret values would still travel in the
     // HTTP body even though the backend only reads `data.variables`.

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -23,12 +23,13 @@ import { importUserCollectionsFromJSON } from "./api"
 import { runDispatchWithOutSyncing } from "@app/lib/sync"
 
 /**
- * Platform-specific import for selfhost-web. Caller (`components/collections/
- * ImportExport.vue`) must have run `ensureRefIds` + `populateLocalStoresFromCollectionTree`
- * upstream — we re-stamp ref-ids defensively. We never populate from the
- * stripped wire payload (raw values are gone by then), but on backend
- * success we re-seed local stores from the original (pre-strip) tree
- * paired to the loaded tree by `_ref_id` via `repopulateLoadedCollectionTree`.
+ * Platform-specific import for selfhost-web. Self-contained — re-stamps
+ * ref-ids and repopulates local stores on both backend success (via
+ * `repopulateLoadedCollectionTree`, paired by `_ref_id`) and failure;
+ * never from the stripped wire payload (raw values are gone by then).
+ * The Vue caller normally pre-runs `ensureRefIds` +
+ * `populateLocalStoresFromCollectionTree` upstream too; the overlap is
+ * intentional defense-in-depth, not a caller contract.
  */
 export const importToPersonalWorkspace = async (
   collections: HoppCollection[],

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -6,6 +6,7 @@ import {
 import { generateUniqueRefId, HoppCollection } from "@hoppscotch/data"
 import {
   ensureRefIds,
+  flushUnmatchedRefIdsFromTree,
   indexCollectionsByRefId,
   populateLocalStoresFromCollectionTree,
   repopulateLoadedCollectionTree,
@@ -78,6 +79,21 @@ export const importToPersonalWorkspace = async (
       loaded.forEach((loadedColl) => {
         repopulateLoadedCollectionTree(loadedColl, originalsByRefId)
       })
+
+      // Flush orphans left under originals' refIds when the backend dropped
+      // `data._ref_id` for some nodes — their entries would otherwise
+      // accumulate in localStorage unreachable from the loaded tree. Runs
+      // AFTER `repopulateLoadedCollectionTree` so paired entries (re-seeded
+      // under their refIds) aren't deleted.
+      const loadedRefIds = new Set<string>()
+      const collectRefIds = (cs: HoppCollection[]) => {
+        cs.forEach((c) => {
+          if (c._ref_id) loadedRefIds.add(c._ref_id)
+          collectRefIds(c.folders ?? [])
+        })
+      }
+      collectRefIds(loaded)
+      flushUnmatchedRefIdsFromTree(collectionsWithRefIds, loadedRefIds)
 
       return E.right({ success: true })
     }

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -62,9 +62,7 @@ export const importToPersonalWorkspace = async (
 
       return E.right({ success: true })
     }
-    // Backend import failed — strip before appending so raw secrets don't
-    // sit in newstore. Raw values remain in the local secret stores keyed
-    // by `_ref_id`.
+    // Backend failed — raw values still live in local stores by `_ref_id`.
     return appendCollectionsToStore(
       collectionsWithRefIds.map(stripCollectionTreeForStore),
       reqType

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -7,6 +7,7 @@ import { generateUniqueRefId, HoppCollection } from "@hoppscotch/data"
 import {
   ensureRefIds,
   indexCollectionsByRefId,
+  populateLocalStoresFromCollectionTree,
   repopulateLoadedCollectionTree,
   stripCollectionTreeForStore,
   stripSecretVariableValuesForWire,
@@ -59,13 +60,17 @@ export const importToPersonalWorkspace = async (
       const originalsByRefId = new Map<string, HoppCollection>()
       indexCollectionsByRefId(collectionsWithRefIds, originalsByRefId)
 
-      // Warn once per import if any loaded root lacks `_ref_id` — likely a
-      // backend that dropped `data._ref_id` from the blob round-trip.
-      // Secret values for those nodes silently won't surface after reload.
-      if (loaded.some((c) => !c._ref_id)) {
+      // Warn once per import if any loaded root's `_ref_id` doesn't match
+      // an original — `exportedCollectionToHoppCollection` backfills
+      // missing ref-ids with fresh UUIDs, so we can't detect the
+      // round-trip failure via a null check. The miss-against-originals
+      // check catches both "backend dropped `data._ref_id`" and "backend
+      // returned a value we never sent."
+      if (loaded.some((c) => !c._ref_id || !originalsByRefId.has(c._ref_id))) {
         console.warn(
-          "[importToPersonalWorkspace] loaded collection(s) missing `_ref_id`; " +
-            "imported secret values may not persist across reload"
+          "[importToPersonalWorkspace] loaded collection(s) don't pair to " +
+            "originals by `_ref_id`; imported secret values may not persist " +
+            "across reload"
         )
       }
 
@@ -75,12 +80,19 @@ export const importToPersonalWorkspace = async (
 
       return E.right({ success: true })
     }
-    // Backend failed — raw values still live in local stores by `_ref_id`.
+    // Backend failed — defensively populate local stores from the raw
+    // (pre-strip) tree before appending the stripped tree to newstore.
+    // The canonical caller already populated upstream, so this is
+    // idempotent in the normal flow; it exists so a future caller that
+    // forgets the upstream populate doesn't silently lose secrets on
+    // backend failure.
+    collectionsWithRefIds.forEach(populateLocalStoresFromCollectionTree)
     return appendCollectionsToStore(
       collectionsWithRefIds.map(stripCollectionTreeForStore),
       reqType
     )
   } catch {
+    collectionsWithRefIds.forEach(populateLocalStoresFromCollectionTree)
     return appendCollectionsToStore(
       collectionsWithRefIds.map(stripCollectionTreeForStore),
       reqType

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -62,17 +62,35 @@ export const importToPersonalWorkspace = async (
       const originalsByRefId = new Map<string, HoppCollection>()
       indexCollectionsByRefId(collectionsWithRefIds, originalsByRefId)
 
-      // Warn once per import if any loaded root's `_ref_id` doesn't match
-      // an original — `exportedCollectionToHoppCollection` backfills
-      // missing ref-ids with fresh UUIDs, so we can't detect the
-      // round-trip failure via a null check. The miss-against-originals
-      // check catches both "backend dropped `data._ref_id`" and "backend
-      // returned a value we never sent."
-      if (loaded.some((c) => !c._ref_id || !originalsByRefId.has(c._ref_id))) {
+      // Collect ALL loaded ref-ids (root + nested folders) so the warning
+      // and the flush both detect nested-level round-trip failures —
+      // `exportedCollectionToHoppCollection` backfills missing
+      // `data._ref_id` with fresh UUIDs, so a root-only check would miss
+      // a buggy backend that dropped `_ref_id` for nested folders.
+      const loadedRefIds = new Set<string>()
+      const collectRefIds = (cs: HoppCollection[]) => {
+        cs.forEach((c) => {
+          if (c._ref_id) loadedRefIds.add(c._ref_id)
+          collectRefIds(c.folders ?? [])
+        })
+      }
+      collectRefIds(loaded)
+
+      let unpairedCount = 0
+      const countUnpaired = (cs: HoppCollection[]) => {
+        cs.forEach((c) => {
+          if (c._ref_id && !loadedRefIds.has(c._ref_id)) unpairedCount++
+          countUnpaired(c.folders ?? [])
+        })
+      }
+      countUnpaired(collectionsWithRefIds)
+
+      if (unpairedCount > 0) {
         console.warn(
-          "[importToPersonalWorkspace] loaded collection(s) don't pair to " +
-            "originals by `_ref_id`; imported secret values may not persist " +
-            "across reload"
+          `[importToPersonalWorkspace] ${unpairedCount} collection node(s) ` +
+            `did not pair to originals by \`_ref_id\` (backend likely dropped ` +
+            `\`data._ref_id\` at those levels); imported secret values for ` +
+            `those nodes will not persist and need to be re-entered.`
         )
       }
 
@@ -85,14 +103,6 @@ export const importToPersonalWorkspace = async (
       // accumulate in localStorage unreachable from the loaded tree. Runs
       // AFTER `repopulateLoadedCollectionTree` so paired entries (re-seeded
       // under their refIds) aren't deleted.
-      const loadedRefIds = new Set<string>()
-      const collectRefIds = (cs: HoppCollection[]) => {
-        cs.forEach((c) => {
-          if (c._ref_id) loadedRefIds.add(c._ref_id)
-          collectRefIds(c.folders ?? [])
-        })
-      }
-      collectRefIds(loaded)
       flushUnmatchedRefIdsFromTree(collectionsWithRefIds, loadedRefIds)
 
       return E.right({ success: true })

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -58,6 +58,17 @@ export const importToPersonalWorkspace = async (
       // populate already ran upstream; missing ref-ids are skipped.
       const originalsByRefId = new Map<string, HoppCollection>()
       indexCollectionsByRefId(collectionsWithRefIds, originalsByRefId)
+
+      // Warn once per import if any loaded root lacks `_ref_id` — likely a
+      // backend that dropped `data._ref_id` from the blob round-trip.
+      // Secret values for those nodes silently won't surface after reload.
+      if (loaded.some((c) => !c._ref_id)) {
+        console.warn(
+          "[importToPersonalWorkspace] loaded collection(s) missing `_ref_id`; " +
+            "imported secret values may not persist across reload"
+        )
+      }
+
       loaded.forEach((loadedColl) => {
         repopulateLoadedCollectionTree(loadedColl, originalsByRefId)
       })

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/import.ts
@@ -22,22 +22,15 @@ import { importUserCollectionsFromJSON } from "./api"
 import { runDispatchWithOutSyncing } from "@app/lib/sync"
 
 /**
- * Platform-specific import function for selfhost-web that uses the correct nested collection queries
+ * Platform-specific import for selfhost-web. Caller (`components/collections/
+ * ImportExport.vue`) must have run `ensureRefIds` + `populateLocalStoresFromCollectionTree`
+ * upstream — we re-stamp ref-ids defensively but do NOT re-populate (raw values
+ * aren't on the variables array by the time the strip runs).
  */
 export const importToPersonalWorkspace = async (
   collections: HoppCollection[],
   reqType: ReqType
 ) => {
-  // CONTRACT: the caller (`components/collections/ImportExport.vue`) is
-  // expected to have already run `ensureRefIds` + `populateLocalStores
-  // FromCollectionTree` over the input. We re-stamp ref-ids here as a
-  // defensive idempotent backstop, but we DO NOT re-populate — the
-  // raw secret/currentValue values aren't on the input variables array
-  // at any later point in this function (the strip runs inside
-  // `translateToPersonalCollectionFormat`), so a populate here would
-  // either duplicate work or, if a future callsite forgets to populate
-  // upstream, silently lose the values. Keeping the populate at exactly
-  // one well-defined point avoids the implicit-ordering trap.
   const collectionsWithRefIds = collections.map(ensureRefIds)
 
   try {
@@ -58,15 +51,9 @@ export const importToPersonalWorkspace = async (
           : "GQL"
       )
 
-      // Defensive re-populate: pair post-load collections with their
-      // originals by `_ref_id` (not array index). The backend may
-      // reorder collections during bulk import; matching by index
-      // would re-key the wrong secret-store entry to the wrong
-      // collection's variables. Pre-walk stamps `_ref_id` and the
-      // `data._ref_id` blob round-trips it, so the pairing is stable
-      // by ref-id. If a node's `_ref_id` is missing (backend dropped
-      // it) the lookup returns no original and populate is skipped —
-      // matching the prior behavior of the index-based path.
+      // Backstop populate: pair loaded → original by `_ref_id` (round-tripped
+      // via `data._ref_id`), not by index — backend may reorder. Canonical
+      // populate already ran upstream; missing ref-ids are skipped.
       const originalsByRefId = new Map<string, HoppCollection>()
       indexCollectionsByRefId(collectionsWithRefIds, originalsByRefId)
       loaded.forEach((loadedColl) => {
@@ -75,10 +62,9 @@ export const importToPersonalWorkspace = async (
 
       return E.right({ success: true })
     }
-    // Backend import failed — append a stripped tree to newstore so raw
-    // secret values don't sit in the store / localStorage / future sync
-    // payloads. Raw values remain in the local secret + currentValue
-    // stores, keyed by the same `_ref_id`s populated above.
+    // Backend import failed — strip before appending so raw secrets don't
+    // sit in newstore. Raw values remain in the local secret stores keyed
+    // by `_ref_id`.
     return appendCollectionsToStore(
       collectionsWithRefIds.map(stripCollectionTreeForStore),
       reqType
@@ -103,19 +89,13 @@ export const appendCollectionsToStore = (
   return E.right({ success: true })
 }
 
+/**
+ * Strip + reshape for the personal-workspace import wire payload.
+ *
+ * Does NOT populate local stores — the caller is responsible (see
+ * `importToPersonalWorkspace`'s contract).
+ */
 export function translateToPersonalCollectionFormat(x: HoppCollection) {
-  // Generate a `_ref_id` if missing — collections from local/non-synced
-  // workspaces may arrive without one, and we need a stable key for the
-  // local secret store both before and after the backend round-trip.
-  //
-  // CONTRACT: this function does NOT populate the local secret /
-  // currentValue stores. The caller MUST do that upstream before
-  // invoking translate (see `components/collections/ImportExport.vue:
-  // importToPersonalWorkspace` which calls
-  // `populateLocalStoresFromCollectionTree` over the pre-walked tree).
-  // Doing it here would duplicate the populate that the caller already
-  // ran — and invite "implicit-ordering" hazards if the caller's data
-  // ever differs from `x.variables` after the strip below.
   const refId = x._ref_id ?? generateUniqueRefId("coll")
 
   const folders: HoppCollection[] = (x.folders ?? []).map(
@@ -127,24 +107,18 @@ export function translateToPersonalCollectionFormat(x: HoppCollection) {
     headers: x.headers,
     variables: stripSecretVariableValuesForWire(x.variables ?? []),
     // Lives inside `data` so it round-trips the backend — the top-level
-    // `_ref_id` on the wire is dropped, only `data._ref_id` is echoed
-    // back. Without it, the local secret store keys orphan on next load.
+    // `_ref_id` on the wire is dropped, only `data._ref_id` is echoed back.
     _ref_id: refId,
     description: x.description ?? null,
     preRequestScript: x.preRequestScript ?? "",
     testScript: x.testScript ?? "",
   }
 
-  // `_ref_id` lives inside `data` (which the backend persists and echoes
-  // back); the top-level field on the wire is ignored, so we don't write it
-  // here.
-  const obj = {
+  return {
     ...x,
     folders,
     data,
   }
-
-  return obj
 }
 
 export async function loadImportedUserCollections(

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/sync.ts
@@ -15,6 +15,8 @@ import {
   HoppRESTRequest,
 } from "@hoppscotch/data"
 
+import { stripSecretVariableValuesForWire } from "@hoppscotch/common/helpers/secretVariables"
+
 import { getSyncInitFunction, StoreSyncDefinitionOf } from "@app/lib/sync"
 import { createMapper } from "@app/lib/sync/mapper"
 import {
@@ -45,7 +47,7 @@ const transformCollectionForBackend = (collection: HoppCollection): any => {
       authActive: true,
     },
     headers: collection.headers ?? [],
-    variables: collection.variables ?? [],
+    variables: stripSecretVariableValuesForWire(collection.variables ?? []),
     _ref_id: collection._ref_id,
     description: collection.description ?? null,
     preRequestScript: collection.preRequestScript ?? "",
@@ -82,7 +84,7 @@ const recursivelySyncCollections = async (
         authActive: true,
       },
       headers: collection.headers ?? [],
-      variables: collection.variables ?? [],
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -133,7 +135,7 @@ const recursivelySyncCollections = async (
         authActive: true,
       },
       headers: collection.headers ?? [],
-      variables: collection.variables ?? [],
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -282,7 +284,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const data = {
       auth: collection.auth,
       headers: collection.headers,
-      variables: collection.variables,
+      variables: stripSecretVariableValuesForWire(collection.variables ?? []),
       _ref_id: collection._ref_id,
       description: collection.description ?? null,
       preRequestScript: collection.preRequestScript ?? "",
@@ -368,7 +370,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const data = {
       auth: folder.auth,
       headers: folder.headers,
-      variables: folder.variables,
+      variables: stripSecretVariableValuesForWire(folder.variables ?? []),
       _ref_id: folder._ref_id,
       description: folder.description,
       preRequestScript: folder.preRequestScript ?? "",

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/api.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/api.ts
@@ -29,8 +29,6 @@ import {
   UserEnvironmentDeletedDocument,
 } from "@app/api/generated/graphql"
 
-import { Environment } from "@hoppscotch/data"
-
 export const createUserEnvironment = (name: string, variables: string) =>
   runMutation<
     CreateUserEnvironmentMutation,
@@ -41,9 +39,15 @@ export const createUserEnvironment = (name: string, variables: string) =>
     variables,
   })()
 
+// `variables` is the pre-stringified JSON payload — callers decide which
+// shape to serialise (a bare `Environment.variables` array for regular
+// envs, a `GlobalEnvironment` wrapper `{ v, variables }` for the global
+// env). Mirrors `createUserEnvironment` and lets the global-env caller
+// preserve the wrapper shape on the wire without a union type / cast.
 export const updateUserEnvironment = (
   id: string,
-  { name, variables }: Environment
+  name: string,
+  variables: string
 ) =>
   runMutation<
     UpdateUserEnvironmentMutation,
@@ -52,7 +56,7 @@ export const updateUserEnvironment = (
   >(UpdateUserEnvironmentDocument, {
     id,
     name,
-    variables: JSON.stringify(variables),
+    variables,
   })
 
 export const deleteUserEnvironment = (id: string) =>

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/index.ts
@@ -138,17 +138,13 @@ async function loadGlobalEnvironments() {
       }
 
       runDispatchWithOutSyncing(() => {
-        // Final fallback when parsing failed both ways: keep the wrapper
-        // shape contract that downstream consumers (`globalEnv.variables.map`)
-        // depend on. If the raw value was a bare array, wrap it; otherwise
-        // surface an empty v2 envelope rather than push a non-wrapper into
-        // the store.
+        // Final fallback: both parses failed, meaning the stored shape is
+        // unrecognized. Surface an empty v2 envelope rather than wrap a
+        // raw array of unknown items — pushing items that don't conform to
+        // the v2 variable schema lets `undefined` initialValue/currentValue
+        // leak into downstream `.variables.map` consumers.
         setGlobalEnvVariables(
-          result.success
-            ? result.data
-            : Array.isArray(parsed)
-              ? { v: 2, variables: parsed }
-              : { v: 2, variables: [] }
+          result.success ? result.data : { v: 2, variables: [] }
         )
         setGlobalEnvID(globalEnv.id)
       })
@@ -216,11 +212,7 @@ function setupUserEnvironmentUpdatedSubscription() {
           }
 
           setGlobalEnvVariables(
-            result.success
-              ? result.data
-              : Array.isArray(parsed)
-                ? { v: 2, variables: parsed }
-                : { v: 2, variables: [] }
+            result.success ? result.data : { v: 2, variables: [] }
           )
         })
       } else {

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/index.ts
@@ -119,15 +119,36 @@ async function loadGlobalEnvironments() {
     const globalEnv = res.right.me.globalEnvironments
 
     if (globalEnv) {
-      const globalEnvVariableEntries = JSON.parse(globalEnv.variables)
+      const parsed = JSON.parse(globalEnv.variables)
 
-      const result = entityReference(GlobalEnvironment).safeParse(
-        globalEnvVariableEntries
-      )
+      // Try parsing as-is first — handles legitimate v0 bare arrays
+      // (`{key, value, secret?}` items, which verzod migrates to v2) and
+      // v1+/v2 wrappers cleanly.
+      let result = entityReference(GlobalEnvironment).safeParse(parsed)
+
+      // Fallback: a bare array with the v2 variable shape
+      // (`{key, initialValue, currentValue, secret}`) is a remnant from
+      // the broken intermediate state where `setGlobalVariables` wrote the
+      // bare array instead of the wrapper. Wrap and reparse.
+      if (!result.success && Array.isArray(parsed)) {
+        result = entityReference(GlobalEnvironment).safeParse({
+          v: 2,
+          variables: parsed,
+        })
+      }
 
       runDispatchWithOutSyncing(() => {
+        // Final fallback when parsing failed both ways: keep the wrapper
+        // shape contract that downstream consumers (`globalEnv.variables.map`)
+        // depend on. If the raw value was a bare array, wrap it; otherwise
+        // surface an empty v2 envelope rather than push a non-wrapper into
+        // the store.
         setGlobalEnvVariables(
-          result.success ? result.data : globalEnvVariableEntries
+          result.success
+            ? result.data
+            : Array.isArray(parsed)
+              ? { v: 2, variables: parsed }
+              : { v: 2, variables: [] }
         )
         setGlobalEnvID(globalEnv.id)
       })
@@ -181,7 +202,26 @@ function setupUserEnvironmentUpdatedSubscription() {
       // handle the case for global environments
       if (isGlobal) {
         runDispatchWithOutSyncing(() => {
-          setGlobalEnvVariables(JSON.parse(variables))
+          const parsed = JSON.parse(variables)
+
+          // Mirror the load path: try as-is first (so v0 bare arrays still
+          // migrate via verzod), only wrap a bare array as a v2 envelope
+          // when the as-is parse fails (the broken-intermediate-state case).
+          let result = entityReference(GlobalEnvironment).safeParse(parsed)
+          if (!result.success && Array.isArray(parsed)) {
+            result = entityReference(GlobalEnvironment).safeParse({
+              v: 2,
+              variables: parsed,
+            })
+          }
+
+          setGlobalEnvVariables(
+            result.success
+              ? result.data
+              : Array.isArray(parsed)
+                ? { v: 2, variables: parsed }
+                : { v: 2, variables: [] }
+          )
         })
       } else {
         // handle the case for normal environments

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/index.ts
@@ -121,15 +121,9 @@ async function loadGlobalEnvironments() {
     if (globalEnv) {
       const parsed = JSON.parse(globalEnv.variables)
 
-      // Try parsing as-is first — handles legitimate v0 bare arrays
-      // (`{key, value, secret?}` items, which verzod migrates to v2) and
-      // v1+/v2 wrappers cleanly.
+      // Parse ladder: wrapper → wrap-bare-array → empty wrapper.
       let result = entityReference(GlobalEnvironment).safeParse(parsed)
 
-      // Fallback: a bare array with the v2 variable shape
-      // (`{key, initialValue, currentValue, secret}`) is a remnant from
-      // the broken intermediate state where `setGlobalVariables` wrote the
-      // bare array instead of the wrapper. Wrap and reparse.
       if (!result.success && Array.isArray(parsed)) {
         result = entityReference(GlobalEnvironment).safeParse({
           v: 2,
@@ -138,11 +132,6 @@ async function loadGlobalEnvironments() {
       }
 
       runDispatchWithOutSyncing(() => {
-        // Final fallback: both parses failed, meaning the stored shape is
-        // unrecognized. Surface an empty v2 envelope rather than wrap a
-        // raw array of unknown items — pushing items that don't conform to
-        // the v2 variable schema lets `undefined` initialValue/currentValue
-        // leak into downstream `.variables.map` consumers.
         setGlobalEnvVariables(
           result.success ? result.data : { v: 2, variables: [] }
         )

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -125,7 +125,11 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   updateEnvironment({ envIndex, updatedEnv }) {
     const backendId = environmentsStore.value.environments[envIndex].id
     if (backendId) {
-      updateUserEnvironment(backendId, updatedEnv)()
+      updateUserEnvironment(
+        backendId,
+        updatedEnv.name,
+        JSON.stringify(updatedEnv.variables)
+      )()
     }
   },
   async deleteEnvironment({ envID }) {
@@ -136,16 +140,22 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   setGlobalVariables({ entries }) {
     const backendId = getGlobalVariableID()
     if (backendId) {
-      // The global env shares the `UpdateUserEnvironment` mutation with
-      // regular envs — store it as the same `Environment` shape with an
-      // empty name. `loadGlobalEnvironments` re-wraps the bare-array
-      // payload into a `GlobalEnvironment` for the local store.
-      updateUserEnvironment(backendId, {
-        name: "",
-        variables: stripSecretVariableValuesForWire(entries.variables ?? []),
-        id: "",
-        v: 2,
-      })()
+      // Send the full `GlobalEnvironment` wrapper (`{ v, variables }`)
+      // on the wire, not a bare array. Pre-this-PR clients stored globals
+      // as the wrapper and their load path expects it back; sending a
+      // bare array here would cause those older clients to fall through
+      // verzod's parse, dump the raw array into `globals`, and crash on
+      // downstream `globalEnv.variables.map`. We can't guarantee
+      // synchronous client upgrades on a self-hosted deployment, so the
+      // wire shape stays compatible with both old and new readers.
+      updateUserEnvironment(
+        backendId,
+        "",
+        JSON.stringify({
+          v: 2,
+          variables: stripSecretVariableValuesForWire(entries.variables ?? []),
+        })
+      )()
     }
   },
   clearGlobalVariables() {

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -125,10 +125,18 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   updateEnvironment({ envIndex, updatedEnv }) {
     const backendId = environmentsStore.value.environments[envIndex].id
     if (backendId) {
+      // Strip at the wire boundary defensively — `Details.vue` and the
+      // `RequestRunner` post-test path already pre-strip before
+      // dispatching, but every other handler in this file (`create`,
+      // `append`, `duplicate`, `setGlobal`) strips here as the last
+      // line of defense, so a future caller that forgets to pre-strip
+      // can't leak secret values to the backend through this path.
       updateUserEnvironment(
         backendId,
         updatedEnv.name,
-        JSON.stringify(updatedEnv.variables)
+        JSON.stringify(
+          stripSecretVariableValuesForWire(updatedEnv.variables ?? [])
+        )
       )()
     }
   },

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -20,6 +20,10 @@ import {
   deleteUserEnvironment,
   updateUserEnvironment,
 } from "./api"
+import {
+  populateLocalStoresFromVariables,
+  stripSecretVariableValuesForWire,
+} from "@hoppscotch/common/helpers/secretVariables"
 import { SecretEnvironmentService } from "@hoppscotch/common/services/secret-environment.service"
 import { getService } from "@hoppscotch/common/modules/dioc"
 import { CurrentValueService } from "@hoppscotch/common/services/current-environment-value.service"
@@ -36,7 +40,10 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   async createEnvironment({ name, variables }) {
     const lastCreatedEnvIndex = environmentsStore.value.environments.length - 1
 
-    const res = await createUserEnvironment(name, JSON.stringify(variables))
+    const res = await createUserEnvironment(
+      name,
+      JSON.stringify(stripSecretVariableValuesForWire(variables))
+    )
 
     if (E.isRight(res)) {
       const id = res.right.createUserEnvironment.id
@@ -66,12 +73,18 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       ;(async function () {
         const res = await createUserEnvironment(
           env.name,
-          JSON.stringify(env.variables)
+          JSON.stringify(stripSecretVariableValuesForWire(env.variables))
         )
 
         if (E.isRight(res)) {
           const id = res.right.createUserEnvironment.id
           environmentsStore.value.environments[envId].id = id
+
+          // Persist the imported secret + currentValue inputs to the local
+          // stores keyed by the new backend ID. Without this, the next
+          // `replaceEnvironments` (run on app load from the now-stripped
+          // backend row) wipes them and the user loses their imported data.
+          populateLocalStoresFromVariables(id, env.variables)
 
           removeDuplicateEntry(id)
         }
@@ -88,12 +101,20 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     if (environmentToDuplicate) {
       const res = await createUserEnvironment(
         `${environmentToDuplicate?.name} - Duplicate`,
-        JSON.stringify(environmentToDuplicate?.variables)
+        JSON.stringify(
+          stripSecretVariableValuesForWire(
+            environmentToDuplicate?.variables ?? []
+          )
+        )
       )
 
       if (E.isRight(res)) {
         const id = res.right.createUserEnvironment.id
         environmentsStore.value.environments[lastCreatedEnvIndex].id = id
+
+        // Secret variable values are intentionally NOT copied to the
+        // duplicated environment — duplicates start fresh on secrets per the
+        // per-entity secret model. The user must re-enter them on this device.
 
         removeDuplicateEntry(id)
       }
@@ -115,7 +136,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     if (backendId) {
       updateUserEnvironment(backendId, {
         name: "",
-        variables: entries,
+        variables: stripSecretVariableValuesForWire(entries),
         id: "",
         v: 2,
       })()

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -24,7 +24,6 @@ import { stripSecretVariableValuesForWire } from "@hoppscotch/common/helpers/sec
 import { SecretEnvironmentService } from "@hoppscotch/common/services/secret-environment.service"
 import { getService } from "@hoppscotch/common/modules/dioc"
 import { CurrentValueService } from "@hoppscotch/common/services/current-environment-value.service"
-import type { Environment, GlobalEnvironment } from "@hoppscotch/data"
 
 export const environmentsMapper = createMapper<number, string>()
 export const globalEnvironmentMapper = createMapper<number, string>()
@@ -137,19 +136,13 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   setGlobalVariables({ entries }) {
     const backendId = getGlobalVariableID()
     if (backendId) {
-      // The backend stores `Environment.variables` JSON-stringified, and
-      // `loadGlobalEnvironments` parses that string via verzod's
-      // `GlobalEnvironment` entity reference — which expects the wrapped
-      // `{ v, variables }` shape, not a bare array. Send the wrapper (with
-      // secrets stripped from its variables) so the round-trip stays
-      // compatible with existing rows.
-      const stripped: GlobalEnvironment = {
-        ...entries,
-        variables: stripSecretVariableValuesForWire(entries.variables ?? []),
-      }
+      // The global env shares the `UpdateUserEnvironment` mutation with
+      // regular envs — store it as the same `Environment` shape with an
+      // empty name. `loadGlobalEnvironments` re-wraps the bare-array
+      // payload into a `GlobalEnvironment` for the local store.
       updateUserEnvironment(backendId, {
         name: "",
-        variables: stripped as unknown as Environment["variables"],
+        variables: stripSecretVariableValuesForWire(entries.variables ?? []),
         id: "",
         v: 2,
       })()

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -20,13 +20,11 @@ import {
   deleteUserEnvironment,
   updateUserEnvironment,
 } from "./api"
-import {
-  populateLocalStoresFromVariables,
-  stripSecretVariableValuesForWire,
-} from "@hoppscotch/common/helpers/secretVariables"
+import { stripSecretVariableValuesForWire } from "@hoppscotch/common/helpers/secretVariables"
 import { SecretEnvironmentService } from "@hoppscotch/common/services/secret-environment.service"
 import { getService } from "@hoppscotch/common/modules/dioc"
 import { CurrentValueService } from "@hoppscotch/common/services/current-environment-value.service"
+import type { Environment, GlobalEnvironment } from "@hoppscotch/data"
 
 export const environmentsMapper = createMapper<number, string>()
 export const globalEnvironmentMapper = createMapper<number, string>()
@@ -71,6 +69,14 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       const envId = ++appendStart
 
       ;(async function () {
+        // Snapshot the temp local id BEFORE the backend create overwrites
+        // it. The local secret + currentValue stores were already populated
+        // under this temp id at import time (`handleImportToStore`), so we
+        // remap rather than re-populate — the sync handler's `env.variables`
+        // is already stripped (newstore was pre-stripped at import time)
+        // and would otherwise overwrite the raw values with empty ones.
+        const tempId = environmentsStore.value.environments[envId].id
+
         const res = await createUserEnvironment(
           env.name,
           JSON.stringify(stripSecretVariableValuesForWire(env.variables))
@@ -78,14 +84,11 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
 
         if (E.isRight(res)) {
           const id = res.right.createUserEnvironment.id
+
+          secretEnvironmentService.updateSecretEnvironmentID(tempId, id)
+          currentEnvironmentValueService.updateEnvironmentID(tempId, id)
+
           environmentsStore.value.environments[envId].id = id
-
-          // Persist the imported secret + currentValue inputs to the local
-          // stores keyed by the new backend ID. Without this, the next
-          // `replaceEnvironments` (run on app load from the now-stripped
-          // backend row) wipes them and the user loses their imported data.
-          populateLocalStoresFromVariables(id, env.variables)
-
           removeDuplicateEntry(id)
         }
       })()
@@ -134,9 +137,19 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   setGlobalVariables({ entries }) {
     const backendId = getGlobalVariableID()
     if (backendId) {
+      // The backend stores `Environment.variables` JSON-stringified, and
+      // `loadGlobalEnvironments` parses that string via verzod's
+      // `GlobalEnvironment` entity reference — which expects the wrapped
+      // `{ v, variables }` shape, not a bare array. Send the wrapper (with
+      // secrets stripped from its variables) so the round-trip stays
+      // compatible with existing rows.
+      const stripped: GlobalEnvironment = {
+        ...entries,
+        variables: stripSecretVariableValuesForWire(entries.variables ?? []),
+      }
       updateUserEnvironment(backendId, {
         name: "",
-        variables: stripSecretVariableValuesForWire(entries),
+        variables: stripped as unknown as Environment["variables"],
         id: "",
         v: 2,
       })()

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -92,18 +92,18 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
             environmentsStore.value.environments[envId].id = id
             removeDuplicateEntry(id)
           } else {
-            // Backend rejected — flush the upstream-populated entries so
-            // they don't linger under a `tempId` no env will ever reference.
-            secretEnvironmentService.deleteSecretEnvironment(tempId)
-            currentEnvironmentValueService.deleteEnvironment(tempId)
+            // Backend rejected — leave local-store entries intact under
+            // `tempId` so the env in newstore (which still references
+            // `tempId`) continues to render secrets for this session.
+            // Reload will drop the env from newstore; the orphaned
+            // entries persist but are bounded (one per failed import).
+            console.error("[appendEnvironments] backend rejected create")
           }
-        } catch (_) {
-          // Network/unexpected throw — same cleanup as backend rejection.
-          // Without this, the fire-and-forget IIFE swallows the rejection
-          // and leaves `tempId` entries orphaned in localStorage.
-          secretEnvironmentService.deleteSecretEnvironment(tempId)
-          currentEnvironmentValueService.deleteEnvironment(tempId)
-          console.error("[appendEnvironments] backend create failed")
+        } catch (e) {
+          // Caught here so the fire-and-forget IIFE doesn't surface an
+          // "unhandled promise rejection." Same in-session preservation
+          // as the `E.isLeft` branch.
+          console.error("[appendEnvironments] backend create threw", e)
         }
       })()
     })

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -72,9 +72,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         // populated under this id at import time; we remap, not re-populate.
         const tempId = environmentsStore.value.environments[envId].id
 
+        // Strip at the wire-write boundary even though the import caller
+        // pre-strips — `appendEnvironments` is a public store API; the
+        // invariant can't rely on callers.
         const res = await createUserEnvironment(
           env.name,
-          JSON.stringify(stripSecretVariableValuesForWire(env.variables))
+          JSON.stringify(stripSecretVariableValuesForWire(env.variables ?? []))
         )
 
         if (E.isRight(res)) {

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -145,8 +145,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         // Bail on malformed input — an empty wrapper would clear globals
         // on the backend irreversibly.
         console.error(
-          "[setGlobalVariables] unexpected variables shape, skipping sync",
-          entries
+          "[setGlobalVariables] unexpected variables shape, skipping sync"
         )
         return
       }

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -33,10 +33,9 @@ const currentEnvironmentValueService = getService(CurrentValueService)
 
 // Tracks env ids that are still client-side temporary (`uniqueID()`) while
 // the backend create is in flight. `deleteEnvironment` skips the backend
-// call when the id is in this set — preventing a spurious 404 (and the
-// associated backend-create-then-orphan race) during the create window.
-// Real backend ids are never added here, so deleting an already-synced env
-// always fires the backend mutation.
+// call when the id is in this set — preventing a spurious 404 during the
+// create-then-delete race window. Real backend ids are never added here,
+// so deleting an already-synced env always fires the backend mutation.
 const pendingTempEnvIds = new Set<string>()
 
 export const storeSyncDefinition: StoreSyncDefinitionOf<
@@ -45,7 +44,8 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   async createEnvironment({ name, variables }) {
     const lastCreatedEnvIndex = environmentsStore.value.environments.length - 1
     const tempId = environmentsStore.value.environments[lastCreatedEnvIndex]?.id
-    if (tempId) pendingTempEnvIds.add(tempId)
+    if (!tempId) return
+    pendingTempEnvIds.add(tempId)
 
     try {
       const res = await createUserEnvironment(
@@ -70,7 +70,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         removeDuplicateEntry(id)
       }
     } finally {
-      if (tempId) pendingTempEnvIds.delete(tempId)
+      pendingTempEnvIds.delete(tempId)
     }
   },
   async appendEnvironments({ envs }) {
@@ -84,7 +84,9 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       ;(async function () {
         // Capture temp id before backend overwrites it — local stores were
         // populated under this id at import time; we remap, not re-populate.
-        const tempId = environmentsStore.value.environments[envId].id
+        const tempId = environmentsStore.value.environments[envId]?.id
+        if (!tempId) return
+        pendingTempEnvIds.add(tempId)
 
         try {
           // Strip at the wire-write boundary even though the import caller
@@ -118,6 +120,8 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
           // "unhandled promise rejection." Same in-session preservation
           // as the `E.isLeft` branch.
           console.error("[appendEnvironments] backend create threw", e)
+        } finally {
+          pendingTempEnvIds.delete(tempId)
         }
       })()
     })
@@ -126,15 +130,19 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const environmentToDuplicate = environmentsStore.value.environments.find(
       (_, index) => index === envIndex
     )
+    if (!environmentToDuplicate) return
 
     const lastCreatedEnvIndex = environmentsStore.value.environments.length - 1
+    const tempId = environmentsStore.value.environments[lastCreatedEnvIndex]?.id
+    if (!tempId) return
+    pendingTempEnvIds.add(tempId)
 
-    if (environmentToDuplicate) {
+    try {
       const res = await createUserEnvironment(
-        `${environmentToDuplicate?.name} - Duplicate`,
+        `${environmentToDuplicate.name} - Duplicate`,
         JSON.stringify(
           stripSecretVariableValuesForWire(
-            environmentToDuplicate?.variables ?? []
+            environmentToDuplicate.variables ?? []
           )
         )
       )
@@ -144,9 +152,10 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         environmentsStore.value.environments[lastCreatedEnvIndex].id = id
 
         // Duplicates start fresh on secrets per the per-entity model.
-
         removeDuplicateEntry(id)
       }
+    } finally {
+      pendingTempEnvIds.delete(tempId)
     }
   },
   updateEnvironment({ envIndex, updatedEnv }) {

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -72,22 +72,38 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         // populated under this id at import time; we remap, not re-populate.
         const tempId = environmentsStore.value.environments[envId].id
 
-        // Strip at the wire-write boundary even though the import caller
-        // pre-strips — `appendEnvironments` is a public store API; the
-        // invariant can't rely on callers.
-        const res = await createUserEnvironment(
-          env.name,
-          JSON.stringify(stripSecretVariableValuesForWire(env.variables ?? []))
-        )
+        try {
+          // Strip at the wire-write boundary even though the import caller
+          // pre-strips — `appendEnvironments` is a public store API; the
+          // invariant can't rely on callers.
+          const res = await createUserEnvironment(
+            env.name,
+            JSON.stringify(
+              stripSecretVariableValuesForWire(env.variables ?? [])
+            )
+          )
 
-        if (E.isRight(res)) {
-          const id = res.right.createUserEnvironment.id
+          if (E.isRight(res)) {
+            const id = res.right.createUserEnvironment.id
 
-          secretEnvironmentService.updateSecretEnvironmentID(tempId, id)
-          currentEnvironmentValueService.updateEnvironmentID(tempId, id)
+            secretEnvironmentService.updateSecretEnvironmentID(tempId, id)
+            currentEnvironmentValueService.updateEnvironmentID(tempId, id)
 
-          environmentsStore.value.environments[envId].id = id
-          removeDuplicateEntry(id)
+            environmentsStore.value.environments[envId].id = id
+            removeDuplicateEntry(id)
+          } else {
+            // Backend rejected — flush the upstream-populated entries so
+            // they don't linger under a `tempId` no env will ever reference.
+            secretEnvironmentService.deleteSecretEnvironment(tempId)
+            currentEnvironmentValueService.deleteEnvironment(tempId)
+          }
+        } catch (_) {
+          // Network/unexpected throw — same cleanup as backend rejection.
+          // Without this, the fire-and-forget IIFE swallows the rejection
+          // and leaves `tempId` entries orphaned in localStorage.
+          secretEnvironmentService.deleteSecretEnvironment(tempId)
+          currentEnvironmentValueService.deleteEnvironment(tempId)
+          console.error("[appendEnvironments] backend create failed")
         }
       })()
     })

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -136,14 +136,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   setGlobalVariables({ entries }) {
     const backendId = getGlobalVariableID()
     if (backendId) {
-      // Send the `{ v, variables }` wrapper, not a bare array — older
-      // clients expect the wrapper and crash on `globalEnv.variables.map`
-      // otherwise. SH deployments can't be guaranteed in-sync, so the
-      // wire shape stays compatible with both.
+      // Bail on malformed input — syncing the dispatcher-coerced `[]`
+      // would clear backend globals irreversibly. Leaving FE/BE desynced
+      // is recoverable (reload re-hydrates from backend), data loss is
+      // not. The dispatcher's coerce only protects FE state.
       const variables = entries?.variables
       if (!Array.isArray(variables)) {
-        // Bail on malformed input — an empty wrapper would clear globals
-        // on the backend irreversibly.
         console.error(
           "[setGlobalVariables] unexpected variables shape, skipping sync"
         )

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -156,12 +156,27 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       // downstream `globalEnv.variables.map`. We can't guarantee
       // synchronous client upgrades on a self-hosted deployment, so the
       // wire shape stays compatible with both old and new readers.
+      const variables = entries?.variables
+      if (!Array.isArray(variables)) {
+        // Guard against a schema mismatch reaching this write path —
+        // do NOT silently send `[]`. The dispatcher's
+        // `coerceGlobalEnvironment` should have already normalised this,
+        // but if a future schema migration or upstream regression
+        // delivers a malformed `entries`, sending an empty wrapper here
+        // would clear the user's globals on the backend irreversibly.
+        // Bail and surface the unexpected shape instead.
+        console.error(
+          "[setGlobalVariables] unexpected variables shape, skipping sync",
+          entries
+        )
+        return
+      }
       updateUserEnvironment(
         backendId,
         "",
         JSON.stringify({
           v: 2,
-          variables: stripSecretVariableValuesForWire(entries.variables ?? []),
+          variables: stripSecretVariableValuesForWire(variables),
         })
       )()
     }

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -31,32 +31,46 @@ export const globalEnvironmentMapper = createMapper<number, string>()
 const secretEnvironmentService = getService(SecretEnvironmentService)
 const currentEnvironmentValueService = getService(CurrentValueService)
 
+// Tracks env ids that are still client-side temporary (`uniqueID()`) while
+// the backend create is in flight. `deleteEnvironment` skips the backend
+// call when the id is in this set — preventing a spurious 404 (and the
+// associated backend-create-then-orphan race) during the create window.
+// Real backend ids are never added here, so deleting an already-synced env
+// always fires the backend mutation.
+const pendingTempEnvIds = new Set<string>()
+
 export const storeSyncDefinition: StoreSyncDefinitionOf<
   typeof environmentsStore
 > = {
   async createEnvironment({ name, variables }) {
     const lastCreatedEnvIndex = environmentsStore.value.environments.length - 1
+    const tempId = environmentsStore.value.environments[lastCreatedEnvIndex]?.id
+    if (tempId) pendingTempEnvIds.add(tempId)
 
-    const res = await createUserEnvironment(
-      name,
-      JSON.stringify(stripSecretVariableValuesForWire(variables))
-    )
-
-    if (E.isRight(res)) {
-      const id = res.right.createUserEnvironment.id
-
-      secretEnvironmentService.updateSecretEnvironmentID(
-        environmentsStore.value.environments[lastCreatedEnvIndex].id,
-        id
+    try {
+      const res = await createUserEnvironment(
+        name,
+        JSON.stringify(stripSecretVariableValuesForWire(variables))
       )
 
-      currentEnvironmentValueService.updateEnvironmentID(
-        environmentsStore.value.environments[lastCreatedEnvIndex].id,
-        id
-      )
+      if (E.isRight(res)) {
+        const id = res.right.createUserEnvironment.id
 
-      environmentsStore.value.environments[lastCreatedEnvIndex].id = id
-      removeDuplicateEntry(id)
+        secretEnvironmentService.updateSecretEnvironmentID(
+          environmentsStore.value.environments[lastCreatedEnvIndex].id,
+          id
+        )
+
+        currentEnvironmentValueService.updateEnvironmentID(
+          environmentsStore.value.environments[lastCreatedEnvIndex].id,
+          id
+        )
+
+        environmentsStore.value.environments[lastCreatedEnvIndex].id = id
+        removeDuplicateEntry(id)
+      }
+    } finally {
+      if (tempId) pendingTempEnvIds.delete(tempId)
     }
   },
   async appendEnvironments({ envs }) {
@@ -148,7 +162,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async deleteEnvironment({ envID }) {
-    if (envID) {
+    // Skip when the id belongs to an env whose backend create is still in
+    // flight — sending the temp `uniqueID()` would 404 and the backend
+    // create would still complete, orphaning a row. Already-synced envs
+    // are never in `pendingTempEnvIds`, so this only filters the race
+    // window; normal deletes fire the backend mutation.
+    if (envID && !pendingTempEnvIds.has(envID)) {
       await deleteUserEnvironment(envID)()
     }
   },

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -56,15 +56,11 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       if (E.isRight(res)) {
         const id = res.right.createUserEnvironment.id
 
-        secretEnvironmentService.updateSecretEnvironmentID(
-          environmentsStore.value.environments[lastCreatedEnvIndex].id,
-          id
-        )
-
-        currentEnvironmentValueService.updateEnvironmentID(
-          environmentsStore.value.environments[lastCreatedEnvIndex].id,
-          id
-        )
+        // Use the captured `tempId` (not a re-read of the array) so the
+        // migration still works if the env list shifted during the await.
+        // Matches the pattern in `appendEnvironments` below.
+        secretEnvironmentService.updateSecretEnvironmentID(tempId, id)
+        currentEnvironmentValueService.updateEnvironmentID(tempId, id)
 
         environmentsStore.value.environments[lastCreatedEnvIndex].id = id
         removeDuplicateEntry(id)

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -68,12 +68,8 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       const envId = ++appendStart
 
       ;(async function () {
-        // Snapshot the temp local id BEFORE the backend create overwrites
-        // it. The local secret + currentValue stores were already populated
-        // under this temp id at import time (`handleImportToStore`), so we
-        // remap rather than re-populate — the sync handler's `env.variables`
-        // is already stripped (newstore was pre-stripped at import time)
-        // and would otherwise overwrite the raw values with empty ones.
+        // Capture temp id before backend overwrites it — local stores were
+        // populated under this id at import time; we remap, not re-populate.
         const tempId = environmentsStore.value.environments[envId].id
 
         const res = await createUserEnvironment(
@@ -114,9 +110,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         const id = res.right.createUserEnvironment.id
         environmentsStore.value.environments[lastCreatedEnvIndex].id = id
 
-        // Secret variable values are intentionally NOT copied to the
-        // duplicated environment — duplicates start fresh on secrets per the
-        // per-entity secret model. The user must re-enter them on this device.
+        // Duplicates start fresh on secrets per the per-entity model.
 
         removeDuplicateEntry(id)
       }
@@ -125,12 +119,6 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   updateEnvironment({ envIndex, updatedEnv }) {
     const backendId = environmentsStore.value.environments[envIndex].id
     if (backendId) {
-      // Strip at the wire boundary defensively — `Details.vue` and the
-      // `RequestRunner` post-test path already pre-strip before
-      // dispatching, but every other handler in this file (`create`,
-      // `append`, `duplicate`, `setGlobal`) strips here as the last
-      // line of defense, so a future caller that forgets to pre-strip
-      // can't leak secret values to the backend through this path.
       updateUserEnvironment(
         backendId,
         updatedEnv.name,
@@ -148,23 +136,14 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   setGlobalVariables({ entries }) {
     const backendId = getGlobalVariableID()
     if (backendId) {
-      // Send the full `GlobalEnvironment` wrapper (`{ v, variables }`)
-      // on the wire, not a bare array. Pre-this-PR clients stored globals
-      // as the wrapper and their load path expects it back; sending a
-      // bare array here would cause those older clients to fall through
-      // verzod's parse, dump the raw array into `globals`, and crash on
-      // downstream `globalEnv.variables.map`. We can't guarantee
-      // synchronous client upgrades on a self-hosted deployment, so the
-      // wire shape stays compatible with both old and new readers.
+      // Send the `{ v, variables }` wrapper, not a bare array — older
+      // clients expect the wrapper and crash on `globalEnv.variables.map`
+      // otherwise. SH deployments can't be guaranteed in-sync, so the
+      // wire shape stays compatible with both.
       const variables = entries?.variables
       if (!Array.isArray(variables)) {
-        // Guard against a schema mismatch reaching this write path —
-        // do NOT silently send `[]`. The dispatcher's
-        // `coerceGlobalEnvironment` should have already normalised this,
-        // but if a future schema migration or upstream regression
-        // delivers a malformed `entries`, sending an empty wrapper here
-        // would clear the user's globals on the backend irreversibly.
-        // Bail and surface the unexpected shape instead.
+        // Bail on malformed input — an empty wrapper would clear globals
+        // on the backend irreversibly.
         console.error(
           "[setGlobalVariables] unexpected variables shape, skipping sync",
           entries
@@ -188,10 +167,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       clearGlobalEnvironmentVariables(backendId)
     }
 
-    // Flush local stores keyed to "Global" — without this, a later
-    // `addGlobalEnvVariable` would land at `varIndex 0` against a stale
-    // entry from the previously-cleared variable and the UI would show
-    // the prior secret value in a fresh field.
+    // Flush "Global" entries so a later add doesn't alias stale `varIndex`.
     secretEnvironmentService.addSecretEnvironment("Global", [])
     currentEnvironmentValueService.addEnvironment("Global", [])
   },

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/desktop/sync.ts
@@ -187,6 +187,13 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     if (backendId) {
       clearGlobalEnvironmentVariables(backendId)
     }
+
+    // Flush local stores keyed to "Global" — without this, a later
+    // `addGlobalEnvVariable` would land at `varIndex 0` against a stale
+    // entry from the previously-cleared variable and the UI would show
+    // the prior secret value in a fresh field.
+    secretEnvironmentService.addSecretEnvironment("Global", [])
+    currentEnvironmentValueService.addEnvironment("Global", [])
   },
 }
 

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/api.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/api.ts
@@ -29,8 +29,6 @@ import {
   UserEnvironmentDeletedDocument,
 } from "@app/api/generated/graphql"
 
-import { Environment } from "@hoppscotch/data"
-
 export const createUserEnvironment = (name: string, variables: string) =>
   runMutation<
     CreateUserEnvironmentMutation,
@@ -41,9 +39,15 @@ export const createUserEnvironment = (name: string, variables: string) =>
     variables,
   })()
 
+// `variables` is the pre-stringified JSON payload — callers decide which
+// shape to serialise (a bare `Environment.variables` array for regular
+// envs, a `GlobalEnvironment` wrapper `{ v, variables }` for the global
+// env). Mirrors `createUserEnvironment` and lets the global-env caller
+// preserve the wrapper shape on the wire without a union type / cast.
 export const updateUserEnvironment = (
   id: string,
-  { name, variables }: Environment
+  name: string,
+  variables: string
 ) =>
   runMutation<
     UpdateUserEnvironmentMutation,
@@ -52,7 +56,7 @@ export const updateUserEnvironment = (
   >(UpdateUserEnvironmentDocument, {
     id,
     name,
-    variables: JSON.stringify(variables),
+    variables,
   })
 
 export const deleteUserEnvironment = (id: string) =>

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/index.ts
@@ -138,17 +138,13 @@ async function loadGlobalEnvironments() {
       }
 
       runDispatchWithOutSyncing(() => {
-        // Final fallback when parsing failed both ways: keep the wrapper
-        // shape contract that downstream consumers (`globalEnv.variables.map`)
-        // depend on. If the raw value was a bare array, wrap it; otherwise
-        // surface an empty v2 envelope rather than push a non-wrapper into
-        // the store.
+        // Final fallback: both parses failed, meaning the stored shape is
+        // unrecognized. Surface an empty v2 envelope rather than wrap a
+        // raw array of unknown items — pushing items that don't conform to
+        // the v2 variable schema lets `undefined` initialValue/currentValue
+        // leak into downstream `.variables.map` consumers.
         setGlobalEnvVariables(
-          result.success
-            ? result.data
-            : Array.isArray(parsed)
-              ? { v: 2, variables: parsed }
-              : { v: 2, variables: [] }
+          result.success ? result.data : { v: 2, variables: [] }
         )
         setGlobalEnvID(globalEnv.id)
       })
@@ -216,11 +212,7 @@ function setupUserEnvironmentUpdatedSubscription() {
           }
 
           setGlobalEnvVariables(
-            result.success
-              ? result.data
-              : Array.isArray(parsed)
-                ? { v: 2, variables: parsed }
-                : { v: 2, variables: [] }
+            result.success ? result.data : { v: 2, variables: [] }
           )
         })
       } else {

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/index.ts
@@ -119,15 +119,36 @@ async function loadGlobalEnvironments() {
     const globalEnv = res.right.me.globalEnvironments
 
     if (globalEnv) {
-      const globalEnvVariableEntries = JSON.parse(globalEnv.variables)
+      const parsed = JSON.parse(globalEnv.variables)
 
-      const result = entityReference(GlobalEnvironment).safeParse(
-        globalEnvVariableEntries
-      )
+      // Try parsing as-is first — handles legitimate v0 bare arrays
+      // (`{key, value, secret?}` items, which verzod migrates to v2) and
+      // v1+/v2 wrappers cleanly.
+      let result = entityReference(GlobalEnvironment).safeParse(parsed)
+
+      // Fallback: a bare array with the v2 variable shape
+      // (`{key, initialValue, currentValue, secret}`) is a remnant from
+      // the broken intermediate state where `setGlobalVariables` wrote the
+      // bare array instead of the wrapper. Wrap and reparse.
+      if (!result.success && Array.isArray(parsed)) {
+        result = entityReference(GlobalEnvironment).safeParse({
+          v: 2,
+          variables: parsed,
+        })
+      }
 
       runDispatchWithOutSyncing(() => {
+        // Final fallback when parsing failed both ways: keep the wrapper
+        // shape contract that downstream consumers (`globalEnv.variables.map`)
+        // depend on. If the raw value was a bare array, wrap it; otherwise
+        // surface an empty v2 envelope rather than push a non-wrapper into
+        // the store.
         setGlobalEnvVariables(
-          result.success ? result.data : globalEnvVariableEntries
+          result.success
+            ? result.data
+            : Array.isArray(parsed)
+              ? { v: 2, variables: parsed }
+              : { v: 2, variables: [] }
         )
         setGlobalEnvID(globalEnv.id)
       })
@@ -181,7 +202,26 @@ function setupUserEnvironmentUpdatedSubscription() {
       // handle the case for global environments
       if (isGlobal) {
         runDispatchWithOutSyncing(() => {
-          setGlobalEnvVariables(JSON.parse(variables))
+          const parsed = JSON.parse(variables)
+
+          // Mirror the load path: try as-is first (so v0 bare arrays still
+          // migrate via verzod), only wrap a bare array as a v2 envelope
+          // when the as-is parse fails (the broken-intermediate-state case).
+          let result = entityReference(GlobalEnvironment).safeParse(parsed)
+          if (!result.success && Array.isArray(parsed)) {
+            result = entityReference(GlobalEnvironment).safeParse({
+              v: 2,
+              variables: parsed,
+            })
+          }
+
+          setGlobalEnvVariables(
+            result.success
+              ? result.data
+              : Array.isArray(parsed)
+                ? { v: 2, variables: parsed }
+                : { v: 2, variables: [] }
+          )
         })
       } else {
         // handle the case for normal environments

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/index.ts
@@ -121,15 +121,9 @@ async function loadGlobalEnvironments() {
     if (globalEnv) {
       const parsed = JSON.parse(globalEnv.variables)
 
-      // Try parsing as-is first — handles legitimate v0 bare arrays
-      // (`{key, value, secret?}` items, which verzod migrates to v2) and
-      // v1+/v2 wrappers cleanly.
+      // Parse ladder: wrapper → wrap-bare-array → empty wrapper.
       let result = entityReference(GlobalEnvironment).safeParse(parsed)
 
-      // Fallback: a bare array with the v2 variable shape
-      // (`{key, initialValue, currentValue, secret}`) is a remnant from
-      // the broken intermediate state where `setGlobalVariables` wrote the
-      // bare array instead of the wrapper. Wrap and reparse.
       if (!result.success && Array.isArray(parsed)) {
         result = entityReference(GlobalEnvironment).safeParse({
           v: 2,
@@ -138,11 +132,6 @@ async function loadGlobalEnvironments() {
       }
 
       runDispatchWithOutSyncing(() => {
-        // Final fallback: both parses failed, meaning the stored shape is
-        // unrecognized. Surface an empty v2 envelope rather than wrap a
-        // raw array of unknown items — pushing items that don't conform to
-        // the v2 variable schema lets `undefined` initialValue/currentValue
-        // leak into downstream `.variables.map` consumers.
         setGlobalEnvVariables(
           result.success ? result.data : { v: 2, variables: [] }
         )

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -24,7 +24,6 @@ import { stripSecretVariableValuesForWire } from "@hoppscotch/common/helpers/sec
 import { SecretEnvironmentService } from "@hoppscotch/common/services/secret-environment.service"
 import { getService } from "@hoppscotch/common/modules/dioc"
 import { CurrentValueService } from "@hoppscotch/common/services/current-environment-value.service"
-import type { Environment, GlobalEnvironment } from "@hoppscotch/data"
 
 export const environmentsMapper = createMapper<number, string>()
 export const globalEnvironmentMapper = createMapper<number, string>()
@@ -136,19 +135,13 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   setGlobalVariables({ entries }) {
     const backendId = getGlobalVariableID()
     if (backendId) {
-      // The backend stores `Environment.variables` JSON-stringified, and
-      // `loadGlobalEnvironments` parses that string via verzod's
-      // `GlobalEnvironment` entity reference — which expects the wrapped
-      // `{ v, variables }` shape, not a bare array. Send the wrapper (with
-      // secrets stripped from its variables) so the round-trip stays
-      // compatible with existing rows.
-      const stripped: GlobalEnvironment = {
-        ...entries,
-        variables: stripSecretVariableValuesForWire(entries.variables ?? []),
-      }
+      // The global env shares the `UpdateUserEnvironment` mutation with
+      // regular envs — store it as the same `Environment` shape with an
+      // empty name. `loadGlobalEnvironments` re-wraps the bare-array
+      // payload into a `GlobalEnvironment` for the local store.
       updateUserEnvironment(backendId, {
         name: "",
-        variables: stripped as unknown as Environment["variables"],
+        variables: stripSecretVariableValuesForWire(entries.variables ?? []),
         id: "",
         v: 2,
       })()

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -20,6 +20,10 @@ import {
   deleteUserEnvironment,
   updateUserEnvironment,
 } from "./api"
+import {
+  populateLocalStoresFromVariables,
+  stripSecretVariableValuesForWire,
+} from "@hoppscotch/common/helpers/secretVariables"
 import { SecretEnvironmentService } from "@hoppscotch/common/services/secret-environment.service"
 import { getService } from "@hoppscotch/common/modules/dioc"
 import { CurrentValueService } from "@hoppscotch/common/services/current-environment-value.service"
@@ -36,7 +40,10 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   async createEnvironment({ name, variables }) {
     const lastCreatedEnvIndex = environmentsStore.value.environments.length - 1
 
-    const res = await createUserEnvironment(name, JSON.stringify(variables))
+    const res = await createUserEnvironment(
+      name,
+      JSON.stringify(stripSecretVariableValuesForWire(variables))
+    )
 
     if (E.isRight(res)) {
       const id = res.right.createUserEnvironment.id
@@ -65,12 +72,18 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       ;(async function () {
         const res = await createUserEnvironment(
           env.name,
-          JSON.stringify(env.variables)
+          JSON.stringify(stripSecretVariableValuesForWire(env.variables))
         )
 
         if (E.isRight(res)) {
           const id = res.right.createUserEnvironment.id
           environmentsStore.value.environments[envId].id = id
+
+          // Persist the imported secret + currentValue inputs to the local
+          // stores keyed by the new backend ID. Without this, the next
+          // `replaceEnvironments` (run on app load from the now-stripped
+          // backend row) wipes them and the user loses their imported data.
+          populateLocalStoresFromVariables(id, env.variables)
 
           removeDuplicateEntry(id)
         }
@@ -87,12 +100,20 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     if (environmentToDuplicate) {
       const res = await createUserEnvironment(
         `${environmentToDuplicate?.name} - Duplicate`,
-        JSON.stringify(environmentToDuplicate?.variables)
+        JSON.stringify(
+          stripSecretVariableValuesForWire(
+            environmentToDuplicate?.variables ?? []
+          )
+        )
       )
 
       if (E.isRight(res)) {
         const id = res.right.createUserEnvironment.id
         environmentsStore.value.environments[lastCreatedEnvIndex].id = id
+
+        // Secret variable values are intentionally NOT copied to the
+        // duplicated environment — duplicates start fresh on secrets per the
+        // per-entity secret model. The user must re-enter them on this device.
 
         removeDuplicateEntry(id)
       }
@@ -114,7 +135,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     if (backendId) {
       updateUserEnvironment(backendId, {
         name: "",
-        variables: entries,
+        variables: stripSecretVariableValuesForWire(entries),
         id: "",
         v: 2,
       })()

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -20,13 +20,11 @@ import {
   deleteUserEnvironment,
   updateUserEnvironment,
 } from "./api"
-import {
-  populateLocalStoresFromVariables,
-  stripSecretVariableValuesForWire,
-} from "@hoppscotch/common/helpers/secretVariables"
+import { stripSecretVariableValuesForWire } from "@hoppscotch/common/helpers/secretVariables"
 import { SecretEnvironmentService } from "@hoppscotch/common/services/secret-environment.service"
 import { getService } from "@hoppscotch/common/modules/dioc"
 import { CurrentValueService } from "@hoppscotch/common/services/current-environment-value.service"
+import type { Environment, GlobalEnvironment } from "@hoppscotch/data"
 
 export const environmentsMapper = createMapper<number, string>()
 export const globalEnvironmentMapper = createMapper<number, string>()
@@ -70,6 +68,14 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       const envId = ++appendStart
 
       ;(async function () {
+        // Snapshot the temp local id BEFORE the backend create overwrites
+        // it. The local secret + currentValue stores were already populated
+        // under this temp id at import time (`handleImportToStore`), so we
+        // remap rather than re-populate — the sync handler's `env.variables`
+        // is already stripped (newstore was pre-stripped at import time)
+        // and would otherwise overwrite the raw values with empty ones.
+        const tempId = environmentsStore.value.environments[envId].id
+
         const res = await createUserEnvironment(
           env.name,
           JSON.stringify(stripSecretVariableValuesForWire(env.variables))
@@ -77,14 +83,11 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
 
         if (E.isRight(res)) {
           const id = res.right.createUserEnvironment.id
+
+          secretEnvironmentService.updateSecretEnvironmentID(tempId, id)
+          currentEnvironmentValueService.updateEnvironmentID(tempId, id)
+
           environmentsStore.value.environments[envId].id = id
-
-          // Persist the imported secret + currentValue inputs to the local
-          // stores keyed by the new backend ID. Without this, the next
-          // `replaceEnvironments` (run on app load from the now-stripped
-          // backend row) wipes them and the user loses their imported data.
-          populateLocalStoresFromVariables(id, env.variables)
-
           removeDuplicateEntry(id)
         }
       })()
@@ -133,9 +136,19 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   setGlobalVariables({ entries }) {
     const backendId = getGlobalVariableID()
     if (backendId) {
+      // The backend stores `Environment.variables` JSON-stringified, and
+      // `loadGlobalEnvironments` parses that string via verzod's
+      // `GlobalEnvironment` entity reference — which expects the wrapped
+      // `{ v, variables }` shape, not a bare array. Send the wrapper (with
+      // secrets stripped from its variables) so the round-trip stays
+      // compatible with existing rows.
+      const stripped: GlobalEnvironment = {
+        ...entries,
+        variables: stripSecretVariableValuesForWire(entries.variables ?? []),
+      }
       updateUserEnvironment(backendId, {
         name: "",
-        variables: stripSecretVariableValuesForWire(entries),
+        variables: stripped as unknown as Environment["variables"],
         id: "",
         v: 2,
       })()

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -124,10 +124,18 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   updateEnvironment({ envIndex, updatedEnv }) {
     const backendId = environmentsStore.value.environments[envIndex].id
     if (backendId) {
+      // Strip at the wire boundary defensively — `Details.vue` and the
+      // `RequestRunner` post-test path already pre-strip before
+      // dispatching, but every other handler in this file (`create`,
+      // `append`, `duplicate`, `setGlobal`) strips here as the last
+      // line of defense, so a future caller that forgets to pre-strip
+      // can't leak secret values to the backend through this path.
       updateUserEnvironment(
         backendId,
         updatedEnv.name,
-        JSON.stringify(updatedEnv.variables)
+        JSON.stringify(
+          stripSecretVariableValuesForWire(updatedEnv.variables ?? [])
+        )
       )()
     }
   },

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -124,7 +124,11 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   updateEnvironment({ envIndex, updatedEnv }) {
     const backendId = environmentsStore.value.environments[envIndex].id
     if (backendId) {
-      updateUserEnvironment(backendId, updatedEnv)()
+      updateUserEnvironment(
+        backendId,
+        updatedEnv.name,
+        JSON.stringify(updatedEnv.variables)
+      )()
     }
   },
   async deleteEnvironment({ envID }) {
@@ -135,16 +139,22 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   setGlobalVariables({ entries }) {
     const backendId = getGlobalVariableID()
     if (backendId) {
-      // The global env shares the `UpdateUserEnvironment` mutation with
-      // regular envs — store it as the same `Environment` shape with an
-      // empty name. `loadGlobalEnvironments` re-wraps the bare-array
-      // payload into a `GlobalEnvironment` for the local store.
-      updateUserEnvironment(backendId, {
-        name: "",
-        variables: stripSecretVariableValuesForWire(entries.variables ?? []),
-        id: "",
-        v: 2,
-      })()
+      // Send the full `GlobalEnvironment` wrapper (`{ v, variables }`)
+      // on the wire, not a bare array. Pre-this-PR clients stored globals
+      // as the wrapper and their load path expects it back; sending a
+      // bare array here would cause those older clients to fall through
+      // verzod's parse, dump the raw array into `globals`, and crash on
+      // downstream `globalEnv.variables.map`. We can't guarantee
+      // synchronous client upgrades on a self-hosted deployment, so the
+      // wire shape stays compatible with both old and new readers.
+      updateUserEnvironment(
+        backendId,
+        "",
+        JSON.stringify({
+          v: 2,
+          variables: stripSecretVariableValuesForWire(entries.variables ?? []),
+        })
+      )()
     }
   },
   clearGlobalVariables() {

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -134,14 +134,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   setGlobalVariables({ entries }) {
     const backendId = getGlobalVariableID()
     if (backendId) {
-      // Send the `{ v, variables }` wrapper, not a bare array — older
-      // clients expect the wrapper and crash on `globalEnv.variables.map`
-      // otherwise. SH deployments can't be guaranteed in-sync, so the
-      // wire shape stays compatible with both.
+      // Bail on malformed input — syncing the dispatcher-coerced `[]`
+      // would clear backend globals irreversibly. Leaving FE/BE desynced
+      // is recoverable (reload re-hydrates from backend), data loss is
+      // not. The dispatcher's coerce only protects FE state.
       const variables = entries?.variables
       if (!Array.isArray(variables)) {
-        // Bail on malformed input — an empty wrapper would clear globals
-        // on the backend irreversibly.
         console.error(
           "[setGlobalVariables] unexpected variables shape, skipping sync"
         )

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -71,9 +71,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         // populated under this id at import time; we remap, not re-populate.
         const tempId = environmentsStore.value.environments[envId].id
 
+        // Strip at the wire-write boundary even though the import caller
+        // pre-strips — `appendEnvironments` is a public store API; the
+        // invariant can't rely on callers.
         const res = await createUserEnvironment(
           env.name,
-          JSON.stringify(stripSecretVariableValuesForWire(env.variables))
+          JSON.stringify(stripSecretVariableValuesForWire(env.variables ?? []))
         )
 
         if (E.isRight(res)) {

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -91,18 +91,18 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
             environmentsStore.value.environments[envId].id = id
             removeDuplicateEntry(id)
           } else {
-            // Backend rejected — flush the upstream-populated entries so
-            // they don't linger under a `tempId` no env will ever reference.
-            secretEnvironmentService.deleteSecretEnvironment(tempId)
-            currentEnvironmentValueService.deleteEnvironment(tempId)
+            // Backend rejected — leave local-store entries intact under
+            // `tempId` so the env in newstore (which still references
+            // `tempId`) continues to render secrets for this session.
+            // Reload will drop the env from newstore; the orphaned
+            // entries persist but are bounded (one per failed import).
+            console.error("[appendEnvironments] backend rejected create")
           }
-        } catch (_) {
-          // Network/unexpected throw — same cleanup as backend rejection.
-          // Without this, the fire-and-forget IIFE swallows the rejection
-          // and leaves `tempId` entries orphaned in localStorage.
-          secretEnvironmentService.deleteSecretEnvironment(tempId)
-          currentEnvironmentValueService.deleteEnvironment(tempId)
-          console.error("[appendEnvironments] backend create failed")
+        } catch (e) {
+          // Caught here so the fire-and-forget IIFE doesn't surface an
+          // "unhandled promise rejection." Same in-session preservation
+          // as the `E.isLeft` branch.
+          console.error("[appendEnvironments] backend create threw", e)
         }
       })()
     })

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -67,12 +67,8 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       const envId = ++appendStart
 
       ;(async function () {
-        // Snapshot the temp local id BEFORE the backend create overwrites
-        // it. The local secret + currentValue stores were already populated
-        // under this temp id at import time (`handleImportToStore`), so we
-        // remap rather than re-populate — the sync handler's `env.variables`
-        // is already stripped (newstore was pre-stripped at import time)
-        // and would otherwise overwrite the raw values with empty ones.
+        // Capture temp id before backend overwrites it — local stores were
+        // populated under this id at import time; we remap, not re-populate.
         const tempId = environmentsStore.value.environments[envId].id
 
         const res = await createUserEnvironment(
@@ -113,10 +109,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         const id = res.right.createUserEnvironment.id
         environmentsStore.value.environments[lastCreatedEnvIndex].id = id
 
-        // Secret variable values are intentionally NOT copied to the
-        // duplicated environment — duplicates start fresh on secrets per the
-        // per-entity secret model. The user must re-enter them on this device.
-
+        // Duplicates start fresh on secrets per the per-entity model.
         removeDuplicateEntry(id)
       }
     }
@@ -124,12 +117,6 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   updateEnvironment({ envIndex, updatedEnv }) {
     const backendId = environmentsStore.value.environments[envIndex].id
     if (backendId) {
-      // Strip at the wire boundary defensively — `Details.vue` and the
-      // `RequestRunner` post-test path already pre-strip before
-      // dispatching, but every other handler in this file (`create`,
-      // `append`, `duplicate`, `setGlobal`) strips here as the last
-      // line of defense, so a future caller that forgets to pre-strip
-      // can't leak secret values to the backend through this path.
       updateUserEnvironment(
         backendId,
         updatedEnv.name,
@@ -147,23 +134,14 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   setGlobalVariables({ entries }) {
     const backendId = getGlobalVariableID()
     if (backendId) {
-      // Send the full `GlobalEnvironment` wrapper (`{ v, variables }`)
-      // on the wire, not a bare array. Pre-this-PR clients stored globals
-      // as the wrapper and their load path expects it back; sending a
-      // bare array here would cause those older clients to fall through
-      // verzod's parse, dump the raw array into `globals`, and crash on
-      // downstream `globalEnv.variables.map`. We can't guarantee
-      // synchronous client upgrades on a self-hosted deployment, so the
-      // wire shape stays compatible with both old and new readers.
+      // Send the `{ v, variables }` wrapper, not a bare array — older
+      // clients expect the wrapper and crash on `globalEnv.variables.map`
+      // otherwise. SH deployments can't be guaranteed in-sync, so the
+      // wire shape stays compatible with both.
       const variables = entries?.variables
       if (!Array.isArray(variables)) {
-        // Guard against a schema mismatch reaching this write path —
-        // do NOT silently send `[]`. The dispatcher's
-        // `coerceGlobalEnvironment` should have already normalised this,
-        // but if a future schema migration or upstream regression
-        // delivers a malformed `entries`, sending an empty wrapper here
-        // would clear the user's globals on the backend irreversibly.
-        // Bail and surface the unexpected shape instead.
+        // Bail on malformed input — an empty wrapper would clear globals
+        // on the backend irreversibly.
         console.error(
           "[setGlobalVariables] unexpected variables shape, skipping sync",
           entries
@@ -187,10 +165,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       clearGlobalEnvironmentVariables(backendId)
     }
 
-    // Flush local stores keyed to "Global" — without this, a later
-    // `addGlobalEnvVariable` would land at `varIndex 0` against a stale
-    // entry from the previously-cleared variable and the UI would show
-    // the prior secret value in a fresh field.
+    // Flush "Global" entries so a later add doesn't alias stale `varIndex`.
     secretEnvironmentService.addSecretEnvironment("Global", [])
     currentEnvironmentValueService.addEnvironment("Global", [])
   },

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -143,8 +143,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         // Bail on malformed input — an empty wrapper would clear globals
         // on the backend irreversibly.
         console.error(
-          "[setGlobalVariables] unexpected variables shape, skipping sync",
-          entries
+          "[setGlobalVariables] unexpected variables shape, skipping sync"
         )
         return
       }

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -31,31 +31,45 @@ export const globalEnvironmentMapper = createMapper<number, string>()
 const secretEnvironmentService = getService(SecretEnvironmentService)
 const currentEnvironmentValueService = getService(CurrentValueService)
 
+// Tracks env ids that are still client-side temporary (`uniqueID()`) while
+// the backend create is in flight. `deleteEnvironment` skips the backend
+// call when the id is in this set — preventing a spurious 404 (and the
+// associated backend-create-then-orphan race) during the create window.
+// Real backend ids are never added here, so deleting an already-synced env
+// always fires the backend mutation.
+const pendingTempEnvIds = new Set<string>()
+
 export const storeSyncDefinition: StoreSyncDefinitionOf<
   typeof environmentsStore
 > = {
   async createEnvironment({ name, variables }) {
     const lastCreatedEnvIndex = environmentsStore.value.environments.length - 1
+    const tempId = environmentsStore.value.environments[lastCreatedEnvIndex]?.id
+    if (tempId) pendingTempEnvIds.add(tempId)
 
-    const res = await createUserEnvironment(
-      name,
-      JSON.stringify(stripSecretVariableValuesForWire(variables))
-    )
-
-    if (E.isRight(res)) {
-      const id = res.right.createUserEnvironment.id
-
-      secretEnvironmentService.updateSecretEnvironmentID(
-        environmentsStore.value.environments[lastCreatedEnvIndex].id,
-        id
-      )
-      currentEnvironmentValueService.updateEnvironmentID(
-        environmentsStore.value.environments[lastCreatedEnvIndex].id,
-        id
+    try {
+      const res = await createUserEnvironment(
+        name,
+        JSON.stringify(stripSecretVariableValuesForWire(variables))
       )
 
-      environmentsStore.value.environments[lastCreatedEnvIndex].id = id
-      removeDuplicateEntry(id)
+      if (E.isRight(res)) {
+        const id = res.right.createUserEnvironment.id
+
+        secretEnvironmentService.updateSecretEnvironmentID(
+          environmentsStore.value.environments[lastCreatedEnvIndex].id,
+          id
+        )
+        currentEnvironmentValueService.updateEnvironmentID(
+          environmentsStore.value.environments[lastCreatedEnvIndex].id,
+          id
+        )
+
+        environmentsStore.value.environments[lastCreatedEnvIndex].id = id
+        removeDuplicateEntry(id)
+      }
+    } finally {
+      if (tempId) pendingTempEnvIds.delete(tempId)
     }
   },
   async appendEnvironments({ envs }) {
@@ -146,7 +160,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async deleteEnvironment({ envID }) {
-    if (envID) {
+    // Skip when the id belongs to an env whose backend create is still in
+    // flight — sending the temp `uniqueID()` would 404 and the backend
+    // create would still complete, orphaning a row. Already-synced envs
+    // are never in `pendingTempEnvIds`, so this only filters the race
+    // window; normal deletes fire the backend mutation.
+    if (envID && !pendingTempEnvIds.has(envID)) {
       await deleteUserEnvironment(envID)()
     }
   },

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -33,10 +33,9 @@ const currentEnvironmentValueService = getService(CurrentValueService)
 
 // Tracks env ids that are still client-side temporary (`uniqueID()`) while
 // the backend create is in flight. `deleteEnvironment` skips the backend
-// call when the id is in this set — preventing a spurious 404 (and the
-// associated backend-create-then-orphan race) during the create window.
-// Real backend ids are never added here, so deleting an already-synced env
-// always fires the backend mutation.
+// call when the id is in this set — preventing a spurious 404 during the
+// create-then-delete race window. Real backend ids are never added here,
+// so deleting an already-synced env always fires the backend mutation.
 const pendingTempEnvIds = new Set<string>()
 
 export const storeSyncDefinition: StoreSyncDefinitionOf<
@@ -45,7 +44,8 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   async createEnvironment({ name, variables }) {
     const lastCreatedEnvIndex = environmentsStore.value.environments.length - 1
     const tempId = environmentsStore.value.environments[lastCreatedEnvIndex]?.id
-    if (tempId) pendingTempEnvIds.add(tempId)
+    if (!tempId) return
+    pendingTempEnvIds.add(tempId)
 
     try {
       const res = await createUserEnvironment(
@@ -69,7 +69,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         removeDuplicateEntry(id)
       }
     } finally {
-      if (tempId) pendingTempEnvIds.delete(tempId)
+      pendingTempEnvIds.delete(tempId)
     }
   },
   async appendEnvironments({ envs }) {
@@ -83,7 +83,9 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       ;(async function () {
         // Capture temp id before backend overwrites it — local stores were
         // populated under this id at import time; we remap, not re-populate.
-        const tempId = environmentsStore.value.environments[envId].id
+        const tempId = environmentsStore.value.environments[envId]?.id
+        if (!tempId) return
+        pendingTempEnvIds.add(tempId)
 
         try {
           // Strip at the wire-write boundary even though the import caller
@@ -117,6 +119,8 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
           // "unhandled promise rejection." Same in-session preservation
           // as the `E.isLeft` branch.
           console.error("[appendEnvironments] backend create threw", e)
+        } finally {
+          pendingTempEnvIds.delete(tempId)
         }
       })()
     })
@@ -125,15 +129,19 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const environmentToDuplicate = environmentsStore.value.environments.find(
       (_, index) => index === envIndex
     )
+    if (!environmentToDuplicate) return
 
     const lastCreatedEnvIndex = environmentsStore.value.environments.length - 1
+    const tempId = environmentsStore.value.environments[lastCreatedEnvIndex]?.id
+    if (!tempId) return
+    pendingTempEnvIds.add(tempId)
 
-    if (environmentToDuplicate) {
+    try {
       const res = await createUserEnvironment(
-        `${environmentToDuplicate?.name} - Duplicate`,
+        `${environmentToDuplicate.name} - Duplicate`,
         JSON.stringify(
           stripSecretVariableValuesForWire(
-            environmentToDuplicate?.variables ?? []
+            environmentToDuplicate.variables ?? []
           )
         )
       )
@@ -145,6 +153,8 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         // Duplicates start fresh on secrets per the per-entity model.
         removeDuplicateEntry(id)
       }
+    } finally {
+      pendingTempEnvIds.delete(tempId)
     }
   },
   updateEnvironment({ envIndex, updatedEnv }) {

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -186,6 +186,13 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     if (backendId) {
       clearGlobalEnvironmentVariables(backendId)
     }
+
+    // Flush local stores keyed to "Global" — without this, a later
+    // `addGlobalEnvVariable` would land at `varIndex 0` against a stale
+    // entry from the previously-cleared variable and the UI would show
+    // the prior secret value in a fresh field.
+    secretEnvironmentService.addSecretEnvironment("Global", [])
+    currentEnvironmentValueService.addEnvironment("Global", [])
   },
 }
 

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -56,14 +56,11 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       if (E.isRight(res)) {
         const id = res.right.createUserEnvironment.id
 
-        secretEnvironmentService.updateSecretEnvironmentID(
-          environmentsStore.value.environments[lastCreatedEnvIndex].id,
-          id
-        )
-        currentEnvironmentValueService.updateEnvironmentID(
-          environmentsStore.value.environments[lastCreatedEnvIndex].id,
-          id
-        )
+        // Use the captured `tempId` (not a re-read of the array) so the
+        // migration still works if the env list shifted during the await.
+        // Matches the pattern in `appendEnvironments` below.
+        secretEnvironmentService.updateSecretEnvironmentID(tempId, id)
+        currentEnvironmentValueService.updateEnvironmentID(tempId, id)
 
         environmentsStore.value.environments[lastCreatedEnvIndex].id = id
         removeDuplicateEntry(id)

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -71,22 +71,38 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
         // populated under this id at import time; we remap, not re-populate.
         const tempId = environmentsStore.value.environments[envId].id
 
-        // Strip at the wire-write boundary even though the import caller
-        // pre-strips — `appendEnvironments` is a public store API; the
-        // invariant can't rely on callers.
-        const res = await createUserEnvironment(
-          env.name,
-          JSON.stringify(stripSecretVariableValuesForWire(env.variables ?? []))
-        )
+        try {
+          // Strip at the wire-write boundary even though the import caller
+          // pre-strips — `appendEnvironments` is a public store API; the
+          // invariant can't rely on callers.
+          const res = await createUserEnvironment(
+            env.name,
+            JSON.stringify(
+              stripSecretVariableValuesForWire(env.variables ?? [])
+            )
+          )
 
-        if (E.isRight(res)) {
-          const id = res.right.createUserEnvironment.id
+          if (E.isRight(res)) {
+            const id = res.right.createUserEnvironment.id
 
-          secretEnvironmentService.updateSecretEnvironmentID(tempId, id)
-          currentEnvironmentValueService.updateEnvironmentID(tempId, id)
+            secretEnvironmentService.updateSecretEnvironmentID(tempId, id)
+            currentEnvironmentValueService.updateEnvironmentID(tempId, id)
 
-          environmentsStore.value.environments[envId].id = id
-          removeDuplicateEntry(id)
+            environmentsStore.value.environments[envId].id = id
+            removeDuplicateEntry(id)
+          } else {
+            // Backend rejected — flush the upstream-populated entries so
+            // they don't linger under a `tempId` no env will ever reference.
+            secretEnvironmentService.deleteSecretEnvironment(tempId)
+            currentEnvironmentValueService.deleteEnvironment(tempId)
+          }
+        } catch (_) {
+          // Network/unexpected throw — same cleanup as backend rejection.
+          // Without this, the fire-and-forget IIFE swallows the rejection
+          // and leaves `tempId` entries orphaned in localStorage.
+          secretEnvironmentService.deleteSecretEnvironment(tempId)
+          currentEnvironmentValueService.deleteEnvironment(tempId)
+          console.error("[appendEnvironments] backend create failed")
         }
       })()
     })

--- a/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/environments/web/sync.ts
@@ -155,12 +155,27 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       // downstream `globalEnv.variables.map`. We can't guarantee
       // synchronous client upgrades on a self-hosted deployment, so the
       // wire shape stays compatible with both old and new readers.
+      const variables = entries?.variables
+      if (!Array.isArray(variables)) {
+        // Guard against a schema mismatch reaching this write path —
+        // do NOT silently send `[]`. The dispatcher's
+        // `coerceGlobalEnvironment` should have already normalised this,
+        // but if a future schema migration or upstream regression
+        // delivers a malformed `entries`, sending an empty wrapper here
+        // would clear the user's globals on the backend irreversibly.
+        // Bail and surface the unexpected shape instead.
+        console.error(
+          "[setGlobalVariables] unexpected variables shape, skipping sync",
+          entries
+        )
+        return
+      }
       updateUserEnvironment(
         backendId,
         "",
         JSON.stringify({
           v: 2,
-          variables: stripSecretVariableValuesForWire(entries.variables ?? []),
+          variables: stripSecretVariableValuesForWire(variables),
         })
       )()
     }


### PR DESCRIPTION
Closes FE-1248 #6259

This PR centralizes secret variable handling across collections and environments
so secret values stay on the user's device and never get persisted to the
backend. Two helpers anchor the change — `stripSecretVariableValuesForWire`
strips secret/current values at wire boundaries, and
`populateLocalStoresFromVariables` restores local secret/current-value stores
after imports and related flows.

### What's changed

- **Secret variable handling**: added `stripSecretVariableValuesForWire` and
  `populateLocalStoresFromVariables` in `secretVariables.ts` to centralize
  stripping secret values before backend writes and restoring them to local
  stores on import. All relevant code paths — collections, environments,
  imports, exports, sync, request runner — now route through the helper,
  replacing the previously scattered ad-hoc logic.
- **Team collection writes**: `setCollectionProperties` mirrors secret-store
  writes by backend collection ID so imported team collection secrets survive
  the backend ID remap.
- **Import / export / duplication**: secret values are stripped before backend
  storage and local stores are populated as needed after import. User secrets
  stay on-device; backend data stays clean.
- **UI rehydration**: collection and environment editors restore secret values
  from local stores when reopening modals, so users see their secrets when
  appropriate without risking backend exposure.
- **Sync layer**: `pendingTempEnvIds` race guard, scope-specific env change
  detection in `platform/environments/{web,desktop}/sync.ts`;
  `updateUserEnvironment` now takes pre-stringified JSON.
- **Collection import**: `ensureRefIds` +
  `populateLocalStoresFromCollectionTree` upstream,
  `repopulateLoadedCollectionTree` downstream for backend round-trip via
  `data._ref_id`; orphaned ref-ids flushed.
- **Team-collection migration**: on `teamCollectionAdded`, remaps
  `_ref_id`-keyed local secret entries to backend IDs
  (`team-collection.service.ts:migrateImportedSecretEntries`).
- **Global environment wrapper**: always sends `{ v: 2, variables }`; loaders
  accept wrapper or bare arrays; `coerceGlobalEnvironment` at the dispatcher
  boundary.
- **Exports**: `myCollections`, `gqlCollections`, `gist`, and environment
  exports strip secrets and clear `currentValue`.
- **Tests**: `secretVariables.spec.ts` (no-leak + reorder-safety invariants),
  `globalEnvShape.spec.ts`, postman env legacy-`type: "secret"` coverage.

### Notes to reviewers

- Shared-package blast radius: `hoppscotch-common` is shared across Cloud,
  SH-CE, SH-Enterprise, and Desktop. Behavioral parity verified.
- Backend round-trip: `_ref_id` is preserved via the opaque Prisma `data` JSON
  field, no backend schema change required.

#### Manual verification

#### Personal environments

- [x] Create new environment with secret + non-secret variables — verify sync, verify ID assigned
- [x] Edit environment variables (secret + non-secret) — verify `UpdateUserEnvironment` mutation called once with secret values stripped from wire payload
- [x] Reopen the same environment — verify secret values rehydrate from local store, not lost
- [x] Delete environment — verify removed from backend
- [x] Duplicate environment — verify duplicate has empty secret values (intentional, secrets do NOT carry to duplicates)
- [x] Switch active environment — verify correct env loaded with secrets intact
- [x] Open DevTools Network tab; in Postman-imported env, verify `currentValue` is empty in the `variables` JSON sent to backend

#### Global environment

- [x] Edit global environment in UI — verify `UpdateUserEnvironment` mutation fires with the wrapped `{v: 2, variables: [...]}` payload (NOT a bare array) and secret values stripped
- [x] Reload the page after a global edit — verify globals load correctly with no crash
- [x] Add a secret global variable, reload, reopen — verify secret value persists locally and is NOT in the backend payload
- [x] Clear globals — verify backend cleared
- [x] Reload app on a fresh user account (no globals row yet) — verify the create-empty-globals path works

#### Team environments

- [x] Create team env with secret + non-secret variables — verify `createTeamEnvironment` mutation only (no spurious `UpdateUserEnvironment`)
- [x] Edit team env variables — verify `updateTeamEnvironment` mutation only, with secrets stripped on the wire
- [x] Confirm secrets visible in UI after save and after reload (rehydrated from local secret service)

#### RequestRunner / test scripts

- [x] Run a request with `pw.env.set("X", "y")` in test script while a **MY_ENV** is selected — verify ONLY `UpdateUserEnvironment` for that env fires, no global mutation if globals untouched
- [x] Run a request with `pw.env.set` while a **TEAM_ENV** is selected — verify ONLY `updateTeamEnvironment` fires, **no `UpdateUserEnvironment`** for globals
- [x] Run a request with `hopp.env.global.set` while a TEAM_ENV is selected — verify ONLY `UpdateUserEnvironment` (globals) fires, no team-env mutation
- [x] Run a request whose script does NOT touch any env variable — verify NO env mutation fires at all
- [x] Set a secret env variable via `pw.env.set` (key marked secret beforehand) — verify wire payload has `initialValue: ""` and `currentValue: ""` for that var; local secret service holds the actual value
- [x] Run the same request flow inside the Test Runner (Collection Runner) — same expectations as above

#### Collections

- [x] Create a new collection with variables (secret + non-secret) — verify variables saved, secrets stripped on wire
- [x] Edit collection properties: change variable values, add/remove variables — verify rehydrate-on-reopen works, secrets visible
- [x] Reload app, reopen the collection — verify variables and secrets intact
- [x] Duplicate a collection — verify duplicate has empty secrets (intentional)
- [x] Folder variables: same expectations as collection-level

#### Imports

- [x] Import Hoppscotch JSON env with secrets — verify secret values land in local secret store, NOT in backend payload, and visible in UI
- [x] Import Postman env (older format with `type: "secret"`) — verify variables marked secret correctly
- [x] Import Postman collection with secret variables — verify same handling at collection level





