### PR TITLE
fix(common/curl): register boolean flags to prevent URL swallowing during cURL import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/curl.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/curl.spec.ts
@@ -74,4 +74,38 @@ describe("parseCurlCommand", () => {
     expect(req.body.contentType).toBe("application/json")
     expect(JSON.parse(req.body.body)).toEqual({ foo: "bar" })
   })
+
+  it("correctly parses curl command with -G/--get without swallowing URL", () => {
+    const curl1 = "curl -G https://example.com?q=search"
+    const req1 = parseCurlCommand(curl1)
+    expect(req1.endpoint).toBe("https://example.com/")
+    expect(req1.method).toBe("GET")
+    expect(req1.params).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "q",
+          value: "search",
+        }),
+      ])
+    )
+
+    const curl2 = "curl -G -d 'foo=bar' https://example.com"
+    const req2 = parseCurlCommand(curl2)
+    expect(req2.endpoint).toBe("https://example.com/")
+    expect(req2.method).toBe("GET")
+    expect(req2.params).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "foo",
+          value: "bar",
+        }),
+      ])
+    )
+  })
+
+  it("correctly handles location boolean flag without resolving to https://true", () => {
+    const curl = "curl -L https://example.com"
+    const req = parseCurlCommand(curl)
+    expect(req.endpoint).toBe("https://example.com/")
+  })
 })

--- a/packages/hoppscotch-common/src/helpers/__tests__/curl.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/curl.spec.ts
@@ -1,0 +1,77 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest"
+import { parseCurlCommand } from "../curl/curlparser"
+
+describe("parseCurlCommand", () => {
+  it("correctly parses standard curl commands", () => {
+    const curl = "curl https://api.example.com/users"
+    const req = parseCurlCommand(curl)
+    expect(req.endpoint).toBe("https://api.example.com/users")
+    expect(req.method).toBe("GET")
+  })
+
+  it("correctly parses curl command with -s and -sS option without swallowing URL", () => {
+    const curl1 = "curl -sS https://example.com"
+    const req1 = parseCurlCommand(curl1)
+    expect(req1.endpoint).toBe("https://example.com/")
+    expect(req1.method).toBe("GET")
+
+    const curl2 = "curl -s https://example.com"
+    const req2 = parseCurlCommand(curl2)
+    expect(req2.endpoint).toBe("https://example.com/")
+    expect(req2.method).toBe("GET")
+
+    const curl3 = "curl --silent https://example.com"
+    const req3 = parseCurlCommand(curl3)
+    expect(req3.endpoint).toBe("https://example.com/")
+    expect(req3.method).toBe("GET")
+  })
+
+  it("correctly parses curl command with connection options like -k/--insecure, -L/--location", () => {
+    const curl1 = "curl -k https://example.com/insecure"
+    const req1 = parseCurlCommand(curl1)
+    expect(req1.endpoint).toBe("https://example.com/insecure")
+
+    const curl2 = "curl --insecure https://example.com/insecure"
+    const req2 = parseCurlCommand(curl2)
+    expect(req2.endpoint).toBe("https://example.com/insecure")
+
+    const curl3 = "curl -L https://example.com/redirect"
+    const req3 = parseCurlCommand(curl3)
+    expect(req3.endpoint).toBe("https://example.com/redirect")
+
+    const curl4 = "curl --location https://example.com/redirect"
+    const req4 = parseCurlCommand(curl4)
+    expect(req4.endpoint).toBe("https://example.com/redirect")
+  })
+
+  it("correctly parses and deduces HEAD request method from -I/--head", () => {
+    const curl1 = "curl -I https://example.com/headers"
+    const req1 = parseCurlCommand(curl1)
+    expect(req1.endpoint).toBe("https://example.com/headers")
+    expect(req1.method).toBe("HEAD")
+
+    const curl2 = "curl --head https://example.com/headers"
+    const req2 = parseCurlCommand(curl2)
+    expect(req2.endpoint).toBe("https://example.com/headers")
+    expect(req2.method).toBe("HEAD")
+  })
+
+  it("correctly parses complex combination of flags", () => {
+    const curl =
+      "curl -fsS -L -k -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer mytoken' -d '{\"foo\":\"bar\"}' https://example.com/post"
+    const req = parseCurlCommand(curl)
+    expect(req.endpoint).toBe("https://example.com/post")
+    expect(req.method).toBe("POST")
+    expect(req.headers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "Authorization",
+          value: "Bearer mytoken",
+        }),
+      ])
+    )
+    expect(req.body.contentType).toBe("application/json")
+    expect(JSON.parse(req.body.body)).toEqual({ foo: "bar" })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
@@ -67,6 +67,8 @@ export const parseCurlCommand = (curlCommand: string) => {
       "remote-header-name",
       "O",
       "remote-name",
+      "G",
+      "get",
     ],
   })
 

--- a/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
@@ -42,7 +42,33 @@ export const parseCurlCommand = (curlCommand: string) => {
 
   curlCommand = preProcessCurlCommand(curlCommand)
 
-  const args: parser.Arguments = parser(curlCommand)
+  const args: parser.Arguments = parser(curlCommand, {
+    boolean: [
+      "s",
+      "silent",
+      "S",
+      "show-error",
+      "f",
+      "fail",
+      "k",
+      "insecure",
+      "L",
+      "location",
+      "compressed",
+      "g",
+      "globoff",
+      "i",
+      "include",
+      "I",
+      "head",
+      "v",
+      "verbose",
+      "J",
+      "remote-header-name",
+      "O",
+      "remote-name",
+    ],
+  })
 
   const parsedArguments = pipe(
     args,

--- a/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
@@ -162,7 +162,11 @@ export const parseCurlCommand = (curlCommand: string) => {
     O.getOrElseW(() => undefined)
   )
 
-  if (objHasProperty("G", "boolean")(parsedArguments) && !!pairs) {
+  if (
+    (objHasProperty("G", "boolean")(parsedArguments) ||
+      objHasProperty("get", "boolean")(parsedArguments)) &&
+    !!pairs
+  ) {
     const newQueries = getQueries(pairs)
     queries = [...queries, ...newQueries.queries]
     danglingParams = [...danglingParams, ...newQueries.danglingParams]

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/method.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/method.ts
@@ -41,7 +41,11 @@ const getMethodByDeduction = (parsedArguments: parser.Arguments) => {
     )(parsedArguments)
   )
     return O.some("head")
-  else if (objHasProperty("G", "boolean")(parsedArguments)) return O.some("get")
+  else if (
+    objHasProperty("G", "boolean")(parsedArguments) ||
+    objHasProperty("get", "boolean")(parsedArguments)
+  )
+    return O.some("get")
   else if (
     pipe(
       objHasProperty("d", "string"),

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
@@ -76,7 +76,10 @@ const parseURL = (urlText: string | number) =>
  * @returns URL object
  */
 export function getURLObject(parsedArguments: parser.Arguments) {
-  const location = parsedArguments.location ?? undefined
+  const location =
+    typeof parsedArguments.location === "string"
+      ? parsedArguments.location
+      : undefined
 
   return pipe(
     // contains raw url strings


### PR DESCRIPTION
## Problem

Closes #5910

When importing cURL commands containing common output/connection control flags like -sS, -s, --silent, -k, --insecure, -L, --location, -I, --head, etc., the import fails or produces incorrect results. The parsed URL falls back to the default endpoint (https://echo.hoppscotch.io), and method deduction (e.g., -I → HEAD) breaks.

### Root Cause

The yargs-parser library, used internally by parseCurlCommand(), treats unknown single-letter flags as **string options** by default. This means -s https://example.com is parsed as { s: 'https://example.com' } instead of { s: true, _: ['curl', 'https://example.com'] }. The URL gets consumed as a flag value and never reaches the positional arguments array (_), causing getURLObject() to return the default endpoint.

The same issue affects -I / --head: instead of being parsed as a boolean (which getMethodByDeduction checks via objHasProperty('I', 'boolean')), it becomes a string containing the URL, so the HEAD method deduction silently fails.

## Solution

Register commonly used cURL boolean flags in the yargs-parser configuration:

\\\	ypescript
parser(curlCommand, {
  boolean: [
    's', 'silent', 'S', 'show-error',
    'f', 'fail', 'k', 'insecure',
    'L', 'location', 'compressed',
    'g', 'globoff', 'i', 'include',
    'I', 'head', 'v', 'verbose',
    'J', 'remote-header-name',
    'O', 'remote-name',
  ],
})
\\\

This tells yargs-parser these flags never take a value argument, so the URL correctly remains in the positional arguments array.

## Testing

Added src/helpers/__tests__/curl.spec.ts with 5 test cases covering:
- Standard cURL parsing
- Silent/show-error flags (-s, -sS, --silent)
- Connection flags (-k, --insecure, -L, --location)
- HEAD method deduction (-I, --head)
- Complex multi-flag combinations with headers and body

All tests pass locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cURL import parsing by registering boolean flags in `yargs-parser` so the URL isn’t swallowed. Adds `-G/--get` support (GET deduction and query merge) and corrects `-L/--location`; endpoints and method detection (e.g., `-I` → HEAD) now work.

- **Bug Fixes**
  - Register common boolean flags in `yargs-parser` (including `-G/--get`) and check both `-G` and `--get` for GET deduction.
  - Fix `-L/--location` boolean so it doesn’t resolve to a URL (no more https://true).
  - Add unit tests for standard cases, flags (incl. `-G/--get`), and complex combinations.

<sup>Written for commit 3738f077d5e28c79af75c93651720eef552be5a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

