### PR TITLE
test(cli): await rejects assertions in getters tests

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -225,26 +225,29 @@ describe("getters", () => {
         },
       ];
 
-      test.each(cases)("$description", ({ args, axiosMock, expected }) => {
-        const { code, response } = axiosMock;
-        const axiosErrMessage = code ?? response?.data?.reason;
+      test.each(cases)(
+        "$description",
+        async ({ args, axiosMock, expected }) => {
+          const { code, response } = axiosMock;
+          const axiosErrMessage = code ?? response?.data?.reason;
 
-        vi.spyOn(axios, "get").mockImplementation(() =>
-          Promise.reject(
-            new AxiosError(
-              axiosErrMessage,
-              code,
-              undefined,
-              undefined,
-              response as AxiosResponse
+          vi.spyOn(axios, "get").mockImplementation(() =>
+            Promise.reject(
+              new AxiosError(
+                axiosErrMessage,
+                code,
+                undefined,
+                undefined,
+                response as AxiosResponse
+              )
             )
-          )
-        );
+          );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
-      });
+          await expect(getResourceContents(args)).rejects.toEqual(expected);
+        }
+      );
 
-      test("Promise rejects with the code `INVALID_SERVER_URL` if the network call succeeds and the received response content type is not `application/json`", () => {
+      test("Promise rejects with the code `INVALID_SERVER_URL` if the network call succeeds and the received response content type is not `application/json`", async () => {
         const expected = {
           code: "INVALID_SERVER_URL",
           data: args.serverUrl,
@@ -257,10 +260,10 @@ describe("getters", () => {
           })
         );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
 
-      test("Promise rejects with the code `UNKNOWN_ERROR` while encountering an error that is not an instance of `AxiosError`", () => {
+      test("Promise rejects with the code `UNKNOWN_ERROR` while encountering an error that is not an instance of `AxiosError`", async () => {
         const expected = {
           code: "UNKNOWN_ERROR",
           data: new Error("UNKNOWN_ERROR"),
@@ -270,7 +273,7 @@ describe("getters", () => {
           Promise.reject(new Error("UNKNOWN_ERROR"))
         );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
     });
 


### PR DESCRIPTION
## Summary

While investigating the CLI test suite, I noticed a few Vitest warnings in `getters.spec.ts` caused by un-awaited `expect(...).rejects` assertions.

This PR updates those tests to properly await the assertions and marks the affected test callbacks as `async`.

## Changes

* Added `await` to `expect(...).rejects.toEqual(...)` assertions
* Marked the relevant test cases as `async`

## Verification

* Ran the CLI test suite using:

  `pnpm --filter @hoppscotch/cli test`

* All tests pass successfully

* The Vitest warnings related to un-awaited `rejects` assertions are no longer emitted

Related to #4136


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes un-awaited `expect(...).rejects` assertions in the `@hoppscotch/cli` getters tests by adding `await` and marking the tests `async`. Removes Vitest warnings and ensures rejection paths are verified correctly.

<sup>Written for commit 8a4bd33e02ac53108e4c771a487cf0fadc2ce650. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

