### PR TITLE
fix: class validation issue for updateRESTUserRequest

### DIFF
--- a/packages/hoppscotch-backend/src/user-request/input-type.args.ts
+++ b/packages/hoppscotch-backend/src/user-request/input-type.args.ts
@@ -73,6 +73,13 @@ export class CreateUserRequestArgs {
 
 @ArgsType()
 export class UpdateUserRequestArgs {
+  @Field(() => ID, {
+    description: 'ID of the user request',
+  })
+  @IsString()
+  @IsNotEmpty()
+  id: string;
+
   @Field({
     nullable: true,
     defaultValue: undefined,

--- a/packages/hoppscotch-backend/src/user-request/resolvers/user-request.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-request/resolvers/user-request.resolver.ts
@@ -146,16 +146,10 @@ export class UserRequestResolver {
   @UseGuards(GqlAuthGuard)
   async updateRESTUserRequest(
     @GqlUser() user: AuthUser,
-    @Args({
-      name: 'id',
-      description: 'ID of the user REST request',
-      type: () => ID,
-    })
-    id: string,
     @Args() args: UpdateUserRequestArgs,
   ) {
     const request = await this.userRequestService.updateRequest(
-      id,
+      args.id,
       args.title,
       ReqType.REST,
       args.request,
@@ -171,16 +165,10 @@ export class UserRequestResolver {
   @UseGuards(GqlAuthGuard)
   async updateGQLUserRequest(
     @GqlUser() user: AuthUser,
-    @Args({
-      name: 'id',
-      description: 'ID of the user GraphQL request',
-      type: () => ID,
-    })
-    id: string,
     @Args() args: UpdateUserRequestArgs,
   ) {
     const request = await this.userRequestService.updateRequest(
-      id,
+      args.id,
       args.title,
       ReqType.GQL,
       args.request,

--- a/packages/hoppscotch-backend/src/user-request/user-request.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-request/user-request.service.spec.ts
@@ -379,6 +379,7 @@ describe('UserRequestService', () => {
       const id = userRequests[0].id;
       const type = userRequests[0].type;
       const args: UpdateUserRequestArgs = {
+        id,
         title: userRequests[0].title,
         request: userRequests[0].request,
       };
@@ -401,6 +402,7 @@ describe('UserRequestService', () => {
       const id = userRequests[0].id;
       const type = userRequests[0].type;
       const args: UpdateUserRequestArgs = {
+        id,
         title: userRequests[0].title,
         request: userRequests[0].request,
       };
@@ -420,7 +422,7 @@ describe('UserRequestService', () => {
       expect(mockPrisma.userRequest.update).toHaveBeenCalledWith({
         where: { id },
         data: {
-          ...args,
+          title: args.title,
           request: JSON.parse(args.request),
         },
       });
@@ -429,6 +431,7 @@ describe('UserRequestService', () => {
       const id = userRequests[0].id;
       const type = userRequests[0].type;
       const args: UpdateUserRequestArgs = {
+        id,
         title: userRequests[0].title,
         request: userRequests[0].request,
       };
@@ -454,6 +457,7 @@ describe('UserRequestService', () => {
       const id = userRequests[0].id;
       const type = userRequests[0].type;
       const args: UpdateUserRequestArgs = {
+        id,
         title: userRequests[0].title,
         request: userRequests[0].request,
       };
@@ -474,6 +478,7 @@ describe('UserRequestService', () => {
       const id = userRequests[0].id;
       const type = userRequests[0].type;
       const args: UpdateUserRequestArgs = {
+        id,
         title: userRequests[0].title,
         request: 'invalid json',
       };


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
This PR fix `class-validation` related issue while updating requests.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes class-validation for update requests by moving the request ID into `UpdateUserRequestArgs` and using it in both resolvers. Updates tests and keeps REST/GQL update signatures consistent with a validated `id`.

- **Bug Fixes**
  - Added `id` field to `UpdateUserRequestArgs` with `@IsString()` and `@IsNotEmpty()`.
  - Switched REST/GQL resolvers and tests to use `args.id`; update payload includes only `title` and parsed `request`.

<sup>Written for commit 9fb9b14d79069b5d657de5badea6af860330ef9c. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6373?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

