### PR TITLE
feat: add scroll-to-top button in response view

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="relative flex flex-1 flex-col overflow-auto">
+  <div
+    ref="scrollContainer"
+    class="relative flex flex-1 flex-col overflow-auto scroll-smooth"
+    @scroll="handleScroll"
+  >
     <HttpResponseMeta
       :response="doc.response"
       :is-embed="isEmbed"
@@ -12,6 +16,18 @@
       :tab-id="tabId"
       @save-as-example="saveAsExample"
     />
+    <Transition name="fade">
+      <div v-if="showScrollTop" class="absolute bottom-4 right-4 z-20">
+        <HoppButtonSecondary
+          v-tippy="{ theme: 'tooltip' }"
+          :title="t('action.scroll_to_top')"
+          :icon="IconArrowUp"
+          filled
+          class="!rounded-full shadow-lg"
+          @click="scrollToTop"
+        />
+      </div>
+    </Transition>
   </div>
   <HttpSaveResponseName
     v-model:response-name="responseName"
@@ -23,6 +39,7 @@
 </template>
 
 <script setup lang="ts">
+import IconArrowUp from "~icons/lucide/arrow-up"
 import { useVModel } from "@vueuse/core"
 import { computed, ref } from "vue"
 import { HoppRequestDocument } from "~/helpers/rest/document"
@@ -54,6 +71,18 @@ const emit = defineEmits<{
 }>()
 
 const doc = useVModel(props, "document", emit)
+
+const scrollContainer = ref<HTMLElement | null>(null)
+const showScrollTop = ref(false)
+
+const handleScroll = (e: Event) => {
+  const target = e.target as HTMLElement
+  showScrollTop.value = target.scrollTop > 300
+}
+
+const scrollToTop = () => {
+  scrollContainer.value?.scrollTo({ top: 0, behavior: "smooth" })
+}
 
 const hasResponse = computed(
   () =>


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a floating “Scroll to top” button in the HTTP response view to make long responses easier to navigate. The button appears after scrolling and smoothly returns to the top.

- **New Features**
  - Added scroll listener and `scroll-smooth` to the container in `Response.vue`.
  - Shows a bottom-right `HoppButtonSecondary` with `IconArrowUp` after 300px scroll.
  - Smoothly scrolls to top on click with a fade-in/out transition and tooltip.

<sup>Written for commit 3c26ef975f5dd60be09e212542e1de980ec3af57. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

