### PR TITLE
feat(accessibility): add aria-label to log entry collapse button

### DIFF
--- a/packages/hoppscotch-common/src/components/realtime/LogEntry.vue
+++ b/packages/hoppscotch-common/src/components/realtime/LogEntry.vue
@@ -43,7 +43,7 @@
         />
         <HoppButtonSecondary
           :icon="IconChevronDown"
-          :aria-label="minimized ? t('state.show') : t('state.hide')"
+          :aria-label="minimized ? t('show.more') : t('hide.more')"
           class="transform"
           :class="{ 'rotate-180': !minimized }"
           @click="toggleExpandPayload()"

--- a/packages/hoppscotch-common/src/components/realtime/LogEntry.vue
+++ b/packages/hoppscotch-common/src/components/realtime/LogEntry.vue
@@ -43,6 +43,7 @@
         />
         <HoppButtonSecondary
           :icon="IconChevronDown"
+          :aria-label="minimized ? t('state.show') : t('state.hide')"
           class="transform"
           :class="{ 'rotate-180': !minimized }"
           @click="toggleExpandPayload()"


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an aria-label to the realtime log entry collapse/expand button to improve screen reader accessibility. The label uses existing i18n keys and toggles between t('show.more') when minimized and t('hide.more') when expanded.

<sup>Written for commit 7003ea7d9f940f024f349eb2d89d444133e42aa8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

