### PR TITLE
fix: preserve asterisk in cURL import query params

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -947,6 +947,35 @@ const samples = [
     }),
   },
   {
+    command: `curl 'https://example.com/search?filter=*'`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://example.com/search",
+      auth: {
+        authType: "inherit",
+        authActive: true,
+      },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      params: [
+        {
+          active: true,
+          key: "filter",
+          value: "*",
+          description: "",
+        },
+      ],
+      headers: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
+  {
     command: `curl --location 'https://api.example.net/id/1164/requests' \
     --header 'Accept: application/vnd.test-data.v2.1+json' \
     --header 'Content-Type: application/x-www-form-urlencoded' \

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
@@ -53,7 +53,7 @@ const parseURL = (urlText: string | number) =>
       u
         .toString()
         .replace(/^'|'$/g, "")
-        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>\s]/g, "")
+        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()*'<>\s]/g, "")
     ),
     O.filter((u) => u.length > 0),
     O.chain((u) =>


### PR DESCRIPTION
## Summary
- preserve \*\ in cURL-imported URLs instead of stripping it during URL sanitization
- add a regression test covering \curl 'https://example.com/search?filter=*'\

## Notes
- this fixes the cURL import case where query parameter values containing an asterisk were imported incorrectly

Fixes #6249

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the literal "*" in query parameter values during cURL import so URLs like ?filter=* parse correctly. Fixes #6249.

- **Bug Fixes**
  - Relaxed URL sanitizer to allow "*" in query strings.
  - Added regression test for `curl 'https://example.com/search?filter=*'`.

<sup>Written for commit 5d9a51f8d313dc17620baf18e073ff5dbcba3052. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

