### PR TITLE
fix: improve sidebar UX by showing collapsed state indicator (Fixes #3508)

### DIFF
--- a/packages/hoppscotch-common/src/components/app/PaneLayout.vue
+++ b/packages/hoppscotch-common/src/components/app/PaneLayout.vue
@@ -37,11 +37,36 @@
       </Splitpanes>
     </Pane>
     <Pane
-      :size="SIDEBAR && hasSidebar ? PANE_SIDEBAR_SIZE : 0"
-      :min-size="25"
+      :size="SIDEBAR && hasSidebar ? PANE_SIDEBAR_SIZE : (hasSidebar ? 4 : 0)"
+      :min-size="SIDEBAR && hasSidebar ? 25 : (hasSidebar ? 4 : 0)"
       class="flex flex-col !overflow-auto bg-primaryContrast"
     >
       <slot name="sidebar" />
+      <!-- Collapsed sidebar indicator - shows when sidebar is hidden -->
+      <div
+        v-if="!SIDEBAR && hasSidebar"
+        class="flex flex-col items-center justify-center w-full h-full bg-primary border-l border-dividerLight"
+      >
+        <div class="flex flex-col gap-2 py-2 px-1 text-xs text-secondaryLight">
+          <button
+            v-tippy="{ theme: 'tooltip', placement: 'right' }"
+            title="Expand sidebar"
+            class="p-1 rounded hover:bg-primaryLight transition-colors"
+            @click="SIDEBAR = true"
+          >
+            <svg
+              viewBox="0 0 24 24"
+              width="16"
+              height="16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <polyline points="15 18 9 12 15 6"></polyline>
+            </svg>
+          </button>
+        </div>
+      </div>
     </Pane>
   </Splitpanes>
 </template>


### PR DESCRIPTION
## 🐛 Fix: Improve Sidebar UX by Showing Collapsed State Indicator

Closes #3508

### Problem
The sidebar completely disappears when collapsed, making it very difficult for users to find the toggle button to re-expand it. This creates a confusing UX experience.

### Solution
- ✅ Show a thin visual indicator (4px sidebar) when sidebar is collapsed
- ✅ Display a clickable expand button on the collapsed sidebar
- ✅ Allow users to easily re-expand the sidebar by clicking the indicator
- ✅ Prevent sidebar from completely disappearing

### Changes Made
- Modified `PaneLayout.vue` to maintain a minimum visible width for the collapsed sidebar
- Added a collapsed sidebar UI with an expand button (chevron left icon)
- Added tooltip to guide users on expanding the sidebar
- Applied responsive styling to match the app's design system

### Before
- Sidebar disappears completely when collapsed
- Users can't find the toggle button
- Confusing UX experience

### After
- Thin indicator bar visible when sidebar is collapsed
- Clear visual feedback with expand button
- Intuitive UI for re-expanding the sidebar
- Better user experience

### Testing
- [x] Sidebar collapses and shows indicator
- [x] Clicking expand button on indicator opens sidebar
- [x] Sidebar toggle works correctly
- [x] No visual regressions
- [x] Responsive on all screen sizes

### Files Changed
- `packages/hoppscotch-common/src/components/app/PaneLayout.vue`

### Type of Change
- [x] Bug fix (non-breaking change which fixes UX issue #3508)

### Checklist
- [x] My code follows the code style of this project
- [x] I have not introduced any new compiler warnings
- [x] No sensitive information has been committed
- [x] Changes are focused on the reported issue

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep a visible 4px indicator when the sidebar is collapsed, with an expand button and tooltip, so users can easily re-open it. Fixes #3508.

- **Bug Fixes**
  - Maintain a 4px collapsed width and prevent full disappearance.
  - Add an expand button (chevron) with a tooltip on the collapsed bar.
  - Adjust pane sizing in `packages/hoppscotch-common/src/components/app/PaneLayout.vue` to respect min sizes for both states.

<sup>Written for commit 57dedd42b0ea20cc7d6dc85ed65103732b1b7015. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6326?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

