### PR TITLE
fix #6341: initialize sync after OAuth login

### DIFF
--- a/packages/hoppscotch-selfhost-web/src/lib/sync/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/lib/sync/index.ts
@@ -82,6 +82,10 @@ export const getSyncInitFunction = <T extends DispatchingStore<any, any>>(
       )
     }
 
+    if (stopSubscriptions) {
+      stopSubscriptions()
+    }
+
     stopSubscriptions = startSubscriptions?.()
   }
 

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
@@ -426,9 +426,7 @@ export const def: AuthPlatformDef = {
         } finally {
           // Reset flag after a short delay to allow for legitimate re-authentication
           // while still preventing rapid duplicate requests
-          setTimeout(() => {
-            isProcessingDeepLink = false
-          }, 1000)
+          isProcessingDeepLink = false
         }
       }
     )

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
@@ -43,6 +43,7 @@ export const probableUser$ = new BehaviorSubject<HoppUserWithAuthDetail | null>(
 )
 
 const isGettingInitialUser: Ref<null | boolean> = ref(null)
+let isProcessingDeepLink = false
 
 const persistenceService = getService(PersistenceService)
 const interceptorService = getService(KernelInterceptorService)
@@ -242,7 +243,7 @@ async function refreshToken() {
 
     if (isSuccessful && currentUser$.value) {
       authEvents$.next({
-        event: "login",
+        event: "token_refresh",
         user: {
           uid: currentUser$.value.uid,
           displayName: currentUser$.value.displayName,
@@ -386,23 +387,48 @@ export const def: AuthPlatformDef = {
     await listen<string>(
       "scheme-request-received",
       async (event: { payload: string }) => {
-        const deepLink = event.payload
-        const params = new URLSearchParams(deepLink.split("?")[1])
-
-        const accessToken = params.get("access_token")
-        const refreshToken = params.get("refresh_token")
-        const token = params.get("token")
-
-        if (accessToken && refreshToken) {
-          await persistenceService.setLocalConfig("access_token", accessToken)
-          await persistenceService.setLocalConfig("refresh_token", refreshToken)
+        // Prevent concurrent deep-link processing to avoid race conditions
+        // and duplicate login events during re-authentication
+        if (isProcessingDeepLink) {
+          console.warn(
+            "[Auth] Deep-link already being processed, ignoring duplicate request"
+          )
           return
         }
 
-        if (token) {
-          await persistenceService.setLocalConfig("verifyToken", token)
-          await this.signInWithEmailLink("", "")
-          await setInitialUser()
+        isProcessingDeepLink = true
+
+        try {
+          const deepLink = event.payload
+          const params = new URLSearchParams(deepLink.split("?")[1])
+
+          const accessToken = params.get("access_token")
+          const refreshToken = params.get("refresh_token")
+          const token = params.get("token")
+
+          if (accessToken && refreshToken) {
+            await persistenceService.setLocalConfig("access_token", accessToken)
+            await persistenceService.setLocalConfig(
+              "refresh_token",
+              refreshToken
+            )
+            // Call setInitialUser to update currentUser$, emit login event,
+            // and trigger sync subscriptions (matches magic-link flow pattern)
+            await setInitialUser()
+            return
+          }
+
+          if (token) {
+            await persistenceService.setLocalConfig("verifyToken", token)
+            await this.signInWithEmailLink("", "")
+            await setInitialUser()
+          }
+        } finally {
+          // Reset flag after a short delay to allow for legitimate re-authentication
+          // while still preventing rapid duplicate requests
+          setTimeout(() => {
+            isProcessingDeepLink = false
+          }, 1000)
         }
       }
     )

--- a/packages/hoppscotch-selfhost-web/vite.config.ts
+++ b/packages/hoppscotch-selfhost-web/vite.config.ts
@@ -110,13 +110,12 @@ export default defineConfig({
       dirs: ["../hoppscotch-common/src/pages", "./src/pages"],
       importMode: "async",
       onRoutesGenerated(routes) {
-        const validRoutes = routes.filter((r) => typeof r.path === "string")
         generateSitemap({
-          routes: validRoutes,
+          routes,
           nuxtStyle: true,
           allowRobots: true,
           dest: ".sitemap-gen",
-          hostname: ENV.VITE_BASE_URL || "https://hoppscotch.io",
+          hostname: ENV.VITE_BASE_URL,
         })
       },
     }),

--- a/packages/hoppscotch-selfhost-web/vite.config.ts
+++ b/packages/hoppscotch-selfhost-web/vite.config.ts
@@ -110,12 +110,13 @@ export default defineConfig({
       dirs: ["../hoppscotch-common/src/pages", "./src/pages"],
       importMode: "async",
       onRoutesGenerated(routes) {
+        const validRoutes = routes.filter((r) => typeof r.path === "string")
         generateSitemap({
-          routes,
+          routes: validRoutes,
           nuxtStyle: true,
           allowRobots: true,
           dest: ".sitemap-gen",
-          hostname: ENV.VITE_BASE_URL,
+          hostname: ENV.VITE_BASE_URL || "https://hoppscotch.io",
         })
       },
     }),


### PR DESCRIPTION
## Summary

Fixes a desktop sync issue where newly created synced interfaces/collections from the browser were not reflected in the desktop app until the user logged out and logged in again.

## Root Cause

During the OAuth deep-link flow inside `performAuthInit()`, the desktop app stored the `access_token` and `refresh_token` but returned before calling `setInitialUser()`.

Because of this:

* `authEvents$` never emitted the `"login"` event
* sync subscriptions were not initialized
* synced collections/interfaces were not refreshed

## Fix  

Call `setInitialUser()` after persisting OAuth tokens so the authentication lifecycle completes properly and sync subscriptions initialize immediately.

## Verification

Tested the following scenarios:

* Login via OAuth on desktop
* Create/update collections/interfaces from browser
* Verified desktop sync updates without re-login
* Verified no console errors or duplicate updates
* Confirmed existing login/logout flow still works

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Initialize sync immediately after OAuth login on the desktop app so new/updated collections and interfaces appear without re-login. Hardened the deep-link flow to prevent duplicate events and races.

- **Bug Fixes**
  - Call `setInitialUser()` after saving OAuth tokens to emit login and start sync.
  - Serialize deep-link handling to avoid duplicate login events and races.
  - Emit `token_refresh` on refresh instead of `login`.
  - Stop existing sync subscriptions before starting new ones.

<sup>Written for commit bb6010a6546f235042863e82dc12b633d51650e0. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6355?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


Fixes #6341
