### PR TITLE
fix(importer): postman body }} corrupted to >> on import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
@@ -1,7 +1,33 @@
 import * as E from "fp-ts/Either"
 import { describe, expect, it } from "vitest"
 
-import { hoppPostmanImporter } from "../import-export/import/postman"
+import {
+  hoppPostmanImporter,
+  replacePMVarTemplating,
+} from "../import-export/import/postman"
+
+const postmanCollectionWithNestedBraces = JSON.stringify({
+  info: {
+    name: "Nested Braces Body",
+    schema:
+      "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+  },
+  item: [
+    {
+      name: "Nested JSON body",
+      request: {
+        method: "POST",
+        header: [{ key: "Content-Type", value: "application/json" }],
+        body: {
+          mode: "raw",
+          raw: '{"id":4,"data":{"type":12,"ext":{"required":["align","style"]}}}',
+          options: { raw: { language: "json" } },
+        },
+        url: "{{serviceInternalUrl}}/api/asset",
+      },
+    },
+  ],
+})
 
 const postmanCollectionWithArrayHeader = JSON.stringify({
   info: {
@@ -30,7 +56,52 @@ const postmanCollectionWithArrayHeader = JSON.stringify({
   ],
 })
 
+describe("replacePMVarTemplating", () => {
+  it("replaces paired {{var}} with <<var>>", () => {
+    expect(replacePMVarTemplating("{{baseUrl}}/api")).toBe("<<baseUrl>>/api")
+  })
+
+  it("does not corrupt literal }} that are not part of a variable", () => {
+    expect(
+      replacePMVarTemplating('{"a":{"b":{"c":1}}}')
+    ).toBe('{"a":{"b":{"c":1}}}')
+  })
+
+  it("replaces variables but leaves standalone }} intact", () => {
+    expect(
+      replacePMVarTemplating("{{host}}/path?x=1}}")
+    ).toBe("<<host>>/path?x=1}}")
+  })
+
+  it("handles whitespace inside {{ }}", () => {
+    expect(replacePMVarTemplating("{{ myVar }}")).toBe("<<myVar>>")
+  })
+})
+
 describe("Postman importer", () => {
+  it("does not corrupt }} in raw request body (issue #6324)", async () => {
+    const result = await hoppPostmanImporter([
+      postmanCollectionWithNestedBraces,
+    ])()
+
+    expect(E.isRight(result)).toBe(true)
+
+    if (E.isLeft(result)) {
+      throw new Error("Expected Postman import to succeed")
+    }
+
+    const body = result.right[0].requests[0].body
+    expect(body.contentType).toBe("application/json")
+    // Body must be byte-identical — no }} → >> corruption
+    expect(body.body).toBe(
+      '{"id":4,"data":{"type":12,"ext":{"required":["align","style"]}}}'
+    )
+    // The variable in the URL should still be translated
+    expect(result.right[0].requests[0].endpoint).toBe(
+      "<<serviceInternalUrl>>/api/asset"
+    )
+  })
+
   it("coerces array header values instead of crashing during import", async () => {
     const result = await hoppPostmanImporter([
       postmanCollectionWithArrayHeader,

--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1028,6 +1028,38 @@ data2: {"type":"test2","typeId":"123"}`,
       responses: {},
     }),
   },
+  {
+    command: `curl 'https://api.example.com/search?q=test*&wildcard=*value*'`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://api.example.com/search",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      params: [
+        {
+          active: true,
+          key: "q",
+          value: "test*",
+          description: "",
+        },
+        {
+          active: true,
+          key: "wildcard",
+          value: "*value*",
+          description: "",
+        },
+      ],
+      headers: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
@@ -53,7 +53,7 @@ const parseURL = (urlText: string | number) =>
       u
         .toString()
         .replace(/^'|'$/g, "")
-        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>\s]/g, "")
+        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>*\s]/g, "")
     ),
     O.filter((u) => u.length > 0),
     O.chain((u) =>

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -65,7 +65,7 @@ const getCollectionSchema = (jsonStr: string): string | null => {
 
 export const replacePMVarTemplating = (value: unknown): string => {
   const str = typeof value === "string" ? value : String(value ?? "")
-  return pipe(str, S.replace(/{{\s*/g, "<<"), S.replace(/\s*}}/g, ">>"))
+  return str.replace(/{{\s*([\s\S]+?)\s*}}/g, "<<$1>>")
 }
 
 const PMRawLanguageOptionsToContentTypeMap: Record<


### PR DESCRIPTION
Fixes #6324

The `replacePMVarTemplating` helper ran two sequential regexes — one replacing every `{{` with `<<`, then a second replacing every `}}` with `>>`. The second pass had no awareness of whether the `}}` was part of a `{{varName}}` pair, so any literal `}}` in request bodies (nested JSON, regex strings, etc.) got silently rewritten.

Replaced the two-step approach with a single non-greedy paired regex:

```
/{{\s*([\s\S]+?)\s*}}/g  →  <<$1>>
```

This only rewrites complete `{{name}}` references. Bare `}}` are left alone.

Added unit tests for `replacePMVarTemplating` and an integration test with a collection that has both nested JSON braces in the body and a `{{variable}}` in the URL, to confirm both cases behave correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes corruption of literal braces in Postman imports by only translating paired `{{var}}` to `<<var>>`. Also keeps the asterisk `*` in cURL query parameters during import.

- **Bug Fixes**
  - Postman import: Replace only paired `{{ var }}` with `<<var>>` using a single non-greedy regex; standalone `}}` are preserved. Added unit tests for `replacePMVarTemplating` and an integration test covering nested JSON bodies and URL variables. Fixes #6324.
  - cURL import: Allow `*` in URL sanitization so query values like `test*` and `*value*` are not stripped. Added parser test. Fixes #6249.

<sup>Written for commit a43af1ca6c871953f165d6c32f7958e59e06874b. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6357?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

