### PR TITLE
test(common): add unit tests for isNumeric utility function

### DIFF
--- a/packages/hoppscotch-common/src/helpers/utils/__tests__/number.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/__tests__/number.spec.ts
@@ -18,6 +18,13 @@ describe("isNumeric", () => {
     expect(isNumeric("42")).toBe(true)
     expect(isNumeric("-1")).toBe(true)
     expect(isNumeric("3.14")).toBe(true)
+    expect(isNumeric(" 42 ")).toBe(true)
+  })
+
+  test("returns true for Infinity values", () => {
+    expect(isNumeric(Infinity)).toBe(true)
+    expect(isNumeric(-Infinity)).toBe(true)
+    expect(isNumeric("Infinity")).toBe(true)
   })
 
   test("returns false for NaN", () => {

--- a/packages/hoppscotch-common/src/helpers/utils/__tests__/number.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/__tests__/number.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest"
+import { isNumeric } from "../number"
+
+describe("isNumeric", () => {
+  test("returns true for integers", () => {
+    expect(isNumeric(0)).toBe(true)
+    expect(isNumeric(42)).toBe(true)
+    expect(isNumeric(-1)).toBe(true)
+  })
+
+  test("returns true for floating point numbers", () => {
+    expect(isNumeric(3.14)).toBe(true)
+    expect(isNumeric(-0.5)).toBe(true)
+  })
+
+  test("returns true for numeric strings", () => {
+    expect(isNumeric("0")).toBe(true)
+    expect(isNumeric("42")).toBe(true)
+    expect(isNumeric("-1")).toBe(true)
+    expect(isNumeric("3.14")).toBe(true)
+  })
+
+  test("returns false for NaN", () => {
+    expect(isNumeric(NaN)).toBe(false)
+  })
+
+  test("returns false for empty and whitespace strings", () => {
+    expect(isNumeric("")).toBe(false)
+    expect(isNumeric(" ")).toBe(false)
+    expect(isNumeric("  ")).toBe(false)
+  })
+
+  test("returns false for non-numeric strings", () => {
+    expect(isNumeric("abc")).toBe(false)
+    expect(isNumeric("12abc")).toBe(false)
+  })
+
+  test("returns false for non-string non-number types", () => {
+    expect(isNumeric(null)).toBe(false)
+    expect(isNumeric(undefined)).toBe(false)
+    expect(isNumeric(true)).toBe(false)
+    expect(isNumeric({})).toBe(false)
+    expect(isNumeric([])).toBe(false)
+  })
+})


### PR DESCRIPTION
### What's changed
- Added unit tests for the `isNumeric` utility function in `packages/hoppscotch-common/src/helpers/utils/number.ts`
- Tests cover integers, floating point numbers, numeric strings, NaN, empty/whitespace strings, non-numeric strings, and non-string/non-number types (null, undefined, boolean, object, array)
- `isNumeric` is used in OpenAPI import logic to validate response status codes but had no test coverage

### Notes to reviewers
This PR only adds tests and does not change any existing code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `isNumeric` in `packages/hoppscotch-common/src/helpers/utils/number.ts`, covering integers, floats, numeric strings (incl. whitespace-padded), Infinity, NaN, empty/whitespace-only, and non-numeric types. Improves confidence in OpenAPI import status code validation; no runtime changes.

<sup>Written for commit 913187cc13aaeb0ebacfb00dee5c067290278194. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6367?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

