### PR TITLE
fix: preserve numeric formatting in JSONC conversion

### DIFF
--- a/packages/hoppscotch-cli/src/utils/jsonc.ts
+++ b/packages/hoppscotch-cli/src/utils/jsonc.ts
@@ -16,7 +16,7 @@ class InvalidJSONCNodeError extends Error {
  * @throws {InvalidJSONCNodeError} if the node is in an invalid configuration
  * @returns The JSON string without comments and trailing commas
  */
-function convertNodeToJSON(node: Node): string {
+function convertNodeToJSON(node: Node, text: string): string {
   switch (node.type) {
     case "string":
       return JSON.stringify(node.value);
@@ -28,10 +28,10 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `[${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, text))
         .join(",")}]`;
     case "number":
-      return JSON.stringify(node.value);
+      return text.substring(node.offset, node.offset + node.length);
     case "boolean":
       return JSON.stringify(node.value);
     case "object":
@@ -40,7 +40,7 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `{${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, text))
         .join(",")}}`;
     case "property":
       if (!node.children || node.children.length !== 2) {
@@ -53,7 +53,7 @@ function convertNodeToJSON(node: Node): string {
       // Attempting to JSON.stringify(keyNode) directly would throw
       // "Converting circular structure to JSON" error.
       // If the valueNode configuration is wrong, this will return an error, which will propagate up
-      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(valueNode)}`;
+      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(valueNode, text)}`;
   }
 }
 
@@ -70,7 +70,7 @@ function stripCommentsAndCommas(text: string): string {
 
   // convertNodeToJSON can throw an error if the tree is invalid
   try {
-    return convertNodeToJSON(tree);
+    return convertNodeToJSON(tree, text);
   } catch (_) {
     return text;
   }

--- a/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
@@ -35,7 +35,7 @@ class InvalidJSONCNodeError extends Error {
  * @throws {InvalidJSONCNodeError} if the node is in an invalid configuration
  * @returns The JSON string without comments and trailing commas
  */
-function convertNodeToJSON(node: Node): string {
+function convertNodeToJSON(node: Node, text: string): string {
   switch (node.type) {
     case "string":
       return JSON.stringify(node.value)
@@ -47,10 +47,10 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `[${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, text))
         .join(",")}]`
     case "number":
-      return JSON.stringify(node.value)
+      return text.substring(node.offset, node.offset + node.length)
     case "boolean":
       return JSON.stringify(node.value)
     case "object":
@@ -59,7 +59,7 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `{${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, text))
         .join(",")}}`
     case "property":
       if (!node.children || node.children.length !== 2) {
@@ -72,7 +72,7 @@ function convertNodeToJSON(node: Node): string {
       // Attempting to JSON.stringify(keyNode) directly would throw
       // "Converting circular structure to JSON" error.
       // If the valueNode configuration is wrong, this will return an error, which will propagate up
-      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(valueNode)}`
+      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(valueNode, text)}`
   }
 }
 
@@ -89,7 +89,7 @@ function stripCommentsAndCommas(text: string): string {
 
   // convertNodeToJSON can throw an error if the tree is invalid
   try {
-    return convertNodeToJSON(tree)
+    return convertNodeToJSON(tree, text)
   } catch (_) {
     return text
   }


### PR DESCRIPTION
Closes #6317

This PR fixes an issue where numeric literals such as `70.0` in JSON request bodies were losing their original formatting and being converted to `70` during JSONC processing.

The issue occurred because the JSONC conversion logic rebuilt parsed numeric values using `JSON.stringify(node.value)`. Since JavaScript parses both `70` and `70.0` as the same numeric type, the trailing `.0` was lost during serialization.

This fix preserves the original numeric literal formatting by extracting the raw source text directly from the JSONC AST using `node.offset` and `node.length`.

### What's changed

* [x] Updated JSONC conversion logic in:

  * `packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts`
  * `packages/hoppscotch-cli/src/utils/jsonc.ts`
* [x] Preserved original numeric literals instead of re-stringifying parsed JS numbers
* [x] Synchronized behavior across Web/Desktop and CLI environments
* [x] Verified JSONC comment/trailing comma cleanup behavior remains unchanged

### Notes to reviewers

Tested with request bodies such as:

```json id="tk7ndm"
{
  "name": "test",
  "val": 70.0
}
```

Verified:

* `70.0` remains preserved
* normal integers remain unchanged
* generated cURL commands preserve numeric formatting
* JSONC cleanup still functions correctly
<img width="1459" height="833" alt="Screenshot 2026-05-14 at 10 45 20 PM" src="https://github.com/user-attachments/assets/5b0cd3eb-98b6-43b6-bfbf-d0fe3e9c6fbe" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves numeric literal formatting in JSONC-to-JSON conversion so values like 70.0 aren’t normalized to 70. Applies to both app and CLI.

- **Bug Fixes**
  - For number nodes, return the raw token from source text using `node.offset`/`node.length` instead of `JSON.stringify(node.value)`.
  - Thread the original text into `convertNodeToJSON(node, text)` and update recursive calls in `packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts` and `packages/hoppscotch-cli/src/utils/jsonc.ts`.
  - Keeps comment and trailing comma stripping behavior unchanged.

<sup>Written for commit 3e96d35daded16b049cd06ebd4ccf3d44643d2f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

