### PR TITLE
i18n: add missing script translations to Chinese (cn) locale

### DIFF
--- a/packages/hoppscotch-common/locales/cn.json
+++ b/packages/hoppscotch-common/locales/cn.json
@@ -1256,6 +1256,12 @@
     "saved": "响应已保存",
     "invalid_name": "请为响应提供名称"
   },
+  "script": {
+    "inheriting": "继承脚本自",
+    "inheriting_from_count": "从 {count} 个集合继承 | 从 {count} 个集合继承",
+    "inherited_scripts": "继承的脚本",
+    "view_inherited": "查看继承的脚本"
+  },
   "settings": {
     "accent_color": "强调色",
     "account": "帐户",


### PR DESCRIPTION
## Summary
- Added the missing `script` translation section to the Chinese (cn) locale
- The `script` key was present in the English locale but entirely absent from the Chinese locale

## What changed
Added Chinese translations:
- `inheriting`: "继承脚本自"
- `inheriting_from_count`: "从 {count} 个集合继承 | 从 {count} 个集合继承"
- `inherited_scripts`: "继承的脚本"
- `view_inherited`: "查看继承的脚本"

## Test plan
- [ ] Verify script-related UI elements render in Chinese when locale is set to Chinese

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the missing `script` translations to the Chinese (cn) locale in `hoppscotch-common` so script-related UI renders correctly in Chinese.

- **Bug Fixes**
  - Added `script.inheriting`: "继承脚本自"
  - Added `script.inheriting_from_count`: "从 {count} 个集合继承 | 从 {count} 个集合继承"
  - Added `script.inherited_scripts`: "继承的脚本"
  - Added `script.view_inherited`: "查看继承的脚本"

<sup>Written for commit 2b7f4f4179d67f3d3ec5e515b9143ecd50f88c69. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6327?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

