### PR TITLE
feat(kernel): enhance CORS error messaging in browser interceptor

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -672,7 +672,9 @@
   "error": {
     "network": {
       "heading": "Network Error",
-      "description": "Network connection failed. {message}: {cause}"
+      "description": "Network connection failed. {message}: {cause}",
+      "cors_heading": "CORS Error",
+      "cors_description": "Cross-Origin Resource Sharing error: Check your CORS configuration or use the proxy."
     },
     "timeout": {
       "heading": "Timeout Error",

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/browser/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/browser/index.ts
@@ -62,11 +62,22 @@ export class BrowserKernelInterceptorService
         pipe(
           either,
           E.mapLeft((error): KernelInterceptorError => {
+            const isCorsLikelyError = (() => {
+              if (error.kind !== "network" || error.message !== "Failed to fetch" || !navigator.onLine) {
+                return false
+              }
+              try {
+                return new URL(processedRequest.url).origin !== window.location.origin
+              } catch {
+                return false
+              }
+            })()
+
             const humanMessage = {
               heading: (t: ReturnType<typeof getI18n>) => {
                 switch (error.kind) {
                   case "network":
-                    return t("error.network.heading")
+                    return isCorsLikelyError ? t("error.network.cors_heading") : t("error.network.heading")
                   case "timeout":
                     return t("error.timeout.heading")
                   case "certificate":
@@ -88,6 +99,9 @@ export class BrowserKernelInterceptorService
               description: (t: ReturnType<typeof getI18n>) => {
                 switch (error.kind) {
                   case "network":
+                    if (isCorsLikelyError) {
+                      return t("error.network.cors_description")
+                    }
                     return t("error.network.description", {
                       message: error.message,
                       cause: error.cause ?? t("error.unknown.cause"),


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve browser error handling by detecting likely CORS failures and showing a CORS-specific heading and guidance. This helps users quickly troubleshoot cross-origin requests.

- **New Features**
  - In `hoppscotch-common` browser interceptor, detect likely CORS errors (network: "Failed to fetch", online, cross-origin) and switch to CORS-specific heading/description.
  - Added `en.json` keys: `error.network.cors_heading` and `error.network.cors_description` with guidance to check CORS config or use the proxy.

<sup>Written for commit 9ac91afbf6c5f6a39aa8eb4ca39c050ee7352c75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

