### PR TITLE
fix(common): improve network error description with CORS guidance

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -669,7 +669,7 @@
     "properties": "Environment Properties",
     "details": "Details"
   },
-"error": {
+  "error": {
     "network": {
       "heading": "Network Error",
       "description": "Network connection failed. {message}: {cause}. This may be caused by a CORS policy. Try enabling the Proxy or installing the Hoppscotch browser extension in Settings."

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -669,10 +669,10 @@
     "properties": "Environment Properties",
     "details": "Details"
   },
-  "error": {
+"error": {
     "network": {
       "heading": "Network Error",
-      "description": "Network connection failed. {message}: {cause}"
+      "description": "Network connection failed. {message}: {cause}. This may be caused by a CORS policy. Try enabling the Proxy or installing the Hoppscotch browser extension in Settings."
     },
     "timeout": {
       "heading": "Timeout Error",


### PR DESCRIPTION
## Summary
- Updates `error.network.description` in `en.json` to include CORS policy guidance
- Suggests enabling the Proxy or installing the Hoppscotch browser extension when a network error occurs

Closes #1376

## Changes
- `packages/hoppscotch-common/locales/en.json`: Updated `error.network.description` to include guidance about CORS policies and suggest enabling the Proxy or installing the Hoppscotch browser extension in Settings.

## Type of change
- [ ] Bug fix
- [x] Improvement (non-breaking change which improves UX)
- [ ] New feature
- [ ] Documentation update

## Testing
- Manually tested by sending a request to an unreachable local URL (`http://localhost:8080/api/test`) with Browser interceptor selected
- Verified the new message appears correctly in the response panel
- Ran `pnpm run lint` — no errors

## Screenshots

**Before:**
<img width="1916" height="949" alt="image" src="https://github.com/user-attachments/assets/dd3a40c1-93f6-4ff3-b85d-cd9b8f6c4566" />



**After:**
<img width="1916" height="987" alt="image" src="https://github.com/user-attachments/assets/9a9082ee-d1f8-4ae7-8746-316cebccb236" />


## Notes
This change only improves the user-facing error message. The underlying CORS restriction is a browser security policy and cannot be resolved by Hoppscotch directly. The goal is to help first-time users understand what may be causing the error and how to work around it using the built-in Proxy or browser extension.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the network error message with CORS guidance, suggesting enabling the Proxy or installing the Hoppscotch browser extension in Settings. Updates `error.network.description` in `packages/hoppscotch-common/locales/en.json` for clearer UX.

<sup>Written for commit d93bd82597f4df17639bb1b7d750870c3bfae120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

