### PR TITLE
feat: show response timing breakdown

### DIFF
--- a/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
+++ b/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
@@ -99,7 +99,15 @@
               )
             }}
           </span>
-          <span v-if="response.meta && response.meta.responseDuration">
+          <span
+            v-if="response.meta && response.meta.responseDuration"
+            v-tippy="
+              responseTimingBreakdown
+                ? { theme: 'tooltip', allowHTML: true }
+                : { onShow: () => false }
+            "
+            :title="responseTimingBreakdown"
+          >
             <span class="text-secondary"> {{ t("response.time") }}: </span>
             {{ `${response.meta.responseDuration} ms` }}
           </span>
@@ -185,6 +193,37 @@ const readableResponseSize = computed(() => {
   if (size >= 1000) return (size / 1000).toFixed(2) + " KB"
 
   return undefined
+})
+
+const responseTimingBreakdown = computed(() => {
+  if (
+    props.response === null ||
+    props.response === undefined ||
+    props.response.type === "loading" ||
+    props.response.type === "network_fail" ||
+    props.response.type === "script_fail" ||
+    props.response.type === "fail" ||
+    props.response.type === "extension_error"
+  )
+    return undefined
+
+  const timings = props.response.meta.responseTimings
+  if (!timings) return undefined
+
+  const phaseLabels: Array<[keyof typeof timings, string]> = [
+    ["dns", "DNS"],
+    ["connect", "Connect"],
+    ["tls", "TLS"],
+    ["send", "Send"],
+    ["wait", "Waiting"],
+    ["receive", "Download"],
+  ]
+
+  const rows = phaseLabels
+    .filter(([phase]) => typeof timings[phase] === "number")
+    .map(([phase, label]) => `${label}: ${timings[phase]} ms`)
+
+  return rows.length > 0 ? rows.join("<br>") : undefined
 })
 
 const statusCategory = computed(() => {

--- a/packages/hoppscotch-common/src/helpers/kernel/__tests__/kernel.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/__tests__/kernel.spec.ts
@@ -227,6 +227,10 @@ describe("REST Response Transformation", () => {
         timing: {
           start: 100,
           end: 200,
+          phases: {
+            wait: 80,
+            receive: 20,
+          },
         },
         size: {
           total: 5,
@@ -258,6 +262,10 @@ describe("REST Response Transformation", () => {
     if (result.type === "success") {
       expect(result.statusCode).toBe(200)
       expect(result.meta.responseDuration).toBe(100)
+      expect(result.meta.responseTimings).toEqual({
+        wait: 80,
+        receive: 20,
+      })
       expect(result.meta.responseSize).toBe(5)
       expect(result.headers).toHaveLength(2)
     }

--- a/packages/hoppscotch-common/src/helpers/kernel/rest/response.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/rest/response.ts
@@ -2,6 +2,7 @@ import { RelayResponse } from "@hoppscotch/kernel"
 import { HoppRESTRequest } from "@hoppscotch/data"
 import {
   HoppRESTResponseHeader,
+  HoppRESTResponseTimingPhases,
   HoppRESTSuccessResponse,
 } from "~/helpers/types/HoppRESTResponse"
 
@@ -17,6 +18,10 @@ const extractTiming = (response: RelayResponse): number =>
   response.meta?.timing
     ? response.meta.timing.end - response.meta.timing.start
     : 0
+
+const extractTimingPhases = (
+  response: RelayResponse
+): HoppRESTResponseTimingPhases | undefined => response.meta?.timing?.phases
 
 const extractSize = (response: RelayResponse): number =>
   response.meta?.size?.total ?? 0
@@ -93,6 +98,7 @@ export const RESTResponse = {
       meta: {
         responseSize: extractSize(response),
         responseDuration: extractTiming(response),
+        responseTimings: extractTimingPhases(response),
       },
       req: originalRequest,
     }

--- a/packages/hoppscotch-common/src/helpers/types/HoppRESTResponse.ts
+++ b/packages/hoppscotch-common/src/helpers/types/HoppRESTResponse.ts
@@ -4,6 +4,15 @@ import { KernelInterceptorError } from "~/services/kernel-interceptor.service"
 
 export type HoppRESTResponseHeader = { key: string; value: string }
 
+export type HoppRESTResponseTimingPhases = {
+  dns?: number
+  connect?: number
+  tls?: number
+  send?: number
+  wait?: number
+  receive?: number
+}
+
 export type HoppRESTSuccessResponse = {
   type: "success"
   headers: HoppRESTResponseHeader[]
@@ -13,6 +22,7 @@ export type HoppRESTSuccessResponse = {
   meta: {
     responseSize: number // in bytes
     responseDuration: number // in millis
+    responseTimings?: HoppRESTResponseTimingPhases
   }
   req: HoppRESTRequest
 }
@@ -26,6 +36,7 @@ export type HoppRESTFailureResponse = {
   meta: {
     responseSize: number // in bytes
     responseDuration: number // in millis
+    responseTimings?: HoppRESTResponseTimingPhases
   }
   req: HoppRESTRequest
 }

--- a/packages/hoppscotch-kernel/src/relay/impl/desktop/v/1.ts
+++ b/packages/hoppscotch-kernel/src/relay/impl/desktop/v/1.ts
@@ -172,6 +172,7 @@ export const implementation: VersionedAPI<RelayV1> = {
                 timing: {
                   start: result.response.meta.timing.start,
                   end: result.response.meta.timing.end,
+                  phases: result.response.meta.timing.phases,
                 },
                 size: result.response.meta.size,
               },


### PR DESCRIPTION
## Summary

Adds support for displaying response timing phase details when the kernel/interceptor provides them.

- preserves desktop relay `meta.timing.phases` instead of dropping them
- carries timing phases into REST response metadata
- shows available phase timings in the response time tooltip, including DNS, connect, TLS, send, waiting, and download
- adds transform coverage for preserving `wait` and `receive` timings

Refs #6411.

## Testing

- `git diff --check`
- Not run: local shell has no `npm` or `pnpm` available, so I could not run the Vitest suite in this checkout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a detailed response timing breakdown (DNS, connect, TLS, send, wait, download) in the response time tooltip when phases are available. Preserves and propagates timing phases from the desktop relay to REST response metadata, fulfilling #6411.

- **New Features**
  - Preserve relay `meta.timing.phases` and expose as `meta.responseTimings` on REST responses.
  - Display available phase timings in the response time tooltip.
  - Add types and tests covering `wait` and `receive` timings.

<sup>Written for commit f652987ae43feacd1037841b92d722c959830632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

