### PR TITLE
docs(js-sandbox): update development instructions

### DIFF
--- a/packages/hoppscotch-js-sandbox/README.md
+++ b/packages/hoppscotch-js-sandbox/README.md
@@ -43,22 +43,28 @@ cd hoppscotch/packages/hoppscotch-js-sandbox
 ```
 
 
-4. Try out the demo [`src/demo.ts`](https://github.com/hoppscotch/hoppscotch/blob/main/packages/hoppscotch-js-sandbox/src/demo.ts) using:
+4. Build the package
 
+```bash
+pnpm run build
 ```
-npm run demo
+
+5. Run the test suite
+
+```bash
+pnpm run test
 ```
 
 ## Versioning
 This project follows [Semantic Versioning](https://semver.org/) but as the project is still pre-1.0. The code and the public exposed API should not be considered to be fixed and stable. Things can change at any time!
 
 ## License
-This project is licensed under the [MIT License](https://opensource.org/licenses/MIT) - see [`LICENSE`](https://github.com/hoppscotch/hopp-js-sandbox/blob/main/LICENSE) for more details.
+This project is licensed under the [MIT License](https://opensource.org/licenses/MIT) - see [`LICENSE`](../../LICENSE) for more details.
 
 <div align="center">
   <br />
   <br />
 
-  ###### built with ❤︎ by the [Hoppscotch Team](https://github.com/hoppscotch) and [contributors](https://github.com/AndrewBastin/hopp-js-sandbox/graphs/contributors).
+  ###### built with ❤︎ by the [Hoppscotch Team](https://github.com/hoppscotch) and [contributors](https://github.com/hoppscotch/hoppscotch/graphs/contributors).
 
 </div>


### PR DESCRIPTION
## Summary
- Replace obsolete js-sandbox demo instructions with current build and test commands.
- Update stale license and contributors links to point at the monorepo.

## Why
The README referenced a nonexistent `src/demo.ts` file and `npm run demo` script, which could confuse contributors trying to work on the package.

## Verification
- Ran `git diff --check`.
- Confirmed stale `npm run demo`, `src/demo.ts`, `hopp-js-sandbox`, and `AndrewBastin` references were removed from the js-sandbox README.
- Checked local Markdown links in the updated README.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the `hoppscotch-js-sandbox` README to reflect the current development workflow. Removed the obsolete demo step, added build and test commands, and corrected license and contributors links to the monorepo.

<sup>Written for commit 31022c642570f29d19ec1b9ad0d2f108623f479a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

