### PR TITLE
feat: duplicate user collection return export data

### DIFF
--- a/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.resolver.ts
@@ -417,7 +417,7 @@ export class UserCollectionResolver {
     return updatedUserCollection.right;
   }
 
-  @Mutation(() => Boolean, {
+  @Mutation(() => UserCollectionExportJSONData, {
     description: 'Duplicate a User Collection',
   })
   @UseGuards(GqlAuthGuard)

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
@@ -1287,7 +1287,7 @@ export class UserCollectionService {
    * Duplicate a User Collection
    *
    * @param collectionID The Collection ID
-   * @returns Boolean of duplication status
+   * @returns An Either of the duplicated UserCollectionExportJSONData
    */
   async duplicateUserCollection(
     collectionID: string,
@@ -1321,7 +1321,7 @@ export class UserCollectionService {
     );
     if (E.isLeft(result)) return E.left(result.left as string);
 
-    return E.right(true);
+    return E.right(result.right);
   }
 
   /**


### PR DESCRIPTION


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
Change the duplicate collection flow to return the duplicated collection's export JSON instead of a boolean. Updated the GraphQL Mutation return type from Boolean to UserCollectionExportJSONData and adjusted the service to return E.right(result.right) (the duplicated UserCollectionExportJSONData) with an updated JSDoc. This lets callers receive the exported collection payload after duplication.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
1. Duplicate a user colection
2. Just after duplicating, try edit/delete the newly duplicated collection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Duplicate user collection now returns the exported collection JSON payload instead of a boolean, so clients can use the data immediately and avoid an extra fetch.

- **New Features**
  - `duplicateUserCollection` GraphQL mutation now returns `UserCollectionExportJSONData`.
  - Service returns the exported payload via `E.right(result.right)` and updates JSDoc.

- **Migration**
  - Update client queries to expect `UserCollectionExportJSONData` instead of `Boolean`.
  - If you only checked for success, treat a non-null response as success and ignore the payload.

<sup>Written for commit 126a2d9261f57d798f7caf1ab68ac34ceac7ea1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

