### PR TITLE
feat: add variable rename support with auto-update of references

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -139,6 +139,7 @@
                         count: index + 1,
                       })}`"
                       :name="'variable' + index"
+                      @change="handleVariableRename(id, env.key)"
                     />
                     <div class="flex items-center flex-1">
                       <SmartEnvInput
@@ -511,6 +512,25 @@ const addEnvironmentVariable = () => {
       initialValue: "",
       secret: selectedEnvOption.value === "secret",
     },
+  })
+}
+const handleVariableRename = (id: number, newKey: string) => {
+  const variable = vars.value.find((e) => e.id === id)
+  if (!variable) return
+
+  const oldKey = variable.env.key
+  if (oldKey === newKey || !oldKey) return
+
+  // Replace all <<oldKey>> references with <<newKey>> in all variables
+  vars.value.forEach((v) => {
+    v.env.initialValue = v.env.initialValue.replaceAll(
+      `<<${oldKey}>>`,
+      `<<${newKey}>>`
+    )
+    v.env.currentValue = v.env.currentValue.replaceAll(
+      `<<${oldKey}>>`,
+      `<<${newKey}>>`
+    )
   })
 }
 

--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -139,6 +139,7 @@
                         count: index + 1,
                       })}`"
                       :name="'variable' + index"
+                      @focus="originalKeys.set(id, env.key)"
                       @change="handleVariableRename(id, env.key)"
                     />
                     <div class="flex items-center flex-1">
@@ -300,7 +301,7 @@ const emit = defineEmits<{
 }>()
 
 const idTicker = ref(0)
-
+const originalKeys = new Map<number, string>()
 const tabsData: ComputedRef<
   {
     id: string
@@ -515,10 +516,7 @@ const addEnvironmentVariable = () => {
   })
 }
 const handleVariableRename = (id: number, newKey: string) => {
-  const variable = vars.value.find((e) => e.id === id)
-  if (!variable) return
-
-  const oldKey = variable.env.key
+  const oldKey = originalKeys.get(id)
   if (oldKey === newKey || !oldKey) return
 
   // Replace all <<oldKey>> references with <<newKey>> in all variables
@@ -532,6 +530,7 @@ const handleVariableRename = (id: number, newKey: string) => {
       `<<${newKey}>>`
     )
   })
+  originalKeys.delete(id)
 }
 
 const removeEnvironmentVariable = (id: number) => {

--- a/packages/hoppscotch-common/src/newstore/__tests__/environments.spec.ts
+++ b/packages/hoppscotch-common/src/newstore/__tests__/environments.spec.ts
@@ -1,10 +1,8 @@
 // @vitest-environment node
 import { describe, expect, test } from "vitest"
 
-describe("handleVariableRename logic", () => {
-  test("replaces <<oldKey>> references in initialValue when key is renamed", () => {
-    const originalKeys = new Map<number, string>()
-
+describe("handleVariableRename", () => {
+  test("replaces <<oldKey>> with <<newKey>> in other variables", () => {
     const vars = [
       {
         id: 0,
@@ -24,89 +22,8 @@ describe("handleVariableRename logic", () => {
       },
     ]
 
-    originalKeys.set(0, vars[0].env.key)
-    vars[0].env.key = "api_url"
-
-    const oldKey = originalKeys.get(0)!
-    const newKey = vars[0].env.key
-
-    if (oldKey && oldKey !== newKey) {
-      vars.forEach((v) => {
-        v.env.initialValue = v.env.initialValue.replaceAll(
-          `<<${oldKey}>>`,
-          `<<${newKey}>>`
-        )
-        v.env.currentValue = v.env.currentValue.replaceAll(
-          `<<${oldKey}>>`,
-          `<<${newKey}>>`
-        )
-      })
-    }
-
-    expect(vars[1].env.initialValue).toBe("<<api_url>>/users")
-  })
-
-  test("does not replace if key did not change", () => {
-    const originalKeys = new Map<number, string>()
-
-    const vars = [
-      {
-        id: 0,
-        env: {
-          key: "base_url",
-          initialValue: "https://api.com",
-          currentValue: "",
-        },
-      },
-      {
-        id: 1,
-        env: {
-          key: "endpoint",
-          initialValue: "<<base_url>>/users",
-          currentValue: "",
-        },
-      },
-    ]
-
-    originalKeys.set(0, "base_url")
-    const oldKey = originalKeys.get(0)!
-    const newKey = "base_url"
-
-    if (oldKey && oldKey !== newKey) {
-      vars.forEach((v) => {
-        v.env.initialValue = v.env.initialValue.replaceAll(
-          `<<${oldKey}>>`,
-          `<<${newKey}>>`
-        )
-      })
-    }
-
-    expect(vars[1].env.initialValue).toBe("<<base_url>>/users")
-  })
-
-  test("replaces multiple occurrences of the same variable", () => {
-    const originalKeys = new Map<number, string>()
-
-    const vars = [
-      {
-        id: 0,
-        env: { key: "host", initialValue: "localhost", currentValue: "" },
-      },
-      {
-        id: 1,
-        env: {
-          key: "url",
-          initialValue: "<<host>>:3000/<<host>>/api",
-          currentValue: "",
-        },
-      },
-    ]
-
-    originalKeys.set(0, "host")
-    vars[0].env.key = "server"
-
-    const oldKey = originalKeys.get(0)!
-    const newKey = vars[0].env.key
+    const oldKey = "base_url"
+    const newKey = "api_url"
 
     vars.forEach((v) => {
       v.env.initialValue = v.env.initialValue.replaceAll(
@@ -115,64 +32,58 @@ describe("handleVariableRename logic", () => {
       )
     })
 
-    expect(vars[1].env.initialValue).toBe("<<server>>:3000/<<server>>/api")
+    expect(vars[1].env.initialValue).toBe("<<api_url>>/users")
   })
 
-  test("replaces references in currentValue as well", () => {
-    const originalKeys = new Map<number, string>()
-
+  test("does nothing if key did not change", () => {
     const vars = [
-      { id: 0, env: { key: "token", initialValue: "", currentValue: "" } },
       {
         id: 1,
         env: {
-          key: "auth",
-          initialValue: "",
-          currentValue: "Bearer <<token>>",
-        },
-      },
-    ]
-
-    originalKeys.set(0, "token")
-    vars[0].env.key = "api_token"
-
-    const oldKey = originalKeys.get(0)!
-    const newKey = vars[0].env.key
-
-    vars.forEach((v) => {
-      v.env.currentValue = v.env.currentValue.replaceAll(
-        `<<${oldKey}>>`,
-        `<<${newKey}>>`
-      )
-    })
-
-    expect(vars[1].env.currentValue).toBe("Bearer <<api_token>>")
-  })
-
-  test("does nothing if oldKey is not in the map", () => {
-    const originalKeys = new Map<number, string>()
-
-    const vars = [
-      {
-        id: 0,
-        env: {
-          key: "base_url",
-          initialValue: "https://api.com",
+          key: "endpoint",
+          initialValue: "<<base_url>>/users",
           currentValue: "",
         },
       },
     ]
 
-    const oldKey = originalKeys.get(99)
-    if (oldKey) {
+    const oldKey = "base_url"
+    const newKey = "base_url"
+
+    if (oldKey !== newKey) {
       vars.forEach((v) => {
         v.env.initialValue = v.env.initialValue.replaceAll(
           `<<${oldKey}>>`,
-          "<<new>>"
+          `<<${newKey}>>`
         )
       })
     }
 
-    expect(vars[0].env.initialValue).toBe("https://api.com")
+    expect(vars[0].env.initialValue).toBe("<<base_url>>/users")
+  })
+
+  test("replaces multiple occurrences", () => {
+    const vars = [
+      {
+        id: 0,
+        env: {
+          key: "url",
+          initialValue: "<<host>>:3000/<<host>>",
+          currentValue: "",
+        },
+      },
+    ]
+
+    const oldKey = "host"
+    const newKey = "server"
+
+    vars.forEach((v) => {
+      v.env.initialValue = v.env.initialValue.replaceAll(
+        `<<${oldKey}>>`,
+        `<<${newKey}>>`
+      )
+    })
+
+    expect(vars[0].env.initialValue).toBe("<<server>>:3000/<<server>>")
   })
 })

--- a/packages/hoppscotch-common/src/newstore/__tests__/environments.spec.ts
+++ b/packages/hoppscotch-common/src/newstore/__tests__/environments.spec.ts
@@ -1,0 +1,178 @@
+// @vitest-environment node
+import { describe, expect, test } from "vitest"
+
+describe("handleVariableRename logic", () => {
+  test("replaces <<oldKey>> references in initialValue when key is renamed", () => {
+    const originalKeys = new Map<number, string>()
+
+    const vars = [
+      {
+        id: 0,
+        env: {
+          key: "base_url",
+          initialValue: "https://api.com",
+          currentValue: "",
+        },
+      },
+      {
+        id: 1,
+        env: {
+          key: "endpoint",
+          initialValue: "<<base_url>>/users",
+          currentValue: "",
+        },
+      },
+    ]
+
+    originalKeys.set(0, vars[0].env.key)
+    vars[0].env.key = "api_url"
+
+    const oldKey = originalKeys.get(0)!
+    const newKey = vars[0].env.key
+
+    if (oldKey && oldKey !== newKey) {
+      vars.forEach((v) => {
+        v.env.initialValue = v.env.initialValue.replaceAll(
+          `<<${oldKey}>>`,
+          `<<${newKey}>>`
+        )
+        v.env.currentValue = v.env.currentValue.replaceAll(
+          `<<${oldKey}>>`,
+          `<<${newKey}>>`
+        )
+      })
+    }
+
+    expect(vars[1].env.initialValue).toBe("<<api_url>>/users")
+  })
+
+  test("does not replace if key did not change", () => {
+    const originalKeys = new Map<number, string>()
+
+    const vars = [
+      {
+        id: 0,
+        env: {
+          key: "base_url",
+          initialValue: "https://api.com",
+          currentValue: "",
+        },
+      },
+      {
+        id: 1,
+        env: {
+          key: "endpoint",
+          initialValue: "<<base_url>>/users",
+          currentValue: "",
+        },
+      },
+    ]
+
+    originalKeys.set(0, "base_url")
+    const oldKey = originalKeys.get(0)!
+    const newKey = "base_url"
+
+    if (oldKey && oldKey !== newKey) {
+      vars.forEach((v) => {
+        v.env.initialValue = v.env.initialValue.replaceAll(
+          `<<${oldKey}>>`,
+          `<<${newKey}>>`
+        )
+      })
+    }
+
+    expect(vars[1].env.initialValue).toBe("<<base_url>>/users")
+  })
+
+  test("replaces multiple occurrences of the same variable", () => {
+    const originalKeys = new Map<number, string>()
+
+    const vars = [
+      {
+        id: 0,
+        env: { key: "host", initialValue: "localhost", currentValue: "" },
+      },
+      {
+        id: 1,
+        env: {
+          key: "url",
+          initialValue: "<<host>>:3000/<<host>>/api",
+          currentValue: "",
+        },
+      },
+    ]
+
+    originalKeys.set(0, "host")
+    vars[0].env.key = "server"
+
+    const oldKey = originalKeys.get(0)!
+    const newKey = vars[0].env.key
+
+    vars.forEach((v) => {
+      v.env.initialValue = v.env.initialValue.replaceAll(
+        `<<${oldKey}>>`,
+        `<<${newKey}>>`
+      )
+    })
+
+    expect(vars[1].env.initialValue).toBe("<<server>>:3000/<<server>>/api")
+  })
+
+  test("replaces references in currentValue as well", () => {
+    const originalKeys = new Map<number, string>()
+
+    const vars = [
+      { id: 0, env: { key: "token", initialValue: "", currentValue: "" } },
+      {
+        id: 1,
+        env: {
+          key: "auth",
+          initialValue: "",
+          currentValue: "Bearer <<token>>",
+        },
+      },
+    ]
+
+    originalKeys.set(0, "token")
+    vars[0].env.key = "api_token"
+
+    const oldKey = originalKeys.get(0)!
+    const newKey = vars[0].env.key
+
+    vars.forEach((v) => {
+      v.env.currentValue = v.env.currentValue.replaceAll(
+        `<<${oldKey}>>`,
+        `<<${newKey}>>`
+      )
+    })
+
+    expect(vars[1].env.currentValue).toBe("Bearer <<api_token>>")
+  })
+
+  test("does nothing if oldKey is not in the map", () => {
+    const originalKeys = new Map<number, string>()
+
+    const vars = [
+      {
+        id: 0,
+        env: {
+          key: "base_url",
+          initialValue: "https://api.com",
+          currentValue: "",
+        },
+      },
+    ]
+
+    const oldKey = originalKeys.get(99)
+    if (oldKey) {
+      vars.forEach((v) => {
+        v.env.initialValue = v.env.initialValue.replaceAll(
+          `<<${oldKey}>>`,
+          "<<new>>"
+        )
+      })
+    }
+
+    expect(vars[0].env.initialValue).toBe("https://api.com")
+  })
+})

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -189,31 +189,7 @@ const dispatchers = defineDispatchers({
       ),
     }
   },
-  renameEnvironmentVariable(
-    { environments }: EnvironmentStore,
-    {
-      envIndex,
-      variableIndex,
-      newKey,
-    }: {
-      envIndex: number
-      variableIndex: number
-      newKey: string
-    }
-  ) {
-    return {
-      environments: environments.map((env, index) =>
-        index === envIndex
-          ? {
-              ...env,
-              variables: env.variables.map((v, vIndex) =>
-                vIndex === variableIndex ? { ...v, key: newKey } : v
-              ),
-            }
-          : env
-      ),
-    }
-  },
+
   updateEnvironment(
     { environments }: EnvironmentStore,
     { envIndex, updatedEnv }: { envIndex: number; updatedEnv: Environment }
@@ -905,21 +881,6 @@ export function renameEnvironment(envIndex: number, newName: string) {
     payload: {
       envIndex,
       newName,
-    },
-  })
-}
-
-export function renameEnvironmentVariable(
-  envIndex: number,
-  variableIndex: number,
-  newKey: string
-) {
-  environmentsStore.dispatch({
-    dispatcher: "renameEnvironmentVariable",
-    payload: {
-      envIndex,
-      variableIndex,
-      newKey,
     },
   })
 }

--- a/packages/hoppscotch-common/src/newstore/environments.ts
+++ b/packages/hoppscotch-common/src/newstore/environments.ts
@@ -189,6 +189,31 @@ const dispatchers = defineDispatchers({
       ),
     }
   },
+  renameEnvironmentVariable(
+    { environments }: EnvironmentStore,
+    {
+      envIndex,
+      variableIndex,
+      newKey,
+    }: {
+      envIndex: number
+      variableIndex: number
+      newKey: string
+    }
+  ) {
+    return {
+      environments: environments.map((env, index) =>
+        index === envIndex
+          ? {
+              ...env,
+              variables: env.variables.map((v, vIndex) =>
+                vIndex === variableIndex ? { ...v, key: newKey } : v
+              ),
+            }
+          : env
+      ),
+    }
+  },
   updateEnvironment(
     { environments }: EnvironmentStore,
     { envIndex, updatedEnv }: { envIndex: number; updatedEnv: Environment }
@@ -880,6 +905,21 @@ export function renameEnvironment(envIndex: number, newName: string) {
     payload: {
       envIndex,
       newName,
+    },
+  })
+}
+
+export function renameEnvironmentVariable(
+  envIndex: number,
+  variableIndex: number,
+  newKey: string
+) {
+  environmentsStore.dispatch({
+    dispatcher: "renameEnvironmentVariable",
+    payload: {
+      envIndex,
+      variableIndex,
+      newKey,
     },
   })
 }


### PR DESCRIPTION
## Summary
Implements variable rename support as requested in hoppscotch/hoppscotch#6245.

## Changes
- Added `renameEnvironmentVariable` dispatcher and exported function in `newstore/environments.ts`
- Added `handleVariableRename` function in `environments/my/Details.vue` that auto-updates all `<<variableName>>` references when a variable key is renamed

## How it works
When a user renames a variable key, all occurrences of `<<oldKey>>` in the `initialValue` and `currentValue` fields of all variables in the environment are automatically replaced with `<<newKey>>`.

## Related Issue
Closes hoppscotch/hoppscotch#6245

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add environment variable rename support with automatic update of all <<key>> references across the environment. Captures the original key on focus to avoid missed updates when renaming, and adds unit tests covering replacement, no-op when unchanged, and multiple occurrences. Closes hoppscotch/hoppscotch#6245.

- **New Features**
  - UI: in `Details.vue`, `@focus` stores the original key per row in `originalKeys`; on `@change`, `handleVariableRename` replaces `<<oldKey>>` with `<<newKey>>` in `initialValue` and `currentValue` for all variables.

- **Refactors**
  - Removed unused `renameEnvironmentVariable` store function; rename logic now lives in the UI.

<sup>Written for commit 5bdd5307a9d9621edb31671c31359785013d2420. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

