### PR TITLE
fix(browser-interceptor): add CORS hint to network error messages

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -672,7 +672,8 @@
   "error": {
     "network": {
       "heading": "Network Error",
-      "description": "Network connection failed. {message}: {cause}"
+      "description": "Network connection failed. {message}: {cause}",
+      "browser_cors_hint": "This is often caused by CORS (Cross-Origin Resource Sharing) restrictions. Install the Hoppscotch browser extension to send requests without CORS limitations."
     },
     "timeout": {
       "heading": "Timeout Error",

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/browser/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/browser/index.ts
@@ -88,10 +88,13 @@ export class BrowserKernelInterceptorService
               description: (t: ReturnType<typeof getI18n>) => {
                 switch (error.kind) {
                   case "network":
-                    return t("error.network.description", {
-                      message: error.message,
-                      cause: error.cause ?? t("error.unknown.cause"),
-                    })
+                    return [
+                      t("error.network.description", {
+                        message: error.message,
+                        cause: error.cause ?? t("error.unknown.cause"),
+                      }),
+                      t("error.network.browser_cors_hint"),
+                    ].join(" ")
                   case "timeout":
                     return t("error.timeout.description", {
                       message: error.message,


### PR DESCRIPTION
## Summary

When the browser interceptor encounters a network error, the error message now appends a helpful hint about CORS restrictions and the Hoppscotch browser extension.

**Before:** Generic "Network connection failed" message with no actionable guidance.
**After:** Message includes: *"This is often caused by CORS (Cross-Origin Resource Sharing) restrictions. Install the Hoppscotch browser extension to send requests without CORS limitations."*

## Changes

- `packages/hoppscotch-common/locales/en.json` — added `browser_cors_hint` key under `error.network`
- `packages/hoppscotch-common/src/platform/std/kernel-interceptors/browser/index.ts` — browser interceptor `"network"` case now joins the base description with the CORS hint

## Why

CORS errors are the #1 cause of network failures in the browser interceptor — they look identical to real network failures (no response body, opaque error). New users routinely get confused and don't know the extension exists. Surfacing this hint at the error site gives users an immediate, actionable path forward without needing to search the docs.

## Testing

1. Open Hoppscotch web app (without the browser extension)
2. Send a request to any endpoint that has CORS restrictions
3. Confirm the network error message now includes the CORS hint

Closes #6400

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CORS hint to browser interceptor network error messages so users understand likely causes and can try the Hoppscotch browser extension. Implements this by appending a localized hint in the browser kernel interceptor and adding `error.network.browser_cors_hint` to `en.json` in `hoppscotch-common`.

<sup>Written for commit 0986a8e0019a5e1813143d9f69768536b8c72732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

