### PR TITLE
fix: prevent data corruption when duplicating personal workspace collections

### DIFF
--- a/packages/hoppscotch-common/src/newstore/__tests__/collections.duplicateCollection.spec.ts
+++ b/packages/hoppscotch-common/src/newstore/__tests__/collections.duplicateCollection.spec.ts
@@ -3,6 +3,7 @@ import {
   HoppCollection,
   makeCollection,
   generateUniqueRefId,
+  getDefaultRESTRequest,
 } from "@hoppscotch/data"
 
 // Mock the i18n module used by the duplicateCollection dispatcher
@@ -55,27 +56,15 @@ import {
 
 function makeRequest(overrides: Record<string, any> = {}) {
   return {
-    v: "8" as const,
+    ...getDefaultRESTRequest(),
     id: undefined,
     name: "Test Request",
-    method: "GET",
-    endpoint: "https://example.com",
-    params: [],
-    headers: [],
-    preRequestScript: "",
-    testScript: "",
-    body: { contentType: null, body: null },
-    auth: { authType: "none", authActive: true },
-    requestVariables: [],
-    responses: {},
-    _ref_id: generateUniqueRefId("req"),
-    description: null,
     ...overrides,
   }
 }
 
 function makeTestCollection(
-  overrides: Partial<HoppCollection> & Record<string, any> = {}
+  overrides: Partial<HoppCollection> = {}
 ): HoppCollection {
   return makeCollection({
     name: "Test Collection",
@@ -83,6 +72,10 @@ function makeTestCollection(
     requests: [],
     auth: { authType: "inherit", authActive: true },
     headers: [],
+    variables: [],
+    description: null,
+    preRequestScript: "",
+    testScript: "",
     ...overrides,
   })
 }

--- a/packages/hoppscotch-common/src/newstore/__tests__/collections.duplicateCollection.spec.ts
+++ b/packages/hoppscotch-common/src/newstore/__tests__/collections.duplicateCollection.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from "vitest"
 import {
   HoppCollection,
   makeCollection,
-  generateUniqueRefId,
   getDefaultRESTRequest,
 } from "@hoppscotch/data"
 

--- a/packages/hoppscotch-common/src/newstore/__tests__/collections.duplicateCollection.spec.ts
+++ b/packages/hoppscotch-common/src/newstore/__tests__/collections.duplicateCollection.spec.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  HoppCollection,
+  makeCollection,
+  generateUniqueRefId,
+} from "@hoppscotch/data"
+
+// Mock the i18n module used by the duplicateCollection dispatcher
+vi.mock("~/modules/i18n", () => ({
+  getI18n: () => (key: string) => key,
+}))
+
+// Mock the dioc service locator used at module scope in collections.ts
+vi.mock("~/modules/dioc", () => ({
+  getService: () => ({
+    getSecretEnvironmentVariable: () => undefined,
+    getCurrentValue: () => undefined,
+  }),
+}))
+
+// Mock the RESTTabService used at module scope
+vi.mock("~/services/tab/rest", () => ({
+  RESTTabService: class {},
+}))
+
+// Mock the SecretEnvironmentService
+vi.mock("~/services/secret-environment.service", () => ({
+  SecretEnvironmentService: class {},
+}))
+
+// Mock the CurrentValueService
+vi.mock("~/services/current-environment-value.service", () => ({
+  CurrentValueService: class {},
+}))
+
+// Mock the scripting helper
+vi.mock("~/helpers/scripting", () => ({
+  hasActualScript: () => false,
+}))
+
+// Mock the collection request helper
+vi.mock("~/helpers/collection/request", () => ({
+  resolveSaveContextOnRequestReorder: () => {},
+}))
+
+import {
+  restCollectionStore,
+  setRESTCollections,
+  duplicateRESTCollection,
+  editRESTRequest,
+  graphqlCollectionStore,
+  setGraphqlCollections,
+  editGraphqlRequest,
+} from "~/newstore/collections"
+
+function makeRequest(overrides: Record<string, any> = {}) {
+  return {
+    v: "8" as const,
+    id: undefined,
+    name: "Test Request",
+    method: "GET",
+    endpoint: "https://example.com",
+    params: [],
+    headers: [],
+    preRequestScript: "",
+    testScript: "",
+    body: { contentType: null, body: null },
+    auth: { authType: "none", authActive: true },
+    requestVariables: [],
+    responses: {},
+    _ref_id: generateUniqueRefId("req"),
+    description: null,
+    ...overrides,
+  }
+}
+
+function makeTestCollection(
+  overrides: Partial<HoppCollection> & Record<string, any> = {}
+): HoppCollection {
+  return makeCollection({
+    name: "Test Collection",
+    folders: [],
+    requests: [],
+    auth: { authType: "inherit", authActive: true },
+    headers: [],
+    ...overrides,
+  })
+}
+
+describe("duplicateCollection — ID clearing", () => {
+  /**
+   * Helper: sets up the store with the given collections, dispatches
+   * duplicateRESTCollection, and returns the resulting store state.
+   */
+  function duplicateAndGetState(
+    collections: HoppCollection[],
+    path: string
+  ): HoppCollection[] {
+    setRESTCollections(collections)
+    duplicateRESTCollection(path)
+    return restCollectionStore.value.state
+  }
+
+  it("should clear backend IDs from all requests in the duplicate", () => {
+    const original = makeTestCollection({
+      id: "coll-backend-1",
+      name: "My Collection",
+      requests: [
+        makeRequest({ id: "req-backend-1", name: "Get Pets" }),
+        makeRequest({ id: "req-backend-2", name: "Add Pet" }),
+      ],
+    })
+
+    const result = duplicateAndGetState([original], "0")
+
+    expect(result).toHaveLength(2)
+    const duplicate = result[1]
+
+    // All request IDs in the duplicate should be undefined (cleared)
+    for (const req of duplicate.requests) {
+      expect(req.id).toBeUndefined()
+    }
+  })
+
+  it("should preserve backend IDs on the original collection", () => {
+    const original = makeTestCollection({
+      id: "coll-backend-1",
+      name: "My Collection",
+      requests: [
+        makeRequest({ id: "req-backend-1", name: "Get Pets" }),
+        makeRequest({ id: "req-backend-2", name: "Add Pet" }),
+      ],
+    })
+
+    const result = duplicateAndGetState([original], "0")
+
+    // The original (index 0) should still have its backend IDs
+    expect(result[0].id).toBe("coll-backend-1")
+    expect(result[0].requests[0].id).toBe("req-backend-1")
+    expect(result[0].requests[1].id).toBe("req-backend-2")
+  })
+
+  it("should set root collection ID with '-duplicate-collection' suffix", () => {
+    const original = makeTestCollection({
+      id: "coll-backend-1",
+      name: "My Collection",
+    })
+
+    const result = duplicateAndGetState([original], "0")
+
+    const duplicate = result[1]
+    expect(duplicate.id).toBe("coll-backend-1-duplicate-collection")
+  })
+
+  it("should clear backend IDs from nested folders", () => {
+    const original = makeTestCollection({
+      id: "coll-root",
+      name: "Root",
+      folders: [
+        makeTestCollection({
+          id: "coll-child-1",
+          name: "Child Folder",
+          requests: [makeRequest({ id: "req-child-1", name: "Child Request" })],
+          folders: [
+            makeTestCollection({
+              id: "coll-grandchild",
+              name: "Grandchild",
+              requests: [
+                makeRequest({ id: "req-gc-1", name: "Grandchild Request" }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    })
+
+    const result = duplicateAndGetState([original], "0")
+
+    const duplicate = result[1]
+
+    // Root gets the suffix, not cleared
+    expect(duplicate.id).toBe("coll-root-duplicate-collection")
+
+    // Nested folder IDs should be cleared
+    expect(duplicate.folders[0].id).toBeUndefined()
+    expect(duplicate.folders[0].folders[0].id).toBeUndefined()
+
+    // All nested request IDs should be cleared
+    expect(duplicate.folders[0].requests[0].id).toBeUndefined()
+    expect(duplicate.folders[0].folders[0].requests[0].id).toBeUndefined()
+  })
+
+  it("should generate new _ref_id for all requests in the duplicate", () => {
+    const originalRefId = "original-ref-id"
+    const original = makeTestCollection({
+      id: "coll-1",
+      name: "Collection",
+      requests: [
+        makeRequest({ id: "req-1", _ref_id: originalRefId, name: "Req 1" }),
+      ],
+    })
+
+    const result = duplicateAndGetState([original], "0")
+
+    const duplicate = result[1]
+
+    // Duplicate request should have a new _ref_id, not the original's
+    expect(duplicate.requests[0]._ref_id).not.toBe(originalRefId)
+    expect(duplicate.requests[0]._ref_id).toBeDefined()
+  })
+
+  it("should generate new _ref_id for all folders in the duplicate", () => {
+    const originalRefId = "original-folder-ref"
+    const original = makeTestCollection({
+      id: "coll-1",
+      name: "Collection",
+      _ref_id: originalRefId,
+      folders: [
+        makeTestCollection({
+          id: "coll-child",
+          name: "Child",
+          _ref_id: "child-ref",
+        }),
+      ],
+    })
+
+    const result = duplicateAndGetState([original], "0")
+
+    const duplicate = result[1]
+
+    // Duplicate collection and its folders should have new _ref_ids
+    expect(duplicate._ref_id).not.toBe(originalRefId)
+    expect(duplicate.folders[0]._ref_id).not.toBe("child-ref")
+  })
+
+  it("should handle collections without backend IDs", () => {
+    const original = makeTestCollection({
+      name: "Local Collection",
+      requests: [makeRequest({ name: "Local Request" })],
+    })
+
+    const result = duplicateAndGetState([original], "0")
+
+    expect(result).toHaveLength(2)
+    const duplicate = result[1]
+    // When original has no id, duplicate should not have the suffix either
+    expect(duplicate.id).toBeUndefined()
+    expect(duplicate.requests[0].id).toBeUndefined()
+  })
+
+  it("should not share object references between original and duplicate", () => {
+    const original = makeTestCollection({
+      id: "coll-1",
+      name: "Collection",
+      requests: [makeRequest({ id: "req-1", name: "Request 1" })],
+      folders: [
+        makeTestCollection({
+          id: "coll-child",
+          name: "Child",
+          requests: [makeRequest({ id: "req-child-1", name: "Child Request" })],
+        }),
+      ],
+    })
+
+    const result = duplicateAndGetState([original], "0")
+
+    const duplicate = result[1]
+
+    // Modifying the duplicate's request should not affect the original
+    duplicate.requests[0].name = "Modified"
+    expect(result[0].requests[0].name).toBe("Request 1")
+
+    // Modifying nested folder request should not affect original
+    duplicate.folders[0].requests[0].name = "Modified Child"
+    expect(result[0].folders[0].requests[0].name).toBe("Child Request")
+  })
+
+  it("should duplicate a sub-folder (non-root) correctly", () => {
+    const root = makeTestCollection({
+      id: "coll-root",
+      name: "Root",
+      folders: [
+        makeTestCollection({
+          id: "coll-child",
+          name: "Child Folder",
+          requests: [makeRequest({ id: "req-1", name: "Child Request" })],
+        }),
+      ],
+    })
+
+    const result = duplicateAndGetState([root], "0/0")
+
+    // The root should now have 2 child folders
+    expect(result[0].folders).toHaveLength(2)
+
+    const duplicatedChild = result[0].folders[1]
+
+    // Root of the duplicate subfolder gets the suffix
+    expect(duplicatedChild.id).toBe("coll-child-duplicate-collection")
+
+    // Request IDs inside the duplicated subfolder should be cleared
+    expect(duplicatedChild.requests[0].id).toBeUndefined()
+  })
+
+  it("should preserve request content (method, endpoint, etc.) in the duplicate", () => {
+    const original = makeTestCollection({
+      id: "coll-1",
+      name: "API Collection",
+      requests: [
+        makeRequest({
+          id: "req-1",
+          name: "Get Pets",
+          method: "GET",
+          endpoint: "https://petstore.swagger.io/v2/pet",
+        }),
+        makeRequest({
+          id: "req-2",
+          name: "Add Pet",
+          method: "POST",
+          endpoint: "https://petstore.swagger.io/v2/pet",
+        }),
+      ],
+    })
+
+    const result = duplicateAndGetState([original], "0")
+
+    const duplicate = result[1]
+
+    expect(duplicate.requests[0].name).toBe("Get Pets")
+    expect(duplicate.requests[0].method).toBe("GET")
+    expect(duplicate.requests[0].endpoint).toBe(
+      "https://petstore.swagger.io/v2/pet"
+    )
+
+    expect(duplicate.requests[1].name).toBe("Add Pet")
+    expect(duplicate.requests[1].method).toBe("POST")
+  })
+})
+
+describe("editRequest — ID preservation", () => {
+  it("REST: should preserve existing backend ID when requestNew has no id", () => {
+    const collection = makeTestCollection({
+      id: "coll-1",
+      name: "Collection",
+      requests: [
+        makeRequest({ id: "req-backend-1", name: "Original Request" }),
+      ],
+    })
+
+    setRESTCollections([collection])
+
+    const updatedRequest = makeRequest({ name: "Updated Request" })
+    // requestNew.id is undefined — the existing backend ID should be preserved
+    editRESTRequest("0", 0, updatedRequest as any)
+
+    const result = restCollectionStore.value.state
+    expect(result[0].requests[0].name).toBe("Updated Request")
+    expect(result[0].requests[0].id).toBe("req-backend-1")
+  })
+
+  it("REST: should use requestNew.id when it is provided", () => {
+    const collection = makeTestCollection({
+      id: "coll-1",
+      name: "Collection",
+      requests: [
+        makeRequest({ id: "req-backend-1", name: "Original Request" }),
+      ],
+    })
+
+    setRESTCollections([collection])
+
+    const updatedRequest = makeRequest({
+      id: "req-new-id",
+      name: "Updated Request",
+    })
+    editRESTRequest("0", 0, updatedRequest as any)
+
+    const result = restCollectionStore.value.state
+    expect(result[0].requests[0].id).toBe("req-new-id")
+  })
+
+  it("GQL: should preserve existing backend ID when requestNew has no id", () => {
+    const collection = makeTestCollection({
+      id: "coll-1",
+      name: "GQL Collection",
+      requests: [
+        makeRequest({ id: "gql-req-backend-1", name: "Original GQL Query" }),
+      ],
+    })
+
+    setGraphqlCollections([collection])
+
+    const updatedRequest = makeRequest({ name: "Updated GQL Query" })
+    editGraphqlRequest("0", 0, updatedRequest as any)
+
+    const result = graphqlCollectionStore.value.state
+    expect(result[0].requests[0].name).toBe("Updated GQL Query")
+    expect(result[0].requests[0].id).toBe("gql-req-backend-1")
+  })
+
+  it("GQL: should use requestNew.id when it is provided", () => {
+    const collection = makeTestCollection({
+      id: "coll-1",
+      name: "GQL Collection",
+      requests: [
+        makeRequest({ id: "gql-req-backend-1", name: "Original GQL Query" }),
+      ],
+    })
+
+    setGraphqlCollections([collection])
+
+    const updatedRequest = makeRequest({
+      id: "gql-req-new-id",
+      name: "Updated GQL Query",
+    })
+    editGraphqlRequest("0", 0, updatedRequest as any)
+
+    const result = graphqlCollectionStore.value.state
+    expect(result[0].requests[0].id).toBe("gql-req-new-id")
+  })
+})

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -281,6 +281,36 @@ function createComparator<T>(
     return 0
   }
 }
+/**
+ * Recursively clears backend IDs and generates new ref IDs for a duplicated
+ * collection and all its nested folders/requests, preventing edits to the
+ * duplicate from targeting the original's backend resources.
+ */
+function recursiveChangeIdsToAvoidConflicts(
+  collection: HoppCollection,
+  isRoot = false
+): HoppCollection {
+  const newCollection = {
+    ...collection,
+    _ref_id: generateUniqueRefId("coll"),
+    // Clear backend id for nested folders so edits won't target the original
+    // Root of the duplicated subtree keeps its id; any suffix is applied by the caller
+    ...(!isRoot ? { id: undefined } : {}),
+  }
+
+  newCollection.folders = newCollection.folders.map((folder) =>
+    recursiveChangeIdsToAvoidConflicts(folder)
+  )
+
+  newCollection.requests = newCollection.requests.map((request) => ({
+    ...request,
+    _ref_id: generateUniqueRefId("req"),
+    id: undefined,
+  }))
+
+  return newCollection
+}
+
 const restCollectionDispatchers = defineDispatchers({
   setCollections(
     _: RESTCollectionStoreType,
@@ -687,41 +717,26 @@ const restCollectionDispatchers = defineDispatchers({
     if (collection) {
       const name = `${collection.name} - ${t("action.duplicate")}`
 
-      function recursiveChangeRefIdToAvoidConflicts(
-        collection: HoppCollection
-      ): HoppCollection {
-        const newCollection = {
-          ...collection,
-          _ref_id: generateUniqueRefId("coll"),
-        }
-
-        newCollection.folders = newCollection.folders.map((folder) =>
-          recursiveChangeRefIdToAvoidConflicts(folder)
-        )
-
-        return newCollection
-      }
-
-      const duplicatedCollection = {
-        ...cloneDeep(collection),
-        name,
-        ...(collection.id
-          ? { id: `${collection.id}-duplicate-collection` }
-          : {}),
-      }
-
-      const duplicatedCollectionWithNewRefId =
-        recursiveChangeRefIdToAvoidConflicts(duplicatedCollection)
+      const duplicatedCollection = recursiveChangeIdsToAvoidConflicts(
+        {
+          ...cloneDeep(collection),
+          name,
+          ...(collection.id
+            ? { id: `${collection.id}-duplicate-collection` }
+            : {}),
+        },
+        true
+      )
 
       if (isRootCollection) {
-        newState.push(duplicatedCollectionWithNewRefId)
+        newState.push(duplicatedCollection)
       } else {
         const parentCollectionIndexPath = indexPaths.slice(0, -1)
 
         const parentCollection = navigateToFolderWithIndexPath(state, [
           ...parentCollectionIndexPath,
         ])
-        parentCollection?.folders.push(duplicatedCollectionWithNewRefId)
+        parentCollection?.folders.push(duplicatedCollection)
       }
     }
 
@@ -751,9 +766,10 @@ const restCollectionDispatchers = defineDispatchers({
       return {}
     }
 
-    targetLocation.requests = targetLocation.requests.map((req, index) =>
-      index !== requestIndex ? req : requestNew
-    )
+    targetLocation.requests = targetLocation.requests.map((req, index) => {
+      if (index !== requestIndex) return req
+      return { ...req, ...requestNew, id: requestNew.id ?? req.id }
+    })
 
     return {
       state: newState,
@@ -1155,13 +1171,16 @@ const gqlCollectionDispatchers = defineDispatchers({
     if (collection) {
       const name = `${collection.name} - ${t("action.duplicate")}`
 
-      const duplicatedCollection = {
-        ...cloneDeep(collection),
-        name,
-        ...(collection.id
-          ? { id: `${collection.id}-duplicate-collection` }
-          : {}),
-      }
+      const duplicatedCollection = recursiveChangeIdsToAvoidConflicts(
+        {
+          ...cloneDeep(collection),
+          name,
+          ...(collection.id
+            ? { id: `${collection.id}-duplicate-collection` }
+            : {}),
+        },
+        true
+      )
 
       if (isRootCollection) {
         newState.push(duplicatedCollection)
@@ -1202,7 +1221,9 @@ const gqlCollectionDispatchers = defineDispatchers({
     }
 
     targetLocation.requests = targetLocation.requests.map((req, index) =>
-      index !== requestIndex ? req : requestNew
+      index !== requestIndex
+        ? req
+        : { ...req, ...requestNew, id: requestNew.id ?? req.id }
     )
 
     return {

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/api.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/api.ts
@@ -77,6 +77,8 @@ import {
   runMutation,
 } from "@hoppscotch/common/helpers/backend/GQLClient"
 
+import * as E from "fp-ts/Either"
+
 export const createRESTRootUserCollection = (title: string, data?: string) =>
   runMutation<
     CreateRestRootUserCollectionMutation,
@@ -212,6 +214,23 @@ export const duplicateUserCollection = (
     collectionID,
     reqType,
   })()
+
+export const duplicateAndReloadCollection = async (
+  collectionSyncID: string,
+  reqType: ReqType,
+  loadUserCollections: (type: "REST" | "GQL") => Promise<void>
+) => {
+  const res = await duplicateUserCollection(collectionSyncID, reqType)
+  if (E.isRight(res)) {
+    // Reload all collections from backend to get proper IDs for the duplicate
+    await loadUserCollections(reqType)
+  } else {
+    // Roll back the optimistic local duplicate so a phantom collection
+    // is not left in the store when the backend duplication fails
+    await loadUserCollections(reqType)
+    console.error(`Failed to duplicate ${reqType} collection`, res.left)
+  }
+}
 
 export const sortUserCollections = (
   parentCollectionID: string | null,

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/gqlCollections.sync.ts
@@ -24,7 +24,7 @@ import {
   createGQLUserRequest,
   deleteUserCollection,
   deleteUserRequest,
-  duplicateUserCollection,
+  duplicateAndReloadCollection,
   editGQLUserRequest,
   importUserCollectionsFromJSON,
   updateUserCollection,
@@ -354,7 +354,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   },
   async duplicateCollection({ collectionSyncID }) {
     if (collectionSyncID) {
-      await duplicateUserCollection(collectionSyncID, ReqType.Gql)
+      const { loadUserCollections } = (await import("./index")).def
+      await duplicateAndReloadCollection(
+        collectionSyncID,
+        ReqType.Gql,
+        loadUserCollections
+      )
     }
   },
   editRequest({ path, requestIndex, requestNew }) {

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/desktop/sync.ts
@@ -23,7 +23,7 @@ import {
   createRESTUserRequest,
   deleteUserCollection,
   deleteUserRequest,
-  duplicateUserCollection,
+  duplicateAndReloadCollection,
   editUserRequest,
   importUserCollectionsFromJSON,
   moveUserCollection,
@@ -407,7 +407,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   },
   async duplicateCollection({ collectionSyncID }) {
     if (collectionSyncID) {
-      await duplicateUserCollection(collectionSyncID, ReqType.Rest)
+      const { loadUserCollections } = (await import("./index")).def
+      await duplicateAndReloadCollection(
+        collectionSyncID,
+        ReqType.Rest,
+        loadUserCollections
+      )
     }
   },
   editRequest({ path, requestIndex, requestNew }) {

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/api.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/api.ts
@@ -77,6 +77,8 @@ import {
   runMutation,
 } from "@hoppscotch/common/helpers/backend/GQLClient"
 
+import * as E from "fp-ts/Either"
+
 export const createRESTRootUserCollection = (title: string, data?: string) =>
   runMutation<
     CreateRestRootUserCollectionMutation,
@@ -212,6 +214,23 @@ export const duplicateUserCollection = (
     collectionID,
     reqType,
   })()
+
+export const duplicateAndReloadCollection = async (
+  collectionSyncID: string,
+  reqType: ReqType,
+  loadUserCollections: (type: "REST" | "GQL") => Promise<void>
+) => {
+  const res = await duplicateUserCollection(collectionSyncID, reqType)
+  if (E.isRight(res)) {
+    // Reload all collections from backend to get proper IDs for the duplicate
+    await loadUserCollections(reqType)
+  } else {
+    // Roll back the optimistic local duplicate so a phantom collection
+    // is not left in the store when the backend duplication fails
+    await loadUserCollections(reqType)
+    console.error(`Failed to duplicate ${reqType} collection`, res.left)
+  }
+}
 
 export const sortUserCollections = (
   parentCollectionID: string | null,

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/gqlCollections.sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/gqlCollections.sync.ts
@@ -24,7 +24,7 @@ import {
   createGQLUserRequest,
   deleteUserCollection,
   deleteUserRequest,
-  duplicateUserCollection,
+  duplicateAndReloadCollection,
   editGQLUserRequest,
   importUserCollectionsFromJSON,
   updateUserCollection,
@@ -354,7 +354,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   },
   async duplicateCollection({ collectionSyncID }) {
     if (collectionSyncID) {
-      await duplicateUserCollection(collectionSyncID, ReqType.Gql)
+      const { loadUserCollections } = (await import("./index")).def
+      await duplicateAndReloadCollection(
+        collectionSyncID,
+        ReqType.Gql,
+        loadUserCollections
+      )
     }
   },
   editRequest({ path, requestIndex, requestNew }) {

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/sync.ts
@@ -411,11 +411,14 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   async duplicateCollection({ collectionSyncID }) {
     if (collectionSyncID) {
       const res = await duplicateUserCollection(collectionSyncID, ReqType.Rest)
+      const { loadUserCollections } = (await import("./index")).def
       if (E.isRight(res)) {
         // Reload all collections from backend to get proper IDs for the duplicate
-        const { loadUserCollections } = (await import("./index")).def
         await loadUserCollections(ReqType.Rest)
       } else {
+        // Roll back the optimistic local duplicate so a phantom collection
+        // is not left in the store when the backend duplication fails
+        await loadUserCollections(ReqType.Rest)
         console.error("Failed to duplicate REST collection", res.left)
       }
     }

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/sync.ts
@@ -23,7 +23,7 @@ import {
   createRESTUserRequest,
   deleteUserCollection,
   deleteUserRequest,
-  duplicateUserCollection,
+  duplicateAndReloadCollection,
   editUserRequest,
   importUserCollectionsFromJSON,
   moveUserCollection,
@@ -410,17 +410,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   },
   async duplicateCollection({ collectionSyncID }) {
     if (collectionSyncID) {
-      const res = await duplicateUserCollection(collectionSyncID, ReqType.Rest)
       const { loadUserCollections } = (await import("./index")).def
-      if (E.isRight(res)) {
-        // Reload all collections from backend to get proper IDs for the duplicate
-        await loadUserCollections(ReqType.Rest)
-      } else {
-        // Roll back the optimistic local duplicate so a phantom collection
-        // is not left in the store when the backend duplication fails
-        await loadUserCollections(ReqType.Rest)
-        console.error("Failed to duplicate REST collection", res.left)
-      }
+      await duplicateAndReloadCollection(
+        collectionSyncID,
+        ReqType.Rest,
+        loadUserCollections
+      )
     }
   },
   editRequest({ path, requestIndex, requestNew }) {

--- a/packages/hoppscotch-selfhost-web/src/platform/collections/web/sync.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/collections/web/sync.ts
@@ -410,7 +410,14 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   },
   async duplicateCollection({ collectionSyncID }) {
     if (collectionSyncID) {
-      await duplicateUserCollection(collectionSyncID, ReqType.Rest)
+      const res = await duplicateUserCollection(collectionSyncID, ReqType.Rest)
+      if (E.isRight(res)) {
+        // Reload all collections from backend to get proper IDs for the duplicate
+        const { loadUserCollections } = (await import("./index")).def
+        await loadUserCollections(ReqType.Rest)
+      } else {
+        console.error("Failed to duplicate REST collection", res.left)
+      }
     }
   },
   editRequest({ path, requestIndex, requestNew }) {


### PR DESCRIPTION
**Summary**
Duplicating a collection in a personal workspace causes edits to the duplicate to silently modify the original collection. This is a data corruption bug — users lose data without any visible error.

Closes #
https://github.com/hoppscotch/hoppscotch/issues/6294

**Root Cause**
When duplicating a collection, cloneDeep(collection) copies the original's backend id fields to the duplicate's nested folders and requests. The userCollectionDuplicated subscription — which should assign new IDs — never fires for personal workspace duplications. As a result, the duplicate's folders and requests retain the original's backend IDs, and any subsequent edit targets the original's backend resource.

**Reproduction**
1. Create a collection with requests in a personal workspace (self-hosted)
2. Duplicate the collection
3. Edit a request in the duplicate
4. Log out and log back in
5. Expected: Both collections reflect their own edits
6. Actual: The original is modified; the duplicate reverts to the original's content

**Fix**
1. Clear backend IDs on duplication (collections.ts)
Extracted a shared recursiveChangeIdsToAvoidConflicts helper that recursively:
Clears id on all nested folders (not the root — its ID gets the -duplicate-collection suffix from the caller)
Clears id on all requests
Generates new _ref_id values for all folders and requests
Used by both REST and GQL duplicateCollection dispatchers.

2. Reload collections after duplication API call (sync.ts)
After duplicateUserCollection succeeds, reload all collections from the backend via loadUserCollections(ReqType.Rest) to ensure the duplicate gets proper server-assigned IDs. Added error logging for failed duplications.

3. Preserve existing backend IDs in editRequest (collections.ts)
Both REST and GQL editRequest dispatchers now use { ...req, ...requestNew, id: requestNew.id ?? req.id } to preserve the existing backend ID when the caller doesn't explicitly provide one, preventing accidental ID loss during edits.

**Testing**
Added 14 unit tests covering:
- Backend IDs are cleared from all requests and nested folders in the duplicate
- Backend IDs are preserved on the original collection
- Root collection ID gets the -duplicate-collection suffix
- New _ref_id values are generated for all items
- Collections without backend IDs are handled gracefully
- No shared object references between original and duplicate
- Sub-folder (non-root) duplication works correctly
- Request content (method, endpoint, etc.) is preserved
- editRequest preserves existing backend ID when requestNew has no ID
- editRequest uses requestNew.id when explicitly provided

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data corruption when duplicating collections in personal workspaces. Edits to a duplicate no longer modify the original (fixes #6294).

- **Bug Fixes**
  - Clear backend IDs and regenerate `_ref_id` on duplicated folders/requests; root keeps its ID with a “-duplicate-collection” suffix. Applied to REST and GraphQL.
  - Preserve existing backend request IDs on edit when `requestNew.id` is not provided.
  - Reload collections after duplication to get server-assigned IDs; on failure, roll back the phantom duplicate and log the error.
  - Added tests for ID clearing, `_ref_id` regeneration, sub-folder duplication, and ID preservation on edits.

- **Refactors**
  - Introduced `duplicateAndReloadCollection` in both desktop and web APIs and used it in `sync.ts` and `gqlCollections.sync.ts` for REST and GQL to centralize reload/rollback logic.

<sup>Written for commit 817667221f4cbd176f490bc9cf15e9036e67cee2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

