### PR TITLE
test(curl): add testcase to verify asterisk preserving in URL parse

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/url.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/url.spec.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from "vitest"
+import { getURLObject } from "../sub_helpers/url"
+
+describe("curl URL parsing - asterisk preservation", () => {
+  test("preserves asterisk in query param value", () => {
+    const parsedArguments: any = {
+      _: ["node", "https://example.com/path?code=14402976*"],
+    }
+
+    const urlObj = getURLObject(parsedArguments)
+
+    expect(urlObj.searchParams.get("code")).toBe("14402976*")
+  })
+
+  test("preserves asterisks when URL is wrapped in single quotes", () => {
+    const parsedArguments: any = {
+      _: ["node", "'https://example.com/path?token=*abc*'"],
+    }
+
+    const urlObj = getURLObject(parsedArguments)
+
+    expect(urlObj.searchParams.get("token")).toBe("*abc*")
+  })
+})


### PR DESCRIPTION
### Summary
A new unit test has been added that assert asterisks in URL query parameter values are preserved when importing cURL commands.

The purpose is to validates the behavior fixed in #6353 (fix(curl-import): preserve asterisk, dollar sign and other RFC 3986 url characters). These tests ensure * is not stripped from query values.

### What's changed
A new unit test has been added to the corresponding directory where the asterisk problem is addressed.

### Notes to reviewers
This PR only adds tests and does not change any other code. If this PR merged before the fix in #6353 lands, the tests will fail until the fix is merged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests to ensure the cURL URL parser preserves asterisks in query parameter values, including when the URL is wrapped in single quotes. Confirms params like code=14402976* and token=*abc* are kept intact.

<sup>Written for commit 817abd6c4a978fcdeaa532be49eae8fc807e7711. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6366?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

