### PR TITLE
feat: make URLs in JSON response clickable

### DIFF
--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -294,6 +294,7 @@ import { useNestedSetting } from "~/composables/settings"
 import { toggleNestedSetting } from "~/newstore/settings"
 import { HoppRESTRequestResponse } from "@hoppscotch/data"
 import { useScrollerRef } from "~/composables/useScrollerRef"
+import { EditorView } from "@codemirror/view"
 
 const t = useI18n()
 
@@ -522,6 +523,27 @@ const { cursor } = useCodemirror(
       readOnly: !props.isEditable,
       lineWrapping: WRAP_LINES,
     },
+    additionalExts: [
+      EditorView.domEventHandlers({
+        click(event, view) {
+          const pos = view.posAtCoords({
+            x: event.clientX,
+            y: event.clientY,
+          })
+
+          if (pos === null) return false
+
+          const line = view.state.doc.lineAt(pos)
+          const urlMatch = line.text.match(/https?:\/\/[^\s"]+/)
+
+          if (urlMatch) {
+            window.open(urlMatch[0], "_blank")
+          }
+
+          return false
+        },
+      }),
+    ],
     linter: null,
     completer: null,
     environmentHighlights: true,

--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -538,6 +538,7 @@ const { cursor } = useCodemirror(
 
           if (urlMatch) {
             window.open(urlMatch[0], "_blank", "noopener,noreferrer")
+            return true
           }
 
           return false

--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -526,6 +526,7 @@ const { cursor } = useCodemirror(
     additionalExts: [
       EditorView.domEventHandlers({
         click(event, view) {
+         if (props.isEditable) return false
           const pos = view.posAtCoords({
             x: event.clientX,
             y: event.clientY,

--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -537,7 +537,7 @@ const { cursor } = useCodemirror(
           const urlMatch = line.text.match(/https?:\/\/[^\s"]+/)
 
           if (urlMatch) {
-            window.open(urlMatch[0], "_blank")
+            window.open(urlMatch[0], "_blank", "noopener,noreferrer")
           }
 
           return false


### PR DESCRIPTION
Closes #6307

## Summary

This PR adds support for clickable URLs inside the JSON response body renderer. Users can now click URLs directly from the response panel to open them in a new browser tab, improving navigation and developer workflow.

## What's changed

* Added a click event handler to the JSON response CodeMirror editor.
* Detects URLs from the clicked line in the response body.
* Opens detected URLs using `window.open()` in a new tab.
* Kept the change isolated to `JSONLensRenderer.vue` without affecting other renderers.

## Testing

Tested locally using:

`https://jsonplaceholder.typicode.com/photos/1`

Verified that clicking URLs in the JSON response body opens the corresponding link in a new browser tab.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make URLs in the JSON response panel clickable so users can open links in a new tab. Works only in read-only mode and opens links safely.

- **New Features**
  - Adds a click handler via `EditorView.domEventHandlers` from `@codemirror/view` in `JSONLensRenderer.vue` to detect `http(s)` URLs on the clicked line, skip when `isEditable`, and return `true` when handled.
  - Opens the URL with `window.open(url, "_blank", "noopener,noreferrer")`. Other lenses unchanged.

<sup>Written for commit 2b55c83a237afba2c760a9bf613bf94dab85ab3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

