### PR TITLE
fix(hoppscotch-common): preserve literal closing braces in Postman import request bodies

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
@@ -78,7 +78,7 @@ describe("Postman importer", () => {
             ],
             body: {
               mode: "raw",
-              raw: '{"url": "{{host}}", "ext": {"required": ["buttonalign", "buttonstyle"]}}',
+              raw: '{"url": "{{host}}", "nested": "{{variable}}text}}", "ext": {"required": ["buttonalign", "buttonstyle"]}}',
               options: {
                 raw: {
                   language: "json",
@@ -102,7 +102,7 @@ describe("Postman importer", () => {
     }
 
     expect(result.right[0].requests[0].body.body).toEqual(
-      '{"url": "<<host>>", "ext": {"required": ["buttonalign", "buttonstyle"]}}'
+      '{"url": "<<host>>", "nested": "<<variable>>text}}", "ext": {"required": ["buttonalign", "buttonstyle"]}}'
     )
   })
 })

--- a/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
@@ -57,4 +57,52 @@ describe("Postman importer", () => {
       ])
     )
   })
+
+  it("preserves literal }} in request bodies while replacing {{var}}", async () => {
+    const postmanCollectionWithLiteralBraces = JSON.stringify({
+      info: {
+        name: "Literal Braces Import",
+        schema:
+          "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+      },
+      item: [
+        {
+          name: "Request with literal braces",
+          request: {
+            method: "POST",
+            header: [
+              {
+                key: "Content-Type",
+                value: "application/json",
+              },
+            ],
+            body: {
+              mode: "raw",
+              raw: '{"url": "{{host}}", "ext": {"required": ["buttonalign", "buttonstyle"]}}',
+              options: {
+                raw: {
+                  language: "json",
+                },
+              },
+            },
+            url: "https://echo.hoppscotch.io/post",
+          },
+        },
+      ],
+    })
+
+    const result = await hoppPostmanImporter([
+      postmanCollectionWithLiteralBraces,
+    ])()
+
+    expect(E.isRight(result)).toBe(true)
+
+    if (E.isLeft(result)) {
+      throw new Error("Expected Postman import to succeed")
+    }
+
+    expect(result.right[0].requests[0].body.body).toEqual(
+      '{"url": "<<host>>", "ext": {"required": ["buttonalign", "buttonstyle"]}}'
+    )
+  })
 })

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -65,7 +65,7 @@ const getCollectionSchema = (jsonStr: string): string | null => {
 
 export const replacePMVarTemplating = (value: unknown): string => {
   const str = typeof value === "string" ? value : String(value ?? "")
-  return pipe(str, S.replace(/{{\s*/g, "<<"), S.replace(/\s*}}/g, ">>"))
+  return str.replace(/{{\s*([^{}]+?)\s*}}/g, "<<$1>>")
 }
 
 const PMRawLanguageOptionsToContentTypeMap: Record<


### PR DESCRIPTION
## Summary

Closes #6324

This PR fixes a bug where importing a Postman collection (v2.1) that contains a request body with literal \}}\ characters (such as in stringified nested JSON or regex patterns) silently corrupts the body by replacing the \}}\ sequences with \>>\.

### Root Cause
In \eplacePMVarTemplating\ inside \postman.ts\, the variable replacement was doing two unconditional global replacements:
\\\	ypescript
pipe(str, S.replace(/{{\\s*/g, \<<\), S.replace(/\\s*}}/g, \>>\))
\\\
This unconditionally replaced ANY closing \}}\ (even without a matching \{{\ opener) into \>>\, breaking legitimate literal braces in stringified bodies.

### Fix
Refactored \eplacePMVarTemplating\ to use a single, precise regular expression that matches only paired Postman template variable patterns:
\\\	ypescript
str.replace(/{{\\s*([^{}]+?)\\s*}}/g, \<<>>\)
\\\
This ensures that only actual variable placeholders like \{{host}}\ are mapped to \<<host>>\, leaving literal \}}\ characters untouched.

### Regression & Boundary Tests
- Added a robust unit test in \postman-import.spec.ts\ validating that literal \}}\ in imported request bodies are fully preserved while regular \{{var}}\ variables are correctly replaced.
- **Coverage for adjacent variable + literal brace edge cases (Greptile feedback)**: Extended the test suite to assert correct behavior for variables directly adjacent to literal braces (e.g. \{{variable}}text}}\ -> \<<variable>>text}}\).
- Verified and formatted the code via \eslint --fix\. All tests pass.