### PR TITLE
fix(common): preserve cURL header values containing ": " on import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1086,3 +1086,44 @@ describe("Parse curl command to Hopp REST Request", () => {
     })
   }
 })
+
+describe("cURL header parsing (#6400)", () => {
+  const cases = [
+    {
+      title: "single ': ' in value",
+      command: `curl https://httpbin.org/get -H 'X-Note: hello: world' -H 'Accept: application/json'`,
+      key: "X-Note",
+      value: "hello: world",
+    },
+    {
+      title: "multiple colons in value",
+      command: `curl --location 'https://httpbin.org/get' --header 'X-Note: hello: ejnfworld:owjen. hi' --header 'Accept: application/json'`,
+      key: "X-Note",
+      value: "hello: ejnfworld:owjen. hi",
+    },
+    {
+      title: "many colons + extra spaces in value",
+      command: `curl --location 'https://httpbin.org/get' --header 'X-Note: hello: ejnfworld:owjen:sdf. :  . hi' --header 'Accept: application/json'`,
+      key: "X-Note",
+      value: "hello: ejnfworld:owjen:sdf. :  . hi",
+    },
+  ]
+
+  for (const { title, command, key, value } of cases) {
+    test(`preserves header values containing colons — ${title}`, () => {
+      const result = parseCurlToHoppRESTReq(command)
+      expect(result.headers).toContainEqual({
+        active: true,
+        key,
+        value,
+        description: "",
+      })
+      expect(result.headers).toContainEqual({
+        active: true,
+        key: "Accept",
+        value: "application/json",
+        description: "",
+      })
+    })
+  }
+})

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -2,7 +2,6 @@ import { HoppRESTHeader } from "@hoppscotch/data"
 import * as A from "fp-ts/Array"
 import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
 import parser from "yargs-parser"
 import {
   objHasArrayProperty,
@@ -10,13 +9,19 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
-const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
-)
+const getHeaderPair = (header: string): O.Option<[string, string]> => {
+  // Split on the FIRST colon only. The name is everything before it; the value
+  // (everything after) may itself contain ": " — e.g. "X-Note: hello: world".
+  const separatorIndex = header.indexOf(":")
+
+  // must have a key and a value (a colon separator must be present)
+  if (separatorIndex === -1) return O.none
+
+  return O.some([
+    header.slice(0, separatorIndex).trim(),
+    header.slice(separatorIndex + 1).trim(),
+  ] as [string, string])
+}
 
 export function getHeaders(parsedArguments: parser.Arguments) {
   let headers: Record<string, string> = {}


### PR DESCRIPTION
Closes #6400

When importing a cURL command, a header whose value contains `": "` (a colon followed by a space) — or multiple colons — was silently dropped from the imported request. This aligns header parsing with RFC 9110, and with how `curl -OJ` and Postman handle such headers.

Example: `-H 'X-Note: hello: world'` was dropped entirely; only headers without `": "` in their value survived.

### What's changed
- Rewrote `getHeaderPair` in `helpers/curl/sub_helpers/headers.ts` to split each header on the **first colon only**: the name is everything before it, and the value (everything after) is kept intact — so colons/spaces inside the value are preserved.
- Previously it split on every `": "` and required exactly two parts, so any value containing `": "` failed the `length === 2` check and the header was discarded by the later `filterMap`.
- Existing behaviour is preserved: `Key:Value` (no space) still works, normal headers are unchanged, and a line with no colon is still dropped.
- Removed the now-unused `fp-ts/string` import.
- Added regression tests covering header values with a single `": "`, multiple colons, and extra internal spaces.

### Notes to reviewers
- Scope is intentionally limited to #6400 — *valid* header values that contain colons. Malformed input (e.g. unclosed quotes) is out of scope.
- Verified locally: the full cURL suite passes (`vitest run src/helpers/curl/`, 45 tests) and the changed files lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cURL import dropping headers when values contain ": " by splitting header lines on the first colon and preserving the full value. This ensures headers like "X-Note: hello: world" import correctly in `hoppscotch-common` (closes #6400).

- **Bug Fixes**
  - Updated `getHeaderPair` in `helpers/curl/sub_helpers/headers.ts` to split on the first colon; keeps colons and spaces inside values.
  - Preserves existing behavior: `Key:Value` works; lines without a colon are ignored.
  - Removed unused `fp-ts/string` import.
  - Added regression tests for values with single/multiple colons and extra spaces.

<sup>Written for commit c1838b6d4ceddbb56f0a8e8a928198a95656696c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

