### PR TITLE
fix: preserve literal braces in Postman imports

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
@@ -1,7 +1,10 @@
 import * as E from "fp-ts/Either"
 import { describe, expect, it } from "vitest"
 
-import { hoppPostmanImporter } from "../import-export/import/postman"
+import {
+  hoppPostmanImporter,
+  replacePMVarTemplating,
+} from "../import-export/import/postman"
 
 const postmanCollectionWithArrayHeader = JSON.stringify({
   info: {
@@ -30,7 +33,108 @@ const postmanCollectionWithArrayHeader = JSON.stringify({
   ],
 })
 
+const literalBracesBody =
+  '{"id":4,"required":1,"data":{"type":12,"len":32,"ext":{"required":["buttonalign","buttonstyle"],"filesize":"1MB"}}}'
+
+const postmanCollectionWithLiteralBracesBody = JSON.stringify({
+  info: {
+    name: "Literal Braces Body",
+    schema:
+      "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+  },
+  item: [
+    {
+      name: "Raw JSON with literal braces",
+      request: {
+        method: "POST",
+        header: [{ key: "Content-Type", value: "application/json" }],
+        body: { mode: "raw", raw: literalBracesBody },
+        url: "https://echo.hoppscotch.io/post",
+      },
+    },
+  ],
+})
+
+const postmanCollectionWithMixedBody = JSON.stringify({
+  info: {
+    name: "Mixed Variable And Literal Braces Body",
+    schema:
+      "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+  },
+  item: [
+    {
+      name: "Raw JSON with variable and literal braces",
+      request: {
+        method: "POST",
+        header: [{ key: "Content-Type", value: "application/json" }],
+        body: {
+          mode: "raw",
+          raw: '{"url":"{{serviceInternalUrl}}","data":{"nested":{"k":"v"}}}',
+        },
+        url: "https://echo.hoppscotch.io/post",
+      },
+    },
+  ],
+})
+
 describe("Postman importer", () => {
+  describe("replacePMVarTemplating", () => {
+    it("converts Postman variable templates to Hoppscotch variable templates", () => {
+      expect(replacePMVarTemplating("{{serviceInternalUrl}}")).toBe(
+        "<<serviceInternalUrl>>"
+      )
+
+      expect(replacePMVarTemplating("{{ serviceInternalUrl }}")).toBe(
+        "<<serviceInternalUrl>>"
+      )
+
+      expect(
+        replacePMVarTemplating(
+          "{{serviceInternalUrl}}/api/{{ serviceToken }}"
+        )
+      ).toBe("<<serviceInternalUrl>>/api/<<serviceToken>>")
+    })
+
+    it("leaves literal and empty brace pairs unchanged", () => {
+      expect(replacePMVarTemplating("}}")).toBe("}}")
+      expect(replacePMVarTemplating('{"nested":{"k":"v"}}}')).toBe(
+        '{"nested":{"k":"v"}}}'
+      )
+      expect(replacePMVarTemplating("{{}}")).toBe("{{}}")
+      expect(replacePMVarTemplating("{{   }}")).toBe("{{   }}")
+    })
+  })
+
+  it("preserves raw JSON bodies containing literal adjacent closing braces", async () => {
+    const result = await hoppPostmanImporter([
+      postmanCollectionWithLiteralBracesBody,
+    ])()
+
+    expect(E.isRight(result)).toBe(true)
+
+    if (E.isLeft(result)) {
+      throw new Error("Expected Postman import to succeed")
+    }
+
+    expect(result.right[0].requests[0].body.body).toBe(literalBracesBody)
+  })
+
+  it("converts real Postman variables while leaving literal braces unchanged", async () => {
+    const result = await hoppPostmanImporter([
+      postmanCollectionWithMixedBody,
+    ])()
+
+    expect(E.isRight(result)).toBe(true)
+
+    if (E.isLeft(result)) {
+      throw new Error("Expected Postman import to succeed")
+    }
+
+    expect(result.right[0].requests[0].body.body).toBe(
+      '{"url":"<<serviceInternalUrl>>","data":{"nested":{"k":"v"}}}'
+    )
+  })
+
   it("coerces array header values instead of crashing during import", async () => {
     const result = await hoppPostmanImporter([
       postmanCollectionWithArrayHeader,

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -65,7 +65,12 @@ const getCollectionSchema = (jsonStr: string): string | null => {
 
 export const replacePMVarTemplating = (value: unknown): string => {
   const str = typeof value === "string" ? value : String(value ?? "")
-  return pipe(str, S.replace(/{{\s*/g, "<<"), S.replace(/\s*}}/g, ">>"))
+  // Only convert a complete Postman variable token (`{{ name }}`) into a
+  // Hoppscotch variable (`<<name>>`). Requiring a matched pair wrapping a
+  // non-empty, non-whitespace token with no braces inside ensures literal
+  // adjacent braces in raw bodies (e.g. JSON `}}}`) and empty/whitespace-only
+  // brace pairs are left untouched. See hoppscotch/hoppscotch#6324.
+  return pipe(str, S.replace(/{{\s*([^{}\s]+)\s*}}/g, "<<$1>>"))
 }
 
 const PMRawLanguageOptionsToContentTypeMap: Record<


### PR DESCRIPTION
Fixes #6324

## Summary

This updates Postman variable conversion so only complete paired Postman variable references such as `{{serviceInternalUrl}}` are translated to Hoppscotch variables.

Previously, standalone `}}` sequences inside raw request bodies could be converted to `>>`, corrupting valid JSON.

## Changes

- Replaced independent `{{` and `}}` substitutions with a single matched-pair replacement.
- Added regression coverage for:
  - preserving literal adjacent closing braces in raw JSON request bodies
  - converting valid Postman variables without altering unrelated braces

## Verification

```bash
cd packages/hoppscotch-common
pnpm vitest run src/helpers/__tests__/postman-import.spec.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Postman import variable conversion to only translate complete, non-empty `{{...}}` tokens into `<<...>>`. This preserves literal braces and empty brace pairs in raw bodies and prevents JSON corruption.

- **Bug Fixes**
  - Use a matched-pair replacement: `/{{\s*([^{}\s]+)\s*}}/g` -> `<<$1>>`.
  - Add regression tests covering literal adjacent `}}` and empty/whitespace-only `{{}}`, while still converting valid Postman variables.

<sup>Written for commit 3264122c0138d0ac903e5a7a415dd673f47741e5. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6328?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

