### PR TITLE
fix(common): add PKCE crypto fallback

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/pkce.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/pkce.spec.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+import { createPKCECodeChallenge } from "../pkce"
+
+const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+const challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+describe("createPKCECodeChallenge", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test("returns the verifier for plain PKCE", async () => {
+    await expect(createPKCECodeChallenge(verifier, "plain")).resolves.toBe(
+      verifier
+    )
+  })
+
+  test("generates the RFC 7636 S256 challenge", async () => {
+    await expect(createPKCECodeChallenge(verifier, "S256")).resolves.toBe(
+      challenge
+    )
+  })
+
+  test("generates S256 challenge without crypto.subtle", async () => {
+    vi.stubGlobal("crypto", {})
+
+    await expect(createPKCECodeChallenge(verifier, "S256")).resolves.toBe(
+      challenge
+    )
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/oauth.ts
+++ b/packages/hoppscotch-common/src/helpers/oauth.ts
@@ -5,6 +5,7 @@ import { getService } from "~/modules/dioc"
 import { PersistenceService } from "~/services/persistence"
 import { KernelInterceptorService } from "~/services/kernel-interceptor.service"
 import { content } from "@hoppscotch/kernel"
+import { createPKCECodeChallenge } from "./pkce"
 
 const kernelInterceptor = getService(KernelInterceptorService)
 const persistenceService = getService(PersistenceService)
@@ -47,21 +48,6 @@ const generateRandomString = () => {
   return Array.from(array, (dec) => `0${dec.toString(16)}`.slice(-2)).join("")
 }
 
-const base64urlencode = (str: ArrayBuffer) => {
-  const hashArray = Array.from(new Uint8Array(str))
-  return btoa(String.fromCharCode.apply(null, hashArray))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "")
-}
-
-const pkceChallengeFromVerifier = async (v: string) => {
-  const encoder = new TextEncoder()
-  const data = encoder.encode(v)
-  const hashed = await window.crypto.subtle.digest("SHA-256", data)
-  return base64urlencode(hashed)
-}
-
 export const tokenRequest = async ({
   oidcDiscoveryUrl,
   grantType,
@@ -98,7 +84,7 @@ export const tokenRequest = async ({
   const codeVerifier = generateRandomString()
   await persistenceService.setLocalConfig("pkce_codeVerifier", codeVerifier)
 
-  const codeChallenge = await pkceChallengeFromVerifier(codeVerifier)
+  const codeChallenge = await createPKCECodeChallenge(codeVerifier, "S256")
 
   const url = new URL(authUrl)
   url.searchParams.set("response_type", grantType)

--- a/packages/hoppscotch-common/src/helpers/pkce.ts
+++ b/packages/hoppscotch-common/src/helpers/pkce.ts
@@ -1,0 +1,132 @@
+const SHA_256_INITIAL_HASH = [
+  0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f,
+  0x9b05688c, 0x1f83d9ab, 0x5be0cd19,
+]
+
+const SHA_256_K = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b,
+  0x59f111f1, 0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01,
+  0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7,
+  0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc,
+  0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152,
+  0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+  0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+  0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819,
+  0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116, 0x1e376c08,
+  0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f,
+  0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+  0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]
+
+export type PKCECodeVerifierMethod = "plain" | "S256"
+
+const rightRotate = (value: number, bits: number) =>
+  (value >>> bits) | (value << (32 - bits))
+
+const sha256Fallback = (data: Uint8Array) => {
+  const bitLength = data.length * 8
+  const paddedLength = Math.ceil((data.length + 9) / 64) * 64
+  const padded = new Uint8Array(paddedLength)
+
+  padded.set(data)
+  padded[data.length] = 0x80
+
+  const paddedView = new DataView(padded.buffer)
+  paddedView.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000))
+  paddedView.setUint32(paddedLength - 4, bitLength >>> 0)
+
+  const hash = [...SHA_256_INITIAL_HASH]
+  const words = new Uint32Array(64)
+
+  for (let offset = 0; offset < paddedLength; offset += 64) {
+    for (let i = 0; i < 16; i++) {
+      words[i] = paddedView.getUint32(offset + i * 4)
+    }
+
+    for (let i = 16; i < 64; i++) {
+      const s0 =
+        rightRotate(words[i - 15], 7) ^
+        rightRotate(words[i - 15], 18) ^
+        (words[i - 15] >>> 3)
+      const s1 =
+        rightRotate(words[i - 2], 17) ^
+        rightRotate(words[i - 2], 19) ^
+        (words[i - 2] >>> 10)
+
+      words[i] = (words[i - 16] + s0 + words[i - 7] + s1) >>> 0
+    }
+
+    let [a, b, c, d, e, f, g, h] = hash
+
+    for (let i = 0; i < 64; i++) {
+      const s1 = rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25)
+      const ch = (e & f) ^ (~e & g)
+      const temp1 = (h + s1 + ch + SHA_256_K[i] + words[i]) >>> 0
+      const s0 = rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22)
+      const maj = (a & b) ^ (a & c) ^ (b & c)
+      const temp2 = (s0 + maj) >>> 0
+
+      h = g
+      g = f
+      f = e
+      e = (d + temp1) >>> 0
+      d = c
+      c = b
+      b = a
+      a = (temp1 + temp2) >>> 0
+    }
+
+    hash[0] = (hash[0] + a) >>> 0
+    hash[1] = (hash[1] + b) >>> 0
+    hash[2] = (hash[2] + c) >>> 0
+    hash[3] = (hash[3] + d) >>> 0
+    hash[4] = (hash[4] + e) >>> 0
+    hash[5] = (hash[5] + f) >>> 0
+    hash[6] = (hash[6] + g) >>> 0
+    hash[7] = (hash[7] + h) >>> 0
+  }
+
+  const digest = new ArrayBuffer(32)
+  const digestView = new DataView(digest)
+
+  hash.forEach((value, index) => {
+    digestView.setUint32(index * 4, value)
+  })
+
+  return digest
+}
+
+export const sha256 = (data: Uint8Array) => {
+  const subtle = globalThis.crypto?.subtle
+
+  if (subtle?.digest) {
+    return subtle.digest("SHA-256", data)
+  }
+
+  return Promise.resolve(sha256Fallback(data))
+}
+
+export const encodeArrayBufferAsUrlEncodedBase64 = (buffer: ArrayBuffer) => {
+  const hashArray = Array.from(new Uint8Array(buffer))
+  const hashBase64URL = btoa(String.fromCharCode(...hashArray))
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+
+  return hashBase64URL
+}
+
+export const createPKCECodeChallenge = async (
+  codeVerifier: string,
+  strategy: PKCECodeVerifierMethod
+) => {
+  if (strategy === "plain") {
+    return codeVerifier
+  }
+
+  const data = new TextEncoder().encode(codeVerifier)
+  const buffer = await sha256(data)
+
+  return encodeArrayBufferAsUrlEncodedBase64(buffer)
+}

--- a/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
@@ -10,6 +10,7 @@ import { z } from "zod"
 import { getService } from "~/modules/dioc"
 import * as E from "fp-ts/Either"
 import { KernelInterceptorService } from "~/services/kernel-interceptor.service"
+import { createPKCECodeChallenge } from "~/helpers/pkce"
 import { content } from "@hoppscotch/kernel"
 import { refreshToken, OAuth2ParamSchema } from "../utils"
 import {
@@ -332,28 +333,7 @@ const generateCodeVerifier = () => {
 const generateCodeChallenge = async (
   codeVerifier: string,
   strategy: AuthCodeOauthFlowParams["codeVerifierMethod"]
-) => {
-  if (strategy === "plain") {
-    return codeVerifier
-  }
-
-  const encoder = new TextEncoder()
-  const data = encoder.encode(codeVerifier)
-
-  const buffer = await crypto.subtle.digest("SHA-256", data)
-
-  return encodeArrayBufferAsUrlEncodedBase64(buffer)
-}
-
-const encodeArrayBufferAsUrlEncodedBase64 = (buffer: ArrayBuffer) => {
-  const hashArray = Array.from(new Uint8Array(buffer))
-  const hashBase64URL = btoa(String.fromCharCode(...hashArray))
-    .replace(/=/g, "")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-
-  return hashBase64URL
-}
+) => createPKCECodeChallenge(codeVerifier, strategy ?? "plain")
 
 export default createFlowConfig(
   "AUTHORIZATION_CODE" as const,


### PR DESCRIPTION
Closes #6287

Adds a fallback for PKCE S256 challenge generation when `crypto.subtle` is unavailable in the desktop OAuth context.

### What's changed
- Moved PKCE challenge generation into a shared helper
- Uses WebCrypto SHA-256 when available
- Falls back to a local SHA-256 implementation when `crypto.subtle` is missing
- Reuses the helper in OAuth login and OAuth2 auth-code flow
- Adds RFC 7636 regression coverage for plain, S256, and no-crypto.subtle paths

### Notes to reviewers
- Verified the RFC 7636 PKCE vector with and without `crypto.subtle`
- Verified `git diff --check`
- Could not run Vitest locally because dependencies are not installed (`vitest` unavailable)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PKCE S256 challenge fallback when `crypto.subtle` is unavailable. Fixes OAuth sign-in on desktop and keeps PKCE compliant with RFC 7636.

- **Bug Fixes**
  - Centralized PKCE challenge creation in a new `createPKCECodeChallenge` helper and reused it in OAuth login and OAuth2 auth-code flow.
  - Uses WebCrypto SHA-256 when available; falls back to a local SHA-256 implementation otherwise.
  - Added unit tests for plain, S256, and no-`crypto.subtle` paths.

<sup>Written for commit baf4265e23e24e44b0f04bd7417186e57e7f2703. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6371?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

