### PR TITLE
fix: preserve binary response bytes on download

### DIFF
--- a/packages/hoppscotch-common/src/composables/lens-actions.ts
+++ b/packages/hoppscotch-common/src/composables/lens-actions.ts
@@ -65,7 +65,11 @@ export function useDownloadResponse(
   const t = useI18n()
 
   const downloadResponse = async () => {
-    const dataToWrite = responseBody.value
+    const rawData = responseBody.value
+    // Ensure binary data is passed as Uint8Array for cross-platform compatibility.
+    // The kernel IO layer expects string | Uint8Array, not ArrayBuffer.
+    const dataToWrite =
+      rawData instanceof ArrayBuffer ? new Uint8Array(rawData) : rawData
 
     // TODO: Look at the mime type and determine extension ?
     const result = await platform.kernelIO.saveFileWithDialog({

--- a/packages/hoppscotch-common/src/helpers/kernel/rest/response.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/rest/response.ts
@@ -87,7 +87,7 @@ export const RESTResponse = {
     return {
       type: "success",
       headers: processHeaders(response.headers),
-      body: response.body.body.buffer,
+      body: new Uint8Array(response.body.body).buffer,
       statusCode: response.status,
       statusText: response.statusText ?? "",
       meta: {

--- a/packages/hoppscotch-common/src/helpers/kernel/rest/response.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/rest/response.ts
@@ -87,7 +87,10 @@ export const RESTResponse = {
     return {
       type: "success",
       headers: processHeaders(response.headers),
-      body: new Uint8Array(response.body.body).buffer,
+      body: response.body.body.buffer.slice(
+        response.body.body.byteOffset,
+        response.body.body.byteOffset + response.body.body.byteLength
+      ),
       statusCode: response.status,
       statusText: response.statusText ?? "",
       meta: {

--- a/packages/hoppscotch-common/src/platform/std/io.ts
+++ b/packages/hoppscotch-common/src/platform/std/io.ts
@@ -15,7 +15,7 @@ export const browserIODef: IOPlatformDef = {
         : opts.data instanceof Uint8Array
           ? opts.data
           : new Uint8Array(opts.data as ArrayBuffer)
-    const file = new Blob([blobData as any], { type: opts.contentType })
+    const file = new Blob([blobData], { type: opts.contentType })
     const a = document.createElement("a")
     const url = URL.createObjectURL(file)
 

--- a/packages/hoppscotch-common/src/platform/std/io.ts
+++ b/packages/hoppscotch-common/src/platform/std/io.ts
@@ -8,7 +8,14 @@ import * as RNEA from "fp-ts/ReadonlyNonEmptyArray"
  */
 export const browserIODef: IOPlatformDef = {
   saveFileWithDialog(opts) {
-    const file = new Blob([opts.data], { type: opts.contentType })
+    // Ensure binary data is properly handled as Uint8Array for Blob construction
+    const blobData =
+      typeof opts.data === "string"
+        ? opts.data
+        : opts.data instanceof Uint8Array
+          ? opts.data
+          : new Uint8Array(opts.data as ArrayBuffer)
+    const file = new Blob([blobData as any], { type: opts.contentType })
     const a = document.createElement("a")
     const url = URL.createObjectURL(file)
 

--- a/packages/hoppscotch-kernel/src/io/impl/desktop/v/1.ts
+++ b/packages/hoppscotch-kernel/src/io/impl/desktop/v/1.ts
@@ -30,7 +30,13 @@ export const implementation: VersionedAPI<IoV1> = {
       if (typeof opts.data === "string") {
         await writeTextFile(path, opts.data)
       } else {
-        await writeFile(path, opts.data)
+        // Ensure we pass Uint8Array to writeFile, as ArrayBuffer may arrive
+        // at runtime due to type mismatches at the platform/kernel boundary.
+        const bytes =
+          opts.data instanceof Uint8Array
+            ? opts.data
+            : new Uint8Array(opts.data as ArrayBuffer)
+        await writeFile(path, bytes)
       }
 
       return { type: "saved" as const, path }

--- a/packages/hoppscotch-kernel/src/io/impl/web/v/1.ts
+++ b/packages/hoppscotch-kernel/src/io/impl/web/v/1.ts
@@ -13,14 +13,16 @@ export const implementation: VersionedAPI<IoV1> = {
   version: { major: 1, minor: 0, patch: 0 },
   api: {
     async saveFileWithDialog(opts: SaveFileWithDialogOptions) {
-      // TODO: Revisit this because perhaps a better approach is
-      // ```ts
-      // const data: BlobPart = typeof opts.data === 'string'
-      //     ? opts.data
-      //     : new Uint8Array(opts.data);
-      // const file = new Blob([data], { type: opts.contentType })
-      // ```
-      const file = new Blob([opts.data as BlobPart], { type: opts.contentType })
+      // Handle both string and binary data explicitly.
+      // ArrayBuffer may arrive at runtime due to type mismatches at the
+      // platform/kernel boundary, so we defensively handle it as well.
+      const blobData =
+        typeof opts.data === "string"
+          ? opts.data
+          : opts.data instanceof Uint8Array
+            ? opts.data
+            : new Uint8Array(opts.data as ArrayBuffer)
+      const file = new Blob([blobData as any], { type: opts.contentType })
       const a = document.createElement("a")
       const url = URL.createObjectURL(file)
 

--- a/packages/hoppscotch-kernel/src/io/impl/web/v/1.ts
+++ b/packages/hoppscotch-kernel/src/io/impl/web/v/1.ts
@@ -22,7 +22,10 @@ export const implementation: VersionedAPI<IoV1> = {
           : opts.data instanceof Uint8Array
             ? opts.data
             : new Uint8Array(opts.data as ArrayBuffer)
-      const file = new Blob([blobData as any], { type: opts.contentType })
+      const blobPart: BlobPart =
+        typeof blobData === "string" ? blobData : new Uint8Array(blobData)
+
+      const file = new Blob([blobPart], { type: opts.contentType })
       const a = document.createElement("a")
       const url = URL.createObjectURL(file)
 


### PR DESCRIPTION
Closes #5586

This PR fixes binary response corruption when downloading large request responses.

After reproducing the issue locally with a controlled binary test setup, I found that the downloaded files were not being truncated, but their byte contents were being altered during the response download pipeline. This caused binary responses such as PDFs, ZIPs, and other attachments to become corrupted/unopenable even though the downloaded file size appeared correct.

The root cause was inconsistent binary data handling across the response download flow:

* response bodies were flowing through the system as `ArrayBuffer`
* some parts of the IO pipeline expected `Uint8Array`
* unsafe `.buffer` usage could expose incorrect/shared underlying memory
* binary responses could end up reconstructed incorrectly before download

### What's changed

* [x] Standardized binary handling using `Uint8Array`
* [x] Removed unsafe buffer access patterns from the response pipeline
* [x] Updated Blob creation flow to safely preserve exact binary bytes
* [x] Added defensive conversion handling for desktop/Tauri file writes
* [x] Synchronized binary handling across:

  * `packages/hoppscotch-common/src/composables/lens-actions.ts`
  * `packages/hoppscotch-common/src/helpers/kernel/rest/response.ts`
  * `packages/hoppscotch-common/src/platform/std/io.ts`
  * `packages/hoppscotch-kernel/src/io/impl/desktop/v/1.ts`
  * `packages/hoppscotch-kernel/src/io/impl/web/v/1.ts`
* [x] Added safer handling for `ArrayBuffer` / `Uint8Array` conversion paths
* [x] Preserved existing JSON/text response download behavior

### Notes to reviewers

I reproduced this issue locally using a generated 20 MB binary file served through a local HTTP server.

Validation before the fix:

* downloaded file size matched the original file
* SHA hashes differed
* binary files became corrupted after download

Validation after the fix:

* SHA hashes match exactly
* binary integrity is preserved correctly during download
* large binary responses download successfully without corruption

I also verified:

* lint passes successfully
* typecheck passes successfully
* existing response download flows remain unaffected

 BEFORE :

 <img width="641" height="120" alt="Screenshot 2026-05-15 at 12 04 02 PM" src="https://github.com/user-attachments/assets/a06df50c-03b2-40b7-8da6-b6998068cd25" />


AFTER:

<img width="658" height="166" alt="Screenshot 2026-05-15 at 11 43 46 PM" src="https://github.com/user-attachments/assets/3b2ceb3f-b6c2-4d87-a1cf-a0a023afb199" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes binary response corruption on large downloads by standardizing byte handling and IO. PDFs, ZIPs, and other binaries now download with exact bytes preserved.

- **Bug Fixes**
  - Use `Uint8Array` consistently; convert from `ArrayBuffer` in `lens-actions` before save.
  - Build REST response body from the correct slice of the underlying buffer to avoid shared memory issues.
  - Browser/web IO: create `Blob` from string or `Uint8Array`, converting `ArrayBuffer` defensively in `@hoppscotch-common` and `@hoppscotch-kernel`.
  - Desktop/Tauri IO: pass `Uint8Array` to `writeFile` for correct bytes on disk.

<sup>Written for commit be5068f4037de99db364c79e4ff431ccd93b5146. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6325?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

