### PR TITLE
test(cli): fix async assertions and guard legacy-sandbox tests against incompatible Node builds

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/helpers/isolated-vm-compat.ts
+++ b/packages/hoppscotch-cli/src/__tests__/helpers/isolated-vm-compat.ts
@@ -1,0 +1,11 @@
+/**
+ * isolated-vm@6.1.2 only ships prebuilt binaries for Node 22 (ABI 127) and
+ * Node 24 (ABI 137) — the versions CI runs on. On other Node builds the
+ * locally-recompiled binary is incompatible with that Node's V8 internals and
+ * new Isolate() segfaults the process (SIGSEGV). Use this flag to skip
+ * legacy-sandbox tests rather than crash the Vitest worker on unsupported builds.
+ */
+export const ISOLATED_VM_COMPATIBLE_ABIS = ["127", "137"];
+export const isolatedVmSupported = ISOLATED_VM_COMPATIBLE_ABIS.includes(
+  process.versions.modules
+);

--- a/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/getters.spec.ts
@@ -225,7 +225,7 @@ describe("getters", () => {
         },
       ];
 
-      test.each(cases)("$description", ({ args, axiosMock, expected }) => {
+      test.each(cases)("$description", async ({ args, axiosMock, expected }) => {
         const { code, response } = axiosMock;
         const axiosErrMessage = code ?? response?.data?.reason;
 
@@ -241,10 +241,10 @@ describe("getters", () => {
           )
         );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
 
-      test("Promise rejects with the code `INVALID_SERVER_URL` if the network call succeeds and the received response content type is not `application/json`", () => {
+      test("Promise rejects with the code `INVALID_SERVER_URL` if the network call succeeds and the received response content type is not `application/json`", async () => {
         const expected = {
           code: "INVALID_SERVER_URL",
           data: args.serverUrl,
@@ -257,10 +257,10 @@ describe("getters", () => {
           })
         );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
 
-      test("Promise rejects with the code `UNKNOWN_ERROR` while encountering an error that is not an instance of `AxiosError`", () => {
+      test("Promise rejects with the code `UNKNOWN_ERROR` while encountering an error that is not an instance of `AxiosError`", async () => {
         const expected = {
           code: "UNKNOWN_ERROR",
           data: new Error("UNKNOWN_ERROR"),
@@ -270,7 +270,7 @@ describe("getters", () => {
           Promise.reject(new Error("UNKNOWN_ERROR"))
         );
 
-        expect(getResourceContents(args)).rejects.toEqual(expected);
+        await expect(getResourceContents(args)).rejects.toEqual(expected);
       });
     });
 

--- a/packages/hoppscotch-cli/src/__tests__/unit/pre-request-inheritance.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/pre-request-inheritance.spec.ts
@@ -28,6 +28,17 @@ const SAMPLE_REQUEST = makeRESTRequest({
   responses: {},
 });
 
+// `isolated-vm@6.1.2` only ships prebuilt binaries for Node 22 (ABI 127) and
+// Node 24 (ABI 137) — the versions CI runs on. On other Node builds, the
+// locally-recompiled binary is incompatible with that Node's V8 internals and
+// `new Isolate()` segfaults the process outright (verified independently of
+// Vitest/mocks: SIGSEGV, not a hang from unresolved promises). Skip the
+// legacy-sandbox test here rather than crash the worker on unsupported builds.
+const ISOLATED_VM_COMPATIBLE_ABIS = ["127", "137"];
+const isolatedVmSupported = ISOLATED_VM_COMPATIBLE_ABIS.includes(
+  process.versions.modules
+);
+
 describe("preRequestScriptRunner - inheritance", () => {
   test("Inherited scripts execute in root → parent → request order", async () => {
     const rootScript = `pw.env.set("ORDER", "root");`;
@@ -182,35 +193,38 @@ describe("preRequestScriptRunner - inheritance", () => {
   // currently user-reachable in the CLI. The web worker path is where the
   // post-`await` drop is user-reachable; covered by the smoke fixture in
   // packages/hoppscotch-cli/src/__tests__/e2e/.
-  test("Legacy sandbox executes inherited scripts in order", async () => {
-    const rootScript = `pw.env.set("ORDER", "root");`;
-    const parentScript = `
-      const prev = pw.env.get("ORDER");
-      pw.env.set("ORDER", prev + ",parent");
-    `;
-    const request = makeRESTRequest({
-      ...SAMPLE_REQUEST,
-      preRequestScript: `
+  test.skipIf(!isolatedVmSupported)(
+    "Legacy sandbox executes inherited scripts in order",
+    async () => {
+      const rootScript = `pw.env.set("ORDER", "root");`;
+      const parentScript = `
         const prev = pw.env.get("ORDER");
-        pw.env.set("ORDER", prev + ",request");
-      `,
-    });
+        pw.env.set("ORDER", prev + ",parent");
+      `;
+      const request = makeRESTRequest({
+        ...SAMPLE_REQUEST,
+        preRequestScript: `
+          const prev = pw.env.get("ORDER");
+          pw.env.set("ORDER", prev + ",request");
+        `,
+      });
 
-    const result = await preRequestScriptRunner(
-      request,
-      SAMPLE_ENVS,
-      true,
-      undefined,
-      [rootScript, parentScript]
-    )();
+      const result = await preRequestScriptRunner(
+        request,
+        SAMPLE_ENVS,
+        true,
+        undefined,
+        [rootScript, parentScript]
+      )();
 
-    expect(result).toBeRight();
+      expect(result).toBeRight();
 
-    if (E.isRight(result)) {
-      const orderVar = result.right.updatedEnvs.selected.find(
-        (v) => v.key === "ORDER"
-      );
-      expect(orderVar?.currentValue).toBe("root,parent,request");
+      if (E.isRight(result)) {
+        const orderVar = result.right.updatedEnvs.selected.find(
+          (v) => v.key === "ORDER"
+        );
+        expect(orderVar?.currentValue).toBe("root,parent,request");
+      }
     }
-  });
+  );
 });

--- a/packages/hoppscotch-cli/src/__tests__/unit/pre-request-inheritance.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/pre-request-inheritance.spec.ts
@@ -4,6 +4,7 @@ import * as E from "fp-ts/Either";
 
 import { preRequestScriptRunner } from "../../utils/pre-request";
 import { HoppEnvs } from "../../types/request";
+import { isolatedVmSupported } from "../helpers/isolated-vm-compat";
 
 const SAMPLE_ENVS: HoppEnvs = {
   global: [],
@@ -27,17 +28,6 @@ const SAMPLE_REQUEST = makeRESTRequest({
   description: null,
   responses: {},
 });
-
-// `isolated-vm@6.1.2` only ships prebuilt binaries for Node 22 (ABI 127) and
-// Node 24 (ABI 137) — the versions CI runs on. On other Node builds, the
-// locally-recompiled binary is incompatible with that Node's V8 internals and
-// `new Isolate()` segfaults the process outright (verified independently of
-// Vitest/mocks: SIGSEGV, not a hang from unresolved promises). Skip the
-// legacy-sandbox test here rather than crash the worker on unsupported builds.
-const ISOLATED_VM_COMPATIBLE_ABIS = ["127", "137"];
-const isolatedVmSupported = ISOLATED_VM_COMPATIBLE_ABIS.includes(
-  process.versions.modules
-);
 
 describe("preRequestScriptRunner - inheritance", () => {
   test("Inherited scripts execute in root → parent → request order", async () => {

--- a/packages/hoppscotch-cli/src/__tests__/unit/test-runner-inheritance.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/test-runner-inheritance.spec.ts
@@ -36,6 +36,17 @@ const SAMPLE_REQUEST = makeRESTRequest({
   responses: {},
 });
 
+// `isolated-vm@6.1.2` only ships prebuilt binaries for Node 22 (ABI 127) and
+// Node 24 (ABI 137) — the versions CI runs on. On other Node builds, the
+// locally-recompiled binary is incompatible with that Node's V8 internals and
+// `new Isolate()` segfaults the process outright (verified independently of
+// Vitest/mocks: SIGSEGV, not a hang from unresolved promises). Skip the
+// legacy-sandbox test here rather than crash the worker on unsupported builds.
+const ISOLATED_VM_COMPATIBLE_ABIS = ["127", "137"];
+const isolatedVmSupported = ISOLATED_VM_COMPATIBLE_ABIS.includes(
+  process.versions.modules
+);
+
 describe("testRunner - inheritance", () => {
   test("Inherited test scripts are executed and register test cases", async () => {
     const rootTestScript = `
@@ -201,34 +212,37 @@ describe("testRunner - inheritance", () => {
   // Note: the post-`await` drop is not currently user-reachable here either
   // (see pre-request-inheritance.spec.ts for context). User-facing coverage
   // for the web worker async path is in packages/hoppscotch-cli/src/__tests__/e2e/.
-  test("Legacy sandbox registers inherited test scripts", async () => {
-    const rootTestScript = `
-      pw.test("Root collection test", () => {
-        pw.expect(pw.response.status).toBe(200);
-      });
-    `;
+  test.skipIf(!isolatedVmSupported)(
+    "Legacy sandbox registers inherited test scripts",
+    async () => {
+      const rootTestScript = `
+        pw.test("Root collection test", () => {
+          pw.expect(pw.response.status).toBe(200);
+        });
+      `;
 
-    const result = await testRunner({
-      request: makeRESTRequest({
-        ...SAMPLE_REQUEST,
-        testScript: `
-          pw.test("Request test", () => {
-            pw.expect(pw.response.status).toBe(200);
-          });
-        `,
-      }),
-      envs: SAMPLE_ENVS,
-      response: SAMPLE_RESPONSE,
-      legacySandbox: true,
-      inheritedTestScripts: [rootTestScript],
-    })();
+      const result = await testRunner({
+        request: makeRESTRequest({
+          ...SAMPLE_REQUEST,
+          testScript: `
+            pw.test("Request test", () => {
+              pw.expect(pw.response.status).toBe(200);
+            });
+          `,
+        }),
+        envs: SAMPLE_ENVS,
+        response: SAMPLE_RESPONSE,
+        legacySandbox: true,
+        inheritedTestScripts: [rootTestScript],
+      })();
 
-    expect(result).toBeRight();
+      expect(result).toBeRight();
 
-    if (E.isRight(result)) {
-      const descriptors = result.right.testsReport.map((r) => r.descriptor);
-      expect(descriptors).toContain("Request test");
-      expect(descriptors).toContain("Root collection test");
+      if (E.isRight(result)) {
+        const descriptors = result.right.testsReport.map((r) => r.descriptor);
+        expect(descriptors).toContain("Request test");
+        expect(descriptors).toContain("Root collection test");
+      }
     }
-  });
+  );
 });

--- a/packages/hoppscotch-cli/src/__tests__/unit/test-runner-inheritance.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/test-runner-inheritance.spec.ts
@@ -4,6 +4,7 @@ import * as E from "fp-ts/Either";
 
 import { testRunner } from "../../utils/test";
 import { HoppEnvs } from "../../types/request";
+import { isolatedVmSupported } from "../helpers/isolated-vm-compat";
 
 const SAMPLE_ENVS: HoppEnvs = {
   global: [],
@@ -35,17 +36,6 @@ const SAMPLE_REQUEST = makeRESTRequest({
   description: null,
   responses: {},
 });
-
-// `isolated-vm@6.1.2` only ships prebuilt binaries for Node 22 (ABI 127) and
-// Node 24 (ABI 137) — the versions CI runs on. On other Node builds, the
-// locally-recompiled binary is incompatible with that Node's V8 internals and
-// `new Isolate()` segfaults the process outright (verified independently of
-// Vitest/mocks: SIGSEGV, not a hang from unresolved promises). Skip the
-// legacy-sandbox test here rather than crash the worker on unsupported builds.
-const ISOLATED_VM_COMPATIBLE_ABIS = ["127", "137"];
-const isolatedVmSupported = ISOLATED_VM_COMPATIBLE_ABIS.includes(
-  process.versions.modules
-);
 
 describe("testRunner - inheritance", () => {
   test("Inherited test scripts are executed and register test cases", async () => {


### PR DESCRIPTION
Closes #4136

## What's changed

**`getters.spec.ts`**
- Added `await` before three `expect(...).rejects.toEqual(...)` assertions (lines 244, 260, 273)
- Made their enclosing test callbacks `async`
- Vitest currently auto-awaits these but will fail in the next major — this fixes them proactively

**`pre-request-inheritance.spec.ts`** and **`test-runner-inheritance.spec.ts`**
- Added a `test.skipIf(!isolatedVmSupported)` guard around the two `legacySandbox: true` tests
- Root cause: `isolated-vm@6.1.2` only ships prebuilt binaries for ABI 127 (Node 22) and ABI 137 (Node 24). On Node 25 (ABI 141), the recompiled binary causes a SIGSEGV crash, which Vitest reports as a worker timeout
- CI pins Node 22 (per `.github/workflows/tests.yml`) so these tests **still run fully on CI** — the skip only applies on incompatible local builds
- The guard is documented with an inline comment explaining the ABI mismatch

## Test results (Node 25.6.1 local)
- 7 test files passed
- 108 tests passed
- 2 skipped (legacy-sandbox tests, skip only on Node 25 — run normally on CI/Node 22)
- 0 failed, 0 timeouts, 0 warnings

## Pre-existing unrelated issue (not in scope)
`src/__tests__/e2e/commands/test.spec.ts` fails locally with `TypeError: The property 'options.recursive' is no longer supported` from `fs.rmdirSync` — Node 25 removed that option. Confirmed via `git stash` that this predates these changes. Not touched as it is a separate failure in a different file.

## Related
Supersedes the incomplete work in #4657.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CLI unit tests by awaiting async rejections and guarding legacy-sandbox tests on unsupported Node builds. Prevents local crashes on Node 25 while keeping full CI coverage.

- **Bug Fixes**
  - Awaited `.rejects` assertions and marked tests async in getters tests to align with upcoming `vitest` behavior.
  - Added `test.skipIf(!isolatedVmSupported)` for legacy sandbox tests based on `isolated-vm` ABI support (127, 137), and extracted the check to a shared helper. Runs on CI (Node 22); skips only on incompatible local builds.

<sup>Written for commit b4856cceaa74f90eace16a2ca4803ae6f5e30d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

