### PR TITLE
feat: use VITE_PROXY_URL for default proxy URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,6 @@ VITE_PROXYSCOTCH_ACCESS_TOKEN=
 
 # Set to `true` for subpath based access
 ENABLE_SUBPATH_BASED_ACCESS=false
+
+# Set the default proxy URL, default to https://proxy.hoppscotch.io/
+VITE_PROXY_URL=

--- a/packages/hoppscotch-common/src/helpers/proxyUrl.ts
+++ b/packages/hoppscotch-common/src/helpers/proxyUrl.ts
@@ -6,6 +6,11 @@ export const DEFAULT_HOPP_PROXY_URL = "https://proxy.hoppscotch.io/"
 
 // Get default proxy URL from platform or return default
 export const getDefaultProxyUrl = async () => {
+  const envProxyUrl = import.meta.env.VITE_PROXY_URL?.trim()
+    if (envProxyUrl && envProxyUrl.length > 0) {
+    return envProxyUrl
+  }
+  
   const proxyAppUrl = platform?.infra?.getProxyAppUrl
 
   if (proxyAppUrl) {


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #4450 
Follow-up of: #5062 

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
Use VITE_PROXY_URL for PROXY_URL or fallback to the default logic. Make default hoppscotch proxy URL configurable through env.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the default Hoppscotch proxy URL configurable via the `VITE_PROXY_URL` env var, falling back to the platform value or `https://proxy.hoppscotch.io/`. This helps self‑hosted setups set a custom proxy without code changes.

- **Migration**
  - Optional: set `VITE_PROXY_URL` in `.env` to override the default proxy URL. No action needed if the platform provides a proxy URL or the default is acceptable.

<sup>Written for commit f54ef26e2a3728f16e5aa7592f07691c643ce6b2. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6347?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

