### PR TITLE
fix: preserve float precision in JSONC conversion for request bodies

### DIFF
--- a/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import { stripComments } from "../jsonc"
+
+describe("stripComments (JSONC to JSON conversion with float precision preservation)", () => {
+  it("should preserve float numbers with .0 ending", () => {
+    const jsonc = `
+      {
+        "price": 70.0,
+        "nested": {
+          "value": 100.00
+        }
+      }
+    `
+    const result = stripComments(jsonc)
+    expect(result).toBe('{"price":70.0,"nested":{"value":100.00}}')
+  })
+
+  it("should remove comments and preserve float precision", () => {
+    const jsonc = `
+      {
+        // This is a comment
+        "price": 70.0, /* another comment */
+        "count": 5
+      }
+    `
+    const result = stripComments(jsonc)
+    expect(result).toBe('{"price":70.0,"count":5}')
+  })
+
+  it("should preserve negative floats and scientific notation", () => {
+    const jsonc = `
+      {
+        "negative": -5.0,
+        "positive": 12.0,
+        "scientific": 1.2e-5,
+        "exponent": 10e+2
+      }
+    `
+    const result = stripComments(jsonc)
+    expect(result).toBe('{"negative":-5.0,"positive":12.0,"scientific":1.2e-5,"exponent":10e+2}')
+  })
+
+  it("should correctly handle trailing commas and comments", () => {
+    const jsonc = `
+      {
+        "a": 1.0,
+        "b": "text", // comment
+      }
+    `
+    const result = stripComments(jsonc)
+    expect(result).toBe('{"a":1.0,"b":"text"}')
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
@@ -35,7 +35,7 @@ class InvalidJSONCNodeError extends Error {
  * @throws {InvalidJSONCNodeError} if the node is in an invalid configuration
  * @returns The JSON string without comments and trailing commas
  */
-function convertNodeToJSON(node: Node): string {
+function convertNodeToJSON(node: Node, text: string): string {
   switch (node.type) {
     case "string":
       return JSON.stringify(node.value)
@@ -47,10 +47,12 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `[${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, text))
         .join(",")}]`
     case "number":
-      return JSON.stringify(node.value)
+      return node.offset !== undefined && node.length !== undefined
+        ? text.slice(node.offset, node.offset + node.length)
+        : JSON.stringify(node.value)
     case "boolean":
       return JSON.stringify(node.value)
     case "object":
@@ -59,7 +61,7 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `{${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, text))
         .join(",")}}`
     case "property":
       if (!node.children || node.children.length !== 2) {
@@ -72,7 +74,7 @@ function convertNodeToJSON(node: Node): string {
       // Attempting to JSON.stringify(keyNode) directly would throw
       // "Converting circular structure to JSON" error.
       // If the valueNode configuration is wrong, this will return an error, which will propagate up
-      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(valueNode)}`
+      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(valueNode, text)}`
   }
 }
 
@@ -89,7 +91,7 @@ function stripCommentsAndCommas(text: string): string {
 
   // convertNodeToJSON can throw an error if the tree is invalid
   try {
-    return convertNodeToJSON(tree)
+    return convertNodeToJSON(tree, text)
   } catch (_) {
     return text
   }


### PR DESCRIPTION
### Description
This PR fixes the issue where float numbers ending in `.0` (e.g., `70.0`) in the JSON/JSONC request body lose their precision and get sent as integers (e.g., `70`).

### Cause of the bug
During the pre-request step, `stripComments` is called to clean comments from the JSONC request body. This internally calls `stripCommentsAndCommas` which parses the JSONC into an AST via `jsonc-parser`, and then rebuilds the JSON using `convertNodeToJSON`. For a `number` node, it previously returned `JSON.stringify(node.value)`. Since JavaScript does not distinguish between floats and integers internally, `70.0` was parsed as `70` and serialized back as `"70"`.

### Solution
Instead of serializing the parsed JS number, we now use `node.offset` and `node.length` to slice the exact number string from the original request body text, preserving the user's float precision and formatting perfectly.

- Fixes #6317
- Added comprehensive unit tests in `jsonc.spec.ts` covering float decimals, trailing commas, negative numbers, and scientific notations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves float precision in JSONC request bodies during comment stripping, so values like 70.0 and 100.00 are sent exactly as typed. Fixes #6317.

- **Bug Fixes**
  - For `number` nodes, slice the exact token from the source using `node.offset`/`node.length` in `convertNodeToJSON` instead of serializing JS numbers, preserving decimals and scientific notation.
  - Pass the source text through all `convertNodeToJSON` calls for arrays, objects, and properties.
  - Added tests covering decimals, negatives, scientific notation, comments, and trailing commas using `jsonc-parser`.

<sup>Written for commit 3f566e026b8c8dd58a4dec589c1a9145204b7e90. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6354?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

