### PR TITLE
fix(common): wait for proxy settings before issuing requests

### DIFF
--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
@@ -209,6 +209,20 @@ export class ProxyKernelInterceptorService
   ): ExecutionResult<KernelInterceptorError> {
     let innerCancel: (() => Promise<void>) | null = null
     let cancelled = false
+    let resolveCancelled:
+      | ((result: E.Either<RelayError, RelayResponse>) => void)
+      | null = null
+
+    const cancelledResult: E.Either<RelayError, RelayResponse> = E.left({
+      kind: "abort",
+      message: "cancelled",
+    })
+
+    const cancellation = new Promise<E.Either<RelayError, RelayResponse>>(
+      (resolve) => {
+        resolveCancelled = resolve
+      }
+    )
 
     // Wait for persisted proxy settings to hydrate before constructing the
     // request, otherwise the in-memory default (`proxy.hoppscotch.io`) is used
@@ -241,8 +255,6 @@ export class ProxyKernelInterceptorService
         const formData = processedRequest.content.content as FormData
         const newFormData = new FormData()
 
-        // @ts-expect-error: `formData.entries` does exist but isn't visible,
-        // see `"lib": ["ESNext", "DOM"],` in `tsconfig.json`
         for (const [key, value] of formData.entries()) {
           newFormData.append(key, value)
         }
@@ -290,18 +302,21 @@ export class ProxyKernelInterceptorService
     })
 
     const response = pipe(
-      pending.then(
-        (
-          relayExecution
-        ):
-          | Promise<E.Either<RelayError, RelayResponse>>
-          | E.Either<RelayError, RelayResponse> => {
-          if (!relayExecution) {
-            return E.left({ kind: "abort", message: "cancelled" })
+      Promise.race([
+        pending.then(
+          (
+            relayExecution
+          ):
+            | Promise<E.Either<RelayError, RelayResponse>>
+            | E.Either<RelayError, RelayResponse> => {
+            if (!relayExecution || cancelled) {
+              return cancelledResult
+            }
+            return relayExecution.response
           }
-          return relayExecution.response
-        }
-      ),
+        ),
+        cancellation,
+      ]),
       (promise) =>
         promise.then((either) =>
           pipe(
@@ -469,7 +484,9 @@ export class ProxyKernelInterceptorService
 
     return {
       cancel: async () => {
+        if (cancelled) return
         cancelled = true
+        resolveCancelled?.(cancelledResult)
         if (innerCancel) await innerCancel()
       },
       response,

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
@@ -1,6 +1,8 @@
 import { markRaw } from "vue"
 import type {
   RelayRequest,
+  RelayResponse,
+  RelayError,
   ContentType,
   Method,
   Version,
@@ -205,240 +207,271 @@ export class ProxyKernelInterceptorService
   public execute(
     request: RelayRequest
   ): ExecutionResult<KernelInterceptorError> {
-    const settings = this.store.getSettings()
-    const accessToken = settings.accessToken
-    const proxyUrl = settings.proxyUrl
+    let innerCancel: (() => Promise<void>) | null = null
+    let cancelled = false
 
-    const processedRequest = preProcessRelayRequest(request)
+    // Wait for persisted proxy settings to hydrate before constructing the
+    // request, otherwise the in-memory default (`proxy.hoppscotch.io`) is used
+    // when `execute()` is called during initial page load — e.g. the OAuth
+    // redirect handler on `/oauth`.
+    const pending = this.store.whenReady().then(() => {
+      if (cancelled) return null
 
-    let content: ContentType
-    const multipartKey = `proxyRequestData-${v4()}`
+      const settings = this.store.getSettings()
+      const accessToken = settings.accessToken
+      const proxyUrl = settings.proxyUrl
 
-    if (
-      processedRequest.content &&
-      processedRequest.content.kind === "multipart" &&
-      processedRequest.content.content instanceof FormData
-    ) {
-      const modifiedRequest = { ...processedRequest }
+      const processedRequest = preProcessRelayRequest(request)
 
-      const proxyRequest = this.constructProxyRequest(
-        modifiedRequest,
-        accessToken
-      )
+      let content: ContentType
+      const multipartKey = `proxyRequestData-${v4()}`
 
-      const formData = processedRequest.content.content as FormData
-      const newFormData = new FormData()
+      if (
+        processedRequest.content &&
+        processedRequest.content.kind === "multipart" &&
+        processedRequest.content.content instanceof FormData
+      ) {
+        const modifiedRequest = { ...processedRequest }
 
-      // @ts-expect-error: `formData.entries` does exist but isn't visible,
-      // see `"lib": ["ESNext", "DOM"],` in `tsconfig.json`
-      for (const [key, value] of formData.entries()) {
-        newFormData.append(key, value)
+        const proxyRequest = this.constructProxyRequest(
+          modifiedRequest,
+          accessToken
+        )
+
+        const formData = processedRequest.content.content as FormData
+        const newFormData = new FormData()
+
+        // @ts-expect-error: `formData.entries` does exist but isn't visible,
+        // see `"lib": ["ESNext", "DOM"],` in `tsconfig.json`
+        for (const [key, value] of formData.entries()) {
+          newFormData.append(key, value)
+        }
+
+        const proxyRequestString = JSON.stringify(proxyRequest)
+        newFormData.append(multipartKey, proxyRequestString)
+
+        content = {
+          kind: "multipart",
+          content: newFormData,
+          mediaType: MediaType.MULTIPART_FORM_DATA,
+        }
+      } else {
+        const proxyRequest = this.constructProxyRequest(
+          processedRequest,
+          accessToken
+        )
+
+        content = {
+          kind: "json",
+          content: proxyRequest,
+          mediaType: MediaType.APPLICATION_JSON,
+        }
       }
 
-      const proxyRequestString = JSON.stringify(proxyRequest)
-      newFormData.append(multipartKey, proxyRequestString)
-
-      content = {
-        kind: "multipart",
-        content: newFormData,
-        mediaType: MediaType.MULTIPART_FORM_DATA,
+      const proxyRelayRequest: RelayRequest = {
+        id: Date.now(),
+        url: proxyUrl,
+        method: "POST" as Method,
+        version: "HTTP/1.1" as Version,
+        headers: {
+          "content-type": content.mediaType,
+          ...(content.kind === "multipart"
+            ? {
+                "multipart-part-key": multipartKey,
+              }
+            : {}),
+        },
+        content,
       }
-    } else {
-      const proxyRequest = this.constructProxyRequest(
-        processedRequest,
-        accessToken
-      )
 
-      content = {
-        kind: "json",
-        content: proxyRequest,
-        mediaType: MediaType.APPLICATION_JSON,
-      }
-    }
+      const relayExecution = Relay.execute(proxyRelayRequest)
+      innerCancel = relayExecution.cancel
+      return relayExecution
+    })
 
-    const proxyRelayRequest: RelayRequest = {
-      id: Date.now(),
-      url: proxyUrl,
-      method: "POST" as Method,
-      version: "HTTP/1.1" as Version,
-      headers: {
-        "content-type": content.mediaType,
-        ...(content.kind === "multipart"
-          ? {
-              "multipart-part-key": multipartKey,
-            }
-          : {}),
-      },
-      content,
-    }
-
-    const relayExecution = Relay.execute(proxyRelayRequest)
-
-    const response = pipe(relayExecution.response, (promise) =>
-      promise.then((either) =>
-        pipe(
-          either,
-          E.mapLeft((error): KernelInterceptorError => {
-            const humanMessage = {
-              heading: (t: ReturnType<typeof getI18n>) => {
-                switch (error.kind) {
-                  case "network":
-                    return t("error.network.heading")
-                  case "timeout":
-                    return t("error.timeout.heading")
-                  case "certificate":
-                    return t("error.certificate.heading")
-                  case "auth":
-                    return t("error.auth.heading")
-                  case "proxy":
-                    return t("error.proxy.heading")
-                  case "parse":
-                    return t("error.parse.heading")
-                  case "version":
-                    return t("error.version.heading")
-                  case "abort":
-                    return t("error.aborted.heading")
-                  default:
-                    return t("error.unknown.heading")
-                }
-              },
-              description: (t: ReturnType<typeof getI18n>) => {
-                switch (error.kind) {
-                  case "network":
-                    return t("error.network.description", {
-                      message: error.message,
-                    })
-                  case "timeout":
-                    return t("error.timeout.description", {
-                      phase: error.phase ?? t("error.unknown.phase"),
-                    })
-                  case "certificate":
-                    return t("error.certificate.description", {
-                      message: error.message,
-                    })
-                  case "auth":
-                    return t("error.auth.description", {
-                      message: error.message,
-                    })
-                  case "proxy":
-                    return t("error.proxy.description", {
-                      message: error.message,
-                    })
-                  case "parse":
-                    return t("error.parse.description", {
-                      message: error.message,
-                    })
-                  case "version":
-                    return t("error.version.description", {
-                      message: error.message,
-                    })
-                  case "abort":
-                    return t("error.aborted.description", {
-                      message: error.message,
-                    })
-                  default:
-                    return t("error.unknown.description")
-                }
-              },
-            }
-            return { humanMessage, error }
-          }),
-          E.chain((res) => {
-            const proxyResponse = parseBytesToJSON<ProxyResponse>(res.body.body)
-
-            if (O.isNone(proxyResponse)) {
-              return E.left({
-                humanMessage: {
-                  heading: (t) => t("error.network.heading"),
-                  description: (t) =>
-                    t("error.network.description", {
-                      message: "Proxy request failed",
-                      cause: "Proxy server may be unresponsive",
-                    }),
+    const response = pipe(
+      pending.then(
+        (
+          relayExecution
+        ):
+          | Promise<E.Either<RelayError, RelayResponse>>
+          | E.Either<RelayError, RelayResponse> => {
+          if (!relayExecution) {
+            return E.left({ kind: "abort", message: "cancelled" })
+          }
+          return relayExecution.response
+        }
+      ),
+      (promise) =>
+        promise.then((either) =>
+          pipe(
+            either,
+            E.mapLeft((error): KernelInterceptorError => {
+              const humanMessage = {
+                heading: (t: ReturnType<typeof getI18n>) => {
+                  switch (error.kind) {
+                    case "network":
+                      return t("error.network.heading")
+                    case "timeout":
+                      return t("error.timeout.heading")
+                    case "certificate":
+                      return t("error.certificate.heading")
+                    case "auth":
+                      return t("error.auth.heading")
+                    case "proxy":
+                      return t("error.proxy.heading")
+                    case "parse":
+                      return t("error.parse.heading")
+                    case "version":
+                      return t("error.version.heading")
+                    case "abort":
+                      return t("error.aborted.heading")
+                    default:
+                      return t("error.unknown.heading")
+                  }
                 },
-                error: {
-                  kind: "network",
-                  message: "Proxy request failed",
+                description: (t: ReturnType<typeof getI18n>) => {
+                  switch (error.kind) {
+                    case "network":
+                      return t("error.network.description", {
+                        message: error.message,
+                      })
+                    case "timeout":
+                      return t("error.timeout.description", {
+                        phase: error.phase ?? t("error.unknown.phase"),
+                      })
+                    case "certificate":
+                      return t("error.certificate.description", {
+                        message: error.message,
+                      })
+                    case "auth":
+                      return t("error.auth.description", {
+                        message: error.message,
+                      })
+                    case "proxy":
+                      return t("error.proxy.description", {
+                        message: error.message,
+                      })
+                    case "parse":
+                      return t("error.parse.description", {
+                        message: error.message,
+                      })
+                    case "version":
+                      return t("error.version.description", {
+                        message: error.message,
+                      })
+                    case "abort":
+                      return t("error.aborted.description", {
+                        message: error.message,
+                      })
+                    default:
+                      return t("error.unknown.description")
+                  }
                 },
-              })
-            }
-
-            const parsedProxyResponse = proxyResponse.value
-
-            if (!parsedProxyResponse?.success) {
-              return E.left({
-                humanMessage: {
-                  heading: (t) => t("error.network.heading"),
-                  description: (t) =>
-                    t("error.network.description", {
-                      message: "Proxy request failed",
-                      cause: "Proxy server may be unresponsive",
-                    }),
-                },
-                error: {
-                  kind: "network",
-                  message: "Proxy request failed",
-                },
-              })
-            }
-
-            // NOTE: This should be conditional but seems to be hit always,
-            // see std/interceptor/proxy.ts for more info. Also see the above similar note.
-            if (parsedProxyResponse.isBinary) {
-              const decodedData = new Uint8Array(
-                decodeB64StringToArrayBuffer(parsedProxyResponse.data)
+              }
+              return { humanMessage, error }
+            }),
+            E.chain((res) => {
+              const proxyResponse = parseBytesToJSON<ProxyResponse>(
+                res.body.body
               )
 
-              // NOTE: This is also for backwards compat,
-              // better solution would be to ask for raw bytes from proxyscotch.
-              const jsonResult = parseBytesToJSON(decodedData)
+              if (O.isNone(proxyResponse)) {
+                return E.left({
+                  humanMessage: {
+                    heading: (t) => t("error.network.heading"),
+                    description: (t) =>
+                      t("error.network.description", {
+                        message: "Proxy request failed",
+                        cause: "Proxy server may be unresponsive",
+                      }),
+                  },
+                  error: {
+                    kind: "network",
+                    message: "Proxy request failed",
+                  },
+                })
+              }
 
-              if (O.isSome(jsonResult)) {
+              const parsedProxyResponse = proxyResponse.value
+
+              if (!parsedProxyResponse?.success) {
+                return E.left({
+                  humanMessage: {
+                    heading: (t) => t("error.network.heading"),
+                    description: (t) =>
+                      t("error.network.description", {
+                        message: "Proxy request failed",
+                        cause: "Proxy server may be unresponsive",
+                      }),
+                  },
+                  error: {
+                    kind: "network",
+                    message: "Proxy request failed",
+                  },
+                })
+              }
+
+              // NOTE: This should be conditional but seems to be hit always,
+              // see std/interceptor/proxy.ts for more info. Also see the above similar note.
+              if (parsedProxyResponse.isBinary) {
+                const decodedData = new Uint8Array(
+                  decodeB64StringToArrayBuffer(parsedProxyResponse.data)
+                )
+
+                // NOTE: This is also for backwards compat,
+                // better solution would be to ask for raw bytes from proxyscotch.
+                const jsonResult = parseBytesToJSON(decodedData)
+
+                if (O.isSome(jsonResult)) {
+                  return E.right({
+                    ...res,
+                    status: parsedProxyResponse.status,
+                    statusText: parsedProxyResponse.statusText,
+                    headers: parsedProxyResponse.headers,
+                    body: {
+                      body: new TextEncoder().encode(
+                        JSON.stringify(jsonResult.value)
+                      ),
+                      mediaType: "application/json",
+                    },
+                  })
+                }
                 return E.right({
                   ...res,
                   status: parsedProxyResponse.status,
                   statusText: parsedProxyResponse.statusText,
                   headers: parsedProxyResponse.headers,
                   body: {
-                    body: new TextEncoder().encode(
-                      JSON.stringify(jsonResult.value)
-                    ),
-                    mediaType: "application/json",
+                    body: decodedData,
+                    mediaType:
+                      parsedProxyResponse.headers["content-type"] ||
+                      "application/octet-stream",
                   },
                 })
               }
+
               return E.right({
                 ...res,
                 status: parsedProxyResponse.status,
                 statusText: parsedProxyResponse.statusText,
                 headers: parsedProxyResponse.headers,
                 body: {
-                  body: decodedData,
+                  body: new TextEncoder().encode(parsedProxyResponse.data),
                   mediaType:
-                    parsedProxyResponse.headers["content-type"] ||
-                    "application/octet-stream",
+                    parsedProxyResponse.headers["content-type"] || "text/plain",
                 },
               })
-            }
-
-            return E.right({
-              ...res,
-              status: parsedProxyResponse.status,
-              statusText: parsedProxyResponse.statusText,
-              headers: parsedProxyResponse.headers,
-              body: {
-                body: new TextEncoder().encode(parsedProxyResponse.data),
-                mediaType:
-                  parsedProxyResponse.headers["content-type"] || "text/plain",
-              },
             })
-          })
+          )
         )
-      )
     )
 
     return {
-      cancel: relayExecution.cancel,
+      cancel: async () => {
+        cancelled = true
+        if (innerCancel) await innerCancel()
+      },
       response,
     }
   }

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/store.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/store.ts
@@ -48,6 +48,14 @@ export class KernelInterceptorProxyStore extends Service {
     accessToken: import.meta.env.VITE_PROXYSCOTCH_ACCESS_TOKEN ?? "",
   })
 
+  private _resolveReady!: () => void
+  // Resolves once persisted settings have been loaded into `_settings`.
+  // Callers that read `proxyUrl` on initial page load (e.g. the OAuth redirect
+  // handler) must await this to avoid using the in-memory default URL.
+  private readonly _ready: Promise<void> = new Promise((resolve) => {
+    this._resolveReady = resolve
+  })
+
   /**
    * Reactive, read-only view of the current proxy settings.
    */
@@ -59,10 +67,12 @@ export class KernelInterceptorProxyStore extends Service {
     const initResult = await Store.init()
     if (E.isLeft(initResult)) {
       console.error("[ProxyStore] Failed to initialize store:", initResult.left)
+      this._resolveReady()
       return
     }
 
     await this.loadSettings()
+    this._resolveReady()
 
     const watcher = await Store.watch(STORE_NAMESPACE, SETTINGS_KEY)
     watcher.on("change", async ({ value }) => {
@@ -78,6 +88,10 @@ export class KernelInterceptorProxyStore extends Service {
         }
       }
     })
+  }
+
+  public whenReady(): Promise<void> {
+    return this._ready
   }
 
   private async loadSettings(): Promise<void> {

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/store.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/store.ts
@@ -64,30 +64,38 @@ export class KernelInterceptorProxyStore extends Service {
   )
 
   async onServiceInit(): Promise<void> {
-    const initResult = await Store.init()
-    if (E.isLeft(initResult)) {
-      console.error("[ProxyStore] Failed to initialize store:", initResult.left)
-      this._resolveReady()
-      return
-    }
-
-    await this.loadSettings()
-    this._resolveReady()
-
-    const watcher = await Store.watch(STORE_NAMESPACE, SETTINGS_KEY)
-    watcher.on("change", async ({ value }) => {
-      if (value) {
-        const storedData = value as StoredData
-        this._settings.value = {
-          ...this._settings.value,
-          // Only sync user-configurable fields from external changes.
-          // Fallback to current value if persisted data is missing the field
-          // (e.g. older schema). accessToken stays env-derived.
-          proxyUrl:
-            storedData.settings?.proxyUrl ?? this._settings.value.proxyUrl,
-        }
+    try {
+      const initResult = await Store.init()
+      if (E.isLeft(initResult)) {
+        console.error(
+          "[ProxyStore] Failed to initialize store:",
+          initResult.left
+        )
+        return
       }
-    })
+
+      await this.loadSettings()
+
+      const watcher = await Store.watch(STORE_NAMESPACE, SETTINGS_KEY)
+      watcher.on("change", async ({ value }: { value?: unknown }) => {
+        if (value) {
+          const storedData = value as StoredData
+          this._settings.value = {
+            ...this._settings.value,
+            // Only sync user-configurable fields from external changes.
+            // Fallback to current value if persisted data is missing the field
+            // (e.g. older schema). accessToken stays env-derived.
+            proxyUrl:
+              storedData.settings?.proxyUrl ?? this._settings.value.proxyUrl,
+          }
+        }
+      })
+    } catch (error) {
+      console.error("[ProxyStore] Failed to finish setup:", error)
+    } finally {
+      // Always resolve readiness so consumers never hang forever.
+      this._resolveReady()
+    }
   }
 
   public whenReady(): Promise<void> {


### PR DESCRIPTION
Closes FE-1263

This update enhances the OAuth flow by ensuring that settings are fully loaded before executing any requests. This change prevents the use of in-memory default URLs during the initial page load, fixes the issue where hoppscotch default proxy url being called isntead of defined one.

### What's changed
- Introduced a mechanism to resolve readiness once settings are loaded.
- Added a `whenReady` method to allow callers to await the loading of settings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make OAuth requests wait for proxy settings to load before executing. Prevents default proxy usage on first load and fixes misrouted calls.

- **Bug Fixes**
  - `ProxyStore` adds `whenReady()` and always resolves it (even if init fails) to avoid hangs; improved init error handling and logging.
  - Interceptor `execute()` awaits readiness, uses the correct `proxyUrl` and access token, and supports early cancel that aborts the wait and the inner relay.

<sup>Written for commit fec6d5b78e25bad559ff502e22636e6131748dba. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6333?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



