### PR TITLE
fix(backend): reject path/query/fragment in SMTP URL validation

### DIFF
--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -205,7 +205,8 @@ export const validateSMTPUrl = (url: string) => {
 
   if (!url || url.length === 0) return false;
 
-  if (/[?#]/.test(url)) return false;
+  if (/[\s\x00-\x1f\x7f]/.test(url)) return false;
+  if (/[?#\\]/.test(url)) return false;
   if (url.endsWith(':')) return false;
 
   let parsed: URL;
@@ -217,10 +218,8 @@ export const validateSMTPUrl = (url: string) => {
 
   // Only the SMTP schemes are permitted.
   if (parsed.protocol !== 'smtp:' && parsed.protocol !== 'smtps:') return false;
-
-  // No path component — only a bare host[:port] endpoint is valid. Query
-  // strings and fragments are already rejected by the raw `[?#]` check above.
-  if (parsed.pathname !== '') return false;
+  if (parsed.pathname !== '' && parsed.pathname !== '/') return false;
+  if (parsed.search !== '' || parsed.hash !== '') return false;
 
   // A hostname is required and must not start with a dot.
   if (!parsed.hostname || parsed.hostname.startsWith('.')) return false;

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -205,6 +205,9 @@ export const validateSMTPUrl = (url: string) => {
 
   if (!url || url.length === 0) return false;
 
+  if (/[?#]/.test(url)) return false;
+  if (url.endsWith(':')) return false;
+
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -215,11 +218,9 @@ export const validateSMTPUrl = (url: string) => {
   // Only the SMTP schemes are permitted.
   if (parsed.protocol !== 'smtp:' && parsed.protocol !== 'smtps:') return false;
 
-  // A path, query string, or fragment must never be present. nodemailer's `createTransport(string)` merges every query-string key into the transport
-  // options (e.g. `?sendmail=true&path=/bin/sh&args=-c&args=<cmd>`), which can switch the transport to `SendmailTransport` and lead to RCE.
-  // Reject anything beyond a bare host[:port] endpoint.
-  if (parsed.search !== '' || parsed.hash !== '') return false;
-  if (parsed.pathname !== '' && parsed.pathname !== '/') return false;
+  // No path component — only a bare host[:port] endpoint is valid. Query
+  // strings and fragments are already rejected by the raw `[?#]` check above.
+  if (parsed.pathname !== '') return false;
 
   // A hostname is required and must not start with a dot.
   if (!parsed.hostname || parsed.hostname.startsWith('.')) return false;

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -205,10 +205,27 @@ export const validateSMTPUrl = (url: string) => {
 
   if (!url || url.length === 0) return false;
 
-  const regex =
-    /^(smtp|smtps):\/\/(?:([^:]+):([^@]+)@)?((?!\.)[^:]+)(?::(\d+))?$/;
-  if (regex.test(url)) return true;
-  return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  // Only the SMTP schemes are permitted.
+  if (parsed.protocol !== 'smtp:' && parsed.protocol !== 'smtps:') return false;
+
+  // A path, query string, or fragment must never be present. nodemailer's `createTransport(string)` merges every query-string key into the transport
+  // options (e.g. `?sendmail=true&path=/bin/sh&args=-c&args=<cmd>`), which can switch the transport to `SendmailTransport` and lead to RCE.
+  // Reject anything beyond a bare host[:port] endpoint.
+  if (parsed.search !== '' || parsed.hash !== '') return false;
+  if (parsed.pathname !== '' && parsed.pathname !== '/') return false;
+
+  // A hostname is required and must not start with a dot.
+  if (!parsed.hostname || parsed.hostname.startsWith('.')) return false;
+
+  // Port, when present, must be numeric (the URL parser already guarantees this).
+  return true;
 };
 
 /**


### PR DESCRIPTION
<!-- Private security fix for GHSA-v7q6-r45w-2c6r -->
Closes BE-777
<!-- GHSA-v7q6-r45w-2c6r -->

Hardens SMTP URL validation to close an admin-reachable remote code execution path in the self-hosted backend ([GHSA-v7q6-r45w-2c6r](https://github.com/hoppscotch/hoppscotch/security/advisories/GHSA-v7q6-r45w-2c6r)).

`validateSMTPUrl` accepted any query string, path, or fragment because the hostname class `[^:]+` in the old regex swallowed them. nodemailer's `createTransport(string)` merges every query-string key into the transport options, so a stored value such as `smtp://x?sendmail=true&path=/bin/sh&args=-c&args=<cmd>` switches the transport to `SendmailTransport` with attacker-controlled `path`/`args` — executing arbitrary commands on the next outbound email (one anonymous magic-link signin is enough). The mutation is admin-gated, but admin mailer config should never be able to escalate to shell access.

### What's changed
- Rewrote `validateSMTPUrl` to parse with the WHATWG `URL` API and reject anything beyond a bare `smtp(s)://[user:pass@]host[:port]` endpoint — no query string, path, or fragment.
- This covers both entry points that flow through `validateEnvValues`: the `updateInfraConfigs` admin GraphQL mutation and the onboarding config endpoint.
- Added `packages/hoppscotch-backend/src/utils.spec.ts` covering the four documented valid URL formats, malformed/wrong-scheme inputs, and the injection payloads as a regression guard.

### Notes to reviewers
- Scope is the validation boundary only; no behavior change for any documented SMTP URL format (none use query strings).
- Out of scope (worth separate follow-ups): forwarding a structured transport object to nodemailer instead of a raw string (defense in depth), and running the AIO container as non-root (`prod.Dockerfile` has no `USER` directive).



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened SMTP URL validation to prevent `nodemailer` transport option injection via non-endpoint components, closing an admin-reachable RCE in the self-hosted backend (GHSA-v7q6-r45w-2c6r). Only bare `smtp://` or `smtps://` endpoints are accepted; valid formats continue to work. Closes BE-777.

- **Bug Fixes**
  - Switch to the WHATWG `URL` parser with pre-parse guards to avoid parser differentials; allow only `smtp(s)://[user:pass@]host[:port]` with empty or `/` path, and reject query/fragment, control chars, backslashes, `[?#]`, trailing colons, and leading-dot hosts.
  - Applies to the admin mailer config and onboarding flows to block option-merging attacks into `nodemailer`.

<sup>Written for commit 5a8578776f85e39f57e571389a20aea6b400f46d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



