### PR TITLE
fix: correct typos in i18n keys and code comments

### DIFF
--- a/packages/hoppscotch-backend/src/team/team.service.ts
+++ b/packages/hoppscotch-backend/src/team/team.service.ts
@@ -323,7 +323,7 @@ export class TeamService implements UserDataHandler, OnModuleInit {
         const user = await this.userService.findUserById(member.userUid);
 
         // // TODO:Investigate if a race condition exists that deletes user from teams.
-        // // Delete the membership if the user doesnt exist
+        // // Delete the membership if the user doesn't exist
         // if (!user) this.leaveTeam(teamID, member.userUid);
 
         if (O.isSome(user)) return member;

--- a/packages/hoppscotch-backend/src/user-environment/user-environments.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-environment/user-environments.service.spec.ts
@@ -135,7 +135,7 @@ describe('UserEnvironmentsService', () => {
       });
     });
 
-    test('Should resolve left and return an error if global env it doesn't exists', async () => {
+    test('Should resolve left and return an error if global env it doesn't exist', async () => {
       mockPrisma.userEnvironment.findFirst.mockResolvedValueOnce(null);
 
       expect(

--- a/packages/hoppscotch-backend/src/user-environment/user-environments.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-environment/user-environments.service.spec.ts
@@ -135,7 +135,7 @@ describe('UserEnvironmentsService', () => {
       });
     });
 
-    test('Should resolve left and return an error if global env it doesnt exists', async () => {
+    test('Should resolve left and return an error if global env it doesn't exists', async () => {
       mockPrisma.userEnvironment.findFirst.mockResolvedValueOnce(null);
 
       expect(
@@ -347,7 +347,7 @@ describe('UserEnvironmentsService', () => {
       ).toEqualRight(result);
     });
 
-    test('Should resolve left and not update a users environment if env doesnt exist ', async () => {
+    test('Should resolve left and not update a users environment if env doesn't exist ', async () => {
       mockPrisma.userEnvironment.update.mockRejectedValueOnce(
         'RejectOnNotFound',
       );

--- a/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
@@ -123,7 +123,7 @@ describe('UserHistoryService', () => {
         await userHistoryService.fetchUserHistory('abc', 2, ReqType.GQL),
       ).toEqual(userHistory);
     });
-    test('Should return an empty list of users REST history if doesnt exists', async () => {
+    test('Should return an empty list of users REST history if doesn't exists', async () => {
       mockPrisma.userHistory.findMany.mockResolvedValueOnce([]);
 
       const userHistory: UserHistory[] = [];
@@ -131,7 +131,7 @@ describe('UserHistoryService', () => {
         await userHistoryService.fetchUserHistory('abc', 2, ReqType.REST),
       ).toEqual(userHistory);
     });
-    test('Should return an empty list of users GQL history if doesnt exists', async () => {
+    test('Should return an empty list of users GQL history if doesn't exists', async () => {
       mockPrisma.userHistory.findMany.mockResolvedValueOnce([]);
 
       const userHistory: UserHistory[] = [];

--- a/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
@@ -123,7 +123,7 @@ describe('UserHistoryService', () => {
         await userHistoryService.fetchUserHistory('abc', 2, ReqType.GQL),
       ).toEqual(userHistory);
     });
-    test('Should return an empty list of users REST history if doesn't exists', async () => {
+    test('Should return an empty list of users REST history if doesn't exist', async () => {
       mockPrisma.userHistory.findMany.mockResolvedValueOnce([]);
 
       const userHistory: UserHistory[] = [];
@@ -131,7 +131,7 @@ describe('UserHistoryService', () => {
         await userHistoryService.fetchUserHistory('abc', 2, ReqType.REST),
       ).toEqual(userHistory);
     });
-    test('Should return an empty list of users GQL history if doesn't exists', async () => {
+    test('Should return an empty list of users GQL history if doesn't exist', async () => {
       mockPrisma.userHistory.findMany.mockResolvedValueOnce([]);
 
       const userHistory: UserHistory[] = [];

--- a/packages/hoppscotch-cli/src/options/test/env.ts
+++ b/packages/hoppscotch-cli/src/options/test/env.ts
@@ -43,14 +43,14 @@ export async function parseEnvsData(options: TestCmdEnvironmentOptions) {
     .array(entityReference(Environment))
     .safeParse(contents);
 
-  // CLI doesnt support bulk environments export
+  // CLI doesn't support bulk environments export
   // Hence we check for this case and throw an error if it matches the format
   if (HoppBulkEnvExportObjectResult.success) {
     throw error({ code: "BULK_ENV_FILE", path: pathOrId, data: error });
   }
 
   //  Checks if the environment file is of the correct format
-  // If it doesnt match either of them, we throw an error
+  // If it doesn't match either of them, we throw an error
   if (
     !HoppEnvKeyPairResult.success &&
     HoppEnvExportObjectResult.type === "err"

--- a/packages/hoppscotch-common/locales/af.json
+++ b/packages/hoppscotch-common/locales/af.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/ar.json
+++ b/packages/hoppscotch-common/locales/ar.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "الاضافة غير مثبتة",
       "extension_unknown_origin": "تأكد من أنك أضفت أصل نقطة نهاية API إلى قائمة ملحق متصفح هوبسكوتش.",
-      "extention_enable_action": "تفعيل الاضافة",
-      "extention_not_enabled": "الاضافة غير مفعلة"
+      "extension_enable_action": "تفعيل الاضافة",
+      "extension_not_enabled": "الاضافة غير مفعلة"
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/ca.json
+++ b/packages/hoppscotch-common/locales/ca.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/cn.json
+++ b/packages/hoppscotch-common/locales/cn.json
@@ -978,8 +978,8 @@
     "url": {
       "extension_not_installed": "未安装扩展。",
       "extension_unknown_origin": "确保您已将 API 端点的源添加到 Hoppscotch 浏览器扩展列表中。",
-      "extention_enable_action": "启用浏览器扩展",
-      "extention_not_enabled": "扩展未启用。",
+      "extension_enable_action": "启用浏览器扩展",
+      "extension_not_enabled": "扩展未启用。",
       "localaccess_unsupported": "当前拦截器不支持本地访问，请考虑使用代理程序(Agent)、扩展拦截器或桌面应用程序"
     },
     "auth": {

--- a/packages/hoppscotch-common/locales/cs.json
+++ b/packages/hoppscotch-common/locales/cs.json
@@ -948,8 +948,8 @@
     "url": {
       "extension_not_installed": "Rozšíření není nainstalováno.",
       "extension_unknown_origin": "Ujistěte se, že jste přidali origin API endpointu do seznamu povolených originů rozšíření Hoppscotch.",
-      "extention_enable_action": "Povolit rozšíření prohlížeče",
-      "extention_not_enabled": "Rozšíření není povoleno.",
+      "extension_enable_action": "Povolit rozšíření prohlížeče",
+      "extension_not_enabled": "Rozšíření není povoleno.",
       "localaccess_unsupported": "Aktuální zachycovač nepodporuje místní přístup, zvažte použití agenta, zachycovače rozšíření nebo desktopové aplikace"
     },
     "auth": {

--- a/packages/hoppscotch-common/locales/da.json
+++ b/packages/hoppscotch-common/locales/da.json
@@ -481,8 +481,8 @@
     "url": {
       "extension_not_installed": "Udvidelse ikke installeret.",
       "extension_unknown_origin": "Sørg for, at du har tilføjet API-endepunktets oprindelse til Hoppscotch Browser Extension-listen.",
-      "extention_enable_action": "Aktivér browserudvidelse",
-      "extention_not_enabled": "Udvidelse ikke aktiveret."
+      "extension_enable_action": "Aktivér browserudvidelse",
+      "extension_not_enabled": "Udvidelse ikke aktiveret."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/de.json
+++ b/packages/hoppscotch-common/locales/de.json
@@ -582,8 +582,8 @@
     "url": {
       "extension_not_installed": "Erweiterung nicht installiert.",
       "extension_unknown_origin": "Stelle sicher, dass du die Quelle für den API-Endpunkt zur Liste in der Hoppscotch Browsererweiterungen hinzugefügt hast.",
-      "extention_enable_action": "Browsererweiterung aktivieren",
-      "extention_not_enabled": "Browsererweiterungen nicht aktiviert."
+      "extension_enable_action": "Browsererweiterung aktivieren",
+      "extension_not_enabled": "Browsererweiterungen nicht aktiviert."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/el.json
+++ b/packages/hoppscotch-common/locales/el.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -979,8 +979,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled.",
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled.",
       "localaccess_unsupported": "Current interceptor does not support local access, please consider using Agent, Extension interceptors or the Desktop App"
     },
     "auth": {

--- a/packages/hoppscotch-common/locales/es.json
+++ b/packages/hoppscotch-common/locales/es.json
@@ -978,8 +978,8 @@
     "url": {
       "extension_not_installed": "Extensión no instalada.",
       "extension_unknown_origin": "Asegúrate de haber agregado el origen del punto final de la API a la lista de Extensiones del Navegador Hoppscotch.",
-      "extention_enable_action": "Activar la extensión del navegador",
-      "extention_not_enabled": "Extensión no habilitada.",
+      "extension_enable_action": "Activar la extensión del navegador",
+      "extension_not_enabled": "Extensión no habilitada.",
       "localaccess_unsupported": "El interceptor actual no soporta acceso local, considera usar los interceptores Agent, Extension o la aplicación de escritorio"
     },
     "auth": {

--- a/packages/hoppscotch-common/locales/fi.json
+++ b/packages/hoppscotch-common/locales/fi.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/fr.json
+++ b/packages/hoppscotch-common/locales/fr.json
@@ -749,8 +749,8 @@
     "url": {
       "extension_not_installed": "Extension non installée.",
       "extension_unknown_origin": "Assurez-vous d'avoir ajouté l'origine du point de terminaison API dans la liste de l'extension web Hoppscotch.",
-      "extention_enable_action": "Activer l'extension web",
-      "extention_not_enabled": "Extension désactivée.",
+      "extension_enable_action": "Activer l'extension web",
+      "extension_not_enabled": "Extension désactivée.",
       "localaccess_unsupported": "L'intercepteur actuel ne gère pas l'accès local, veuillez considérer l'utilisation d'Agent, des extensions des intercepteurs ou l'application de bureau Hoppscotch"
     },
     "auth": {

--- a/packages/hoppscotch-common/locales/he.json
+++ b/packages/hoppscotch-common/locales/he.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/hu.json
+++ b/packages/hoppscotch-common/locales/hu.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Bővítmény nincs telepítve.",
       "extension_unknown_origin": "Ellenőrizze, hogy hozzáadta az API végpont forrását Hoppscotch Browser bővítmény listájához.",
-      "extention_enable_action": "Bővítmény engedélyezése",
-      "extention_not_enabled": "Bővítmény nincs engedélyezve."
+      "extension_enable_action": "Bővítmény engedélyezése",
+      "extension_not_enabled": "Bővítmény nincs engedélyezve."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/hy.json
+++ b/packages/hoppscotch-common/locales/hy.json
@@ -948,8 +948,8 @@
         "url": {
             "extension_not_installed": "Ընդլայնումը տեղադրված չէ:",
             "extension_unknown_origin": "Համոզվեք, որ ավելացրել եք API վերջնակետի ծագման աղբյուրը (origin) Hoppscotch դիտարկիչի ընդլայնման ցանկում:",
-            "extention_enable_action": "Միացնել դիտարկիչի ընդլայնումը",
-            "extention_not_enabled": "Ընդլայնումը միացված չէ:",
+            "extension_enable_action": "Միացնել դիտարկիչի ընդլայնումը",
+            "extension_not_enabled": "Ընդլայնումը միացված չէ:",
             "localaccess_unsupported": "Ընթացիկ որսիչը չի աջակցում տեղական հասանելիություն, խնդրում ենք օգտագործել Agent, Extension որսիչներ կամ Desktop հավելվածը"
         },
         "auth": {

--- a/packages/hoppscotch-common/locales/id.json
+++ b/packages/hoppscotch-common/locales/id.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/it.json
+++ b/packages/hoppscotch-common/locales/it.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/ja.json
+++ b/packages/hoppscotch-common/locales/ja.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/ko.json
+++ b/packages/hoppscotch-common/locales/ko.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/nl.json
+++ b/packages/hoppscotch-common/locales/nl.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extensie niet geïnstalleerd.",
       "extension_unknown_origin": "Zorg ervoor dat je de oorsprong van het API-eindpunt hebt toegevoegd aan de lijst met Hoppscotch-browserextensies.",
-      "extention_enable_action": "Browser-extensie inschakelen",
-      "extention_not_enabled": "Extensie niet ingeschakeld."
+      "extension_enable_action": "Browser-extensie inschakelen",
+      "extension_not_enabled": "Extensie niet ingeschakeld."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/no.json
+++ b/packages/hoppscotch-common/locales/no.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/pl.json
+++ b/packages/hoppscotch-common/locales/pl.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/pt-br.json
+++ b/packages/hoppscotch-common/locales/pt-br.json
@@ -577,8 +577,8 @@
     "url": {
       "extension_not_installed": "Extensão não instalada",
       "extension_unknown_origin": "Verifique se você adicionou a origem do endpoint da API à lista da extensão de navegador do Hoppscotch.",
-      "extention_enable_action": "Habilitar Extensão do Navegador",
-      "extention_not_enabled": "Extensão não habilitada."
+      "extension_enable_action": "Habilitar Extensão do Navegador",
+      "extension_not_enabled": "Extensão não habilitada."
     },
     "requestBody": {
       "active_interceptor_doesnt_support_binary_body": "O interceptor selecionado ainda não possui suporte para envio de dados binários."

--- a/packages/hoppscotch-common/locales/pt.json
+++ b/packages/hoppscotch-common/locales/pt.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/ro.json
+++ b/packages/hoppscotch-common/locales/ro.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/ru.json
+++ b/packages/hoppscotch-common/locales/ru.json
@@ -480,8 +480,8 @@
     "url": {
       "extension_not_installed": "Расширение не установлено",
       "extension_unknown_origin": "Убедитесь, что текущий домен добавлен в список доверенных ресурсов в расширении браузера",
-      "extention_enable_action": "Подключить расширение",
-      "extention_not_enabled": "Расширение в браузере не подключено"
+      "extension_enable_action": "Подключить расширение",
+      "extension_not_enabled": "Расширение в браузере не подключено"
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/sr.json
+++ b/packages/hoppscotch-common/locales/sr.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/sv.json
+++ b/packages/hoppscotch-common/locales/sv.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/tr.json
+++ b/packages/hoppscotch-common/locales/tr.json
@@ -978,8 +978,8 @@
     "url": {
       "extension_not_installed": "Eklenti yüklenmemiş.",
       "extension_unknown_origin": "API uç noktasının kaynağını Hoppscotch Tarayıcı Eklentisi listesine eklediğinizden emin olun.",
-      "extention_enable_action": "Tarayıcı Eklentisini Etkinleştir",
-      "extention_not_enabled": "Eklenti etkin değil.",
+      "extension_enable_action": "Tarayıcı Eklentisini Etkinleştir",
+      "extension_not_enabled": "Eklenti etkin değil.",
       "localaccess_unsupported": "Mevcut interceptor yerel erişimi desteklemiyor, lütfen Agent, Extension interceptor veya Masaüstü Uygulamasını kullanmayı düşünün"
     },
     "auth": {

--- a/packages/hoppscotch-common/locales/tw.json
+++ b/packages/hoppscotch-common/locales/tw.json
@@ -500,8 +500,8 @@
     "url": {
       "extension_not_installed": "未安裝擴充套件。",
       "extension_unknown_origin": "請確認您是否已將 API 端點的來源加入 Hoppscotch 擴充套件的清單。",
-      "extention_enable_action": "啟用瀏覽器擴充套件",
-      "extention_not_enabled": "未啟用擴充套件。"
+      "extension_enable_action": "啟用瀏覽器擴充套件",
+      "extension_not_enabled": "未啟用擴充套件。"
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/uk.json
+++ b/packages/hoppscotch-common/locales/uk.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/locales/vi.json
+++ b/packages/hoppscotch-common/locales/vi.json
@@ -484,8 +484,8 @@
     "url": {
       "extension_not_installed": "Extension not installed.",
       "extension_unknown_origin": "Make sure you've added the API endpoint's origin to the Hoppscotch Browser Extension list.",
-      "extention_enable_action": "Enable Browser Extension",
-      "extention_not_enabled": "Extension not enabled."
+      "extension_enable_action": "Enable Browser Extension",
+      "extension_not_enabled": "Extension not enabled."
     }
   },
   "layout": {

--- a/packages/hoppscotch-common/src/components/graphql/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Authorization.vue
@@ -236,7 +236,7 @@ const selectOAuth2AuthType = () => {
     token: "",
   }
 
-  // @ts-expect-error - the existing grantTypeInfo might be in the auth object, typescript doesnt know that
+  // @ts-expect-error - the existing grantTypeInfo might be in the auth object, typescript doesn't know that
   const existingGrantTypeInfo = auth.value.grantTypeInfo as
     | HoppGQLAuthOAuth2["grantTypeInfo"]
     | undefined

--- a/packages/hoppscotch-common/src/components/http/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/http/Authorization.vue
@@ -387,7 +387,7 @@ function selectOAuth2AuthType() {
     token: "",
   }
 
-  // @ts-expect-error - the existing grantTypeInfo might be in the auth object, typescript doesnt know that
+  // @ts-expect-error - the existing grantTypeInfo might be in the auth object, typescript doesn't know that
   const existingGrantTypeInfo = auth.value.grantTypeInfo as
     | HoppRESTAuthOAuth2["grantTypeInfo"]
     | undefined


### PR DESCRIPTION
## Summary
- Fix misspelled i18n key `"extention"` → `"extension"` across 32 locale files (64 occurrences)
- Fix `"doesnt"` → `"doesn't"` in code comments and test descriptions (6 occurrences)

## Changes
- `packages/hoppscotch-common/locales/*.json` — renamed `extention_enable_action` and `extention_not_enabled` keys
- `packages/hoppscotch-common/src/components/graphql/Authorization.vue` — comment typo
- `packages/hoppscotch-common/src/components/http/Authorization.vue` — comment typo
- `packages/hoppscotch-cli/src/options/test/env.ts` — comment typos
- `packages/hoppscotch-backend/src/team/team.service.ts` — comment typo
- `packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts` — test description typos
- `packages/hoppscotch-backend/src/user-environment/user-environments.service.spec.ts` — test description typos

## Notes
- The `"extention"` i18n keys are not referenced in source code (dead keys), so renaming them is safe
- All `"doesnt"` fixes are in comments and test descriptions only

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed typos in i18n keys and in code comments/tests to improve consistency; no runtime impact (the affected i18n keys were unused). Renamed "extention_enable_action"/"extention_not_enabled" to "extension_enable_action"/"extension_not_enabled" across 32 locale files, corrected "doesnt" to "doesn't" in comments, and fixed "doesn't exists" to "doesn't exist" in test descriptions.

<sup>Written for commit 0d9fc691eabbf8db1299be4edc6353a7714d3e73. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6345?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

