### PR TITLE
feat: improve network error message for first-time users

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -672,7 +672,7 @@
   "error": {
     "network": {
       "heading": "Network Error",
-      "description": "Network request failed. This may be caused by CORS restrictions, an invalid domain, internet connectivity issues, or the server not responding."
+      "description": "Network request failed. Possible causes include CORS restrictions, invalid domains, connectivity issues, or server unavailability. {message}: {cause}"
     },
     "timeout": {
       "heading": "Timeout Error",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -672,7 +672,7 @@
   "error": {
     "network": {
       "heading": "Network Error",
-      "description": "Network connection failed. {message}: {cause}"
+      "description": "Network request failed. This may be caused by CORS restrictions, an invalid domain, internet connectivity issues, or the server not responding."
     },
     "timeout": {
       "heading": "Timeout Error",


### PR DESCRIPTION
## What does this PR do?

Improves the network error message shown to users when requests fail.

## Why?

The previous message was generic and difficult for first-time users to understand. This update provides more helpful context about possible causes such as:

* CORS restrictions
* Invalid domains
* Internet connectivity issues
* Server unavailability

## Changes made

* Updated network error description to be more beginner-friendly and informative.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the "Network Error" message to list common causes (CORS, invalid domain, connectivity issues, server unavailability) and preserve `{message}` and `{cause}` details for easier troubleshooting.
Revised the `error.network.description` string in `packages/hoppscotch-common/locales/en.json`.

<sup>Written for commit 8bbf5c776e621d8338a779650fbf4961a452ee1b. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6372?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

