### PR TITLE
fix: preserve array buffer view offsets in hopp fetch

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/unit/hopp-fetch.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/hopp-fetch.spec.ts
@@ -494,6 +494,23 @@ describe("CLI hopp-fetch", () => {
       expect((response as any)._bodyBytes).toEqual([72, 101, 108, 108, 111])
     })
 
+    it("should preserve byte offsets for response body ArrayBuffer views", async () => {
+      const hoppFetch = createHoppFetchHook()
+
+      const backingBytes = new Uint8Array([1, 2, 3, 4, 5])
+      const dataView = new DataView(backingBytes.buffer, 1, 3)
+      mockAxiosInstance.mockResolvedValue({
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        data: dataView,
+      })
+
+      const response = await hoppFetch("https://api.example.com/data")
+
+      expect((response as any)._bodyBytes).toEqual([2, 3, 4])
+    })
+
     it("should handle response body text conversion", async () => {
       const hoppFetch = createHoppFetchHook()
 

--- a/packages/hoppscotch-cli/src/utils/hopp-fetch.ts
+++ b/packages/hoppscotch-cli/src/utils/hopp-fetch.ts
@@ -160,7 +160,9 @@ function createSerializableResponse(
       bodyBytes = Array.from(body);
     } else if (ArrayBuffer.isView(body)) {
       // Other typed array
-      bodyBytes = Array.from(new Uint8Array(body.buffer));
+      bodyBytes = Array.from(
+        new Uint8Array(body.buffer, body.byteOffset, body.byteLength)
+      );
     } else if (typeof body === "string") {
       // String body
       bodyBytes = Array.from(new TextEncoder().encode(body));

--- a/packages/hoppscotch-common/src/helpers/__tests__/hopp-fetch.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/hopp-fetch.spec.ts
@@ -659,6 +659,27 @@ describe("Common hopp-fetch", () => {
       expect((response as any)._bodyBytes).toEqual([72, 101, 108, 108, 111])
     })
 
+    it("should preserve byte offsets for response body ArrayBuffer views", async () => {
+      const hoppFetch = createHoppFetchHook(mockKernelInterceptor)
+
+      const backingBytes = new Uint8Array([1, 2, 3, 4, 5])
+      const dataView = new DataView(backingBytes.buffer, 1, 3)
+      ;(mockKernelInterceptor.execute as any).mockReturnValue({
+        response: Promise.resolve(
+          E.right({
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { body: dataView },
+          })
+        ),
+      })
+
+      const response = await hoppFetch("https://api.example.com/data")
+
+      expect((response as any)._bodyBytes).toEqual([2, 3, 4])
+    })
+
     it("should handle response body text conversion", async () => {
       const hoppFetch = createHoppFetchHook(mockKernelInterceptor)
 

--- a/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
+++ b/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
@@ -269,7 +269,13 @@ function convertRelayResponseToSerializableResponse(
       bodyBytes = Array.from(actualBody)
     } else if (ArrayBuffer.isView(actualBody)) {
       // Other typed array
-      bodyBytes = Array.from(new Uint8Array(actualBody.buffer))
+      bodyBytes = Array.from(
+        new Uint8Array(
+          actualBody.buffer,
+          actualBody.byteOffset,
+          actualBody.byteLength
+        )
+      )
     } else if (typeof actualBody === "object") {
       // Check if it's a Buffer-like object with 'type' and 'data' properties
       if ("type" in actualBody && "data" in actualBody) {


### PR DESCRIPTION
## Summary
- Preserve `byteOffset` and `byteLength` when serializing `ArrayBuffer` views in web/common and CLI `hopp.fetch` response handling.
- Add regression tests for sliced `DataView` response bodies in both fetch hook test suites.

## Root Cause
The serializers handled generic `ArrayBuffer` views with `new Uint8Array(view.buffer)`, which reads the entire backing buffer instead of the view range. For views like `new DataView(buffer, 1, 3)`, that included unrelated prefix/suffix bytes in `_bodyBytes`.

## Verification
- Ran `git diff --check`.
- Ran a direct Node check confirming the corrected expression reads only the view range: `[2, 3, 4]`.
- Vitest was not run locally because `pnpm` is not installed on PATH in this workspace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `byteOffset` and `byteLength` for `ArrayBuffer` views when serializing `hopp.fetch` responses in `hoppscotch-common` and `hoppscotch-cli`. Prevents extra bytes from appearing in `_bodyBytes` for sliced `TypedArray`/`DataView` bodies.

- **Bug Fixes**
  - Serialize generic `ArrayBuffer` views with `new Uint8Array(view.buffer, view.byteOffset, view.byteLength)`.
  - Add regression tests validating sliced `DataView` bodies produce `[2, 3, 4]` instead of reading the full backing buffer.

<sup>Written for commit 4604b8dde1be6502290d9bbdec2375b818a54f9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

