### PR TITLE
fix(mock-server): persist `isPublic` on creation, default to private

### DIFF
--- a/packages/hoppscotch-backend/src/mock-server/mock-server.model.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.model.ts
@@ -179,8 +179,8 @@ export class CreateMockServerInput {
   @IsOptional()
   @Field({
     nullable: true,
-    defaultValue: true,
-    description: 'Whether the mock server is publicly accessible',
+    description:
+      'Whether the mock server is publicly accessible (defaults to false/private if omitted)',
   })
   isPublic?: boolean;
 }

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.service.spec.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.service.spec.ts
@@ -394,9 +394,12 @@ describe('MockServerService', () => {
     test('should persist isPublic: false when input requests a private server', async () => {
       mockPrisma.userCollection.findUnique.mockResolvedValue(userCollection);
       mockPrisma.mockServer.findUnique.mockResolvedValue(null);
-      mockPrisma.mockServer.create.mockResolvedValue(dbMockServer);
+      mockPrisma.mockServer.create.mockResolvedValue({
+        ...dbMockServer,
+        isPublic: false,
+      });
 
-      await mockServerService.createMockServer(user, {
+      const result = await mockServerService.createMockServer(user, {
         ...createInput,
         isPublic: false,
       });
@@ -406,14 +409,21 @@ describe('MockServerService', () => {
           data: expect.objectContaining({ isPublic: false }),
         }),
       );
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect((result.right as any).isPublic).toBe(false);
+      }
     });
 
     test('should persist isPublic: true when input requests a public server', async () => {
       mockPrisma.userCollection.findUnique.mockResolvedValue(userCollection);
       mockPrisma.mockServer.findUnique.mockResolvedValue(null);
-      mockPrisma.mockServer.create.mockResolvedValue(dbMockServer);
+      mockPrisma.mockServer.create.mockResolvedValue({
+        ...dbMockServer,
+        isPublic: true,
+      });
 
-      await mockServerService.createMockServer(user, {
+      const result = await mockServerService.createMockServer(user, {
         ...createInput,
         isPublic: true,
       });
@@ -423,12 +433,19 @@ describe('MockServerService', () => {
           data: expect.objectContaining({ isPublic: true }),
         }),
       );
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect((result.right as any).isPublic).toBe(true);
+      }
     });
 
     test('should default to private (isPublic: false) when input omits isPublic', async () => {
       mockPrisma.userCollection.findUnique.mockResolvedValue(userCollection);
       mockPrisma.mockServer.findUnique.mockResolvedValue(null);
-      mockPrisma.mockServer.create.mockResolvedValue(dbMockServer);
+      mockPrisma.mockServer.create.mockResolvedValue({
+        ...dbMockServer,
+        isPublic: false,
+      });
 
       await mockServerService.createMockServer(user, createInput);
 

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.service.spec.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.service.spec.ts
@@ -389,6 +389,56 @@ describe('MockServerService', () => {
       );
     });
 
+    // Regression: GHSA-c68f-wr5p-j6jf — isPublic from input must be persisted,
+    // and must default to private (false) when omitted.
+    test('should persist isPublic: false when input requests a private server', async () => {
+      mockPrisma.userCollection.findUnique.mockResolvedValue(userCollection);
+      mockPrisma.mockServer.findUnique.mockResolvedValue(null);
+      mockPrisma.mockServer.create.mockResolvedValue(dbMockServer);
+
+      await mockServerService.createMockServer(user, {
+        ...createInput,
+        isPublic: false,
+      });
+
+      expect(mockPrisma.mockServer.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ isPublic: false }),
+        }),
+      );
+    });
+
+    test('should persist isPublic: true when input requests a public server', async () => {
+      mockPrisma.userCollection.findUnique.mockResolvedValue(userCollection);
+      mockPrisma.mockServer.findUnique.mockResolvedValue(null);
+      mockPrisma.mockServer.create.mockResolvedValue(dbMockServer);
+
+      await mockServerService.createMockServer(user, {
+        ...createInput,
+        isPublic: true,
+      });
+
+      expect(mockPrisma.mockServer.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ isPublic: true }),
+        }),
+      );
+    });
+
+    test('should default to private (isPublic: false) when input omits isPublic', async () => {
+      mockPrisma.userCollection.findUnique.mockResolvedValue(userCollection);
+      mockPrisma.mockServer.findUnique.mockResolvedValue(null);
+      mockPrisma.mockServer.create.mockResolvedValue(dbMockServer);
+
+      await mockServerService.createMockServer(user, createInput);
+
+      expect(mockPrisma.mockServer.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ isPublic: false }),
+        }),
+      );
+    });
+
     test('should create team mock server successfully', async () => {
       const teamInput: CreateMockServerInput = {
         name: 'Team Mock Server',

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.service.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.service.ts
@@ -421,6 +421,7 @@ export class MockServerService {
               ? input.workspaceID
               : user.uid,
           delayInMs: input.delayInMs,
+          isPublic: input.isPublic ?? false,
         },
       });
       this.mockServerAnalyticsService.recordActivity(


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes BE-776
<!-- security advisory GHSA-c68f-wr5p-j6jf (private) -->

Mock servers were being created as **public** regardless of what the user requested. `createMockServer` never wrote the `isPublic` field into the Prisma `create` payload, so the DB column default `@default(true)` always took effect. The GraphQL input and the UI "Make public" toggle both send `isPublic`, but the value was silently discarded — meaning a user who explicitly set a server to **private** still got an unauthenticated, publicly reachable mock endpoint (the mock-request guard only enforces PAT auth when `!isPublic`). This exposed the linked collection's mock responses to anyone.

### What's changed
- [x] `createMockServer` now persists `isPublic: input.isPublic ?? false` in the create payload, so the user's choice is honored and the default is **private** when omitted (`mock-server.service.ts`)
- [x] Removed `defaultValue: true` from `CreateMockServerInput.isPublic` so the GraphQL layer no longer re-introduces a public default; the service is the single source of the default (`mock-server.model.ts`)
- [x] Added regression tests covering `isPublic: false` / `isPublic: true` / omitted-defaults-to-private (`mock-server.service.spec.ts`)

### Notes to reviewers
- `updateMockServer` already persisted `isPublic` correctly via `data: input` — only the create path was affected.
- No DB migration and no UI default-toggle change: the DB `@default(true)` stays but is now always overridden on create, and the frontend always sends an explicit value.
- Scope is backend-only (`packages/hoppscotch-backend`). `pnpm jest mock-server.service.spec.ts` passes (84 tests).
- **Pre-existing mock servers** created before this fix may already be `isPublic = true` in the DB and are not retroactively changed — worth a separate remediation/notification if that's a concern for deployed instances.
- Addresses security advisory **[GHSA-c68f-wr5p-j6jf](https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-c68f-wr5p-j6jf)**.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where new mock servers were always created as public. We now honor the requested `isPublic` value and default to private when omitted (addresses BE-776).

- **Bug Fixes**
  - Persist `isPublic` in `createMockServer` using `input.isPublic ?? false`.
  - Remove `defaultValue: true` from `CreateMockServerInput.isPublic` and clarify the field description to default to private.
  - Add regression tests covering `isPublic: false`, `isPublic: true`, and the default-to-private case.

<sup>Written for commit bbf8c038958607cf2b398d7b63d7b9d6d7674457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



