### PR TITLE
fix(i18n): add missing Chinese script translations

### DIFF
--- a/packages/hoppscotch-common/locales/cn.json
+++ b/packages/hoppscotch-common/locales/cn.json
@@ -841,6 +841,7 @@
     "authorization": "授权头将会在您发送请求时自动生成。",
     "collection_properties_authorization": "这个授权将被应用在当前集合下的所有请求。",
     "collection_properties_header": "这个请求头将被应用在当前集合下的所有请求。",
+    "collection_properties_scripts": "这些脚本将在该集合中的每个请求中运行。预请求脚本在请求之前运行，测试脚本在响应之后运行。",
     "generate_documentation_first": "请先生成文档",
     "network_fail": "无法到达 API 端点。请检查网络连接并重试。",
     "offline": "您似乎处于离线状态，该工作区中的数据可能不是最新。",
@@ -1796,7 +1797,8 @@
     "websocket": "WebSocket",
     "all_tests": "所有",
     "passed": "通过",
-    "failed": "失败"
+    "failed": "失败",
+    "scripts": "脚本"
   },
   "team": {
     "activity_logs": "活动日志",
@@ -2326,5 +2328,11 @@
       "delete_success": "Mock 服务删除成功",
       "delete_error": "删除 Mock 服务失败"
     }
+  },
+  "script": {
+    "inherited_scripts": "继承的脚本",
+    "inheriting": "继承脚本自",
+    "inheriting_from_count": "从 {count} 个集合继承 | 从 {count} 个集合继承",
+    "view_inherited": "查看继承的脚本"
   }
 }

--- a/packages/hoppscotch-common/locales/cn.json
+++ b/packages/hoppscotch-common/locales/cn.json
@@ -1782,6 +1782,7 @@
     "parameters": "参数",
     "post_request_script": "请求后脚本",
     "pre_request_script": "预请求脚本",
+    "scripts": "脚本",
     "queries": "查询",
     "query": "查询",
     "schema": "模式",
@@ -1797,8 +1798,7 @@
     "websocket": "WebSocket",
     "all_tests": "所有",
     "passed": "通过",
-    "failed": "失败",
-    "scripts": "脚本"
+    "failed": "失败"
   },
   "team": {
     "activity_logs": "活动日志",


### PR DESCRIPTION
Closes #6329

## Description

This PR adds the missing Chinese (`cn.json`) translations for the script-related UI in Hoppscotch.

Previously, several script-related labels and helper texts were falling back to English when the application locale was set to Chinese. This update adds the missing translation keys while preserving the existing locale structure and formatting conventions.

### What's changed

* [x] Added `helpers.collection_properties_scripts`
* [x] Added `tab.scripts`
* [x] Added missing `script.*` translations:

  * `inherited_scripts`
  * `inheriting`
  * `inheriting_from_count`
  * `view_inherited`
* [x] Preserved existing placeholders such as `{count}`
* [x] Verified translations render correctly in the Chinese locale UI
* [x] Kept the change scoped only to `cn.json`

### Modified file

* `packages/hoppscotch-common/locales/cn.json`

### Notes to reviewers

* The implementation was compared against `en.json` to ensure key parity and correct nesting structure.
* `inheriting_from_count` preserves the Vue I18n pluralization format using the pipe (`|`) syntax to avoid runtime rendering inconsistencies.
* Verified locally by switching the application locale to Chinese and testing the script-related UI sections.


BEFORE : 
<img width="1285" height="265" alt="Screenshot 2026-05-16 at 1 04 22 PM" src="https://github.com/user-attachments/assets/c1c0a8f2-c061-479f-a4ef-4f22a4bd6e08" />

AFTER :

<img width="1201" height="197" alt="Screenshot 2026-05-16 at 1 02 59 PM" src="https://github.com/user-attachments/assets/1e70722b-587d-4c8b-9e03-93ec872f3579" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing Chinese translations for the script UI so labels no longer fall back to English. Preserves `{count}` placeholders and Vue I18n pluralization.

- **Bug Fixes**
  - Added `helpers.collection_properties_scripts`, `tab.scripts`, and `script.*` keys (`inherited_scripts`, `inheriting`, `inheriting_from_count`, `view_inherited`).
  - Scoped to `packages/hoppscotch-common/locales/cn.json` and verified in the Chinese UI.

- **Refactors**
  - Aligned `cn.json` key ordering with English to reduce diff noise.

<sup>Written for commit 334bb01c2459e9b4fed31e4af127f1863fc1c971. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6330?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

