### PR TITLE
fix(common): trim decoded base64 padding bytes

### DIFF
--- a/packages/hoppscotch-common/src/helpers/utils/__tests__/b64.spec.js
+++ b/packages/hoppscotch-common/src/helpers/utils/__tests__/b64.spec.js
@@ -2,11 +2,24 @@ import { describe, expect, test } from "vitest"
 import { decodeB64StringToArrayBuffer } from "../b64"
 
 describe("decodeB64StringToArrayBuffer", () => {
+  const decodeAsBytes = (input) =>
+    Array.from(new Uint8Array(decodeB64StringToArrayBuffer(input)))
+
   test("decodes content correctly", () => {
-    expect(
-      decodeB64StringToArrayBuffer("aG9wcHNjb3RjaCBpcyBhd2Vzb21lIQ==")
-    ).toEqual(Buffer.from("hoppscotch is awesome!", "utf-8").buffer)
+    expect(decodeAsBytes("aG9wcHNjb3RjaCBpcyBhd2Vzb21lIQ==")).toEqual(
+      Array.from(Buffer.from("hoppscotch is awesome!", "utf-8"))
+    )
   })
 
-  // TODO : More tests for binary data ?
+  test("does not include zero bytes for padded base64 strings", () => {
+    expect(decodeAsBytes("YQ==")).toEqual([97])
+    expect(decodeAsBytes("YWI=")).toEqual([97, 98])
+  })
+
+  test("decodes binary data", () => {
+    const bytes = [0, 255, 16, 32, 128, 64, 7]
+    const input = Buffer.from(bytes).toString("base64")
+
+    expect(decodeAsBytes(input)).toEqual(bytes)
+  })
 })

--- a/packages/hoppscotch-common/src/helpers/utils/b64.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/b64.ts
@@ -1,5 +1,8 @@
 export function decodeB64StringToArrayBuffer(input: string): ArrayBuffer {
-  const bytes = Math.floor((input.length / 4) * 3)
+  input = input.replace(/[^A-Za-z0-9+/=]/g, "")
+
+  const padding = input.endsWith("==") ? 2 : input.endsWith("=") ? 1 : 0
+  const bytes = Math.floor((input.length / 4) * 3) - padding
   const ab = new ArrayBuffer(bytes)
   const uarray = new Uint8Array(ab)
 
@@ -9,8 +12,6 @@ export function decodeB64StringToArrayBuffer(input: string): ArrayBuffer {
   let chr1, chr2, chr3
   let enc1, enc2, enc3, enc4
   let j = 0
-
-  input = input.replace(/[^A-Za-z0-9+/=]/g, "")
 
   for (let i = 0; i < bytes; i += 3) {
     // get the 3 octets in 4 ASCII chars


### PR DESCRIPTION
## What changed

- Adjusted `decodeB64StringToArrayBuffer` to calculate the decoded `ArrayBuffer` length after removing base64 padding.
- Updated the base64 utility tests to compare decoded bytes directly.
- Added coverage for padded strings and binary payloads.

## Why

Padded base64 strings such as `YQ==` and `YWI=` could allocate an `ArrayBuffer` that was too long, leaving trailing zero bytes in decoded responses. The previous test compared against `Buffer.buffer`, which did not clearly assert the exact decoded byte length.

## Validation

- `git diff --check`
- Manual Node verification for padded text and binary base64 cases

The targeted Vitest command could not run locally because `vitest`/`node_modules` are not installed in this checkout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes base64 decoding in `hoppscotch-common` by trimming padding when computing the output size, preventing trailing zero bytes in decoded ArrayBuffers. Updates tests to assert exact decoded bytes, including padded strings and binary payloads.

- **Bug Fixes**
  - Updated `decodeB64StringToArrayBuffer` to sanitize input and subtract padding when calculating byte length.
  - Revised tests to compare decoded byte arrays; added cases for `YQ==`, `YWI=`, and binary data.

<sup>Written for commit 7de934c8d276c631af765c0f107dae2d6c7b414e. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6343?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

