### PR TITLE
feat(ui): add loading state spinner to send button

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -75,6 +75,7 @@
         :label="`${
           !isTabResponseLoading ? t('action.send') : t('action.cancel')
         }`"
+        :loading="isTabResponseLoading"
         class="min-w-[5rem] flex-1 rounded-r-none"
         @click="!isTabResponseLoading ? newSendRequest() : cancelRequest()"
       />


### PR DESCRIPTION
Fixes #6265. Improves loading feedback during API requests by hooking the button's loading prop to the existing isTabResponseLoading state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a loading spinner on the Send/Cancel button while a request is in progress for clearer feedback. Hooks the button’s loading prop to the existing isTabResponseLoading state so users see progress and can still cancel.

<sup>Written for commit 0379bc8199283fac7da78c56938384c5e3a458ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

