### PR TITLE
fix(common): improve dark theme contrast for better readability

### DIFF
--- a/packages/hoppscotch-common/assets/themes/base-themes.scss
+++ b/packages/hoppscotch-common/assets/themes/base-themes.scss
@@ -63,25 +63,25 @@
 }
 
 @mixin dark-theme {
-  --primary-color: #181818;
-  --primary-light-color: #1c1c1e;
-  --primary-dark-color: theme("colors.neutral.800");
+  --primary-color: #262626;
+  --primary-light-color: #2a2a2a;
+  --primary-dark-color: theme("colors.neutral.700");
   --primary-contrast-color: theme("colors.neutral.900");
 
   --secondary-color: theme("colors.neutral.400");
   --secondary-light-color: theme("colors.neutral.500");
   --secondary-dark-color: theme("colors.zinc.50");
 
-  --divider-color: #1f1f1f;
-  --divider-light-color: #1f1f1f;
-  --divider-dark-color: theme("colors.zinc.800");
+  --divider-color: #333333;
+  --divider-light-color: #2e2e2e;
+  --divider-dark-color: theme("colors.zinc.700");
 
   --banner-info-color: theme("colors.stone.800");
   --banner-warning-color: theme("colors.yellow.800");
   --banner-error-color: theme("colors.red.800");
 
   --tooltip-color: theme("colors.neutral.100");
-  --popover-color: #1b1b1b;
+  --popover-color: #242424;
 
   --method-get-color: theme("colors.emerald.500");
   --method-post-color: theme("colors.yellow.500");

--- a/packages/hoppscotch-common/assets/themes/base-themes.scss
+++ b/packages/hoppscotch-common/assets/themes/base-themes.scss
@@ -72,8 +72,8 @@
   --secondary-light-color: theme("colors.neutral.500");
   --secondary-dark-color: theme("colors.zinc.50");
 
-  --divider-color: #333333;
-  --divider-light-color: #2e2e2e;
+  --divider-color: #2e2e2e;
+  --divider-light-color: #333333;
   --divider-dark-color: theme("colors.zinc.700");
 
   --banner-info-color: theme("colors.stone.800");
@@ -81,7 +81,7 @@
   --banner-error-color: theme("colors.red.800");
 
   --tooltip-color: theme("colors.neutral.100");
-  --popover-color: #242424;
+  --popover-color: #2c2c2c;
 
   --method-get-color: theme("colors.emerald.500");
   --method-post-color: theme("colors.yellow.500");


### PR DESCRIPTION
Closes #4390

This PR improves the contrast between background, panel, divider, and popover surfaces in the dark theme so the interface is easier to read. It is a CSS only change scoped to the existing dark theme. The light theme and the black (OLED) theme are not touched.

### What's changed

- Adjusted the background, divider, and popover color values inside the `dark-theme` mixin in `packages/hoppscotch-common/assets/themes/base-themes.scss`.
- The new values are a few shades lighter so panels and borders separate cleanly from the base background instead of blending into it.
- No new themes, tokens, or component changes are introduced.

### Notes to reviewers

The low contrast issue was originally reported in #4390 and was raised again recently in #6261, which additionally asks for multiple themes. That broader request is out of scope here.

There was a previous attempt at fixing this in PR #4413 by @gitadityakumar that was not merged. This PR takes a smaller and more focused approach, touching only the variables that caused the readability complaint.

Before and after screenshots of the dark theme.

**Before**

<img width="1906" height="1036" alt="image" src="https://github.com/user-attachments/assets/c1cffc63-f5a2-435d-947a-5e19edc3af37" />

**After**

<img width="1906" height="1036" alt="image" src="https://github.com/user-attachments/assets/20628c8e-4598-4fb2-beec-4688745ce6a1" />




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves dark theme readability by increasing contrast between background, panels, dividers, and popovers. Also corrects divider token order and adjusts popover tone for clearer layering.

- **Bug Fixes**
  - Updated `--primary-*`, `--divider-*` (fixed light/dark order), and `--popover-color` in the `dark-theme` mixin in `packages/hoppscotch-common/assets/themes/base-themes.scss`.
  - Clearer separation and proper layering between background, panels, borders, and popovers; addresses #4390. No new themes, tokens, or component changes.

<sup>Written for commit dc4e8dca52b041243fd1e900e577a153ebd8c70d. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6337?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

