### PR TITLE
Fix/issue 4136 cli tests

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/functions/checks/isHoppCLIError.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/functions/checks/isHoppCLIError.spec.ts
@@ -1,3 +1,4 @@
+import { describe, test, expect } from "vitest";
 import { isHoppCLIError } from "../../../utils/checks";
 
 describe("isHoppCLIError", () => {

--- a/packages/hoppscotch-cli/src/__tests__/functions/collection/collectionsRunner.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/functions/collection/collectionsRunner.spec.ts
@@ -1,10 +1,23 @@
+import { describe, test, expect, beforeEach, afterAll, vi } from "vitest";
 import { collectionsRunner } from "../../../utils/collections";
 import { HoppRESTRequest } from "@hoppscotch/data";
 import axios, { AxiosResponse } from "axios";
 
 import "@relmify/jest-fp-ts";
 
-jest.mock("axios");
+vi.mock("axios", () => {
+  const mockAxios: any = vi.fn();
+  mockAxios.create = vi.fn(() => mockAxios);
+  mockAxios.interceptors = {
+    request: { use: vi.fn(), eject: vi.fn(), handlers: [] },
+    response: { use: vi.fn(), eject: vi.fn(), handlers: [] },
+  };
+  mockAxios.isAxiosError = vi.fn();
+  return {
+    default: mockAxios,
+    isAxiosError: mockAxios.isAxiosError,
+  };
+});
 
 const SAMPLE_HOPP_REQUEST = <HoppRESTRequest>{
   v: "1",
@@ -41,11 +54,11 @@ const SAMPLE_ENVS = { global: [], selected: [] };
 
 describe("collectionsRunner", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   afterAll(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   test("Empty HoppCollection.", () => {
@@ -71,7 +84,7 @@ describe("collectionsRunner", () => {
   });
 
   test("Non-empty requests in collection.", () => {
-    (axios as unknown as jest.Mock).mockResolvedValue(SAMPLE_RESOLVED_RESPONSE);
+    vi.mocked(axios).mockResolvedValue(SAMPLE_RESOLVED_RESPONSE);
 
     return expect(
       collectionsRunner({
@@ -96,7 +109,7 @@ describe("collectionsRunner", () => {
   });
 
   test("Non-empty folders in collection.", () => {
-    (axios as unknown as jest.Mock).mockResolvedValue(SAMPLE_RESOLVED_RESPONSE);
+    vi.mocked(axios).mockResolvedValue(SAMPLE_RESOLVED_RESPONSE);
 
     return expect(
       collectionsRunner({

--- a/packages/hoppscotch-cli/src/__tests__/functions/getters/getEffectiveFinalMetaData.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/functions/getters/getEffectiveFinalMetaData.spec.ts
@@ -1,3 +1,4 @@
+import { describe, test, expect } from "vitest";
 import { Environment } from "@hoppscotch/data";
 import { getEffectiveFinalMetaData } from "../../../utils/getters";
 
@@ -5,19 +6,19 @@ import "@relmify/jest-fp-ts";
 
 const DEFAULT_ENV = <Environment>{
   name: "name",
-  variables: [{ key: "PARAM", value: "parsed_param" }],
+  variables: [{ key: "PARAM", initialValue: "parsed_param", currentValue: "parsed_param", secret: false }],
 };
 
 describe("getEffectiveFinalMetaData", () => {
   test("Empty list of meta-data.", () => {
-    expect(getEffectiveFinalMetaData([], DEFAULT_ENV)).toSubsetEqualRight([]);
+    expect(getEffectiveFinalMetaData([], DEFAULT_ENV.variables)).toSubsetEqualRight([]);
   });
 
   test("Non-empty active list of meta-data with unavailable ENV.", () => {
     expect(
       getEffectiveFinalMetaData(
         [{ active: true, key: "<<UNKNOWN_KEY>>", value: "<<UNKNOWN_VALUE>>" }],
-        DEFAULT_ENV
+        DEFAULT_ENV.variables
       )
     ).toSubsetEqualRight([{ active: true, key: "", value: "" }]);
   });
@@ -26,7 +27,7 @@ describe("getEffectiveFinalMetaData", () => {
     expect(
       getEffectiveFinalMetaData(
         [{ active: false, key: "KEY", value: "<<PARAM>>" }],
-        DEFAULT_ENV
+        DEFAULT_ENV.variables
       )
     ).toSubsetEqualRight([]);
   });
@@ -35,7 +36,7 @@ describe("getEffectiveFinalMetaData", () => {
     expect(
       getEffectiveFinalMetaData(
         [{ active: true, key: "PARAM", value: "<<PARAM>>" }],
-        DEFAULT_ENV
+        DEFAULT_ENV.variables
       )
     ).toSubsetEqualRight([
       { active: true, key: "PARAM", value: "parsed_param" },

--- a/packages/hoppscotch-cli/src/__tests__/functions/mutators/parseCollectionData.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/functions/mutators/parseCollectionData.spec.ts
@@ -1,10 +1,11 @@
+import { describe, test, expect } from "vitest";
 import { HoppCLIError } from "../../../types/errors";
 import { parseCollectionData } from "../../../utils/mutators";
 
 describe("parseCollectionData", () => {
   test("Reading non-existing file.", () => {
     return expect(
-      parseCollectionData("./src/__tests__/samples/notexist.json")
+      parseCollectionData("./src/__tests__/e2e/fixtures/collections/notexist.json")
     ).rejects.toMatchObject(<HoppCLIError>{
       code: "FILE_NOT_FOUND",
     });
@@ -12,7 +13,7 @@ describe("parseCollectionData", () => {
 
   test("Unparseable JSON contents.", () => {
     return expect(
-      parseCollectionData("./src/__tests__/samples/malformed-collection.json")
+      parseCollectionData("./src/__tests__/e2e/fixtures/collections/malformed-coll.json")
     ).rejects.toMatchObject(<HoppCLIError>{
       code: "UNKNOWN_ERROR",
     });
@@ -20,7 +21,7 @@ describe("parseCollectionData", () => {
 
   test("Invalid HoppCollection.", () => {
     return expect(
-      parseCollectionData("./src/__tests__/samples/malformed-collection2.json")
+      parseCollectionData("./src/__tests__/e2e/fixtures/collections/malformed-coll-2.json")
     ).rejects.toMatchObject(<HoppCLIError>{
       code: "MALFORMED_COLLECTION",
     });
@@ -28,7 +29,7 @@ describe("parseCollectionData", () => {
 
   test("Valid HoppCollection.", () => {
     return expect(
-      parseCollectionData("./src/__tests__/samples/passes.json")
+      parseCollectionData("./src/__tests__/e2e/fixtures/collections/passes-coll.json")
     ).resolves.toBeTruthy();
   });
 });

--- a/packages/hoppscotch-cli/src/__tests__/functions/pre-request/getEffectiveRESTRequest.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/functions/pre-request/getEffectiveRESTRequest.spec.ts
@@ -1,3 +1,4 @@
+import { describe, test, expect, beforeEach } from "vitest";
 import { Environment, HoppRESTRequest } from "@hoppscotch/data";
 import { EffectiveHoppRESTRequest } from "../../../interfaces/request";
 import { HoppCLIError } from "../../../types/errors";
@@ -10,12 +11,14 @@ const DEFAULT_ENV = <Environment>{
   variables: [
     {
       key: "HEADER",
-      value: "parsed_header",
+      initialValue: "parsed_header",
+      currentValue: "parsed_header",
+      secret: false,
     },
-    { key: "PARAM", value: "parsed_param" },
-    { key: "TOKEN", value: "parsed_token" },
-    { key: "BODY_PROP", value: "parsed_body_prop" },
-    { key: "ENDPOINT", value: "https://parsed-endpoint.com" },
+    { key: "PARAM", initialValue: "parsed_param", currentValue: "parsed_param", secret: false },
+    { key: "TOKEN", initialValue: "parsed_token", currentValue: "parsed_token", secret: false },
+    { key: "BODY_PROP", initialValue: "parsed_body_prop", currentValue: "parsed_body_prop", secret: false },
+    { key: "ENDPOINT", initialValue: "https://parsed-endpoint.com", currentValue: "https://parsed-endpoint.com", secret: false },
   ],
 };
 
@@ -36,6 +39,7 @@ const DEFAULT_REQUEST = <HoppRESTRequest>{
     contentType: null,
     body: null,
   },
+  requestVariables: [],
 };
 
 describe("getEffectiveRESTRequest", () => {
@@ -45,7 +49,7 @@ describe("getEffectiveRESTRequest", () => {
     SAMPLE_REQUEST = Object.assign({}, DEFAULT_REQUEST);
   });
 
-  test("Endpoint, headers and params with unavailable ENV.", () => {
+  test("Endpoint, headers and params with unavailable ENV.", async () => {
     SAMPLE_REQUEST.headers = [
       {
         key: "HEADER",
@@ -62,45 +66,46 @@ describe("getEffectiveRESTRequest", () => {
     ];
     SAMPLE_REQUEST.endpoint = "<<UNKNOWN>>";
 
-    expect(
-      getEffectiveRESTRequest(SAMPLE_REQUEST, DEFAULT_ENV)
-    ).toSubsetEqualRight(<EffectiveHoppRESTRequest>{
-      effectiveFinalHeaders: [{ active: true, key: "HEADER", value: "" }],
-      effectiveFinalParams: [{ active: true, key: "PARAM", value: "" }],
-      effectiveFinalURL: "",
+    const result = await getEffectiveRESTRequest(SAMPLE_REQUEST, DEFAULT_ENV);
+    expect(result).toSubsetEqualRight({
+      effectiveRequest: {
+        effectiveFinalHeaders: [{ active: true, key: "HEADER", value: "" }],
+        effectiveFinalParams: [{ active: true, key: "PARAM", value: "" }],
+        effectiveFinalURL: "",
+      },
     });
   });
 
-  test("Auth with unavailable ENV.", () => {
+  test("Auth with unavailable ENV.", async () => {
     SAMPLE_REQUEST.auth = {
       authActive: true,
       authType: "bearer",
       token: "<<UNKNOWN>>",
     };
 
-    expect(
-      getEffectiveRESTRequest(SAMPLE_REQUEST, DEFAULT_ENV)
-    ).toSubsetEqualRight(<EffectiveHoppRESTRequest>{
-      effectiveFinalHeaders: [
-        { active: true, key: "Authorization", value: "Bearer " },
-      ],
+    const result = await getEffectiveRESTRequest(SAMPLE_REQUEST, DEFAULT_ENV);
+    expect(result).toSubsetEqualRight({
+      effectiveRequest: {
+        effectiveFinalHeaders: [
+          { active: true, key: "Authorization", value: "Bearer " },
+        ],
+      },
     });
   });
 
-  test("Body with unavailable ENV.", () => {
+  test("Body with unavailable ENV.", async () => {
     SAMPLE_REQUEST.body = {
       contentType: "text/plain",
       body: "<<UNKNOWN>>",
     };
 
-    expect(
-      getEffectiveRESTRequest(SAMPLE_REQUEST, DEFAULT_ENV)
-    ).toSubsetEqualLeft(<HoppCLIError>{
+    const result = await getEffectiveRESTRequest(SAMPLE_REQUEST, DEFAULT_ENV);
+    expect(result).toSubsetEqualLeft(<HoppCLIError>{
       code: "PARSING_ERROR",
     });
   });
 
-  test("Request meta-data with available ENVs.", () => {
+  test("Request meta-data with available ENVs.", async () => {
     SAMPLE_REQUEST.headers = [
       {
         key: "HEADER",
@@ -128,23 +133,24 @@ describe("getEffectiveRESTRequest", () => {
 
     const vars = DEFAULT_ENV.variables;
 
-    expect(
-      getEffectiveRESTRequest(SAMPLE_REQUEST, DEFAULT_ENV)
-    ).toSubsetEqualRight(<EffectiveHoppRESTRequest>{
-      effectiveFinalHeaders: [
-        { active: true, key: "HEADER", value: vars[0].value },
-        {
-          active: true,
-          key: "Authorization",
-          value: `Bearer ${vars[2].value}`,
-        },
-        { active: true, key: "content-type", value: "text/plain" },
-      ],
-      effectiveFinalParams: [
-        { active: true, key: "PARAM", value: vars[1].value },
-      ],
-      effectiveFinalURL: vars[4].value,
-      effectiveFinalBody: vars[3].value,
+    const result = await getEffectiveRESTRequest(SAMPLE_REQUEST, DEFAULT_ENV);
+    expect(result).toSubsetEqualRight({
+      effectiveRequest: {
+        effectiveFinalHeaders: [
+          { active: true, key: "HEADER", value: vars[0].currentValue },
+          {
+            active: true,
+            key: "Authorization",
+            value: `Bearer ${vars[2].currentValue}`,
+          },
+          { active: true, key: "Content-Type", value: "text/plain" },
+        ],
+        effectiveFinalParams: [
+          { active: true, key: "PARAM", value: vars[1].currentValue },
+        ],
+        effectiveFinalURL: vars[4].currentValue,
+        effectiveFinalBody: vars[3].currentValue,
+      },
     });
   });
 });

--- a/packages/hoppscotch-cli/src/__tests__/functions/pre-request/preRequestScriptRunner.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/functions/pre-request/preRequestScriptRunner.spec.ts
@@ -1,3 +1,4 @@
+import { describe, test, expect, beforeAll } from "vitest";
 import { HoppRESTRequest } from "@hoppscotch/data";
 import { HoppEnvs } from "../../../types/request";
 import * as E from "fp-ts/Either";
@@ -29,37 +30,40 @@ const SAMPLE_REQUEST: HoppRESTRequest = {
     contentType: null,
     body: null,
   },
+  requestVariables: [],
 };
 
 describe("preRequestScriptRunner", () => {
   let SUCCESS_PRE_REQUEST_RUNNER: E.Either<
       HoppCLIError,
-      EffectiveHoppRESTRequest
+      { effectiveRequest: EffectiveHoppRESTRequest; updatedEnvs: HoppEnvs }
     >,
     FAILURE_PRE_REQUEST_RUNNER: E.Either<
       HoppCLIError,
-      EffectiveHoppRESTRequest
+      { effectiveRequest: EffectiveHoppRESTRequest; updatedEnvs: HoppEnvs }
     >;
 
   beforeAll(async () => {
     SAMPLE_REQUEST.preRequestScript = VALID_PRE_REQUEST_SCRIPT;
     SUCCESS_PRE_REQUEST_RUNNER = await preRequestScriptRunner(
       SAMPLE_REQUEST,
-      SAMPLE_ENVS
+      SAMPLE_ENVS,
+      false
     )();
 
     SAMPLE_REQUEST.preRequestScript = INVALID_PRE_REQUEST_SCRIPT;
     FAILURE_PRE_REQUEST_RUNNER = await preRequestScriptRunner(
       SAMPLE_REQUEST,
-      SAMPLE_ENVS
+      SAMPLE_ENVS,
+      false
     )();
   });
 
   test("Parsing of request endpoint with set ENV.", () => {
-    expect(SUCCESS_PRE_REQUEST_RUNNER).toSubsetEqualRight(<
-      EffectiveHoppRESTRequest
-    >{
-      effectiveFinalURL: "https://example.com",
+    expect(SUCCESS_PRE_REQUEST_RUNNER).toSubsetEqualRight({
+      effectiveRequest: {
+        effectiveFinalURL: "https://example.com",
+      },
     });
   });
 

--- a/packages/hoppscotch-cli/src/__tests__/functions/request/processRequest.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/functions/request/processRequest.spec.ts
@@ -1,3 +1,4 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
 import { HoppRESTRequest } from "@hoppscotch/data";
 import axios, { AxiosResponse } from "axios";
 import { processRequest } from "../../../utils/request";
@@ -5,7 +6,19 @@ import { HoppEnvs } from "../../../types/request";
 
 import "@relmify/jest-fp-ts";
 
-jest.mock("axios");
+vi.mock("axios", () => {
+  const mockAxios: any = vi.fn();
+  mockAxios.create = vi.fn(() => mockAxios);
+  mockAxios.interceptors = {
+    request: { use: vi.fn(), eject: vi.fn(), handlers: [] },
+    response: { use: vi.fn(), eject: vi.fn(), handlers: [] },
+  };
+  mockAxios.isAxiosError = vi.fn();
+  return {
+    default: mockAxios,
+    isAxiosError: mockAxios.isAxiosError,
+  };
+});
 
 const DEFAULT_REQUEST = <HoppRESTRequest>{
   v: "1",
@@ -47,7 +60,7 @@ describe("processRequest", () => {
   let SAMPLE_REQUEST = DEFAULT_REQUEST;
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -55,7 +68,7 @@ describe("processRequest", () => {
   });
 
   test("With empty envs for 'true' result.", () => {
-    (axios as unknown as jest.Mock).mockResolvedValue(DEFAULT_RESPONSE);
+    vi.mocked(axios).mockResolvedValue(DEFAULT_RESPONSE);
 
     return expect(
       processRequest({
@@ -81,7 +94,7 @@ describe("processRequest", () => {
 			});
 		`;
 
-    (axios as unknown as jest.Mock).mockResolvedValue(DEFAULT_RESPONSE);
+    vi.mocked(axios).mockResolvedValue(DEFAULT_RESPONSE);
 
     return expect(
       processRequest({
@@ -92,7 +105,7 @@ describe("processRequest", () => {
       })()
     ).resolves.toMatchObject({
       envs: {
-        selected: [{ key: "ENDPOINT", value: "https://example.com" }],
+        selected: [{ key: "ENDPOINT", currentValue: "https://example.com" }],
       },
       report: {
         result: true,
@@ -103,7 +116,7 @@ describe("processRequest", () => {
   test("With invalid-pre-request-script.", () => {
     SAMPLE_REQUEST.preRequestScript = `invalid`;
 
-    (axios as unknown as jest.Mock).mockResolvedValue(DEFAULT_RESPONSE);
+    vi.mocked(axios).mockResolvedValue(DEFAULT_RESPONSE);
 
     return expect(
       processRequest({

--- a/packages/hoppscotch-cli/src/__tests__/functions/request/requestRunner.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/functions/request/requestRunner.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import axios, { AxiosError, AxiosResponse } from "axios";
 import { RequestConfig } from "../../../interfaces/request";
 import { requestRunner } from "../../../utils/request";
@@ -5,7 +6,7 @@ import { RequestRunnerResponse } from "../../../interfaces/response";
 
 import "@relmify/jest-fp-ts";
 
-jest.mock("axios");
+vi.mock("axios");
 
 describe("requestRunner", () => {
   let SAMPLE_REQUEST_CONFIG: RequestConfig = {
@@ -17,16 +18,16 @@ describe("requestRunner", () => {
   beforeEach(() => {
     SAMPLE_REQUEST_CONFIG.url = "https://example.com";
     SAMPLE_REQUEST_CONFIG.method = "GET";
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   afterAll(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it("Should handle axios-error with response info.", () => {
-    jest.spyOn(axios, "isAxiosError").mockReturnValue(true);
-    (axios as unknown as jest.Mock).mockRejectedValueOnce(<AxiosError>{
+    vi.spyOn(axios, "isAxiosError").mockReturnValue(true);
+    vi.mocked(axios).mockRejectedValueOnce(<AxiosError>{
       name: "name",
       message: "message",
       config: SAMPLE_REQUEST_CONFIG,
@@ -50,8 +51,8 @@ describe("requestRunner", () => {
   });
 
   it("Should handle axios-error for unsupported request.", () => {
-    jest.spyOn(axios, "isAxiosError").mockReturnValue(true);
-    (axios as unknown as jest.Mock).mockRejectedValueOnce(<AxiosError>{
+    vi.spyOn(axios, "isAxiosError").mockReturnValue(true);
+    vi.mocked(axios).mockRejectedValueOnce(<AxiosError>{
       name: "name",
       message: "message",
       config: SAMPLE_REQUEST_CONFIG,
@@ -68,8 +69,8 @@ describe("requestRunner", () => {
   });
 
   it("Should handle axios-error with request info.", () => {
-    jest.spyOn(axios, "isAxiosError").mockReturnValue(true);
-    (axios as unknown as jest.Mock).mockRejectedValueOnce(<AxiosError>{
+    vi.spyOn(axios, "isAxiosError").mockReturnValue(true);
+    vi.mocked(axios).mockRejectedValueOnce(<AxiosError>{
       name: "name",
       message: "message",
       config: SAMPLE_REQUEST_CONFIG,
@@ -82,14 +83,14 @@ describe("requestRunner", () => {
   });
 
   it("Should handle unknown error.", () => {
-    jest.spyOn(axios, "isAxiosError").mockReturnValue(false);
-    (axios as unknown as jest.Mock).mockRejectedValueOnce({});
+    vi.spyOn(axios, "isAxiosError").mockReturnValue(false);
+    vi.mocked(axios).mockRejectedValueOnce({});
 
     return expect(requestRunner(SAMPLE_REQUEST_CONFIG)()).resolves.toBeLeft();
   });
 
   it("Should successfully execute.", () => {
-    (axios as unknown as jest.Mock).mockResolvedValue(<AxiosResponse>{
+    vi.mocked(axios).mockResolvedValue(<AxiosResponse>{
       data: "data",
       status: 200,
       config: SAMPLE_REQUEST_CONFIG,

--- a/packages/hoppscotch-cli/src/__tests__/functions/test/testRunner.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/functions/test/testRunner.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, beforeAll } from "vitest";
 import { TestResponse } from "@hoppscotch/js-sandbox";
 import * as E from "fp-ts/Either";
 import { TestRunnerRes } from "../../../types/response";
@@ -28,7 +29,15 @@ describe("testRunner", () => {
 
   beforeAll(async () => {
     SUCCESS_TEST_RUNNER_RES = await testRunner({
-      testScript: `
+      request: {
+        v: "1",
+        name: "name",
+        method: "GET",
+        endpoint: "https://example.com",
+        params: [],
+        headers: [],
+        preRequestScript: "",
+        testScript: `
 			// Check status code is 200
 			pw.test("Status code is 200", ()=> {
 					pw.expect(pw.response.status).toBe(200);
@@ -40,14 +49,42 @@ describe("testRunner", () => {
 					pw.expect(pw.response.body).toBe("body");
 			});
 			`,
+        auth: {
+          authActive: false,
+          authType: "none",
+        },
+        body: {
+          contentType: null,
+          body: null,
+        },
+      },
       envs: SAMPLE_ENVS,
       response: SAMPLE_RESPONSE,
+      legacySandbox: false,
     })();
 
     FAILURE_TEST_RUNNER_RES = await testRunner({
-      testScript: "a",
+      request: {
+        v: "1",
+        name: "name",
+        method: "GET",
+        endpoint: "https://example.com",
+        params: [],
+        headers: [],
+        preRequestScript: "",
+        testScript: "a",
+        auth: {
+          authActive: false,
+          authType: "none",
+        },
+        body: {
+          contentType: null,
+          body: null,
+        },
+      },
       envs: SAMPLE_ENVS,
       response: SAMPLE_RESPONSE,
+      legacySandbox: false,
     })();
   });
 

--- a/packages/hoppscotch-cli/src/utils/collections.ts
+++ b/packages/hoppscotch-cli/src/utils/collections.ts
@@ -126,11 +126,11 @@ const processCollection = async (
   ]);
 
   // Process each request in the collection
-  for (const request of collection.requests) {
+  for (const request of collection.requests || []) {
     const _request = preProcessRequest(request as HoppRESTRequest, collection);
     const requestPath = `${path}/${_request.name}`;
 
-    const collectionVariables = collection.variables.filter(
+    const collectionVariables = (collection.variables || []).filter(
       (variable) => variable.key && variable.key.trim() !== ""
     );
 
@@ -162,14 +162,19 @@ const processCollection = async (
   }
 
   // Process each folder in the collection
-  for (const folder of collection.folders) {
-    const updatedFolder: HoppCollection = { ...folder };
+  for (const folder of collection.folders || []) {
+    const updatedFolder: HoppCollection = {
+      ...folder,
+      auth: folder.auth ?? { authActive: false, authType: "none" },
+      headers: folder.headers ?? [],
+      variables: folder.variables ?? [],
+    };
 
-    if (updatedFolder.auth.authType === "inherit") {
-      updatedFolder.auth = collection.auth;
+    if (updatedFolder.auth && updatedFolder.auth.authType === "inherit") {
+      updatedFolder.auth = collection.auth ?? { authActive: false, authType: "none" };
     }
 
-    if (collection.headers.length) {
+    if (collection.headers && collection.headers.length) {
       // Filter out header entries present in the parent collection under the same name
       // This ensures the folder headers take precedence over the collection headers
       const filteredHeaders = collection.headers.filter(
@@ -184,7 +189,7 @@ const processCollection = async (
     }
 
     // Inherit collection variables into folder, with folder variables taking precedence
-    if (collection.variables.length) {
+    if (collection.variables && collection.variables.length) {
       // Filter out collection variables with same key as folder variables
       const filteredVariables = collection.variables.filter(
         (collectionVariableEntries) => {

--- a/packages/hoppscotch-cli/src/utils/getters.ts
+++ b/packages/hoppscotch-cli/src/utils/getters.ts
@@ -274,12 +274,12 @@ export const getResourceContents = async (
  * @returns {EnvironmentVariable[]} The resolved list of variables that conforms to the shape of environment variables.
  */
 export const getResolvedVariables = (
-  requestVariables: HoppRESTRequestVariables,
+  requestVariables: HoppRESTRequestVariables | undefined,
   environmentVariables: EnvironmentVariable[],
   collectionVariables: HoppCollectionVariable[] = []
 ): EnvironmentVariable[] => {
   // Transforming request variables to the shape of environment variables
-  const activeRequestVariables = requestVariables
+  const activeRequestVariables = (requestVariables || [])
     .filter(({ active, value }) => active && value)
     .map(({ key, value }) => ({
       key,

--- a/packages/hoppscotch-cli/src/utils/mutators.ts
+++ b/packages/hoppscotch-cli/src/utils/mutators.ts
@@ -132,7 +132,7 @@ export async function readJsonFile(
  */
 export async function parseCollectionData(
   pathOrId: string,
-  options: TestCmdCollectionOptions
+  options: TestCmdCollectionOptions = {}
 ): Promise<HoppCollection[]> {
   const { token: accessToken, server: serverUrl } = options;
 

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -179,6 +179,9 @@ export const requestRunner =
             }
           }
           runnerResponse.headers = transformedHeaders;
+        } else if ((e.config as RequestConfig)?.supported === false && !e.request) {
+          runnerResponse.status = 501;
+          runnerResponse.statusText = responseErrors[501];
         } else if (e.request) {
           return E.left(error({ code: "REQUEST_ERROR", data: E.toError(e) }));
         }

--- a/packages/hoppscotch-cli/vitest.config.ts
+++ b/packages/hoppscotch-cli/vitest.config.ts
@@ -2,13 +2,13 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    globals: true,
     environment: "node",
     setupFiles: ["./setupFiles.ts"],
     include: ["**/src/__tests__/**/**/*.{test,spec}.ts"],
     exclude: [
       "**/node_modules/**",
       "**/dist/**",
-      "**/src/__tests__/functions/**/*.ts",
     ],
   },
 });


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated CLI unit tests from `jest` to `vitest` and updated specs to match the new request/env shapes. Also hardened collection and request utilities and improved error handling to stabilize tests and behavior.

- **Refactors**
  - Switched tests to `vitest` (`vi.mock`, `vi.spyOn`, `globals: true` in config).
  - Updated specs for `initialValue`/`currentValue` env vars and nested `effectiveRequest` return.
  - Moved test fixtures to `src/__tests__/e2e/fixtures`.

- **Bug Fixes**
  - Made collection processing safe when `requests`, `folders`, `headers`, or `variables` are missing.
  - Allowed undefined `requestVariables` in getters.
  - Defaulted `parseCollectionData` options to `{}`.
  - Added 501 handling for unsupported requests without a transport in `requestRunner` (`axios` errors).

<sup>Written for commit ca86a2543b5c4b33dd90fdcd21e3c79672e093e4. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6352?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

