### PR TITLE
fix(common): preserve float precision in JSON request bodies

### DIFF
--- a/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest"
+import { stripComments } from "../jsonc"
+
+describe("jsonc helpers", () => {
+  describe("stripComments", () => {
+    it("preserves exact floating point precision like 70.0", () => {
+      const input = `{"val": 70.0}`
+      const result = stripComments(input)
+      expect(result).toBe(`{"val":70.0}`)
+    })
+
+    it("preserves integers accurately", () => {
+      const input = `{"val": 100}`
+      const result = stripComments(input)
+      expect(result).toBe(`{"val":100}`)
+    })
+
+    it("preserves floating points with multiple trailing zeros", () => {
+      const input = `{"val": 1.050}`
+      const result = stripComments(input)
+      expect(result).toBe(`{"val":1.050}`)
+    })
+
+    it("preserves 0.0 accurately", () => {
+      const input = `{"val": 0.0}`
+      const result = stripComments(input)
+      expect(result).toBe(`{"val":0.0}`)
+    })
+
+    it("preserves scientific notation accurately", () => {
+      const input = `{"val": 1e3}`
+      const result = stripComments(input)
+      expect(result).toBe(`{"val":1e3}`)
+    })
+
+    it("safely strips comments while preserving nearby numbers", () => {
+      const input = `{
+        // The price
+        "price": 70.0,
+        /* The weight */
+        "weight": 1.050
+      }`
+      const result = stripComments(input)
+      expect(result).toBe(`{"price":70.0,"weight":1.050}`)
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
@@ -35,7 +35,7 @@ class InvalidJSONCNodeError extends Error {
  * @throws {InvalidJSONCNodeError} if the node is in an invalid configuration
  * @returns The JSON string without comments and trailing commas
  */
-function convertNodeToJSON(node: Node): string {
+function convertNodeToJSON(node: Node, text: string): string {
   switch (node.type) {
     case "string":
       return JSON.stringify(node.value)
@@ -47,10 +47,10 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `[${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, text))
         .join(",")}]`
     case "number":
-      return JSON.stringify(node.value)
+      return text.substring(node.offset, node.offset + node.length)
     case "boolean":
       return JSON.stringify(node.value)
     case "object":
@@ -59,7 +59,7 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `{${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, text))
         .join(",")}}`
     case "property":
       if (!node.children || node.children.length !== 2) {
@@ -72,7 +72,7 @@ function convertNodeToJSON(node: Node): string {
       // Attempting to JSON.stringify(keyNode) directly would throw
       // "Converting circular structure to JSON" error.
       // If the valueNode configuration is wrong, this will return an error, which will propagate up
-      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(valueNode)}`
+      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(valueNode, text)}`
   }
 }
 
@@ -89,7 +89,7 @@ function stripCommentsAndCommas(text: string): string {
 
   // convertNodeToJSON can throw an error if the tree is invalid
   try {
-    return convertNodeToJSON(tree)
+    return convertNodeToJSON(tree, text)
   } catch (_) {
     return text
   }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6317

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
When a user entered a floating point number with a trailing zero (like `70.0`) in a JSON request body, it was being stripped to an integer (like `70`) before the request was sent. This PR ensures that the exact numeric precision formatted by the user is preserved when the JSON is parsed to strip comments.

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
- Updated `convertNodeToJSON` in `linting/jsonc.ts` to accept the original JSON string as an argument.
- Extracted the precise numeric string using `text.substring(node.offset, node.offset + node.length)` for `number` AST nodes, instead of re-serializing the parsed JavaScript primitive via `JSON.stringify()`.

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
Because the `jsonc-parser` offsets directly map to the original string, slicing the `number` node preserves exact literals like `70.0`, `.05`, or `1e3` without breaking the comment-stripping logic. Unit tests in `hoppscotch-common` run successfully with these changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves numeric formatting in JSON request bodies so values like 70.0, .05, and 1e3 are sent exactly as typed. Fixes #6317.

- **Bug Fixes**
  - Preserve exact numeric literals by passing the original JSON text through `convertNodeToJSON` recursion and slicing `number` nodes with `text.substring(node.offset, node.offset + node.length)`.
  - Added unit tests for `stripComments` covering 70.0, 1.050, 0.0, 1e3, and numbers near comments.

<sup>Written for commit f95cc4a74355bd5e7f35e4049c4aab85b7213bae. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6331?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

