### PR TITLE
fix: preserve colons in cURL basic-auth password on import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1086,3 +1086,41 @@ describe("Parse curl command to Hopp REST Request", () => {
     })
   }
 })
+
+describe("cURL basic-auth password with colons", () => {
+  // curl splits user:password on the FIRST colon only; the password may itself
+  // contain colons (e.g. tokens, base64). The username cannot contain a colon.
+  // base64("admin:p:a:s:s") === "YWRtaW46cDphOnM6cw=="
+  const cases = [
+    {
+      title: "-u with colons in password",
+      command: `curl http://localhost -u "admin:p:a:s:s"`,
+      username: "admin",
+      password: "p:a:s:s",
+    },
+    {
+      title: "--user long form with colons in password",
+      command: `curl http://localhost --user "admin:a:b:c"`,
+      username: "admin",
+      password: "a:b:c",
+    },
+    {
+      title: "Authorization: Basic header with colons in password",
+      command: `curl http://localhost -H "Authorization: Basic YWRtaW46cDphOnM6cw=="`,
+      username: "admin",
+      password: "p:a:s:s",
+    },
+  ]
+
+  for (const { title, command, username, password } of cases) {
+    test(`preserves colons in the password — ${title}`, () => {
+      const result = parseCurlToHoppRESTReq(command)
+      expect(result.auth).toMatchObject({
+        authActive: true,
+        authType: "basic",
+        username,
+        password,
+      })
+    })
+  }
+})

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/auth.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/auth.ts
@@ -1,12 +1,23 @@
 import { HoppRESTAuth } from "@hoppscotch/data"
 import parser from "yargs-parser"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
 import { pipe } from "fp-ts/function"
 import { getDefaultRESTRequest } from "~/helpers/rest/default"
 import { objHasProperty } from "~/helpers/functional/object"
 
 const defaultRESTReq = getDefaultRESTRequest()
+
+/**
+ * Split a `username:password` credential on the FIRST colon only.
+ * curl uses the first colon as the separator, so the password may itself
+ * contain colons (e.g. tokens, base64); the username cannot.
+ */
+const splitOnFirstColon = (value: string): [string, string] => {
+  const separatorIndex = value.indexOf(":")
+  return separatorIndex === -1
+    ? [value, ""]
+    : [value.slice(0, separatorIndex), value.slice(separatorIndex + 1)]
+}
 
 const getAuthFromAuthHeader = (headers: Record<string, string>) =>
   pipe(
@@ -27,14 +38,9 @@ const getAuthFromAuthHeader = (headers: Record<string, string>) =>
             case "basic": {
               const [username, password] = pipe(
                 O.tryCatch(() => atob(kv[1])),
-                O.map(S.split(":")),
-                // can have a username with no password
-                O.filter((arr) => arr.length > 0),
-                O.map(
-                  ([username, password]) =>
-                    <[string, string]>[username, password]
-                ),
-                O.getOrElse(() => ["", ""])
+                // split on the first colon only — password may contain colons
+                O.map(splitOnFirstColon),
+                O.getOrElse(() => ["", ""] as [string, string])
               )
 
               if (!username) return undefined
@@ -58,17 +64,10 @@ const getAuthFromParsedArgs = (parsedArguments: parser.Arguments) =>
   pipe(
     parsedArguments,
     O.fromPredicate(objHasProperty("u", "string")),
-    O.chain((args) =>
-      pipe(
-        args.u,
-        S.split(":"),
-        // can have a username with no password
-        O.fromPredicate((arr) => arr.length > 0 && arr[0].length > 0),
-        O.map(
-          ([username, password]) => <[string, string]>[username, password ?? ""]
-        )
-      )
-    ),
+    // split on the first colon only — password may contain colons
+    O.map((args) => splitOnFirstColon(args.u)),
+    // can have a username with no password
+    O.filter(([username]) => username.length > 0),
     O.map(
       ([username, password]) =>
         <HoppRESTAuth>{


### PR DESCRIPTION
Closes #6403

Importing a cURL command with basic auth truncated the password at the first colon. Both import paths in `packages/hoppscotch-common/src/helpers/curl/sub_helpers/auth.ts` used `S.split(":")` and destructured `[username, password]`, discarding everything after the second piece.

curl splits the credential on the **first** colon only — the password may itself contain colons (e.g. tokens, base64); the username cannot.

### What's changed
- Added a shared `splitOnFirstColon` helper (username = before the first colon, password = everything after).
- Used it in `getAuthFromParsedArgs` (`-u` / `--user`) and `getAuthFromAuthHeader` (`Authorization: Basic <base64>`).
- Removed the now-unused `fp-ts/string` import.
- The "username with no password" case is preserved (no colon → empty password).
- Added regression tests for `-u`, `--user`, and the `Authorization: Basic` header, each with colons in the password.

All `curlparser` tests pass (32/32); eslint clean on the changed files.

### Notes to reviewers
`curl -u 'admin:p:a:s:s'` sends `Authorization: Basic` decoding to `admin:p:a:s:s` (password `p:a:s:s`); previously Hoppscotch imported it as `p`. This is a separate fix from #6401 (which addressed colons in header *values*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cURL basic-auth import to preserve colons in passwords by splitting on the first colon, matching curl’s behavior.

- **Bug Fixes**
  - Use a shared first-colon splitter in both `-u/--user` and `Authorization: Basic` paths.
  - Preserve the “username only” case; keep the full password even with colons.
  - Added regression tests for both paths; removed unused `fp-ts/string` import.

<sup>Written for commit 405247e06fc2aca63618cf4644f45eb0efe3c938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

