### PR TITLE
fix(common): apply OAuth2 token request params

### DIFF
--- a/packages/hoppscotch-common/src/services/oauth/__tests__/tokenRequest.spec.ts
+++ b/packages/hoppscotch-common/src/services/oauth/__tests__/tokenRequest.spec.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from "vitest"
+import { buildAuthCodeTokenRequest } from "../tokenRequest"
+
+const parseUrlEncodedContent = (
+  request: ReturnType<typeof buildAuthCodeTokenRequest>
+) => new URLSearchParams(request.content.content as string)
+
+describe("buildAuthCodeTokenRequest", () => {
+  test("adds active token request params to the request body by default", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      tokenRequestParams: [
+        {
+          key: "scope",
+          value: "openid",
+          active: true,
+        },
+      ],
+    })
+
+    const body = parseUrlEncodedContent(request)
+
+    expect(body.get("grant_type")).toBe("authorization_code")
+    expect(body.get("scope")).toBe("openid")
+  })
+
+  test("keeps required OAuth fields from being overridden by custom params", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      codeVerifier: "code-verifier",
+      tokenRequestParams: [
+        {
+          key: "code",
+          value: "custom-code",
+          active: true,
+        },
+        {
+          key: "grant_type",
+          value: "client_credentials",
+          active: true,
+        },
+        {
+          key: "client_id",
+          value: "custom-client-id",
+          active: true,
+        },
+        {
+          key: "client_secret",
+          value: "custom-client-secret",
+          active: true,
+        },
+        {
+          key: "redirect_uri",
+          value: "https://custom.example.com/oauth",
+          active: true,
+        },
+        {
+          key: "code_verifier",
+          value: "custom-code-verifier",
+          active: true,
+        },
+        {
+          key: "scope",
+          value: "openid",
+          active: true,
+        },
+      ],
+    })
+
+    const body = parseUrlEncodedContent(request)
+
+    expect(body.get("code")).toBe("auth-code")
+    expect(body.get("grant_type")).toBe("authorization_code")
+    expect(body.get("client_id")).toBe("client-id")
+    expect(body.get("client_secret")).toBe("client-secret")
+    expect(body.get("redirect_uri")).toBe(
+      "https://hoppscotch.example.com/oauth"
+    )
+    expect(body.get("code_verifier")).toBe("code-verifier")
+    expect(body.get("scope")).toBe("openid")
+  })
+
+  test("adds code verifier when provided", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      codeVerifier: "code-verifier",
+    })
+
+    const body = parseUrlEncodedContent(request)
+
+    expect(body.get("code_verifier")).toBe("code-verifier")
+  })
+
+  test("omits code verifier when not provided", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+    })
+
+    const body = parseUrlEncodedContent(request)
+
+    expect(body.has("code_verifier")).toBe(false)
+  })
+
+  test("adds active token request params to the request URL", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      tokenRequestParams: [
+        {
+          key: "resource",
+          value: "https://graph.microsoft.com",
+          active: true,
+          sendIn: "url",
+        },
+      ],
+    })
+
+    const url = new URL(request.url)
+
+    expect(url.searchParams.get("resource")).toBe("https://graph.microsoft.com")
+  })
+
+  test("does not parse the token endpoint when URL params are absent", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "<<token_endpoint>>",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+    })
+
+    expect(request.url).toBe("<<token_endpoint>>")
+  })
+
+  test("does not add required OAuth fields from URL or header params", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      tokenRequestParams: [
+        {
+          key: "grant_type",
+          value: "client_credentials",
+          active: true,
+          sendIn: "url",
+        },
+        {
+          key: "client_id",
+          value: "custom-client-id",
+          active: true,
+          sendIn: "headers",
+        },
+        {
+          key: "resource",
+          value: "https://graph.microsoft.com",
+          active: true,
+          sendIn: "url",
+        },
+        {
+          key: "X-Tenant",
+          value: "tenant-id",
+          active: true,
+          sendIn: "headers",
+        },
+      ],
+    })
+
+    const url = new URL(request.url)
+    const body = parseUrlEncodedContent(request)
+
+    expect(url.searchParams.has("grant_type")).toBe(false)
+    expect(request.headers.client_id).toBeUndefined()
+    expect(url.searchParams.get("resource")).toBe("https://graph.microsoft.com")
+    expect(request.headers["X-Tenant"]).toBe("tenant-id")
+    expect(body.get("grant_type")).toBe("authorization_code")
+    expect(body.get("client_id")).toBe("client-id")
+  })
+
+  test("adds active token request params to the request headers", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      tokenRequestParams: [
+        {
+          key: "X-Tenant",
+          value: "tenant-id",
+          active: true,
+          sendIn: "headers",
+        },
+      ],
+    })
+
+    expect(request.headers["X-Tenant"]).toBe("tenant-id")
+  })
+
+  test("ignores inactive token request params", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "https://auth.example.com/oauth/token",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      tokenRequestParams: [
+        {
+          key: "scope",
+          value: "openid",
+          active: false,
+          sendIn: "body",
+        },
+      ],
+    })
+
+    const body = parseUrlEncodedContent(request)
+
+    expect(body.has("scope")).toBe(false)
+  })
+})

--- a/packages/hoppscotch-common/src/services/oauth/__tests__/tokenRequest.spec.ts
+++ b/packages/hoppscotch-common/src/services/oauth/__tests__/tokenRequest.spec.ts
@@ -1,9 +1,17 @@
 import { describe, expect, test } from "vitest"
 import { buildAuthCodeTokenRequest } from "../tokenRequest"
+import type { OAuth2RequestParam } from "../tokenRequest"
 
 const parseUrlEncodedContent = (
   request: ReturnType<typeof buildAuthCodeTokenRequest>
 ) => new URLSearchParams(request.content.content as string)
+
+const tokenRequestParam = (
+  param: Omit<OAuth2RequestParam, "id"> & { id?: number }
+): OAuth2RequestParam => ({
+  id: 1,
+  ...param,
+})
 
 describe("buildAuthCodeTokenRequest", () => {
   test("adds active token request params to the request body by default", () => {
@@ -14,11 +22,11 @@ describe("buildAuthCodeTokenRequest", () => {
       clientSecret: "client-secret",
       redirectURI: "https://hoppscotch.example.com/oauth",
       tokenRequestParams: [
-        {
+        tokenRequestParam({
           key: "scope",
           value: "openid",
           active: true,
-        },
+        }),
       ],
     })
 
@@ -37,41 +45,41 @@ describe("buildAuthCodeTokenRequest", () => {
       redirectURI: "https://hoppscotch.example.com/oauth",
       codeVerifier: "code-verifier",
       tokenRequestParams: [
-        {
+        tokenRequestParam({
           key: "code",
           value: "custom-code",
           active: true,
-        },
-        {
+        }),
+        tokenRequestParam({
           key: "grant_type",
           value: "client_credentials",
           active: true,
-        },
-        {
+        }),
+        tokenRequestParam({
           key: "client_id",
           value: "custom-client-id",
           active: true,
-        },
-        {
+        }),
+        tokenRequestParam({
           key: "client_secret",
           value: "custom-client-secret",
           active: true,
-        },
-        {
+        }),
+        tokenRequestParam({
           key: "redirect_uri",
           value: "https://custom.example.com/oauth",
           active: true,
-        },
-        {
+        }),
+        tokenRequestParam({
           key: "code_verifier",
           value: "custom-code-verifier",
           active: true,
-        },
-        {
+        }),
+        tokenRequestParam({
           key: "scope",
           value: "openid",
           active: true,
-        },
+        }),
       ],
     })
 
@@ -125,12 +133,12 @@ describe("buildAuthCodeTokenRequest", () => {
       clientSecret: "client-secret",
       redirectURI: "https://hoppscotch.example.com/oauth",
       tokenRequestParams: [
-        {
+        tokenRequestParam({
           key: "resource",
           value: "https://graph.microsoft.com",
           active: true,
           sendIn: "url",
-        },
+        }),
       ],
     })
 
@@ -151,6 +159,28 @@ describe("buildAuthCodeTokenRequest", () => {
     expect(request.url).toBe("<<token_endpoint>>")
   })
 
+  test("adds URL params without requiring an absolute token endpoint URL", () => {
+    const request = buildAuthCodeTokenRequest({
+      tokenEndpoint: "<<token_endpoint>>",
+      code: "auth-code",
+      clientID: "client-id",
+      clientSecret: "client-secret",
+      redirectURI: "https://hoppscotch.example.com/oauth",
+      tokenRequestParams: [
+        tokenRequestParam({
+          key: "resource",
+          value: "https://graph.microsoft.com",
+          active: true,
+          sendIn: "url",
+        }),
+      ],
+    })
+
+    expect(request.url).toBe(
+      "<<token_endpoint>>?resource=https%3A%2F%2Fgraph.microsoft.com"
+    )
+  })
+
   test("does not add required OAuth fields from URL or header params", () => {
     const request = buildAuthCodeTokenRequest({
       tokenEndpoint: "https://auth.example.com/oauth/token",
@@ -159,30 +189,30 @@ describe("buildAuthCodeTokenRequest", () => {
       clientSecret: "client-secret",
       redirectURI: "https://hoppscotch.example.com/oauth",
       tokenRequestParams: [
-        {
+        tokenRequestParam({
           key: "grant_type",
           value: "client_credentials",
           active: true,
           sendIn: "url",
-        },
-        {
+        }),
+        tokenRequestParam({
           key: "client_id",
           value: "custom-client-id",
           active: true,
           sendIn: "headers",
-        },
-        {
+        }),
+        tokenRequestParam({
           key: "resource",
           value: "https://graph.microsoft.com",
           active: true,
           sendIn: "url",
-        },
-        {
+        }),
+        tokenRequestParam({
           key: "X-Tenant",
           value: "tenant-id",
           active: true,
           sendIn: "headers",
-        },
+        }),
       ],
     })
 
@@ -205,12 +235,12 @@ describe("buildAuthCodeTokenRequest", () => {
       clientSecret: "client-secret",
       redirectURI: "https://hoppscotch.example.com/oauth",
       tokenRequestParams: [
-        {
+        tokenRequestParam({
           key: "X-Tenant",
           value: "tenant-id",
           active: true,
           sendIn: "headers",
-        },
+        }),
       ],
     })
 
@@ -225,12 +255,12 @@ describe("buildAuthCodeTokenRequest", () => {
       clientSecret: "client-secret",
       redirectURI: "https://hoppscotch.example.com/oauth",
       tokenRequestParams: [
-        {
+        tokenRequestParam({
           key: "scope",
           value: "openid",
           active: false,
           sendIn: "body",
-        },
+        }),
       ],
     })
 

--- a/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
@@ -10,12 +10,12 @@ import { z } from "zod"
 import { getService } from "~/modules/dioc"
 import * as E from "fp-ts/Either"
 import { KernelInterceptorService } from "~/services/kernel-interceptor.service"
-import { content } from "@hoppscotch/kernel"
 import { refreshToken, OAuth2ParamSchema } from "../utils"
 import {
   AuthCodeGrantTypeParams,
   OAuth2AuthRequestParam,
 } from "@hoppscotch/data"
+import { buildAuthCodeTokenRequest } from "../tokenRequest"
 
 const persistenceService = getService(PersistenceService)
 const interceptorService = getService(KernelInterceptorService)
@@ -239,6 +239,7 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
     clientID: z.string(),
     codeVerifier: z.string().optional(),
     codeChallenge: z.string().optional(),
+    tokenRequestParams: z.array(OAuth2ParamSchema).optional().default([]),
   })
 
   const decodedLocalConfig = expectedSchema.safeParse(
@@ -255,26 +256,17 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
   }
 
   // exchange the code for a token
-  const { response } = interceptorService.execute({
-    id: Date.now(),
-    url: decodedLocalConfig.data.tokenEndpoint,
-    method: "POST",
-    version: "HTTP/1.1",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-      Accept: "application/json",
-    },
-    content: content.urlencoded({
+  const { response } = interceptorService.execute(
+    buildAuthCodeTokenRequest({
+      tokenEndpoint: decodedLocalConfig.data.tokenEndpoint,
       code,
-      grant_type: "authorization_code",
-      client_id: decodedLocalConfig.data.clientID,
-      client_secret: decodedLocalConfig.data.clientSecret,
-      redirect_uri: OauthAuthService.redirectURI,
-      ...(decodedLocalConfig.data.codeVerifier && {
-        code_verifier: decodedLocalConfig.data.codeVerifier,
-      }),
-    }),
-  })
+      clientID: decodedLocalConfig.data.clientID,
+      clientSecret: decodedLocalConfig.data.clientSecret,
+      redirectURI: OauthAuthService.redirectURI,
+      codeVerifier: decodedLocalConfig.data.codeVerifier,
+      tokenRequestParams: decodedLocalConfig.data.tokenRequestParams,
+    })
+  )
 
   const res = await response
 

--- a/packages/hoppscotch-common/src/services/oauth/tokenRequest.ts
+++ b/packages/hoppscotch-common/src/services/oauth/tokenRequest.ts
@@ -1,11 +1,8 @@
 import { RelayRequest, content } from "@hoppscotch/kernel"
+import type { z } from "zod"
+import type { OAuth2ParamSchema } from "./utils"
 
-export type OAuth2RequestParam = {
-  key: string
-  value: string
-  active: boolean
-  sendIn?: "headers" | "url" | "body"
-}
+export type OAuth2RequestParam = z.infer<typeof OAuth2ParamSchema>
 
 type BuildAuthCodeTokenRequestParams = {
   tokenEndpoint: string
@@ -66,12 +63,26 @@ const buildTokenEndpointUrl = (
     return tokenEndpoint
   }
 
-  const url = new URL(tokenEndpoint)
+  const hashIndex = tokenEndpoint.indexOf("#")
+  const endpointWithoutHash =
+    hashIndex === -1 ? tokenEndpoint : tokenEndpoint.slice(0, hashIndex)
+  const hash = hashIndex === -1 ? "" : tokenEndpoint.slice(hashIndex)
+  const queryIndex = endpointWithoutHash.indexOf("?")
+  const endpointWithoutQuery =
+    queryIndex === -1
+      ? endpointWithoutHash
+      : endpointWithoutHash.slice(0, queryIndex)
+  const query = new URLSearchParams(
+    queryIndex === -1 ? "" : endpointWithoutHash.slice(queryIndex + 1)
+  )
+
   urlParamEntries.forEach(([key, value]) => {
-    url.searchParams.set(key, value)
+    query.set(key, value)
   })
 
-  return url.toString()
+  const queryString = query.toString()
+
+  return `${endpointWithoutQuery}${queryString ? `?${queryString}` : ""}${hash}`
 }
 
 export const buildAuthCodeTokenRequest = ({

--- a/packages/hoppscotch-common/src/services/oauth/tokenRequest.ts
+++ b/packages/hoppscotch-common/src/services/oauth/tokenRequest.ts
@@ -1,0 +1,120 @@
+import { RelayRequest, content } from "@hoppscotch/kernel"
+
+export type OAuth2RequestParam = {
+  key: string
+  value: string
+  active: boolean
+  sendIn?: "headers" | "url" | "body"
+}
+
+type BuildAuthCodeTokenRequestParams = {
+  tokenEndpoint: string
+  code: string
+  clientID: string
+  clientSecret: string
+  redirectURI: string
+  codeVerifier?: string
+  tokenRequestParams?: Array<OAuth2RequestParam>
+}
+
+const AUTH_CODE_TOKEN_RESERVED_PARAM_KEYS = new Set([
+  "code",
+  "grant_type",
+  "client_id",
+  "client_secret",
+  "redirect_uri",
+  "code_verifier",
+])
+
+const applyOAuth2RequestParams = ({
+  params,
+  headers,
+  bodyParams,
+  urlParams,
+}: {
+  params?: Array<OAuth2RequestParam>
+  headers: Record<string, string>
+  bodyParams: Record<string, string>
+  urlParams: Record<string, string>
+}) => {
+  params
+    ?.filter(
+      (param) =>
+        param.active &&
+        param.key &&
+        param.value &&
+        !AUTH_CODE_TOKEN_RESERVED_PARAM_KEYS.has(param.key)
+    )
+    .forEach((param) => {
+      if (param.sendIn === "headers") {
+        headers[param.key] = param.value
+      } else if (param.sendIn === "url") {
+        urlParams[param.key] = param.value
+      } else {
+        bodyParams[param.key] = param.value
+      }
+    })
+}
+
+const buildTokenEndpointUrl = (
+  tokenEndpoint: string,
+  urlParams: Record<string, string>
+) => {
+  const urlParamEntries = Object.entries(urlParams)
+
+  if (urlParamEntries.length === 0) {
+    return tokenEndpoint
+  }
+
+  const url = new URL(tokenEndpoint)
+  urlParamEntries.forEach(([key, value]) => {
+    url.searchParams.set(key, value)
+  })
+
+  return url.toString()
+}
+
+export const buildAuthCodeTokenRequest = ({
+  tokenEndpoint,
+  code,
+  clientID,
+  clientSecret,
+  redirectURI,
+  codeVerifier,
+  tokenRequestParams,
+}: BuildAuthCodeTokenRequestParams): RelayRequest => {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json",
+  }
+
+  const bodyParams: Record<string, string> = {}
+  const urlParams: Record<string, string> = {}
+
+  applyOAuth2RequestParams({
+    params: tokenRequestParams,
+    headers,
+    bodyParams,
+    urlParams,
+  })
+
+  // Required OAuth fields should always win over user-defined advanced params.
+  bodyParams.code = code
+  bodyParams.grant_type = "authorization_code"
+  bodyParams.client_id = clientID
+  bodyParams.client_secret = clientSecret
+  bodyParams.redirect_uri = redirectURI
+
+  if (codeVerifier) {
+    bodyParams.code_verifier = codeVerifier
+  }
+
+  return {
+    id: Date.now(),
+    url: buildTokenEndpointUrl(tokenEndpoint, urlParams),
+    method: "POST",
+    version: "HTTP/1.1",
+    headers,
+    content: content.urlencoded(bodyParams),
+  }
+}


### PR DESCRIPTION
## Summary
- include advanced token request params in the Authorization Code token exchange
- preserve required OAuth fields while allowing non-reserved body, URL, and header params
- keep PKCE code_verifier behavior covered

Fixes #5598

## Validation
- pnpm --dir packages/hoppscotch-common exec vitest run src/services/oauth/__tests__/tokenRequest.spec.ts
- pnpm --dir packages/hoppscotch-common exec eslint src/services/oauth/tokenRequest.ts src/services/oauth/flows/authCode.ts src/services/oauth/__tests__/tokenRequest.spec.ts
- pnpm --dir packages/hoppscotch-common run do-typecheck
- pnpm --dir packages/hoppscotch-common run test
- pnpm --dir packages/hoppscotch-common run do-lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies advanced OAuth2 token request params during the Authorization Code token exchange. Protects required fields, preserves PKCE, and safely handles token endpoint URL params. Fixes #5598.

- **Bug Fixes**
  - Apply active token request params in body, URL, or headers.
  - Ignore inactive params and prevent reserved fields from being overridden.
  - Safely handle token endpoint URL params (merge with existing query/hash, support non-absolute URLs, skip parsing when none).

- **Refactors**
  - Added `buildAuthCodeTokenRequest` and used it in the auth code flow.
  - Added unit tests for the token request builder.

<sup>Written for commit aa7ab6e6f847f32b93bcda6e20b328ec153332e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

