### PR TITLE
test: add getUserOfCollection unit tests

### DIFF
--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.spec.ts
@@ -10,6 +10,7 @@ import {
   USER_COLL_SAME_NEXT_COLL,
   USER_COLL_SHORT_TITLE,
   USER_COLL_ALREADY_ROOT,
+  USER_NOT_FOUND,
   USER_NOT_OWNER,
   USER_COLL_DATA_INVALID,
   USER_COLLECTION_CREATION_FAILED,
@@ -642,6 +643,50 @@ describe('getChildrenOfUserCollection', () => {
       ReqType.GQL,
     );
     expect(result).toEqual([]);
+  });
+});
+
+describe('getUserOfCollection', () => {
+  test('should return the user of a collection with valid collectionID', async () => {
+    mockPrisma.userCollection.findUniqueOrThrow.mockResolvedValueOnce({
+      ...rootRESTUserCollection,
+      user,
+    } as any);
+
+    const result = await userCollectionService.getUserOfCollection(
+      rootRESTUserCollection.id,
+    );
+
+    expect(result).toEqualRight(user);
+    expect(mockPrisma.userCollection.findUniqueOrThrow).toHaveBeenCalledWith({
+      where: {
+        id: rootRESTUserCollection.id,
+      },
+      include: {
+        user: true,
+      },
+    });
+  });
+
+  test('should throw USER_NOT_FOUND when collectionID is invalid', async () => {
+    mockPrisma.userCollection.findUniqueOrThrow.mockRejectedValueOnce(
+      'NotFoundError',
+    );
+
+    const result =
+      await userCollectionService.getUserOfCollection('invalidID');
+
+    expect(result).toEqualLeft(USER_NOT_FOUND);
+  });
+
+  test('should throw USER_NOT_FOUND when collectionID is empty', async () => {
+    mockPrisma.userCollection.findUniqueOrThrow.mockRejectedValueOnce(
+      'NotFoundError',
+    );
+
+    const result = await userCollectionService.getUserOfCollection('');
+
+    expect(result).toEqualLeft(USER_NOT_FOUND);
   });
 });
 


### PR DESCRIPTION
### Pull Request

**Title:** Add unit tests for `getUserOfCollection`

**Description:**

This PR adds unit tests for the `getUserOfCollection` service function.

### What was added

* A test case to verify that the function returns the correct user when a valid collection ID is provided.
* A test case to verify that `USER_NOT_FOUND` is returned when the collection ID is invalid.
* A test case to verify that `USER_NOT_FOUND` is returned when the collection ID is empty.

### Notes

* The tests also validate that `findUniqueOrThrow` is called with the correct Prisma arguments.
* This improves coverage for the collection-to-user lookup flow and ensures the service handles error cases properly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added unit tests for `getUserOfCollection` to validate user retrieval and error handling. Tests cover returning the correct user for a valid collection ID, returning `USER_NOT_FOUND` for invalid or empty IDs, and verifying Prisma `findUniqueOrThrow` is called with the expected args.

<sup>Written for commit 351b5638faedc4a4a86597d4d4235f8a75bb3ab8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

