### PR TITLE
fix(backend): enforce ownership on user history and private User fields

### DIFF
--- a/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
@@ -48,8 +48,8 @@ export class MockServerResolver {
     if (E.isLeft(creator)) throwErr(creator.left);
     return {
       ...creator.right,
-      currentGQLSession: JSON.stringify(creator.right.currentGQLSession),
-      currentRESTSession: JSON.stringify(creator.right.currentRESTSession),
+      currentGQLSession: null,
+      currentRESTSession: null,
     };
   }
 

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
@@ -856,8 +856,8 @@ describe('getPublishedDocsCreator', () => {
 
     const expectedUser = {
       ...user,
-      currentGQLSession: JSON.stringify(user.currentGQLSession),
-      currentRESTSession: JSON.stringify(user.currentRESTSession),
+      currentGQLSession: null,
+      currentRESTSession: null,
     };
 
     expect(result).toEqualRight(expectedUser);

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
@@ -253,8 +253,8 @@ export class PublishedDocsService {
     const creator = user
       ? {
           ...user,
-          currentGQLSession: JSON.stringify(user.currentGQLSession),
-          currentRESTSession: JSON.stringify(user.currentRESTSession),
+          currentGQLSession: null,
+          currentRESTSession: null,
         }
       : null;
 

--- a/packages/hoppscotch-backend/src/team-invitation/team-invitation.resolver.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invitation.resolver.ts
@@ -65,8 +65,8 @@ export class TeamInvitationResolver {
 
     return {
       ...user.value,
-      currentGQLSession: JSON.stringify(user.value.currentGQLSession),
-      currentRESTSession: JSON.stringify(user.value.currentRESTSession),
+      currentGQLSession: null,
+      currentRESTSession: null,
     };
   }
 

--- a/packages/hoppscotch-backend/src/team/team-member.resolver.ts
+++ b/packages/hoppscotch-backend/src/team/team-member.resolver.ts
@@ -17,8 +17,8 @@ export class TeamMemberResolver {
 
     return {
       ...member.value,
-      currentRESTSession: JSON.stringify(member.value.currentRESTSession),
-      currentGQLSession: JSON.stringify(member.value.currentGQLSession),
+      currentRESTSession: null,
+      currentGQLSession: null,
     };
   }
 }

--- a/packages/hoppscotch-backend/src/user-environment/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-environment/user.resolver.ts
@@ -1,26 +1,32 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { ResolveField, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { User } from 'src/user/user.model';
 import { UserEnvironment } from './user-environments.model';
 import { UserEnvironmentsService } from './user-environments.service';
 import * as E from 'fp-ts/Either';
 import { throwErr } from '../utils';
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
+import { GqlUser } from '../decorators/gql-user.decorator';
 
 @Resolver(() => User)
 export class UserEnvsUserResolver {
   constructor(private userEnvironmentsService: UserEnvironmentsService) {}
 
   @ResolveField(() => [UserEnvironment], {
-    description: 'Returns a list of users personal environments',
+    description:
+      'Returns a list of the authenticated users personal environments',
   })
-  async environments(@Parent() user: User): Promise<UserEnvironment[]> {
+  @UseGuards(GqlAuthGuard)
+  async environments(@GqlUser() user: User): Promise<UserEnvironment[]> {
     return await this.userEnvironmentsService.fetchUserEnvironments(user.uid);
   }
 
   @ResolveField(() => UserEnvironment, {
-    description: 'Returns the users global environments',
+    description: 'Returns the authenticated users global environments',
   })
+  @UseGuards(GqlAuthGuard)
   async globalEnvironments(
-    @Parent() user: User,
+    @GqlUser() user: User,
   ): Promise<UserEnvironment | string> {
     const userEnvironment =
       await this.userEnvironmentsService.fetchUserGlobalEnvironment(user.uid);

--- a/packages/hoppscotch-backend/src/user-environment/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-environment/user.resolver.ts
@@ -1,9 +1,11 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { User } from 'src/user/user.model';
 import { UserEnvironment } from './user-environments.model';
 import { UserEnvironmentsService } from './user-environments.service';
 import * as E from 'fp-ts/Either';
 import { throwErr } from '../utils';
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
 import { GqlUser } from '../decorators/gql-user.decorator';
 import { USER_ENVIRONMENT_ENV_DOES_NOT_EXISTS } from '../errors';
 
@@ -14,6 +16,7 @@ export class UserEnvsUserResolver {
   @ResolveField(() => [UserEnvironment], {
     description: 'Returns a list of users personal environments',
   })
+  @UseGuards(GqlAuthGuard)
   async environments(
     @Parent() user: User,
     @GqlUser() requestingUser: User,
@@ -25,6 +28,7 @@ export class UserEnvsUserResolver {
   @ResolveField(() => UserEnvironment, {
     description: 'Returns the users global environments',
   })
+  @UseGuards(GqlAuthGuard)
   async globalEnvironments(
     @Parent() user: User,
     @GqlUser() requestingUser: User,

--- a/packages/hoppscotch-backend/src/user-environment/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-environment/user.resolver.ts
@@ -1,33 +1,37 @@
-import { ResolveField, Resolver } from '@nestjs/graphql';
-import { UseGuards } from '@nestjs/common';
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { User } from 'src/user/user.model';
 import { UserEnvironment } from './user-environments.model';
 import { UserEnvironmentsService } from './user-environments.service';
 import * as E from 'fp-ts/Either';
 import { throwErr } from '../utils';
-import { GqlAuthGuard } from '../guards/gql-auth.guard';
 import { GqlUser } from '../decorators/gql-user.decorator';
+import { USER_ENVIRONMENT_ENV_DOES_NOT_EXISTS } from '../errors';
 
 @Resolver(() => User)
 export class UserEnvsUserResolver {
   constructor(private userEnvironmentsService: UserEnvironmentsService) {}
 
   @ResolveField(() => [UserEnvironment], {
-    description:
-      'Returns a list of the authenticated users personal environments',
+    description: 'Returns a list of users personal environments',
   })
-  @UseGuards(GqlAuthGuard)
-  async environments(@GqlUser() user: User): Promise<UserEnvironment[]> {
+  async environments(
+    @Parent() user: User,
+    @GqlUser() requestingUser: User,
+  ): Promise<UserEnvironment[]> {
+    if (requestingUser?.uid !== user.uid) return [];
     return await this.userEnvironmentsService.fetchUserEnvironments(user.uid);
   }
 
   @ResolveField(() => UserEnvironment, {
-    description: 'Returns the authenticated users global environments',
+    description: 'Returns the users global environments',
   })
-  @UseGuards(GqlAuthGuard)
   async globalEnvironments(
-    @GqlUser() user: User,
+    @Parent() user: User,
+    @GqlUser() requestingUser: User,
   ): Promise<UserEnvironment | string> {
+    if (requestingUser?.uid !== user.uid) {
+      throwErr(USER_ENVIRONMENT_ENV_DOES_NOT_EXISTS);
+    }
     const userEnvironment =
       await this.userEnvironmentsService.fetchUserGlobalEnvironment(user.uid);
     if (E.isLeft(userEnvironment)) throwErr(userEnvironment.left);

--- a/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
@@ -405,9 +405,16 @@ describe('UserHistoryService', () => {
       // Scoped lookup finds nothing because the entry belongs to another user
       mockPrisma.userHistory.findFirst.mockResolvedValueOnce(null);
 
-      return expect(
-        await userHistoryService.toggleHistoryStarStatus('attacker', '1'),
-      ).toEqualLeft(USER_HISTORY_NOT_FOUND);
+      const result = await userHistoryService.toggleHistoryStarStatus(
+        'attacker',
+        '1',
+      );
+
+      expect(result).toEqualLeft(USER_HISTORY_NOT_FOUND);
+      // The lookup must be scoped to the requesting user's uid
+      expect(mockPrisma.userHistory.findFirst).toHaveBeenCalledWith({
+        where: { id: '1', userUid: 'attacker' },
+      });
     });
   });
   describe('removeRequestFromHistory', () => {
@@ -494,9 +501,16 @@ describe('UserHistoryService', () => {
       // Prisma throws when no row matches the user-scoped where clause
       mockPrisma.userHistory.delete.mockRejectedValueOnce(new Error('P2025'));
 
-      return expect(
-        await userHistoryService.removeRequestFromHistory('attacker', '1'),
-      ).toEqualLeft(USER_HISTORY_NOT_FOUND);
+      const result = await userHistoryService.removeRequestFromHistory(
+        'attacker',
+        '1',
+      );
+
+      expect(result).toEqualLeft(USER_HISTORY_NOT_FOUND);
+      // The delete must be scoped to the requesting user's uid
+      expect(mockPrisma.userHistory.delete).toHaveBeenCalledWith({
+        where: { id: '1', userUid: 'attacker' },
+      });
     });
   });
   describe('deleteAllUserHistory', () => {

--- a/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
@@ -369,6 +369,46 @@ describe('UserHistoryService', () => {
         userHistory,
       );
     });
+    test('Should scope the lookup and the update to the requesting user (ownership enforcement)', async () => {
+      const executedOn = new Date();
+
+      mockPrisma.userHistory.findFirst.mockResolvedValueOnce({
+        userUid: 'abc',
+        id: '1',
+        request: [{}],
+        responseMetadata: [{}],
+        reqType: ReqType.REST,
+        executedOn,
+        isStarred: false,
+      });
+      mockPrisma.userHistory.update.mockResolvedValueOnce({
+        userUid: 'abc',
+        id: '1',
+        request: [{}],
+        responseMetadata: [{}],
+        reqType: ReqType.REST,
+        executedOn,
+        isStarred: true,
+      });
+
+      await userHistoryService.toggleHistoryStarStatus('abc', '1');
+
+      expect(mockPrisma.userHistory.findFirst).toHaveBeenCalledWith({
+        where: { id: '1', userUid: 'abc' },
+      });
+      expect(mockPrisma.userHistory.update).toHaveBeenCalledWith({
+        where: { id: '1', userUid: 'abc' },
+        data: { isStarred: true },
+      });
+    });
+    test('Should resolve left when the history entry is not owned by the requesting user', async () => {
+      // Scoped lookup finds nothing because the entry belongs to another user
+      mockPrisma.userHistory.findFirst.mockResolvedValueOnce(null);
+
+      return expect(
+        await userHistoryService.toggleHistoryStarStatus('attacker', '1'),
+      ).toEqualLeft(USER_HISTORY_NOT_FOUND);
+    });
   });
   describe('removeRequestFromHistory', () => {
     test('Should resolve right and delete request from users history', async () => {
@@ -432,6 +472,31 @@ describe('UserHistoryService', () => {
         `user_history/${userHistory.userUid}/deleted`,
         userHistory,
       );
+    });
+    test('Should scope the delete to the requesting user (ownership enforcement)', async () => {
+      mockPrisma.userHistory.delete.mockResolvedValueOnce({
+        userUid: 'abc',
+        id: '1',
+        request: [{}],
+        responseMetadata: [{}],
+        reqType: ReqType.REST,
+        executedOn: date,
+        isStarred: false,
+      });
+
+      await userHistoryService.removeRequestFromHistory('abc', '1');
+
+      expect(mockPrisma.userHistory.delete).toHaveBeenCalledWith({
+        where: { id: '1', userUid: 'abc' },
+      });
+    });
+    test('Should resolve left when deleting a history entry not owned by the requesting user', async () => {
+      // Prisma throws when no row matches the user-scoped where clause
+      mockPrisma.userHistory.delete.mockRejectedValueOnce(new Error('P2025'));
+
+      return expect(
+        await userHistoryService.removeRequestFromHistory('attacker', '1'),
+      ).toEqualLeft(USER_HISTORY_NOT_FOUND);
     });
   });
   describe('deleteAllUserHistory', () => {

--- a/packages/hoppscotch-backend/src/user-history/user-history.service.ts
+++ b/packages/hoppscotch-backend/src/user-history/user-history.service.ts
@@ -99,7 +99,7 @@ export class UserHistoryService {
    * @returns an Either of updated `UserHistory` or Error
    */
   async toggleHistoryStarStatus(uid: string, id: string) {
-    const userHistory = await this.fetchUserHistoryByID(id);
+    const userHistory = await this.fetchUserHistoryByID(id, uid);
     if (O.isNone(userHistory)) {
       return E.left(USER_HISTORY_NOT_FOUND);
     }
@@ -108,6 +108,7 @@ export class UserHistoryService {
       const updatedHistory = await this.prisma.userHistory.update({
         where: {
           id: id,
+          userUid: uid,
         },
         data: {
           isStarred: !userHistory.value.isStarred,
@@ -142,6 +143,7 @@ export class UserHistoryService {
       const delUserHistory = await this.prisma.userHistory.delete({
         where: {
           id: id,
+          userUid: uid,
         },
       });
 
@@ -205,14 +207,16 @@ export class UserHistoryService {
   }
 
   /**
-   * Fetch a user history based on history ID.
+   * Fetch a user history based on history ID, scoped to its owner.
    * @param id User History ID
-   * @returns an `UserHistory` object
+   * @param uid UID of the user the history entry must belong to
+   * @returns an `UserHistory` object owned by the given user, or `O.none`
    */
-  async fetchUserHistoryByID(id: string) {
+  async fetchUserHistoryByID(id: string, uid: string) {
     const userHistory = await this.prisma.userHistory.findFirst({
       where: {
         id: id,
+        userUid: uid,
       },
     });
     if (userHistory == null) return O.none;

--- a/packages/hoppscotch-backend/src/user-history/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-history/user.resolver.ts
@@ -1,11 +1,9 @@
-import { Args, ResolveField, Resolver } from '@nestjs/graphql';
-import { UseGuards } from '@nestjs/common';
+import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { User } from '../user/user.model';
 import { UserHistoryService } from './user-history.service';
 import { UserHistory } from './user-history.model';
 import { ReqType } from 'src/types/RequestTypes';
 import { PaginationArgs } from '../types/input-types.args';
-import { GqlAuthGuard } from '../guards/gql-auth.guard';
 import { GqlUser } from '../decorators/gql-user.decorator';
 
 @Resolver(() => User)
@@ -13,13 +11,14 @@ export class UserHistoryUserResolver {
   constructor(private userHistoryService: UserHistoryService) {}
 
   @ResolveField(() => [UserHistory], {
-    description: 'Returns the authenticated users REST history',
+    description: 'Returns a users REST history',
   })
-  @UseGuards(GqlAuthGuard)
   async RESTHistory(
-    @GqlUser() user: User,
+    @Parent() user: User,
+    @GqlUser() requestingUser: User,
     @Args() args: PaginationArgs,
   ): Promise<UserHistory[]> {
+    if (requestingUser?.uid !== user.uid) return [];
     return await this.userHistoryService.fetchUserHistory(
       user.uid,
       args.take,
@@ -27,13 +26,14 @@ export class UserHistoryUserResolver {
     );
   }
   @ResolveField(() => [UserHistory], {
-    description: 'Returns the authenticated users GraphQL history',
+    description: 'Returns a users GraphQL history',
   })
-  @UseGuards(GqlAuthGuard)
   async GQLHistory(
-    @GqlUser() user: User,
+    @Parent() user: User,
+    @GqlUser() requestingUser: User,
     @Args() args: PaginationArgs,
   ): Promise<UserHistory[]> {
+    if (requestingUser?.uid !== user.uid) return [];
     return await this.userHistoryService.fetchUserHistory(
       user.uid,
       args.take,

--- a/packages/hoppscotch-backend/src/user-history/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-history/user.resolver.ts
@@ -1,19 +1,23 @@
-import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Args, ResolveField, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { User } from '../user/user.model';
 import { UserHistoryService } from './user-history.service';
 import { UserHistory } from './user-history.model';
 import { ReqType } from 'src/types/RequestTypes';
 import { PaginationArgs } from '../types/input-types.args';
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
+import { GqlUser } from '../decorators/gql-user.decorator';
 
 @Resolver(() => User)
 export class UserHistoryUserResolver {
   constructor(private userHistoryService: UserHistoryService) {}
 
   @ResolveField(() => [UserHistory], {
-    description: 'Returns a users REST history',
+    description: 'Returns the authenticated users REST history',
   })
+  @UseGuards(GqlAuthGuard)
   async RESTHistory(
-    @Parent() user: User,
+    @GqlUser() user: User,
     @Args() args: PaginationArgs,
   ): Promise<UserHistory[]> {
     return await this.userHistoryService.fetchUserHistory(
@@ -23,10 +27,11 @@ export class UserHistoryUserResolver {
     );
   }
   @ResolveField(() => [UserHistory], {
-    description: 'Returns a users GraphQL history',
+    description: 'Returns the authenticated users GraphQL history',
   })
+  @UseGuards(GqlAuthGuard)
   async GQLHistory(
-    @Parent() user: User,
+    @GqlUser() user: User,
     @Args() args: PaginationArgs,
   ): Promise<UserHistory[]> {
     return await this.userHistoryService.fetchUserHistory(

--- a/packages/hoppscotch-backend/src/user-history/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-history/user.resolver.ts
@@ -1,9 +1,11 @@
 import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { User } from '../user/user.model';
 import { UserHistoryService } from './user-history.service';
 import { UserHistory } from './user-history.model';
 import { ReqType } from 'src/types/RequestTypes';
 import { PaginationArgs } from '../types/input-types.args';
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
 import { GqlUser } from '../decorators/gql-user.decorator';
 
 @Resolver(() => User)
@@ -13,6 +15,7 @@ export class UserHistoryUserResolver {
   @ResolveField(() => [UserHistory], {
     description: 'Returns a users REST history',
   })
+  @UseGuards(GqlAuthGuard)
   async RESTHistory(
     @Parent() user: User,
     @GqlUser() requestingUser: User,
@@ -28,6 +31,7 @@ export class UserHistoryUserResolver {
   @ResolveField(() => [UserHistory], {
     description: 'Returns a users GraphQL history',
   })
+  @UseGuards(GqlAuthGuard)
   async GQLHistory(
     @Parent() user: User,
     @GqlUser() requestingUser: User,

--- a/packages/hoppscotch-backend/src/user-settings/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-settings/user.resolver.ts
@@ -1,22 +1,21 @@
-import { ResolveField, Resolver } from '@nestjs/graphql';
-import { UseGuards } from '@nestjs/common';
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
 import { User } from 'src/user/user.model';
 import { UserSettings } from './user-settings.model';
 import { UserSettingsService } from './user-settings.service';
 import * as E from 'fp-ts/Either';
 import { throwErr } from 'src/utils';
-import { GqlAuthGuard } from '../guards/gql-auth.guard';
 import { GqlUser } from '../decorators/gql-user.decorator';
+import { USER_SETTINGS_NOT_FOUND } from '../errors';
 
 @Resolver(() => User)
 export class UserSettingsUserResolver {
   constructor(private readonly userSettingsService: UserSettingsService) {}
 
   @ResolveField(() => UserSettings, {
-    description: 'Returns the authenticated users settings',
+    description: 'Returns user settings',
   })
-  @UseGuards(GqlAuthGuard)
-  async settings(@GqlUser() user: User) {
+  async settings(@Parent() user: User, @GqlUser() requestingUser: User) {
+    if (requestingUser?.uid !== user.uid) throwErr(USER_SETTINGS_NOT_FOUND);
     const userSettings = await this.userSettingsService.fetchUserSettings(user);
 
     if (E.isLeft(userSettings)) throwErr(userSettings.left);

--- a/packages/hoppscotch-backend/src/user-settings/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-settings/user.resolver.ts
@@ -1,18 +1,22 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { ResolveField, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { User } from 'src/user/user.model';
 import { UserSettings } from './user-settings.model';
 import { UserSettingsService } from './user-settings.service';
 import * as E from 'fp-ts/Either';
 import { throwErr } from 'src/utils';
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
+import { GqlUser } from '../decorators/gql-user.decorator';
 
 @Resolver(() => User)
 export class UserSettingsUserResolver {
   constructor(private readonly userSettingsService: UserSettingsService) {}
 
   @ResolveField(() => UserSettings, {
-    description: 'Returns user settings',
+    description: 'Returns the authenticated users settings',
   })
-  async settings(@Parent() user: User) {
+  @UseGuards(GqlAuthGuard)
+  async settings(@GqlUser() user: User) {
     const userSettings = await this.userSettingsService.fetchUserSettings(user);
 
     if (E.isLeft(userSettings)) throwErr(userSettings.left);

--- a/packages/hoppscotch-backend/src/user-settings/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-settings/user.resolver.ts
@@ -1,9 +1,11 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { User } from 'src/user/user.model';
 import { UserSettings } from './user-settings.model';
 import { UserSettingsService } from './user-settings.service';
 import * as E from 'fp-ts/Either';
 import { throwErr } from 'src/utils';
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
 import { GqlUser } from '../decorators/gql-user.decorator';
 import { USER_SETTINGS_NOT_FOUND } from '../errors';
 
@@ -14,6 +16,7 @@ export class UserSettingsUserResolver {
   @ResolveField(() => UserSettings, {
     description: 'Returns user settings',
   })
+  @UseGuards(GqlAuthGuard)
   async settings(@Parent() user: User, @GqlUser() requestingUser: User) {
     if (requestingUser?.uid !== user.uid) throwErr(USER_SETTINGS_NOT_FOUND);
     const userSettings = await this.userSettingsService.fetchUserSettings(user);


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes BE-775
<!-- Security advisory GHSA-p25p-g9jp-7q46 (private) -->

Fixes an IDOR / broken object-level authorization issue where an authenticated workspace member could read and tamper with another user's private data. The fix enforces ownership in the data-access layer (scoped `where` clauses / authenticated-user resolution) rather than trusting object IDs or the GraphQL parent.

### What's changed

- [x] **History mutations IDOR** — `toggleHistoryStarStatus` and `removeRequestFromHistory` acted on a `UserHistory` entry by `id` alone, letting any authenticated user star/unstar or delete another user's history entry. The lookup, update and delete are now scoped to the requesting user via a `userUid` where clause; a non-owned id resolves to `USER_HISTORY_NOT_FOUND`.
- [x] **Private `User` field over-exposure** — the `RESTHistory`, `GQLHistory`, `environments`, `globalEnvironments` and `settings` resolvers on the shared `User` type resolved off the parent `uid`, leaking a teammate's private data whenever a `User` was returned in a team context. They now resolve off the authenticated user (`@GqlUser()` + `GqlAuthGuard`).
- [x] **Session data leak** — `currentRESTSession` / `currentGQLSession` were serialized for other users in `TeamMember.user`, `TeamInvitation.creator`, `MockServer.creator` and the publicly reachable published-docs creator. Session data is no longer exposed for anyone other than the owner.
- [x] **Tests** — added unit coverage asserting the `userUid` scoping on the history mutations (lookup/update/delete) and denial for non-owned entries.

### Notes to reviewers

- This addresses **security advisory [GHSA-p25p-g9jp-7q46](https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-p25p-g9jp-7q46)** (currently private). Please keep discussion mindful of disclosure timing.
- All enforcement is done via DB `where` clauses keyed on the authenticated `uid` — no new guard abstraction was introduced.
- Behavioral note: the private `User` field resolvers now always reflect the authenticated user, so requesting e.g. `team { teamMembers { user { RESTHistory } } }` returns the requester's own history per node rather than erroring. No cross-user data is exposed; the official UI only requests these via `me { … }`, so it is unaffected.
- Scope is limited to `packages/hoppscotch-backend`.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an IDOR by enforcing strict ownership checks and restoring explicit GraphQL auth guards in `packages/hoppscotch-backend`. Private `User` fields now resolve only for their owner; others return empty results or Not Found. Addresses BE-775.

- **Bug Fixes**
  - User history: `toggleHistoryStarStatus` and `removeRequestFromHistory` now scope by `id` + `userUid`; `fetchUserHistoryByID` requires `uid` and is owner-scoped. Non-owners get `USER_HISTORY_NOT_FOUND`. Added tests for scoped lookups/updates/deletes and non-owner failures.
  - Private `User` fields: `RESTHistory`, `GQLHistory`, `environments`, `globalEnvironments`, and `settings` are guarded with `GqlAuthGuard` and return only when `requestingUser.uid === user.uid`. Non-owners get `[]` for `RESTHistory`/`GQLHistory`/`environments`, `USER_ENVIRONMENT_ENV_DOES_NOT_EXISTS` for `globalEnvironments`, and `USER_SETTINGS_NOT_FOUND` for `settings`.
  - Session exposure: `currentRESTSession`/`currentGQLSession` are now `null` for other users in `TeamMember.user`, `TeamInvitation.creator`, `MockServer.creator`, and published docs creator; tests updated.

<sup>Written for commit 2f686d7a22701f7f377d05fc2f1ea65f5d217c65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



