### PR TITLE
 feat(common): add translation item for `All Topics`

### DIFF
--- a/packages/hoppscotch-common/locales/cn.json
+++ b/packages/hoppscotch-common/locales/cn.json
@@ -1061,6 +1061,7 @@
     "qos": "QoS",
     "ssl": "SSL",
     "subscribe": "订阅",
+    "all_topics": "所有主题",
     "topic": "主题",
     "topic_name": "主题名称",
     "topic_title": "发布/订阅主题",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1071,6 +1071,7 @@
     "qos": "QoS",
     "ssl": "SSL",
     "subscribe": "Subscribe",
+    "all_topics": "All Topics",
     "topic": "Topic",
     "topic_name": "Topic Name",
     "topic_title": "Publish / Subscribe topic",

--- a/packages/hoppscotch-common/src/newstore/MQTTSession.ts
+++ b/packages/hoppscotch-common/src/newstore/MQTTSession.ts
@@ -1,5 +1,6 @@
 import { distinctUntilChanged, pluck } from "rxjs/operators"
 import DispatchingStore, { defineDispatchers } from "./DispatchingStore"
+import { getI18n } from "~/modules/i18n"
 import { MQTTConnection } from "~/helpers/realtime/MQTTConnection"
 import {
   HoppRealtimeLog,
@@ -28,6 +29,8 @@ type HoppMQTTSession = {
   currentTabId: string
 }
 
+const t = getI18n()
+
 const defaultMQTTRequest: HoppMQTTRequest = {
   endpoint: "wss://test.mosquitto.org:8081",
   clientID: "hoppscotch",
@@ -35,7 +38,7 @@ const defaultMQTTRequest: HoppMQTTRequest = {
 
 const defaultTab: MQTTTab = {
   id: "all",
-  name: "All Topics",
+  name: t("mqtt.all_topics"),
   color: "var(--accent-color)",
   removable: false,
   logs: [],


### PR DESCRIPTION
Changes:

- Convert `All Topics` hardcoded string to an i18n key in MQTTSession.ts 
- Add en and cn translations for the `all_topics` key

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hardcoded "All Topics" label for the default MQTT tab with a localized string to support i18n.

Added `mqtt.all_topics` to `en.json` and `cn.json`, and set the tab name using `getI18n()` in `MQTTSession.ts`.

<sup>Written for commit 168e16f2454888d2635951245a4844790ecc3070. Summary will update on new commits. <a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6374?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

