### PR TITLE
fix(common): render grouped console output

### DIFF
--- a/packages/hoppscotch-common/src/components/console/Item.vue
+++ b/packages/hoppscotch-common/src/components/console/Item.vue
@@ -1,33 +1,59 @@
 <template>
-  <div class="console-entry-wrapper group" :class="[color, hoverClass]">
-    <component :is="icon" class="mr-2 shrink-0 svg-icons" />
-
-    <div class="flex flex-col space-y-2 text-xs flex-1 min-w-0">
-      <div class="text-secondary">{{ formattedTimestamp }}</div>
-
-      <div class="flex flex-col space-y-1">
-        <ConsoleValue
-          v-for="(arg, idx) in sanitizedArgs"
-          :key="idx"
-          :value="arg"
+  <div>
+    <div class="console-entry-wrapper group" :class="[color, hoverClass]">
+      <button
+        v-if="isGroup && hasChildren"
+        type="button"
+        class="mr-2 shrink-0"
+        aria-label="Toggle console group"
+        :aria-expanded="!isCollapsed"
+        @click="toggleGroup"
+      >
+        <component
+          :is="isCollapsed ? IconChevronRight : IconChevronDown"
+          class="svg-icons"
         />
+      </button>
+      <component v-else :is="icon" class="mr-2 shrink-0 svg-icons" />
+
+      <div class="flex flex-col space-y-2 text-xs flex-1 min-w-0">
+        <div class="text-secondary">{{ formattedTimestamp }}</div>
+
+        <div class="flex flex-col space-y-1">
+          <ConsoleValue
+            v-for="(arg, idx) in displayArgs"
+            :key="idx"
+            :value="arg"
+          />
+        </div>
       </div>
+
+      <button
+        v-tippy="{ theme: 'tooltip' }"
+        :title="t('action.copy')"
+        :aria-label="t('action.copy')"
+        class="ml-2 shrink-0 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity p-1 hover:bg-dividerLight rounded"
+        @click="copyEntry"
+      >
+        <component :is="copyIcon" class="w-4 h-4 svg-icons" />
+      </button>
     </div>
 
-    <button
-      v-tippy="{ theme: 'tooltip' }"
-      :title="t('action.copy')"
-      :aria-label="t('action.copy')"
-      class="ml-2 shrink-0 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity p-1 hover:bg-dividerLight rounded"
-      @click="copyEntry"
+    <div
+      v-if="isGroup && !isCollapsed && hasChildren"
+      class="ml-6 mt-2 space-y-2 border-l border-dividerLight pl-3"
     >
-      <component :is="copyIcon" class="w-4 h-4 svg-icons" />
-    </button>
+      <ConsoleItem
+        v-for="(child, index) in entry.children"
+        :key="index"
+        :entry="child"
+      />
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue"
+import { computed, ref } from "vue"
 import { refAutoReset } from "@vueuse/core"
 
 import IconAlertCircle from "~icons/lucide/alert-circle"
@@ -35,15 +61,25 @@ import IconAlertTriangle from "~icons/lucide/alert-triangle"
 import IconBug from "~icons/lucide/bug"
 import IconInfo from "~icons/lucide/info"
 import IconTerminal from "~icons/lucide/terminal"
+import IconChevronDown from "~icons/lucide/chevron-down"
+import IconChevronRight from "~icons/lucide/chevron-right"
+import IconClock from "~icons/lucide/clock"
 import IconCopy from "~icons/lucide/copy"
 import IconCheck from "~icons/lucide/check"
+import IconFolder from "~icons/lucide/folder"
+import IconHash from "~icons/lucide/hash"
+import IconTable from "~icons/lucide/table"
 
-import { ConsoleEntry, ConsoleLogLevel } from "./Panel.vue"
+import type { ConsoleEntry, ConsoleEntryType } from "./Panel.vue"
 import { useI18n } from "@composables/i18n"
 import { copyToClipboard } from "@helpers/utils/clipboard"
 import { useToast } from "@composables/toast"
 
-type LogLevelsWithBgColor = "info" | "warn" | "error"
+defineOptions({
+  name: "ConsoleItem",
+})
+
+type LogLevelsWithBgColor = "info" | "warn" | "error" | "assert"
 
 const props = defineProps<{
   entry: ConsoleEntry
@@ -53,26 +89,42 @@ const t = useI18n()
 const toast = useToast()
 const copyIcon = refAutoReset(IconCopy, 1000)
 
-const bgColors: Pick<Record<ConsoleLogLevel, string>, LogLevelsWithBgColor> = {
+const bgColors: Pick<Record<ConsoleEntryType, string>, LogLevelsWithBgColor> = {
   info: "bg-bannerInfo",
   warn: "bg-bannerWarning",
   error: "bg-bannerError",
+  assert: "bg-bannerError",
 }
 
-const icons: Record<ConsoleLogLevel, unknown> = {
+const icons: Partial<Record<ConsoleEntryType, unknown>> = {
   info: IconInfo,
   warn: IconAlertCircle,
   error: IconAlertTriangle,
   log: IconTerminal,
   debug: IconBug,
+  trace: IconBug,
+  count: IconHash,
+  timeEnd: IconClock,
+  timeLog: IconClock,
+  group: IconFolder,
+  assert: IconAlertTriangle,
+  dir: IconTerminal,
+  table: IconTable,
 }
 
 const color = computed(() => bgColors[props.entry.type as LogLevelsWithBgColor])
-const icon = computed(() => icons[props.entry.type])
+const icon = computed(() => icons[props.entry.type] ?? IconTerminal)
 
 // Only apply hover background for entries without semantic backgrounds (log, debug)
 const hoverClass = computed(() =>
-  props.entry.type in bgColors ? "" : "hover:bg-primaryLight"
+  color.value ? "" : "hover:bg-primaryLight"
+)
+
+const isGroup = computed(() => props.entry.type === "group")
+const hasChildren = computed(() => Boolean(props.entry.children?.length))
+const userCollapsed = ref<boolean | null>(null)
+const isCollapsed = computed(
+  () => userCollapsed.value ?? (props.entry.collapsed === true)
 )
 
 const formattedTimestamp = computed(() => {
@@ -84,6 +136,20 @@ const sanitizeArg = (arg: unknown): unknown =>
   typeof arg === "bigint" ? `${arg}n` : arg
 
 const sanitizedArgs = computed(() => props.entry.args.map(sanitizeArg))
+
+const displayArgs = computed(() => {
+  if (isGroup.value && sanitizedArgs.value.length === 0) {
+    return [props.entry.collapsed ? "console.groupCollapsed" : "console.group"]
+  }
+
+  return sanitizedArgs.value
+})
+
+const toggleGroup = () => {
+  if (hasChildren.value) {
+    userCollapsed.value = !isCollapsed.value
+  }
+}
 
 // Serialize value for clipboard copy
 const serializeConsoleValue = (value: unknown): string => {
@@ -109,7 +175,7 @@ const serializeConsoleValue = (value: unknown): string => {
 }
 
 const copyEntry = () => {
-  const content = sanitizedArgs.value.map(serializeConsoleValue).join(" ")
+  const content = displayArgs.value.map(serializeConsoleValue).join(" ")
 
   copyToClipboard(content)
   copyIcon.value = IconCheck

--- a/packages/hoppscotch-common/src/components/console/Panel.vue
+++ b/packages/hoppscotch-common/src/components/console/Panel.vue
@@ -29,12 +29,29 @@ import { computed } from "vue"
 import { useI18n } from "~/composables/i18n"
 import { useColorMode } from "~/composables/theming"
 
-export type ConsoleLogLevel = "log" | "warn" | "info" | "error" | "debug"
+export type ConsoleEntryType =
+  | "log"
+  | "warn"
+  | "info"
+  | "error"
+  | "debug"
+  | "trace"
+  | "count"
+  | "timeEnd"
+  | "timeLog"
+  | "group"
+  | "groupEnd"
+  | "clear"
+  | "assert"
+  | "dir"
+  | "table"
 
 export type ConsoleEntry = {
-  type: ConsoleLogLevel
+  type: ConsoleEntryType
   args: unknown[]
   timestamp: number
+  collapsed?: boolean
+  children?: ConsoleEntry[]
 }
 
 const props = defineProps<{
@@ -44,12 +61,47 @@ const props = defineProps<{
 const colorMode = useColorMode()
 const t = useI18n()
 
-// Filter out "clear" and compute final list to show (simulate console.clear)
 const renderedMessages = computed(() => {
   const output: ConsoleEntry[] = []
-  for (const entry of props.messages) {
+
+  const groupStack: ConsoleEntry[] = []
+  const appendEntry = (entry: ConsoleEntry) => {
+    const currentGroup = groupStack[groupStack.length - 1]
+
+    if (currentGroup) {
+      currentGroup.children?.push(entry)
+      return
+    }
+
     output.push(entry)
   }
+
+  for (const entry of props.messages) {
+    if (entry.type === "clear") {
+      output.length = 0
+      groupStack.length = 0
+      continue
+    }
+
+    if (entry.type === "group") {
+      const groupEntry: ConsoleEntry = {
+        ...entry,
+        children: [],
+      }
+
+      appendEntry(groupEntry)
+      groupStack.push(groupEntry)
+      continue
+    }
+
+    if (entry.type === "groupEnd") {
+      groupStack.pop()
+      continue
+    }
+
+    appendEntry(entry)
+  }
+
   return output
 })
 </script>

--- a/packages/hoppscotch-common/src/components/console/Value.vue
+++ b/packages/hoppscotch-common/src/components/console/Value.vue
@@ -16,7 +16,9 @@
       >{{ formattedJSONString }}
     </pre>
 
-    <pre v-else class="truncate select-text"
+    <pre
+      v-else
+      class="max-h-96 overflow-auto whitespace-pre-wrap break-words select-text"
       >{{ formattedPrimitive }}
     </pre>
   </div>

--- a/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
@@ -168,9 +168,7 @@ const consoleEntries = computed(() => {
     return []
   }
 
-  return doc.value.testResults?.consoleEntries.filter(({ type }) =>
-    ["log", "warn", "debug", "error", "info"].includes(type)
-  ) as ConsoleEntry[]
+  return doc.value.testResults?.consoleEntries as ConsoleEntry[]
 })
 
 watch(

--- a/packages/hoppscotch-js-sandbox/src/__tests__/console.spec.ts
+++ b/packages/hoppscotch-js-sandbox/src/__tests__/console.spec.ts
@@ -1,0 +1,73 @@
+import { getDefaultRESTRequest } from "@hoppscotch/data"
+import { describe, expect, test } from "vitest"
+
+import { runPreRequestScript } from "~/web"
+
+describe("console output capture", () => {
+  test("captures grouping, table, clear, and multiline log entries", () => {
+    return expect(
+      runPreRequestScript(
+        `
+        console.log("before clear")
+        console.clear()
+        console.group("outer")
+        console.log("line 1\\nline 2")
+        console.groupCollapsed("nested")
+        console.table([{ name: "alpha", enabled: true }])
+        console.groupEnd()
+        console.groupEnd()
+        console.assert(true, "should not be captured")
+        console.assert(false, "should be captured")
+        `,
+        {
+          envs: { global: [], selected: [] },
+          request: getDefaultRESTRequest(),
+          cookies: null,
+          experimentalScriptingSandbox: true,
+        }
+      )
+    ).resolves.toEqualRight(
+      expect.objectContaining({
+        consoleEntries: [
+          expect.objectContaining({
+            type: "log",
+            args: ["before clear"],
+          }),
+          expect.objectContaining({
+            type: "clear",
+            args: [],
+          }),
+          expect.objectContaining({
+            type: "group",
+            args: ["outer"],
+          }),
+          expect.objectContaining({
+            type: "log",
+            args: ["line 1\nline 2"],
+          }),
+          expect.objectContaining({
+            type: "group",
+            args: ["nested"],
+            collapsed: true,
+          }),
+          expect.objectContaining({
+            type: "table",
+            args: [[{ name: "alpha", enabled: true }]],
+          }),
+          expect.objectContaining({
+            type: "groupEnd",
+            args: [],
+          }),
+          expect.objectContaining({
+            type: "groupEnd",
+            args: [],
+          }),
+          expect.objectContaining({
+            type: "assert",
+            args: ["should be captured"],
+          }),
+        ],
+      })
+    )
+  })
+})

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/default.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/default.ts
@@ -1,22 +1,32 @@
 import {
   blobPolyfill,
-  ConsoleEntry,
   console as ConsoleModule,
   encoding,
   esmModuleLoader,
   timers,
   urlPolyfill,
 } from "faraday-cage/modules"
-import type { HoppFetchHook } from "~/types"
+import type { HoppFetchHook, SandboxConsoleEntry } from "~/types"
 import { customCryptoModule } from "./crypto"
 import { customFetchModule } from "./fetch"
 
 type DefaultModulesConfig = {
-  handleConsoleEntry?: (consoleEntries: ConsoleEntry) => void
+  handleConsoleEntry?: (consoleEntry: SandboxConsoleEntry) => void
   hoppFetchHook?: HoppFetchHook
 }
 
 export const defaultModules = (config?: DefaultModulesConfig) => {
+  const emitConsoleEntry = (
+    entry: Omit<SandboxConsoleEntry, "timestamp">
+  ) => {
+    if (config?.handleConsoleEntry) {
+      config.handleConsoleEntry({
+        ...entry,
+        timestamp: Date.now(),
+      })
+    }
+  }
+
   return [
     urlPolyfill,
     blobPolyfill,
@@ -24,40 +34,115 @@ export const defaultModules = (config?: DefaultModulesConfig) => {
       onLog(level, ...args) {
         console[level](...args)
 
-        if (config?.handleConsoleEntry) {
-          config.handleConsoleEntry({
-            type: level,
-            args,
-            timestamp: Date.now(),
+        emitConsoleEntry({
+          type: level,
+          args,
+        })
+      },
+      onCount(label: string | undefined, count: number) {
+        const displayLabel = label ?? "default"
+
+        if (label === undefined) {
+          console.count()
+        } else {
+          console.count(label)
+        }
+
+        emitConsoleEntry({
+          type: "count",
+          args: [displayLabel, count],
+        })
+      },
+      onTime(label: string | undefined, duration: number) {
+        const displayLabel = label ?? "default"
+
+        if (label === undefined) {
+          console.timeEnd()
+        } else {
+          console.timeEnd(label)
+        }
+
+        emitConsoleEntry({
+          type: "timeEnd",
+          args: [`${displayLabel}: ${duration}ms`],
+        })
+      },
+      onTimeLog(
+        label: string | undefined,
+        duration: number,
+        ...args: unknown[]
+      ) {
+        const displayLabel = label ?? "default"
+
+        if (label === undefined) {
+          console.timeLog()
+        } else {
+          console.timeLog(label, ...args)
+        }
+
+        emitConsoleEntry({
+          type: "timeLog",
+          args: [`${displayLabel}: ${duration}ms`, ...args],
+        })
+      },
+      onGroup(label, collapsed) {
+        if (collapsed) {
+          if (label === undefined) {
+            console.groupCollapsed()
+          } else {
+            console.groupCollapsed(label)
+          }
+        } else {
+          if (label === undefined) {
+            console.group()
+          } else {
+            console.group(label)
+          }
+        }
+
+        emitConsoleEntry({
+          type: "group",
+          args: label === undefined ? [] : [label],
+          collapsed,
+        })
+      },
+      onGroupEnd() {
+        console.groupEnd()
+        emitConsoleEntry({
+          type: "groupEnd",
+          args: [],
+        })
+      },
+      onClear() {
+        console.clear()
+        emitConsoleEntry({
+          type: "clear",
+          args: [],
+        })
+      },
+      onAssert(condition, ...args) {
+        console.assert(condition, ...args)
+
+        if (!condition) {
+          emitConsoleEntry({
+            type: "assert",
+            args: args.length > 0 ? args : ["Assertion failed"],
           })
         }
       },
-      onCount(...args) {
-        console.count(args[0])
+      onDir(obj, options) {
+        console.dir(obj, options)
+        emitConsoleEntry({
+          type: "dir",
+          args: [obj],
+        })
       },
-      onTime(...args) {
-        console.timeEnd(args[0])
-      },
-      onTimeLog(...args) {
-        console.timeLog(...args)
-      },
-      onGroup(...args) {
-        console.group(...args)
-      },
-      onGroupEnd(...args) {
-        console.groupEnd(...args)
-      },
-      onClear(...args) {
-        console.clear(...args)
-      },
-      onAssert(...args) {
-        console.assert(...args)
-      },
-      onDir(...args) {
-        console.dir(...args)
-      },
-      onTable(...args) {
-        console.table(...args)
+      onTable(tabularData, properties) {
+        console.table(tabularData, properties)
+        emitConsoleEntry({
+          type: "table",
+          args: properties ? [tabularData, properties] : [tabularData],
+        })
       },
     }),
     customCryptoModule({

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -162,16 +162,20 @@ export type TestResult = {
 export type GlobalEnvItem = TestResult["envs"]["global"][number]
 export type SelectedEnvItem = TestResult["envs"]["selected"][number]
 
+export type SandboxConsoleEntry = ConsoleEntry & {
+  collapsed?: boolean
+}
+
 export type SandboxTestResult = {
   tests: TestDescriptor
   envs: TestResult["envs"]
-  consoleEntries?: ConsoleEntry[]
+  consoleEntries?: SandboxConsoleEntry[]
   updatedCookies: Cookie[] | null
 }
 
 export type SandboxPreRequestResult = {
   updatedEnvs: TestResult["envs"]
-  consoleEntries?: ConsoleEntry[]
+  consoleEntries?: SandboxConsoleEntry[]
   updatedRequest?: HoppRESTRequest
   updatedCookies: Cookie[] | null
 }


### PR DESCRIPTION
Closes #6048

Adds support for grouped console output in the Hoppscotch console panel.

### What's changed
- Captures non-log console events from the sandbox, including group/groupEnd, groupCollapsed, table, clear, count, time, assert, and dir
- Renders console groups as nested collapsible entries
- Preserves multiline string output in console values
- Shows table/dir/count/time entries in the Console tab
- Adds a regression test for grouped, table, clear, and multiline logs

### Notes to reviewers
- `console.clear()` is handled in the renderer by clearing previous visible entries
- Verified `git diff --check`
- Tried running `npm --prefix packages/hoppscotch-js-sandbox run test -- console.spec.ts`, but local dependencies are not installed, so `vitest` was unavailable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render grouped console output in the Console panel with nested, collapsible groups and clearer icons. Captures more console APIs, preserves multiline output, and honors console.clear.

- **New Features**
  - Capture and emit non-log console events from `hoppscotch-js-sandbox` with normalized payloads: `group` (with `collapsed`)/`groupEnd`, `table`, `dir`, `count`, `timeEnd`/`timeLog`, `assert` (only on failure), `clear`.
  - Build a grouped tree and render nested groups with toggle chevrons and appropriate icons; copy uses the visible text.
  - Preserve multiline strings and let long values scroll instead of truncating.
  - Show all console entry types in the Console tab and clear previous entries on `console.clear()`; added a regression test for groups, table, clear, assert, and multiline logs.

<sup>Written for commit 6cbe3af4f110e1ad62e51f05714016d0fef18c36. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6364?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

