### PR TITLE
Update isHoppCLIError.spec.ts to use Vitest imports

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/functions/checks/isHoppCLIError.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/functions/checks/isHoppCLIError.spec.ts
@@ -1,3 +1,4 @@
+import { describe, test, expect } from "vitest";
 import { isHoppCLIError } from "../../../utils/checks";
 
 describe("isHoppCLIError", () => {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use explicit `vitest` imports in isHoppCLIError.spec.ts to align with our Vitest setup and avoid relying on globals. This ensures `describe`, `test`, and `expect` are always defined.

<sup>Written for commit cf2e0cd22303d98f8b3753188eaeb35974c40f05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

