### PR TITLE
fix(published-docs): validate creator access before fetching live collection data in autoSync

### DIFF
--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
@@ -1123,7 +1123,7 @@ describe('getPublishedDocBySlugPublic - access revocation', () => {
     ] as any);
     mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(docWithSnapshot);
     // Creator is no longer a team member
-    mockPrisma.teamMember.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.teamMember.findUnique.mockResolvedValueOnce(null);
 
     const result = await publishedDocsService.getPublishedDocBySlugPublic(
       teamPublishedDoc.slug,
@@ -1151,7 +1151,7 @@ describe('getPublishedDocBySlugPublic - access revocation', () => {
       docNoSnapshot,
     ] as any);
     mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(docNoSnapshot);
-    mockPrisma.teamMember.findFirst.mockResolvedValueOnce(null);
+    mockPrisma.teamMember.findUnique.mockResolvedValueOnce(null);
 
     const result = await publishedDocsService.getPublishedDocBySlugPublic(
       teamPublishedDoc.slug,
@@ -1172,7 +1172,7 @@ describe('getPublishedDocBySlugPublic - access revocation', () => {
     ] as any);
     mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(teamPublishedDoc);
     // Creator is still a member
-    mockPrisma.teamMember.findFirst.mockResolvedValueOnce({ id: 'member_1' } as any);
+    mockPrisma.teamMember.findUnique.mockResolvedValueOnce({ id: 'member_1' } as any);
     mockTeamCollectionService.exportCollectionToJSONObject.mockResolvedValueOnce(
       E.right(collectionData as any),
     );

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
@@ -1109,6 +1109,138 @@ describe('getPublishedDocsVersions', () => {
   });
 });
 
+describe('getPublishedDocBySlugPublic - access revocation', () => {
+  test('should fall back to stored snapshot when team creator is removed from team', async () => {
+    const snapshot = { folders: [], requests: [] };
+    const docWithSnapshot = {
+      ...teamPublishedDoc,
+      autoSync: true,
+      documentTree: snapshot,
+    };
+
+    mockPrisma.publishedDocs.findMany.mockResolvedValueOnce([
+      docWithSnapshot,
+    ] as any);
+    mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(docWithSnapshot);
+    // Creator is no longer a team member
+    mockPrisma.teamMember.findFirst.mockResolvedValueOnce(null);
+
+    const result = await publishedDocsService.getPublishedDocBySlugPublic(
+      teamPublishedDoc.slug,
+      teamPublishedDoc.version,
+    );
+
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.documentTree).toBe(JSON.stringify(snapshot));
+    }
+    // Should not attempt to fetch live collection data
+    expect(
+      mockTeamCollectionService.exportCollectionToJSONObject,
+    ).not.toHaveBeenCalled();
+  });
+
+  test('should return PUBLISHED_DOCS_NOT_FOUND when creator is removed and no snapshot exists', async () => {
+    const docNoSnapshot = {
+      ...teamPublishedDoc,
+      autoSync: true,
+      documentTree: null,
+    };
+
+    mockPrisma.publishedDocs.findMany.mockResolvedValueOnce([
+      docNoSnapshot,
+    ] as any);
+    mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(docNoSnapshot);
+    mockPrisma.teamMember.findFirst.mockResolvedValueOnce(null);
+
+    const result = await publishedDocsService.getPublishedDocBySlugPublic(
+      teamPublishedDoc.slug,
+      teamPublishedDoc.version,
+    );
+
+    expect(result).toEqualLeft(PUBLISHED_DOCS_NOT_FOUND);
+    expect(
+      mockTeamCollectionService.exportCollectionToJSONObject,
+    ).not.toHaveBeenCalled();
+  });
+
+  test('should fetch live data when creator is still a team member', async () => {
+    const collectionData = { id: 'team_collection_1', folders: [], requests: [] };
+
+    mockPrisma.publishedDocs.findMany.mockResolvedValueOnce([
+      teamPublishedDoc,
+    ] as any);
+    mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(teamPublishedDoc);
+    // Creator is still a member
+    mockPrisma.teamMember.findFirst.mockResolvedValueOnce({ id: 'member_1' } as any);
+    mockTeamCollectionService.exportCollectionToJSONObject.mockResolvedValueOnce(
+      E.right(collectionData as any),
+    );
+
+    const result = await publishedDocsService.getPublishedDocBySlugPublic(
+      teamPublishedDoc.slug,
+      teamPublishedDoc.version,
+    );
+
+    expect(E.isRight(result)).toBe(true);
+    expect(
+      mockTeamCollectionService.exportCollectionToJSONObject,
+    ).toHaveBeenCalledWith(teamPublishedDoc.workspaceID, teamPublishedDoc.collectionID);
+  });
+
+  test('should fall back to stored snapshot when user account no longer exists', async () => {
+    const snapshot = { folders: [], requests: [] };
+    const docWithSnapshot = {
+      ...userPublishedDoc,
+      autoSync: true,
+      documentTree: snapshot,
+    };
+
+    mockPrisma.publishedDocs.findMany.mockResolvedValueOnce([
+      docWithSnapshot,
+    ] as any);
+    mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(docWithSnapshot);
+    // User account deleted
+    mockPrisma.user.findUnique.mockResolvedValueOnce(null);
+
+    const result = await publishedDocsService.getPublishedDocBySlugPublic(
+      userPublishedDoc.slug,
+      userPublishedDoc.version,
+    );
+
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right.documentTree).toBe(JSON.stringify(snapshot));
+    }
+    expect(
+      mockUserCollectionService.exportUserCollectionToJSONObject,
+    ).not.toHaveBeenCalled();
+  });
+
+  test('should fetch live data when user account still exists', async () => {
+    const collectionData = { id: 'collection_1', folders: [], requests: [] };
+
+    mockPrisma.publishedDocs.findMany.mockResolvedValueOnce([
+      userPublishedDoc,
+    ] as any);
+    mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(userPublishedDoc);
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ uid: user.uid } as any);
+    mockUserCollectionService.exportUserCollectionToJSONObject.mockResolvedValueOnce(
+      E.right(collectionData as any),
+    );
+
+    const result = await publishedDocsService.getPublishedDocBySlugPublic(
+      userPublishedDoc.slug,
+      userPublishedDoc.version,
+    );
+
+    expect(E.isRight(result)).toBe(true);
+    expect(
+      mockUserCollectionService.exportUserCollectionToJSONObject,
+    ).toHaveBeenCalledWith(userPublishedDoc.creatorUid, userPublishedDoc.collectionID);
+  });
+});
+
 describe('getPublishedDocBySlugPublic', () => {
   test('should return published document by slug and version with autoSync enabled', async () => {
     const collectionData = {

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
@@ -1217,6 +1217,30 @@ describe('getPublishedDocBySlugPublic - access revocation', () => {
     ).not.toHaveBeenCalled();
   });
 
+  test('should return PUBLISHED_DOCS_NOT_FOUND when user account is deleted and no snapshot exists', async () => {
+    const docNoSnapshot = {
+      ...userPublishedDoc,
+      autoSync: true,
+      documentTree: null,
+    };
+
+    mockPrisma.publishedDocs.findMany.mockResolvedValueOnce([
+      docNoSnapshot,
+    ] as any);
+    mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(docNoSnapshot);
+    mockPrisma.user.findUnique.mockResolvedValueOnce(null);
+
+    const result = await publishedDocsService.getPublishedDocBySlugPublic(
+      userPublishedDoc.slug,
+      userPublishedDoc.version,
+    );
+
+    expect(result).toEqualLeft(PUBLISHED_DOCS_NOT_FOUND);
+    expect(
+      mockUserCollectionService.exportUserCollectionToJSONObject,
+    ).not.toHaveBeenCalled();
+  });
+
   test('should fetch live data when user account still exists', async () => {
     const collectionData = { id: 'collection_1', folders: [], requests: [] };
 
@@ -1263,6 +1287,7 @@ describe('getPublishedDocBySlugPublic', () => {
         autoSync: userPublishedDoc.autoSync,
       },
     ] as any);
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ uid: user.uid } as any);
     mockUserCollectionService.exportUserCollectionToJSONObject.mockResolvedValueOnce(
       E.right(collectionData as any),
     );
@@ -1926,6 +1951,7 @@ describe('getPublishedDocBySlugPublic - environment support', () => {
       docWithEnv,
     ] as any);
     mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(docWithEnv);
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ uid: user.uid } as any);
     mockUserCollectionService.exportUserCollectionToJSONObject.mockResolvedValueOnce(
       E.right(collectionData as any),
     );
@@ -1990,6 +2016,7 @@ describe('getPublishedDocBySlugPublic - environment support', () => {
       userPublishedDoc,
     ] as any);
     mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(userPublishedDoc);
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ uid: user.uid } as any);
     mockUserCollectionService.exportUserCollectionToJSONObject.mockResolvedValueOnce(
       E.right(collectionData as any),
     );
@@ -2023,6 +2050,7 @@ describe('getPublishedDocBySlugPublic - environment support', () => {
       docWithEnv,
     ] as any);
     mockPrisma.publishedDocs.findUnique.mockResolvedValueOnce(docWithEnv);
+    mockPrisma.user.findUnique.mockResolvedValueOnce({ uid: user.uid } as any);
     mockUserCollectionService.exportUserCollectionToJSONObject.mockResolvedValueOnce(
       E.right(collectionData as any),
     );

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
@@ -323,6 +323,37 @@ export class PublishedDocsService {
   }
 
   /**
+   * Check whether the creator of a published doc still has access to the
+   * underlying workspace. For USER workspaces we confirm the user account
+   * still exists; for TEAM workspaces we confirm the creator is still a
+   * member of the team.
+   */
+  private async creatorStillHasAccess(
+    publishedDocs: DbPublishedDocs,
+  ): Promise<boolean> {
+    if (publishedDocs.workspaceType === WorkspaceType.USER) {
+      const user = await this.prisma.user.findUnique({
+        where: { uid: publishedDocs.creatorUid },
+        select: { uid: true },
+      });
+      return user !== null;
+    }
+
+    if (publishedDocs.workspaceType === WorkspaceType.TEAM) {
+      const member = await this.prisma.teamMember.findFirst({
+        where: {
+          teamID: publishedDocs.workspaceID,
+          userUid: publishedDocs.creatorUid,
+        },
+        select: { id: true },
+      });
+      return member !== null;
+    }
+
+    return false;
+  }
+
+  /**
    * Get a published document by slug and version for public access (unauthenticated)
    * @param slug - The slug of the published document
    * @param version - The version of the published document
@@ -348,6 +379,24 @@ export class PublishedDocsService {
 
     // if autoSync is enabled, fetch from the collection directly
     if (publishedDocs.autoSync) {
+      const hasAccess = await this.creatorStillHasAccess(publishedDocs);
+
+      if (!hasAccess) {
+        // The creator no longer has access to the workspace. Fall back to the
+        // last stored snapshot if one exists, otherwise the doc is unusable.
+        if (!publishedDocs.documentTree) {
+          return E.left(PUBLISHED_DOCS_NOT_FOUND);
+        }
+
+        return E.right(
+          plainToInstance(
+            PublishedDocs,
+            this.cast(docToReturn, allVersions.right),
+            { excludeExtraneousValues: true, enableCircularCheck: true },
+          ),
+        );
+      }
+
       const collectionResult =
         publishedDocs.workspaceType === WorkspaceType.USER
           ? await this.userCollectionService.exportUserCollectionToJSONObject(

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
@@ -340,10 +340,12 @@ export class PublishedDocsService {
     }
 
     if (publishedDocs.workspaceType === WorkspaceType.TEAM) {
-      const member = await this.prisma.teamMember.findFirst({
+      const member = await this.prisma.teamMember.findUnique({
         where: {
-          teamID: publishedDocs.workspaceID,
-          userUid: publishedDocs.creatorUid,
+          teamID_userUid: {
+            teamID: publishedDocs.workspaceID,
+            userUid: publishedDocs.creatorUid,
+          },
         },
         select: { id: true },
       });


### PR DESCRIPTION
__Problem:__ The public docs endpoint (`GET /v1/published-docs/:slug`) fetched live data from private team collections using stored identifiers without verifying the creator still had access. A team member removed after publishing would continue to expose the team's private collection data to anyone with the public URL (GHSA-c3fq-x5hm-p482).

### What's changed
__Fix:__ Before fetching live collection data when `autoSync` is enabled, the service now validates that the creator is still an active member of the team (TEAM workspace) or that their account still exists (USER workspace). If access has been revoked, the endpoint safely falls back to the last stored snapshot, or returns not found if no snapshot exists. The normal autoSync flow is completely unchanged for users with valid access.

Closes https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-c3fq-x5hm-p482


<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate creator access before fetching live collection data for public published docs, preventing exposure when creators lose access. Applies to `GET /v1/published-docs/:slug` with `autoSync`.

- **Bug Fixes**
  - Enforce access check on `autoSync` (USER exists or TEAM membership) before exporting live data.
  - If access is revoked: fall back to the stored snapshot; return 404 if none. Added tests for team removal and user-deleted/no-snapshot cases.
  - Behavior is unchanged when access is valid.

- **Refactors**
  - Use `teamMember.findUnique` with compound key (`teamID_userUid`) via `creatorStillHasAccess` for precise team membership checks.

<sup>Written for commit 8bad59bbec103e5dee77f7b0a4a66cec5e951302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



