### PR TITLE
Fix/network fail cors message

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -672,7 +672,7 @@
   "error": {
     "network": {
       "heading": "Network Error",
-      "description": "Network connection failed. {message}: {cause}"
+      "description": "Network connection failed. {message}: {cause}. This may be caused by a CORS policy. Try enabling the Proxy or installing the Hoppscotch browser extension in Settings."
     },
     "timeout": {
       "heading": "Timeout Error",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -737,7 +737,7 @@
     "json_parsing_failed": "Invalid JSON",
     "json_prettify_invalid_body": "Couldn't prettify an invalid body, solve json syntax errors and try again",
     "network_error": "There seems to be a network error. Please try again.",
-    "network_fail": "Could not send request",
+    "network_fail": "Could not send request. This may be caused by a CORS policy. Try enabling the Proxy or installing the Hoppscotch browser extension in Settings.",
     "no_collections_to_export": "No collections to export. Please create a collection to get started.",
     "no_duration": "No duration",
     "no_environments_to_export": "No environments to export. Please create an environment to get started.",


### PR DESCRIPTION
  ## Summary
  - Improves the `network_fail` error message in `en.json` to include guidance about CORS policies
  - Suggests enabling the Proxy or installing the browser extension when a network error occurs

  ## Changes
  `packages/hoppscotch-common/locales/en.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve network error messaging by adding CORS guidance and clear next steps. When a request fails, users are prompted to enable the Proxy or install the Hoppscotch browser extension from Settings.

<sup>Written for commit 98e40885b7f179cbf832ac1f8e24316841158299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

