### PR TITLE
fix: improve accessibility fallback aria-label for navigation tabs

### DIFF
--- a/packages/hoppscotch-common/src/components/TabsNav.vue
+++ b/packages/hoppscotch-common/src/components/TabsNav.vue
@@ -19,7 +19,7 @@
           :exact="item.exactMatch"
           class="tab"
           :class="[{ vertical: vertical }]"
-          :aria-label="item.label || ''"
+          :aria-label="item.label || 'Navigation Tab'"
           role="link"
         >
           <component


### PR DESCRIPTION
This PR improves accessibility for navigation tabs by adding a meaningful fallback value for the `aria-label` attribute instead of using an empty string.

 Changes Made

* Replaced:
  `:aria-label="item.label || ''"`

* With:
  `:aria-label="item.label || 'Navigation Tab'"`

### Why

Previously, when `item.label` was empty or undefined, the generated `aria-label` became an empty string. This could reduce accessibility for screen reader users.

By adding a descriptive fallback label, navigation elements remain more accessible and provide better context to assistive technologies.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve accessibility for navigation tabs by adding a meaningful `aria-label` fallback in `packages/hoppscotch-common/src/components/TabsNav.vue`. If `item.label` is missing, we now set `aria-label` to 'Navigation Tab' instead of an empty string to aid screen readers.

<sup>Written for commit 09ce826cb0802f7a62db908c02a22491edd1599f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

