### PR TITLE
fix(common): apply OAuth2 token request params

### DIFF
--- a/packages/hoppscotch-common/src/services/oauth/__tests__/tokenRequest.spec.ts
+++ b/packages/hoppscotch-common/src/services/oauth/__tests__/tokenRequest.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "vitest"
+import { buildAuthCodeTokenRequest } from "../tokenRequest"
+
+const parseUrlEncodedContent = (
+  request: ReturnType<typeof buildAuthCodeTokenRequest>
+) => new URLSearchParams(request.content.content as string)
+
+describe("buildAuthCodeTokenRequest", () => {
+  test("adds active token request params to the request body by default", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      tokenRequestParams: [
+        {
+          key: "scope",
+          value: "openid",
+          active: true,
+        },
+      ],
+    })
+
+    const body = parseUrlEncodedContent(request)
+
+    expect(body.get("grant_type")).toBe("authorization_code")
+    expect(body.get("scope")).toBe("openid")
+  })
+
+  test("adds active token request params to the request URL", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      tokenRequestParams: [
+        {
+          key: "resource",
+          value: "https://graph.microsoft.com",
+          active: true,
+          sendIn: "url",
+        },
+      ],
+    })
+
+    const url = new URL(request.url)
+
+    expect(url.searchParams.get("resource")).toBe("https://graph.microsoft.com")
+  })
+
+  test("adds active token request params to the request headers", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      tokenRequestParams: [
+        {
+          key: "X-Tenant",
+          value: "tenant-id",
+          active: true,
+          sendIn: "headers",
+        },
+      ],
+    })
+
+    expect(request.headers["X-Tenant"]).toBe("tenant-id")
+  })
+
+  test("ignores inactive token request params", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      tokenRequestParams: [
+        {
+          key: "scope",
+          value: "openid",
+          active: false,
+          sendIn: "body",
+        },
+      ],
+    })
+
+    const body = parseUrlEncodedContent(request)
+
+    expect(body.has("scope")).toBe(false)
+  })
+})

--- a/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
@@ -10,12 +10,12 @@ import { z } from "zod"
 import { getService } from "~/modules/dioc"
 import * as E from "fp-ts/Either"
 import { KernelInterceptorService } from "~/services/kernel-interceptor.service"
-import { content } from "@hoppscotch/kernel"
 import { refreshToken, OAuth2ParamSchema } from "../utils"
 import {
   AuthCodeGrantTypeParams,
   OAuth2AuthRequestParam,
 } from "@hoppscotch/data"
+import { buildAuthCodeTokenRequest } from "../tokenRequest"
 
 const persistenceService = getService(PersistenceService)
 const interceptorService = getService(KernelInterceptorService)
@@ -239,6 +239,7 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
     clientID: z.string(),
     codeVerifier: z.string().optional(),
     codeChallenge: z.string().optional(),
+    tokenRequestParams: z.array(OAuth2ParamSchema).optional().default([]),
   })
 
   const decodedLocalConfig = expectedSchema.safeParse(
@@ -255,26 +256,17 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
   }
 
   // exchange the code for a token
-  const { response } = interceptorService.execute({
-    id: Date.now(),
-    url: decodedLocalConfig.data.tokenEndpoint,
-    method: "POST",
-    version: "HTTP/1.1",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
-    },
-    content: content.urlencoded({
+  const { response } = interceptorService.execute(
+    buildAuthCodeTokenRequest({
+      tokenEndpoint: decodedLocalConfig.data.tokenEndpoint,
       code,
-      grant_type: "authorization_code",
-      client_id: decodedLocalConfig.data.clientID,
-      client_secret: decodedLocalConfig.data.clientSecret,
-      redirect_uri: OauthAuthService.redirectURI,
-      ...(decodedLocalConfig.data.codeVerifier && {
-        code_verifier: decodedLocalConfig.data.codeVerifier,
-      }),
-    }),
-  })
+      clientID: decodedLocalConfig.data.clientID,
+      clientSecret: decodedLocalConfig.data.clientSecret,
+      redirectURI: OauthAuthService.redirectURI,
+      codeVerifier: decodedLocalConfig.data.codeVerifier,
+      tokenRequestParams: decodedLocalConfig.data.tokenRequestParams,
+    })
+  )
 
   const res = await response
 

--- a/packages/hoppscotch-common/src/services/oauth/tokenRequest.ts
+++ b/packages/hoppscotch-common/src/services/oauth/tokenRequest.ts
@@ -1,0 +1,92 @@
+import { RelayRequest, content } from "@hoppscotch/kernel"
+
+export type OAuth2RequestParam = {
+  key: string
+  value: string
+  active: boolean
+  sendIn?: "headers" | "url" | "body"
+}
+
+type BuildAuthCodeTokenRequestParams = {
+  tokenEndpoint: string
+  code: string
+  clientID: string
+  clientSecret: string
+  redirectURI: string
+  codeVerifier?: string
+  tokenRequestParams?: Array<OAuth2RequestParam>
+}
+
+const applyOAuth2RequestParams = ({
+  params,
+  headers,
+  bodyParams,
+  urlParams,
+}: {
+  params?: Array<OAuth2RequestParam>
+  headers: Record<string, string>
+  bodyParams: Record<string, string>
+  urlParams: Record<string, string>
+}) => {
+  params
+    ?.filter((param) => param.active && param.key && param.value)
+    .forEach((param) => {
+      if (param.sendIn === "headers") {
+        headers[param.key] = param.value
+      } else if (param.sendIn === "url") {
+        urlParams[param.key] = param.value
+      } else {
+        bodyParams[param.key] = param.value
+      }
+    })
+}
+
+export const buildAuthCodeTokenRequest = ({
+  tokenEndpoint,
+  code,
+  clientID,
+  clientSecret,
+  redirectURI,
+  codeVerifier,
+  tokenRequestParams,
+}: BuildAuthCodeTokenRequestParams): RelayRequest => {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json",
+  }
+
+  const bodyParams: Record<string, string> = {
+    code,
+    grant_type: "authorization_code",
+    client_id: clientID,
+    client_secret: clientSecret,
+    redirect_uri: redirectURI,
+  }
+
+  if (codeVerifier) {
+    bodyParams.code_verifier = codeVerifier
+  }
+
+  const urlParams: Record<string, string> = {}
+
+  applyOAuth2RequestParams({
+    params: tokenRequestParams,
+    headers,
+    bodyParams,
+    urlParams,
+  })
+
+  const url = new URL(tokenEndpoint)
+  Object.entries(urlParams).forEach(([key, value]) => {
+    url.searchParams.set(key, value)
+  })
+
+  return {
+    id: Date.now(),
+    url: url.toString(),
+    method: "POST",
+    version: "HTTP/1.1",
+    headers,
+    content: content.urlencoded(bodyParams),
+  }
+}


### PR DESCRIPTION
Closes #5598

This applies the existing OAuth2 Token Request advanced configuration during the Authorization Code code-to-token exchange. The UI already persists `tokenRequestParams`, but the redirect callback previously only sent the fixed OAuth fields, so providers that require extra token params, for example `scope`, could reject the request.

### What's changed
- Added a builder for Authorization Code token exchange requests.
- Merged active token request params into the request body, URL query, or headers according to `sendIn`.
- Added unit coverage for body, URL, headers, and inactive params.

### Notes to reviewers
Validated with:
- `pnpm --dir packages/hoppscotch-common exec vitest run src/services/oauth/__tests__/tokenRequest.spec.ts`
- `pnpm --dir packages/hoppscotch-common exec eslint src/services/oauth/tokenRequest.ts src/services/oauth/flows/authCode.ts src/services/oauth/__tests__/tokenRequest.spec.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use saved OAuth2 advanced token params during the Authorization Code token exchange to prevent provider rejections when extra params (like scope) are required. Fixes #5598.

- **Bug Fixes**
  - Added a token request builder and wired it into the `authCode` flow.
  - Apply active params to body, URL, or headers based on `sendIn`; ignore inactive.
  - Added unit tests covering body, URL, headers, and inactive params.

<sup>Written for commit f7b98b939a36ee3a66729f8161bef0bc1c4c3985. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

