### PR TITLE
Testes infra token

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@commitlint/cli": "20.5.2",
     "@commitlint/config-conventional": "20.5.0",
     "@hoppscotch/ui": "0.2.5",
+    "@types/jest": "30.0.0",
     "@types/node": "24.10.1",
     "cross-env": "10.1.0",
     "http-server": "14.1.1",

--- a/packages/hoppscotch-backend/src/infra-token/infra-token.service.spec.ts
+++ b/packages/hoppscotch-backend/src/infra-token/infra-token.service.spec.ts
@@ -1,0 +1,59 @@
+import { InfraTokenService } from './infra-token.service';
+import * as E from 'fp-ts/Either';
+import { INFRA_TOKEN_EXPIRY_INVALID, INFRA_TOKEN_LABEL_SHORT } from 'src/errors';
+import { Admin } from 'src/admin/admin.model';
+
+describe('InfraTokenService - create', () => {
+  let service: InfraTokenService;
+  let prismaMock: any;
+  let adminServiceMock: any;
+
+  beforeEach(() => {
+    // Configuração do Dublê de Teste (Mock) para o Banco de Dados
+    prismaMock = {
+      infraToken: {
+        create: jest.fn().mockResolvedValue({
+          token: 'mocked-token-123',
+          id: '1',
+          label: 'API',
+          createdOn: new Date(),
+          expiresOn: new Date(),
+          updatedOn: new Date(),
+        }),
+      },
+    };
+    adminServiceMock = {};
+    service = new InfraTokenService(prismaMock, adminServiceMock);
+  });
+
+  const mockAdmin: Admin = { uid: 'admin-uid-123' } as Admin;
+
+  // --- Testes Caixa-Branca (Cobertura MC/DC para expiração) ---
+
+  it('CT01 [MC/DC - V,F]: Deve criar token vitalício quando expiryInDays for nulo', async () => {
+    const result = await service.create('API', null as any, mockAdmin);
+    expect(E.isRight(result)).toBeTruthy();
+  });
+
+  it('CT02 [MC/DC - F,V]: Deve criar token quando expiryInDays for válido (ex: 30)', async () => {
+    const result = await service.create('API', 30, mockAdmin);
+    expect(E.isRight(result)).toBeTruthy();
+  });
+
+  it('CT03 [MC/DC - F,F]: Deve retornar falha quando expiryInDays estiver fora do padrão (ex: 15)', async () => {
+    const result = await service.create('API', 15, mockAdmin);
+    expect(result).toEqual(E.left(INFRA_TOKEN_EXPIRY_INVALID));
+  });
+
+  // --- Testes Caixa-Preta (Valor Limite para tamanho do Label) ---
+
+  it('CT04 [Valor Limite Válido]: Deve criar token quando label possuir exatamente 3 caracteres', async () => {
+    const result = await service.create('API', 30, mockAdmin);
+    expect(E.isRight(result)).toBeTruthy();
+  });
+
+  it('CT05 [Valor Limite Inválido]: Deve retornar falha quando label possuir 2 caracteres', async () => {
+    const result = await service.create('CI', 30, mockAdmin);
+    expect(result).toEqual(E.left(INFRA_TOKEN_LABEL_SHORT));
+  });
+});

--- a/packages/hoppscotch-backend/src/infra-token/infra-token.service.spec.ts
+++ b/packages/hoppscotch-backend/src/infra-token/infra-token.service.spec.ts
@@ -9,7 +9,7 @@ describe('InfraTokenService - create', () => {
   let adminServiceMock: any;
 
   beforeEach(() => {
-    // Configuração do Dublê de Teste (Mock) para o Banco de Dados
+    // Setup Test Double (Mock) for the Database
     prismaMock = {
       infraToken: {
         create: jest.fn().mockResolvedValue({
@@ -28,31 +28,32 @@ describe('InfraTokenService - create', () => {
 
   const mockAdmin: Admin = { uid: 'admin-uid-123' } as Admin;
 
-  // --- Testes Caixa-Branca (Cobertura MC/DC para expiração) ---
+  // --- White-box Tests (MC/DC coverage for expiry) ---
 
-  it('CT01 [MC/DC - V,F]: Deve criar token vitalício quando expiryInDays for nulo', async () => {
+  it('should create a lifetime token when expiryInDays is null', async () => {
     const result = await service.create('API', null as any, mockAdmin);
     expect(E.isRight(result)).toBeTruthy();
   });
 
-  it('CT02 [MC/DC - F,V]: Deve criar token quando expiryInDays for válido (ex: 30)', async () => {
+  it('should create a token when expiryInDays is valid (e.g., 30)', async () => {
     const result = await service.create('API', 30, mockAdmin);
     expect(E.isRight(result)).toBeTruthy();
   });
 
-  it('CT03 [MC/DC - F,F]: Deve retornar falha quando expiryInDays estiver fora do padrão (ex: 15)', async () => {
+  it('should return error when expiryInDays is outside the allowed range (e.g., 15)', async () => {
     const result = await service.create('API', 15, mockAdmin);
     expect(result).toEqual(E.left(INFRA_TOKEN_EXPIRY_INVALID));
   });
 
-  // --- Testes Caixa-Preta (Valor Limite para tamanho do Label) ---
+  // --- Black-box Tests (Boundary Value Analysis for Label length) ---
 
-  it('CT04 [Valor Limite Válido]: Deve criar token quando label possuir exatamente 3 caracteres', async () => {
-    const result = await service.create('API', 30, mockAdmin);
+  it('should create a token when label has exactly 3 characters', async () => {
+    // Changed expiry to 7 to be independent of CT02
+    const result = await service.create('API', 7, mockAdmin);
     expect(E.isRight(result)).toBeTruthy();
   });
 
-  it('CT05 [Valor Limite Inválido]: Deve retornar falha quando label possuir 2 caracteres', async () => {
+  it('should return error when label has 2 characters', async () => {
     const result = await service.create('CI', 30, mockAdmin);
     expect(result).toEqual(E.left(INFRA_TOKEN_LABEL_SHORT));
   });

--- a/packages/hoppscotch-backend/src/infra-token/infra-token.service.spec.ts
+++ b/packages/hoppscotch-backend/src/infra-token/infra-token.service.spec.ts
@@ -1,7 +1,8 @@
 import { InfraTokenService } from './infra-token.service';
 import * as E from 'fp-ts/Either';
-import { INFRA_TOKEN_EXPIRY_INVALID, INFRA_TOKEN_LABEL_SHORT } from 'src/errors';
+import { INFRA_TOKEN_EXPIRY_INVALID, INFRA_TOKEN_LABEL_SHORT, INFRA_TOKEN_NOT_FOUND,} from 'src/errors';
 import { Admin } from 'src/admin/admin.model';
+
 
 describe('InfraTokenService - create', () => {
   let service: InfraTokenService;
@@ -58,3 +59,50 @@ describe('InfraTokenService - create', () => {
     expect(result).toEqual(E.left(INFRA_TOKEN_LABEL_SHORT));
   });
 });
+
+describe('InfraTokenService - revoke', () => {
+  let service: InfraTokenService;
+  let prismaMock: any;
+  let adminServiceMock: any;
+
+  beforeEach(() => {
+    // Database Mock setup focused on the delete function
+    prismaMock = {
+      infraToken: {
+        delete: jest.fn(), 
+      },
+    };
+    adminServiceMock = {};
+    service = new InfraTokenService(prismaMock, adminServiceMock);
+  });
+
+  // --- White-box Tests (try/catch coverage) ---
+
+  it('should return E.right(true) when the token is successfully deleted in Prisma', async () => {
+    prismaMock.infraToken.delete.mockResolvedValue({ id: 'valid-id-123' });
+
+    const result = await service.revoke('valid-id-123');
+
+    expect(prismaMock.infraToken.delete).toHaveBeenCalledWith({
+      where: { id: 'valid-id-123' },
+    });
+    //Ensures the return is a success containing "true"
+    expect(result).toEqual(E.right(true));
+  });
+
+  it('should return E.left(INFRA_TOKEN_NOT_FOUND) when Prisma throws an error', async () => {
+    
+    prismaMock.infraToken.delete.mockRejectedValue(
+      new Error('Record to delete does not exist.')
+    );
+
+    const result = await service.revoke('invalid-id-456');
+
+    expect(prismaMock.infraToken.delete).toHaveBeenCalledWith({
+      where: { id: 'invalid-id-456' },
+    });
+    // Ensures it caught the error and returned the expected Left
+    expect(result).toEqual(E.left(INFRA_TOKEN_NOT_FOUND));
+  });
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@hoppscotch/ui':
         specifier: 0.2.5
         version: 0.2.5(eslint@10.2.1(jiti@2.6.1))(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
+      '@types/jest':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/node':
         specifier: 24.10.1
         version: 24.10.1


### PR DESCRIPTION
# Description:

## Objective
This Pull Request adds unit test coverage for the InfraTokenService, focusing on the revoke function and its internal business rule validations. This implementation is part of the Unit Testing delivery (PTOSS-2) by the Cavalo de Tróia team.

### Changes Made

Configured Test Doubles (Mocks) to isolate external dependencies (PrismaService and AdminService).

Structural Testing (White-box): Applied the Decision coverage criterion to ensure coverage of less complex logical decisions .

### Implemented Test Cases
Developed 2 test cases covering the following scenarios:

[White-box] Success when receive a token to delete in database.

[White-box] Throw an exception when prisma launch an error (ID token not found).


### Results and Coverage

All tests executed successfully (PASS).

Achieved 100% Branch Coverage for the logic tested in the infra-token.service.ts file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `InfraTokenService` create and revoke, covering expiry/label validation and not-found delete errors. Achieves 100% branch coverage for the tested logic and aligns with PTOSS-2.

- **Dependencies**
  - Added `@types/jest` for TypeScript test typing.

<sup>Written for commit 1ea448442af1ff454e9b251fab32336a3e62a7a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

