### PR TITLE
feat(desktop): desktop cookie persistence and reapplication

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -394,6 +394,8 @@
       "empty_domain": "Domain is empty",
       "empty_domains": "Domain list is empty",
       "enter_cookie_string": "Enter cookie string",
+      "http_only": "HttpOnly",
+      "http_only_info": "Not exposed to page scripts. Still sent on matching requests.",
       "interceptor_no_support": "Your currently selected interceptor does not support cookies. Select a different Interceptor and try again.",
       "managed_tab": "Managed",
       "new_domain_name": "New domain name",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -393,6 +393,7 @@
       "cookie_value": "Value",
       "empty_domain": "Domain is empty",
       "empty_domains": "Domain list is empty",
+      "invalid_domain": "Domain has invalid characters",
       "enter_cookie_string": "Enter cookie string",
       "http_only": "HttpOnly",
       "http_only_info": "Not exposed to page scripts. Still sent on matching requests.",

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -224,7 +224,7 @@ watch(
 const showEditModalFor = ref<EditCookieConfig | null>(null)
 
 function saveCookieChanges() {
-  cookieJarService.replaceAll(workingCookieJar.value)
+  void cookieJarService.replaceAll(workingCookieJar.value)
   hideModal()
 }
 

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -289,20 +289,19 @@ async function saveCookieChanges() {
   // Domains the user removed from `workingCookieJar` may have
   // gained new cookies in the live jar (response capture during
   // the modal session). The delta against baseline would leave
-  // them alive even though the user clicked delete on the domain.
-  // Clear All also produces an empty `workingCookieJar`, and a
-  // domain captured for the first time during the session is in
-  // neither baseline nor working, so the baseline-only loop would
-  // miss it. The removed-domain set walks both baseline and the
-  // live jar so every domain absent from working contributes its
-  // live cookies to the delete list.
+  // them alive even though the user clicked delete on the
+  // domain, so the removed-domain sweep walks baseline keys and
+  // catches any concurrent capture under those keys.
+  //
+  // The sweep is restricted to baseline keys deliberately. A
+  // domain that first appeared in the live jar during the modal
+  // session is in neither baseline nor working, and treating it
+  // as removed-by-the-user would delete cookies for a domain the
+  // user never saw and never decided about. Clear All has the
+  // same constraint, the at-open baseline is the only signal of
+  // what the user could have decided to remove.
   const removedDomains = new Set<string>()
   for (const d of baselineCookieJar.value.keys()) {
-    if (!workingCookieJar.value.has(d)) {
-      removedDomains.add(d)
-    }
-  }
-  for (const d of cookieJarService.cookieJar.value.keys()) {
     if (!workingCookieJar.value.has(d)) {
       removedDomains.add(d)
     }

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -286,16 +286,28 @@ async function saveCookieChanges() {
     }
   }
 
-  // A domain the user removed from `workingCookieJar` may have
+  // Domains the user removed from `workingCookieJar` may have
   // gained new cookies in the live jar (response capture during
-  // the modal session) that are not in `baseline`. The delta would
-  // otherwise leave them alive even though the user clicked
-  // delete on the domain. For each removed-from-working domain,
-  // also delete any cookies currently in the live jar under it.
-  for (const domain of baselineCookieJar.value.keys()) {
-    if (workingCookieJar.value.has(domain)) {
-      continue
+  // the modal session). The delta against baseline would leave
+  // them alive even though the user clicked delete on the domain.
+  // Clear All also produces an empty `workingCookieJar`, and a
+  // domain captured for the first time during the session is in
+  // neither baseline nor working, so the baseline-only loop would
+  // miss it. The removed-domain set walks both baseline and the
+  // live jar so every domain absent from working contributes its
+  // live cookies to the delete list.
+  const removedDomains = new Set<string>()
+  for (const d of baselineCookieJar.value.keys()) {
+    if (!workingCookieJar.value.has(d)) {
+      removedDomains.add(d)
     }
+  }
+  for (const d of cookieJarService.cookieJar.value.keys()) {
+    if (!workingCookieJar.value.has(d)) {
+      removedDomains.add(d)
+    }
+  }
+  for (const domain of removedDomains) {
     const liveCookies = cookieJarService.cookieJar.value.get(domain) ?? []
     for (const c of liveCookies) {
       const key = cookieKey(c)

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -201,6 +201,15 @@ function addNewDomain() {
     toast.error(`${t("cookies.modal.empty_domain")}`)
     return
   }
+  // If the user types a domain that already has a row, `.set` with
+  // an empty array would wipe the existing cookies under that
+  // domain on save. The duplicate-add is treated as a no-op so an
+  // accidental re-type does not remove cookies the user can see in
+  // the same modal.
+  if (workingCookieJar.value.has(newDomainText.value)) {
+    newDomainText.value = ""
+    return
+  }
   workingCookieJar.value.set(newDomainText.value, [])
   newDomainText.value = ""
 }

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -89,6 +89,14 @@
                       :value="`${entry.name} => ${entry.value}`"
                       readonly
                     />
+                    <span
+                      v-if="entry.httpOnly"
+                      v-tippy="{ theme: 'tooltip' }"
+                      :title="t('cookies.modal.http_only_info')"
+                      class="px-2 text-tiny font-semibold text-secondaryLight"
+                    >
+                      {{ t("cookies.modal.http_only") }}
+                    </span>
                     <HoppButtonSecondary
                       v-tippy="{ theme: 'tooltip' }"
                       :title="t('action.copy')"

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -259,7 +259,7 @@ function flatten(jar: Map<string, Cookie[]>): Cookie[] {
 // tuples the way a space separator can when a path contains
 // whitespace.
 const cookieKey = (c: Cookie) =>
-  `${cookieJarService.canonStoreDomain(c.domain)}\u0000${c.name}\u0000${c.path ?? "/"}`
+  `${cookieJarService.canonStoreDomain(c.domain)}\u0000${c.name}\u0000${c.path && c.path.length > 0 ? c.path : "/"}`
 
 async function saveCookieChanges() {
   const before = new Map<string, Cookie>()

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -197,7 +197,11 @@ const currentInterceptorSupportsCookies = computed(() => {
 })
 
 function addNewDomain() {
-  if (newDomainText.value.trim() === "") {
+  // Trim once and use the trimmed value as both the duplicate-key
+  // probe and the Map key, so two adds that differ only by
+  // whitespace do not produce two rows.
+  const trimmed = newDomainText.value.trim()
+  if (trimmed === "") {
     toast.error(`${t("cookies.modal.empty_domain")}`)
     return
   }
@@ -206,11 +210,11 @@ function addNewDomain() {
   // domain on save. The duplicate-add is treated as a no-op so an
   // accidental re-type does not remove cookies the user can see in
   // the same modal.
-  if (workingCookieJar.value.has(newDomainText.value)) {
+  if (workingCookieJar.value.has(trimmed)) {
     newDomainText.value = ""
     return
   }
-  workingCookieJar.value.set(newDomainText.value, [])
+  workingCookieJar.value.set(trimmed, [])
   newDomainText.value = ""
 }
 

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -246,7 +246,7 @@ function flatten(jar: Map<string, Cookie[]>): Cookie[] {
 // tuples the way a space separator can when a path contains
 // whitespace.
 const cookieKey = (c: Cookie) =>
-  `${c.domain}\u0000${c.name}\u0000${c.path ?? "/"}`
+  `${cookieJarService.canonStoreDomain(c.domain)}\u0000${c.name}\u0000${c.path ?? "/"}`
 
 async function saveCookieChanges() {
   const before = new Map<string, Cookie>()

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -216,7 +216,7 @@ watch(
 const showEditModalFor = ref<EditCookieConfig | null>(null)
 
 function saveCookieChanges() {
-  cookieJarService.cookieJar.value = workingCookieJar.value
+  cookieJarService.replaceAll(workingCookieJar.value)
   hideModal()
 }
 

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -165,7 +165,7 @@ import IconEdit from "~icons/lucide/edit"
 import IconTrash2 from "~icons/lucide/trash-2"
 import IconPlus from "~icons/lucide/plus"
 import IconCopy from "~icons/lucide/copy"
-import { cloneDeep } from "lodash-es"
+import { cloneDeep, isEqual } from "lodash-es"
 import { ref, watch, computed } from "vue"
 import { EditCookieConfig } from "./EditCookie.vue"
 import { useColorMode } from "@composables/theming"
@@ -183,6 +183,12 @@ const newDomainText = ref("")
 const interceptorService = useService(KernelInterceptorService)
 const cookieJarService = useService(CookieJarService)
 
+// `baselineCookieJar` is the user's view of the jar at modal-open
+// time, kept separately from `workingCookieJar` so the save can
+// apply only the user's edits as a per-cookie delta. Without this
+// the previous wholesale `replaceAll` overwrote any cookies the
+// request flow captured into the live jar while the modal was open.
+const baselineCookieJar = ref(cloneDeep(cookieJarService.cookieJar.value))
 const workingCookieJar = ref(cloneDeep(cookieJarService.cookieJar.value))
 
 const currentInterceptorSupportsCookies = computed(() => {
@@ -214,8 +220,10 @@ function clearAllDomains() {
 
 watch(
   () => props.show,
-  (show) => {
+  async (show) => {
     if (show) {
+      await cookieJarService.whenReady()
+      baselineCookieJar.value = cloneDeep(cookieJarService.cookieJar.value)
       workingCookieJar.value = cloneDeep(cookieJarService.cookieJar.value)
     }
   }
@@ -223,8 +231,53 @@ watch(
 
 const showEditModalFor = ref<EditCookieConfig | null>(null)
 
-function saveCookieChanges() {
-  void cookieJarService.replaceAll(workingCookieJar.value)
+function flatten(jar: Map<string, Cookie[]>): Cookie[] {
+  const out: Cookie[] = []
+  for (const cookies of jar.values()) {
+    for (const c of cookies) {
+      out.push(c)
+    }
+  }
+  return out
+}
+
+const cookieKey = (c: Cookie) => `${c.domain} ${c.name} ${c.path ?? "/"}`
+
+async function saveCookieChanges() {
+  const before = new Map<string, Cookie>()
+  for (const c of flatten(baselineCookieJar.value)) {
+    before.set(cookieKey(c), c)
+  }
+  const after = new Map<string, Cookie>()
+  for (const c of flatten(workingCookieJar.value)) {
+    after.set(cookieKey(c), c)
+  }
+
+  const upserts: Cookie[] = []
+  for (const [key, post] of after) {
+    const prior = before.get(key)
+    if (!prior || !isEqual(prior, post)) {
+      upserts.push(post)
+    }
+  }
+
+  const removes: Array<{ domain: string; name: string; path?: string }> = []
+  for (const [key, prior] of before) {
+    if (!after.has(key)) {
+      removes.push({
+        domain: prior.domain,
+        name: prior.name,
+        path: prior.path,
+      })
+    }
+  }
+
+  if (upserts.length > 0) {
+    await cookieJarService.upsertCookies(upserts)
+  }
+  if (removes.length > 0) {
+    await cookieJarService.deleteCookies(removes)
+  }
   hideModal()
 }
 

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -277,6 +277,25 @@ async function saveCookieChanges() {
     }
   }
 
+  // A domain the user removed from `workingCookieJar` may have
+  // gained new cookies in the live jar (response capture during
+  // the modal session) that are not in `baseline`. The delta would
+  // otherwise leave them alive even though the user clicked
+  // delete on the domain. For each removed-from-working domain,
+  // also delete any cookies currently in the live jar under it.
+  for (const domain of baselineCookieJar.value.keys()) {
+    if (workingCookieJar.value.has(domain)) {
+      continue
+    }
+    const liveCookies = cookieJarService.cookieJar.value.get(domain) ?? []
+    for (const c of liveCookies) {
+      const key = cookieKey(c)
+      if (!before.has(key)) {
+        removes.push({ domain: c.domain, name: c.name, path: c.path })
+      }
+    }
+  }
+
   if (upserts.length > 0) {
     await cookieJarService.upsertCookies(upserts)
   }

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -241,7 +241,12 @@ function flatten(jar: Map<string, Cookie[]>): Cookie[] {
   return out
 }
 
-const cookieKey = (c: Cookie) => `${c.domain} ${c.name} ${c.path ?? "/"}`
+// NUL between fields, never a valid cookie character per RFC 6265,
+// so the key cannot collide across different (domain, name, path)
+// tuples the way a space separator can when a path contains
+// whitespace.
+const cookieKey = (c: Cookie) =>
+  `${c.domain}\u0000${c.name}\u0000${c.path ?? "/"}`
 
 async function saveCookieChanges() {
   const before = new Map<string, Cookie>()

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -328,7 +328,20 @@ function saveCookie(value: string) {
     const { domain } = showEditModalFor.value
     const entry = workingCookieJar.value.get(domain)!
 
-    const name = `Cookie-${entry.length}`
+    // Auto-name uses one past the highest existing `Cookie-N` so
+    // a delete-then-create flow does not produce two rows with
+    // the same name (which `cookieKey`'s `(domain, name, path)`
+    // merge would collapse to one on save and silently drop the
+    // duplicate).
+    let next = 0
+    for (const existing of entry) {
+      const m = /^Cookie-(\d+)$/.exec(existing.name)
+      if (m) {
+        const n = Number(m[1])
+        if (n >= next) next = n + 1
+      }
+    }
+    const name = `Cookie-${next}`
     entry.push(makeUICookie(domain, value, name))
     showEditModalFor.value = null
     return

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -197,24 +197,28 @@ const currentInterceptorSupportsCookies = computed(() => {
 })
 
 function addNewDomain() {
-  // Trim once and use the trimmed value as both the duplicate-key
-  // probe and the Map key, so two adds that differ only by
-  // whitespace do not produce two rows.
+  // Canonicalize through the service so the new row's key matches
+  // the form the eventual save uses. Without this the modal row
+  // and `cookieKey` would disagree (modal row keyed `Example.COM`,
+  // save key `example.com`), and two visually different
+  // entries that canonicalize to the same domain would add as
+  // separate rows then clobber each other at save time.
   const trimmed = newDomainText.value.trim()
   if (trimmed === "") {
     toast.error(`${t("cookies.modal.empty_domain")}`)
     return
   }
+  const canon = cookieJarService.canonStoreDomain(trimmed)
   // If the user types a domain that already has a row, `.set` with
   // an empty array would wipe the existing cookies under that
   // domain on save. The duplicate-add is treated as a no-op so an
   // accidental re-type does not remove cookies the user can see in
   // the same modal.
-  if (workingCookieJar.value.has(trimmed)) {
+  if (workingCookieJar.value.has(canon)) {
     newDomainText.value = ""
     return
   }
-  workingCookieJar.value.set(trimmed, [])
+  workingCookieJar.value.set(canon, [])
   newDomainText.value = ""
 }
 

--- a/packages/hoppscotch-common/src/components/cookies/AllModal.vue
+++ b/packages/hoppscotch-common/src/components/cookies/AllModal.vue
@@ -209,6 +209,15 @@ function addNewDomain() {
     return
   }
   const canon = cookieJarService.canonStoreDomain(trimmed)
+  // `upsertCookies` skips a domain that canonicalizes to empty or
+  // carries internal whitespace, so the modal would otherwise let
+  // the user create a row that vanishes silently on save. The
+  // validation mirrors the service contract and surfaces a
+  // localized error instead.
+  if (canon.length === 0 || /\s/.test(canon)) {
+    toast.error(`${t("cookies.modal.invalid_domain")}`)
+    return
+  }
   // If the user types a domain that already has a row, `.set` with
   // an empty array would wipe the existing cookies under that
   // domain on save. The duplicate-add is treated as a no-op so an

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -654,19 +654,10 @@ export function runRESTRequest$(
             const updatedCookies = postRequestScriptResult.right.updatedCookies
 
             if (updatedCookies) {
-              const newCookieMap = new Map<string, Cookie[]>()
-
-              for (const cookie of updatedCookies) {
-                const domain = cookie.domain
-
-                if (!newCookieMap.has(domain)) {
-                  newCookieMap.set(domain, [])
-                }
-
-                newCookieMap.get(domain)!.push(cookie)
-              }
-
-              cookieJarService.cookieJar.value = newCookieMap
+              // Merge the script's cookies in rather than replacing the
+              // whole jar, so cookies captured from the response during
+              // this request are not clobbered.
+              cookieJarService.upsertCookies(updatedCookies)
             }
           } else {
             console.error(

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -809,7 +809,7 @@ const getCookieJarEntries = () => {
 }
 
 const cookieKey = (c: { domain: string; name: string; path?: string }) =>
-  `${c.domain}\u0000${c.name}\u0000${c.path ?? "/"}`
+  `${cookieJarService.canonStoreDomain(c.domain)}\u0000${c.name}\u0000${c.path ?? "/"}`
 
 const applyScriptCookieDelta = async (
   preScript: Cookie[],

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -17,7 +17,7 @@ import * as A from "fp-ts/Array"
 import * as E from "fp-ts/Either"
 import * as O from "fp-ts/Option"
 import { flow, pipe } from "fp-ts/function"
-import { cloneDeep } from "lodash-es"
+import { cloneDeep, isEqual } from "lodash-es"
 import { Observable, Subject } from "rxjs"
 import { filter } from "rxjs/operators"
 import { Ref } from "vue"
@@ -654,10 +654,19 @@ export function runRESTRequest$(
             const updatedCookies = postRequestScriptResult.right.updatedCookies
 
             if (updatedCookies) {
-              // Merge the script's cookies in rather than replacing the
-              // whole jar, so cookies captured from the response during
-              // this request are not clobbered.
-              await cookieJarService.upsertCookies(updatedCookies)
+              // The script's `updatedCookies` is the post-script state of
+              // its pre-script view, so a set difference against the
+              // pre-script snapshot gives the actual mutations. Cookies
+              // the script returned identical to what it received get
+              // skipped because the response capture may have updated
+              // them in the jar in the interim and re-upserting the
+              // script's stale copy would overwrite that. Cookies the
+              // script omitted from its returned array are treated as
+              // deletes, restoring `hopp.cookies.delete` semantics.
+              await applyScriptCookieDelta(
+                cookieJarEntries ?? [],
+                updatedCookies
+              )
             }
           } else {
             console.error(
@@ -789,6 +798,45 @@ const getCookieJarEntries = () => {
   ).flatMap((cookies) => cookies)
 
   return cookieJarEntries
+}
+
+const cookieKey = (c: { domain: string; name: string; path?: string }) =>
+  `${c.domain} ${c.name} ${c.path ?? "/"}`
+
+const applyScriptCookieDelta = async (
+  preScript: Cookie[],
+  postScript: Cookie[]
+): Promise<void> => {
+  const preMap = new Map<string, Cookie>()
+  for (const c of preScript) {
+    preMap.set(cookieKey(c), c)
+  }
+  const postMap = new Map<string, Cookie>()
+  for (const c of postScript) {
+    postMap.set(cookieKey(c), c)
+  }
+
+  const mutated: Cookie[] = []
+  for (const [key, post] of postMap) {
+    const before = preMap.get(key)
+    if (!before || !isEqual(before, post)) {
+      mutated.push(post)
+    }
+  }
+
+  const removed: Array<{ domain: string; name: string; path?: string }> = []
+  for (const [key, pre] of preMap) {
+    if (!postMap.has(key)) {
+      removed.push({ domain: pre.domain, name: pre.name, path: pre.path })
+    }
+  }
+
+  if (mutated.length > 0) {
+    await cookieJarService.upsertCookies(mutated)
+  }
+  if (removed.length > 0) {
+    await cookieJarService.deleteCookies(removed)
+  }
 }
 
 /**

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -653,7 +653,7 @@ export function runRESTRequest$(
 
             const updatedCookies = postRequestScriptResult.right.updatedCookies
 
-            if (updatedCookies) {
+            if (updatedCookies && cookieJarEntries !== null) {
               // The script's `updatedCookies` is the post-script state of
               // its pre-script view, so a set difference against the
               // pre-script snapshot gives the actual mutations. Cookies
@@ -663,10 +663,13 @@ export function runRESTRequest$(
               // script's stale copy would overwrite that. Cookies the
               // script omitted from its returned array are treated as
               // deletes, restoring `hopp.cookies.delete` semantics.
-              await applyScriptCookieDelta(
-                cookieJarEntries ?? [],
-                updatedCookies
-              )
+              //
+              // Skipped entirely when `cookieJarEntries` is null
+              // (cookies disabled on the platform). The previous
+              // `?? []` made the empty pre-script snapshot classify
+              // every script cookie as new and never as removed, so
+              // delete-by-omission silently broke on non-desktop.
+              await applyScriptCookieDelta(cookieJarEntries, updatedCookies)
             }
           } else {
             console.error(

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -793,9 +793,17 @@ const getCookieJarEntries = () => {
     return null
   }
 
-  const cookieJarEntries = Array.from(
-    cookieJarService.cookieJar.value.values()
-  ).flatMap((cookies) => cookies)
+  // `cloneDeep` so the sandbox cannot mutate the live jar through
+  // a shared reference, and so `applyScriptCookieDelta`'s
+  // pre-script snapshot is independent of whatever the script
+  // returns. Without this a script that mutates a cookie in place
+  // and returns the same array would produce a pre-vs-post delta
+  // of "identical" and the mutation would silently drop.
+  const cookieJarEntries = cloneDeep(
+    Array.from(cookieJarService.cookieJar.value.values()).flatMap(
+      (cookies) => cookies
+    )
+  )
 
   return cookieJarEntries
 }

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -657,7 +657,7 @@ export function runRESTRequest$(
               // Merge the script's cookies in rather than replacing the
               // whole jar, so cookies captured from the response during
               // this request are not clobbered.
-              cookieJarService.upsertCookies(updatedCookies)
+              await cookieJarService.upsertCookies(updatedCookies)
             }
           } else {
             console.error(

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -801,7 +801,7 @@ const getCookieJarEntries = () => {
 }
 
 const cookieKey = (c: { domain: string; name: string; path?: string }) =>
-  `${c.domain} ${c.name} ${c.path ?? "/"}`
+  `${c.domain}\u0000${c.name}\u0000${c.path ?? "/"}`
 
 const applyScriptCookieDelta = async (
   preScript: Cookie[],

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -809,7 +809,7 @@ const getCookieJarEntries = () => {
 }
 
 const cookieKey = (c: { domain: string; name: string; path?: string }) =>
-  `${cookieJarService.canonStoreDomain(c.domain)}\u0000${c.name}\u0000${c.path ?? "/"}`
+  `${cookieJarService.canonStoreDomain(c.domain)}\u0000${c.name}\u0000${c.path && c.path.length > 0 ? c.path : "/"}`
 
 const applyScriptCookieDelta = async (
   preScript: Cookie[],

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/index.ts
@@ -126,15 +126,7 @@ export class AgentKernelInterceptorService
       const effectiveRequest = this.store.completeRequest(
         preProcessRelayRequest(request)
       )
-      const relevantCookies = this.cookieJar.getCookiesForURL(
-        new URL(effectiveRequest.url!)
-      )
-
-      if (relevantCookies.length > 0) {
-        effectiveRequest.headers!["Cookie"] = relevantCookies
-          .map((cookie) => `${cookie.name!}=${cookie.value!}`)
-          .join(";")
-      }
+      this.cookieJar.applyCookiesToRequest(effectiveRequest)
 
       const existingUserAgentHeader = Object.keys(
         effectiveRequest.headers || {}
@@ -211,6 +203,11 @@ export class AgentKernelInterceptorService
         body: { ...transformedBody },
         multiHeaders: multiHeaders.length > 0 ? multiHeaders : undefined,
       }
+
+      this.cookieJar.captureResponseCookies(
+        transformedResponse,
+        effectiveRequest.url
+      )
 
       return E.right(transformedResponse)
     } catch (e) {

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/index.ts
@@ -126,7 +126,7 @@ export class AgentKernelInterceptorService
       const effectiveRequest = this.store.completeRequest(
         preProcessRelayRequest(request)
       )
-      this.cookieJar.applyCookiesToRequest(effectiveRequest)
+      await this.cookieJar.applyCookiesToRequest(effectiveRequest)
 
       const existingUserAgentHeader = Object.keys(
         effectiveRequest.headers || {}
@@ -204,7 +204,7 @@ export class AgentKernelInterceptorService
         multiHeaders: multiHeaders.length > 0 ? multiHeaders : undefined,
       }
 
-      this.cookieJar.captureResponseCookies(
+      await this.cookieJar.captureResponseCookies(
         transformedResponse,
         effectiveRequest.url
       )

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/native/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/native/index.ts
@@ -185,15 +185,7 @@ export class NativeKernelInterceptorService
         preProcessRelayRequest(request)
       )
 
-      const relevantCookies = this.cookieJar.getCookiesForURL(
-        new URL(effectiveRequest.url!)
-      )
-
-      if (relevantCookies.length > 0) {
-        effectiveRequest.headers!["Cookie"] = relevantCookies
-          .map((cookie) => `${cookie.name!}=${cookie.value!}`)
-          .join(";")
-      }
+      this.cookieJar.applyCookiesToRequest(effectiveRequest)
 
       const existingUserAgentHeader = Object.keys(
         effectiveRequest.headers || {}
@@ -219,7 +211,14 @@ export class NativeKernelInterceptorService
 
       setRelayExecution(relayExecution)
 
-      return await relayExecution.response
+      const relayResponse = await relayExecution.response
+      if (E.isRight(relayResponse)) {
+        this.cookieJar.captureResponseCookies(
+          relayResponse.right,
+          effectiveRequest.url
+        )
+      }
+      return relayResponse
     } catch (e) {
       return E.left(e)
     }

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/native/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/native/index.ts
@@ -185,7 +185,7 @@ export class NativeKernelInterceptorService
         preProcessRelayRequest(request)
       )
 
-      this.cookieJar.applyCookiesToRequest(effectiveRequest)
+      await this.cookieJar.applyCookiesToRequest(effectiveRequest)
 
       const existingUserAgentHeader = Object.keys(
         effectiveRequest.headers || {}
@@ -213,7 +213,7 @@ export class NativeKernelInterceptorService
 
       const relayResponse = await relayExecution.response
       if (E.isRight(relayResponse)) {
-        this.cookieJar.captureResponseCookies(
+        await this.cookieJar.captureResponseCookies(
           relayResponse.right,
           effectiveRequest.url
         )

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
@@ -12,6 +12,7 @@ import { Service } from "dioc"
 import { Relay } from "~/kernel/relay"
 import SettingsProxy from "~/components/settings/Proxy.vue"
 import { KernelInterceptorProxyStore } from "./store"
+import { CookieJarService } from "~/services/cookie-jar.service"
 import type {
   KernelInterceptor,
   ExecutionResult,
@@ -56,6 +57,7 @@ export class ProxyKernelInterceptorService
 {
   public static readonly ID = "KERNEL_PROXY_INTERCEPTOR_SERVICE"
   private readonly store = this.bind(KernelInterceptorProxyStore)
+  private readonly cookieJar = this.bind(CookieJarService)
 
   public readonly id = "proxy"
   public readonly name = (t: ReturnType<typeof getI18n>) =>
@@ -236,6 +238,11 @@ export class ProxyKernelInterceptorService
       const proxyUrl = settings.proxyUrl
 
       const processedRequest = preProcessRelayRequest(request)
+
+      // Same shared send path as native and agent. proxyscotch returns
+      // Set-Cookie as a header string rather than structured cookies, so
+      // receive-side capture for the proxy path is a separate follow-up.
+      this.cookieJar.applyCookiesToRequest(processedRequest)
 
       let content: ContentType
       const multipartKey = `proxyRequestData-${v4()}`

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
@@ -233,7 +233,7 @@ export class ProxyKernelInterceptorService
     // request, otherwise the in-memory default (`proxy.hoppscotch.io`) is used
     // when `execute()` is called during initial page load — e.g. the OAuth
     // redirect handler on `/oauth`.
-    const pending = this.store.whenReady().then(() => {
+    const pending = this.store.whenReady().then(async () => {
       if (cancelled) return null
 
       const settings = this.store.getSettings()

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
@@ -78,7 +78,10 @@ export class ProxyKernelInterceptorService
     auth: new Set(["basic"]),
     security: new Set([]),
     proxy: new Set([]),
-    advanced: new Set([]),
+    // Proxy now attaches stored cookies to outgoing requests through
+    // the shared send path. Receive-side capture is a follow-up
+    // because proxyscotch returns Set-Cookie as a header string.
+    advanced: new Set(["cookies"]),
   } as const
   public readonly settingsEntry = markRaw({
     title: (t: ReturnType<typeof getI18n>) =>

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
@@ -242,7 +242,7 @@ export class ProxyKernelInterceptorService
       // Same shared send path as native and agent. proxyscotch returns
       // Set-Cookie as a header string rather than structured cookies, so
       // receive-side capture for the proxy path is a separate follow-up.
-      this.cookieJar.applyCookiesToRequest(processedRequest)
+      await this.cookieJar.applyCookiesToRequest(processedRequest)
 
       let content: ContentType
       const multipartKey = `proxyRequestData-${v4()}`

--- a/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
@@ -36,6 +36,31 @@ describe("CookieJarService", () => {
     })
   })
 
+  describe("toMap migration on hydrate", () => {
+    it("canonicalizes a leading-dot domain key from on-disk payload", () => {
+      const map = (service as any).toMap({
+        ".Example.COM": [cookie({ name: "a", value: "1", domain: ".Example.COM" })],
+      })
+      expect(map.has("example.com")).toBe(true)
+      expect(map.get("example.com")?.[0].domain).toBe("example.com")
+    })
+
+    it("merges two non-canonical keys that collapse to the same canon", () => {
+      const map = (service as any).toMap({
+        ".Example.COM": [cookie({ name: "a", value: "1", domain: ".Example.COM" })],
+        "EXAMPLE.com": [cookie({ name: "b", value: "2", domain: "EXAMPLE.com" })],
+      })
+      expect(map.get("example.com")).toHaveLength(2)
+    })
+
+    it("drops an entry whose key canonicalizes to empty", () => {
+      const map = (service as any).toMap({
+        ".": [cookie({ name: "a", value: "1" })],
+      })
+      expect(map.size).toBe(0)
+    })
+  })
+
   describe("getCookiesForURL", () => {
     it("matches the exact host per RFC 6265 5.1.3", async () => {
       await service.upsertCookies([cookie({ name: "a", value: "1" })])
@@ -234,6 +259,32 @@ describe("CookieJarService", () => {
       }
       await service.applyCookiesToRequest(req)
       expect(req.headers["Cookie"]).toBeUndefined()
+    })
+  })
+
+  describe("parseStored", () => {
+    it("rejects a payload whose cookie has non-string path", () => {
+      expect(() =>
+        (service as any).parseStored({
+          domains: {
+            "example.com": [
+              { name: "a", value: "1", domain: "example.com", path: 1, secure: false },
+            ],
+          },
+        })
+      ).toThrow()
+    })
+
+    it("rejects a payload whose cookie has non-boolean secure", () => {
+      expect(() =>
+        (service as any).parseStored({
+          domains: {
+            "example.com": [
+              { name: "a", value: "1", domain: "example.com", path: "/", secure: "false" },
+            ],
+          },
+        })
+      ).toThrow()
     })
   })
 

--- a/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
@@ -1,0 +1,301 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { TestContainer } from "dioc/testing"
+import { Cookie } from "@hoppscotch/data"
+
+import { CookieJarService } from "../cookie-jar.service"
+
+const cookie = (
+  overrides: Partial<Cookie> & Pick<Cookie, "name" | "value">
+): Cookie => ({
+  domain: "example.com",
+  path: "/",
+  httpOnly: false,
+  secure: false,
+  sameSite: "Lax",
+  ...overrides,
+})
+
+describe("CookieJarService", () => {
+  let container: TestContainer
+  let service: CookieJarService
+
+  beforeEach(async () => {
+    container = new TestContainer()
+    service = container.bind(CookieJarService)
+    // `Store.init` fails outside the desktop runtime, the service
+    // sets `initFailed` and stays operational on its in-memory
+    // map. `whenReady` resolves either way.
+    await service.whenReady()
+  })
+
+  describe("canonStoreDomain", () => {
+    it("strips a leading dot, lowercases, and trims", () => {
+      expect(service.canonStoreDomain(".Example.COM")).toBe("example.com")
+      expect(service.canonStoreDomain("  example.com  ")).toBe("example.com")
+      expect(service.canonStoreDomain("Example.COM")).toBe("example.com")
+    })
+  })
+
+  describe("getCookiesForURL", () => {
+    it("matches the exact host per RFC 6265 5.1.3", async () => {
+      await service.upsertCookies([cookie({ name: "a", value: "1" })])
+      const cookies = service.getCookiesForURL(new URL("https://example.com/"))
+      expect(cookies).toHaveLength(1)
+      expect(cookies[0].value).toBe("1")
+    })
+
+    it("does not match `evil-example.com` against `example.com`", async () => {
+      await service.upsertCookies([cookie({ name: "a", value: "1" })])
+      const cookies = service.getCookiesForURL(
+        new URL("https://evil-example.com/")
+      )
+      expect(cookies).toHaveLength(0)
+    })
+
+    it("matches a subdomain when the cookie has a parent domain", async () => {
+      await service.upsertCookies([cookie({ name: "a", value: "1" })])
+      const cookies = service.getCookiesForURL(
+        new URL("https://api.example.com/")
+      )
+      expect(cookies).toHaveLength(1)
+    })
+
+    it("compares the host case-insensitively per RFC 6265 5.1.2", async () => {
+      await service.upsertCookies([cookie({ name: "a", value: "1" })])
+      const cookies = service.getCookiesForURL(new URL("https://EXAMPLE.com/"))
+      expect(cookies).toHaveLength(1)
+    })
+
+    it("sorts results longest-path-first per RFC 6265 5.4", async () => {
+      await service.upsertCookies([
+        cookie({ name: "sid", value: "root", path: "/" }),
+        cookie({ name: "sid", value: "admin", path: "/admin" }),
+      ])
+      const cookies = service.getCookiesForURL(
+        new URL("https://example.com/admin/users")
+      )
+      expect(cookies).toHaveLength(2)
+      expect(cookies[0].path).toBe("/admin")
+      expect(cookies[1].path).toBe("/")
+    })
+
+    it("drops secure cookies on http URLs", async () => {
+      await service.upsertCookies([
+        cookie({ name: "a", value: "1", secure: true }),
+      ])
+      expect(
+        service.getCookiesForURL(new URL("http://example.com/"))
+      ).toHaveLength(0)
+      expect(
+        service.getCookiesForURL(new URL("https://example.com/"))
+      ).toHaveLength(1)
+    })
+
+    it("treats a non-finite expires as a session cookie, not expired", async () => {
+      await service.upsertCookies([
+        cookie({ name: "a", value: "1", expires: "not-a-date" }),
+      ])
+      expect(
+        service.getCookiesForURL(new URL("https://example.com/"))
+      ).toHaveLength(1)
+    })
+
+    it("respects path boundary per RFC 6265 5.1.4", async () => {
+      await service.upsertCookies([
+        cookie({ name: "a", value: "1", path: "/admin" }),
+      ])
+      expect(
+        service.getCookiesForURL(new URL("https://example.com/admin"))
+      ).toHaveLength(1)
+      expect(
+        service.getCookiesForURL(new URL("https://example.com/admin/x"))
+      ).toHaveLength(1)
+      expect(
+        service.getCookiesForURL(new URL("https://example.com/administrator"))
+      ).toHaveLength(0)
+    })
+  })
+
+  describe("upsertCookies", () => {
+    it("canonicalizes domain (strip leading dot, lowercase, trim)", async () => {
+      await service.upsertCookies([
+        cookie({ name: "a", value: "1", domain: " .Example.COM " }),
+      ])
+      const cookies = service.getCookiesForURL(new URL("https://example.com/"))
+      expect(cookies).toHaveLength(1)
+    })
+
+    it("normalizes an empty-string path to `/`", async () => {
+      await service.upsertCookies([cookie({ name: "a", value: "1", path: "" })])
+      const stored = service.cookieJar.value.get("example.com")?.[0]
+      expect(stored?.path).toBe("/")
+    })
+
+    it("skips a cookie with empty domain", async () => {
+      await service.upsertCookies([
+        cookie({ name: "a", value: "1", domain: "" }),
+      ])
+      expect(service.cookieJar.value.size).toBe(0)
+    })
+
+    it("skips a cookie whose canonicalized domain has internal whitespace", async () => {
+      await service.upsertCookies([
+        cookie({ name: "a", value: "1", domain: "ex ample.com" }),
+      ])
+      expect(service.cookieJar.value.size).toBe(0)
+    })
+
+    it("merges by (domain, name, path) instead of duplicating", async () => {
+      await service.upsertCookies([
+        cookie({ name: "a", value: "old" }),
+        cookie({ name: "a", value: "new" }),
+      ])
+      const stored = service.cookieJar.value.get("example.com")
+      expect(stored).toHaveLength(1)
+      expect(stored?.[0].value).toBe("new")
+    })
+  })
+
+  describe("deleteCookies", () => {
+    it("canonicalizes the target domain", async () => {
+      await service.upsertCookies([cookie({ name: "a", value: "1" })])
+      await service.deleteCookies([
+        { domain: ".Example.COM", name: "a", path: "/" },
+      ])
+      expect(service.cookieJar.value.size).toBe(0)
+    })
+
+    it("treats an empty path as `/`", async () => {
+      await service.upsertCookies([cookie({ name: "a", value: "1" })])
+      await service.deleteCookies([
+        { domain: "example.com", name: "a", path: "" },
+      ])
+      expect(service.cookieJar.value.size).toBe(0)
+    })
+  })
+
+  describe("applyCookiesToRequest", () => {
+    it("attaches matching cookies to the Cookie header", async () => {
+      await service.upsertCookies([cookie({ name: "a", value: "1" })])
+      const req = {
+        url: "https://example.com/",
+        headers: {} as Record<string, string>,
+      }
+      await service.applyCookiesToRequest(req)
+      expect(req.headers["Cookie"]).toBe("a=1")
+    })
+
+    it("yields to a user-set non-empty Cookie header (any case)", async () => {
+      await service.upsertCookies([cookie({ name: "a", value: "1" })])
+      const req = {
+        url: "https://example.com/",
+        headers: { cookie: "user=set" } as Record<string, string>,
+      }
+      await service.applyCookiesToRequest(req)
+      expect(req.headers["cookie"]).toBe("user=set")
+      expect(req.headers["Cookie"]).toBeUndefined()
+    })
+
+    it("strips empty case-variant Cookie headers before setting the canonical one", async () => {
+      await service.upsertCookies([cookie({ name: "a", value: "1" })])
+      const req = {
+        url: "https://example.com/",
+        headers: { cookie: "" } as Record<string, string>,
+      }
+      await service.applyCookiesToRequest(req)
+      expect(req.headers["Cookie"]).toBe("a=1")
+      expect(req.headers["cookie"]).toBeUndefined()
+    })
+
+    it("does not set Cookie when the URL is unparseable", async () => {
+      const req = {
+        url: "not-a-url",
+        headers: {} as Record<string, string>,
+      }
+      await service.applyCookiesToRequest(req)
+      expect(req.headers["Cookie"]).toBeUndefined()
+    })
+
+    it('does not send `Cookie: ""` when every matching cookie fails value validation', async () => {
+      await service.upsertCookies([cookie({ name: "a", value: "has;semi" })])
+      const req = {
+        url: "https://example.com/",
+        headers: {} as Record<string, string>,
+      }
+      await service.applyCookiesToRequest(req)
+      expect(req.headers["Cookie"]).toBeUndefined()
+    })
+  })
+
+  describe("extractFromResponse", () => {
+    it("defaults the path to the request directory per RFC 6265 5.1.4", async () => {
+      await service.extractFromResponse(
+        [{ name: "a", value: "1" }],
+        new URL("https://example.com/v1/users/42")
+      )
+      expect(
+        service.getCookiesForURL(new URL("https://example.com/v1/users"))
+      ).toHaveLength(1)
+      expect(
+        service.getCookiesForURL(new URL("https://example.com/other"))
+      ).toHaveLength(0)
+    })
+
+    it("tolerates an Invalid Date in `expires`", async () => {
+      await service.extractFromResponse(
+        [{ name: "a", value: "1", expires: new Date("not-a-date") }],
+        new URL("https://example.com/")
+      )
+      expect(
+        service.getCookiesForURL(new URL("https://example.com/"))
+      ).toHaveLength(1)
+    })
+
+    it("accepts a single-label host as a host-only cookie", async () => {
+      await service.extractFromResponse(
+        [{ name: "a", value: "1" }],
+        new URL("http://localhost:3000/")
+      )
+      expect(
+        service.getCookiesForURL(new URL("http://localhost:3000/"))
+      ).toHaveLength(1)
+    })
+
+    it("rejects a single-label Domain attribute (public-suffix gate)", async () => {
+      await service.extractFromResponse(
+        [{ name: "a", value: "1", domain: "com" }],
+        new URL("https://example.com/")
+      )
+      expect(service.cookieJar.value.size).toBe(0)
+    })
+  })
+
+  describe("serializeCookieHeader", () => {
+    it("joins `name=value` pairs with `; `", () => {
+      expect(
+        service.serializeCookieHeader([
+          cookie({ name: "a", value: "1" }),
+          cookie({ name: "b", value: "2" }),
+        ])
+      ).toBe("a=1; b=2")
+    })
+
+    it("skips a cookie whose value contains an RFC 6265 5.4 forbidden character", () => {
+      expect(
+        service.serializeCookieHeader([
+          cookie({ name: "a", value: "has;semi" }),
+          cookie({ name: "b", value: "ok" }),
+        ])
+      ).toBe("b=ok")
+    })
+
+    it("skips a cookie whose name is not a valid RFC 7230 token", () => {
+      expect(
+        service.serializeCookieHeader([
+          cookie({ name: "has;semi", value: "1" }),
+          cookie({ name: "b", value: "2" }),
+        ])
+      ).toBe("b=2")
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
@@ -53,6 +53,16 @@ describe("CookieJarService", () => {
       expect(map.get("example.com")).toHaveLength(2)
     })
 
+    it("dedupes by (name, path) across non-canonical keys that collapse onto the same canon", () => {
+      const map = (service as any).toMap({
+        ".Example.COM": [cookie({ name: "sid", value: "old", path: "/" })],
+        "EXAMPLE.com": [cookie({ name: "sid", value: "new", path: "/" })],
+      })
+      const bucket = map.get("example.com")
+      expect(bucket).toHaveLength(1)
+      expect(bucket?.[0].value).toBe("new")
+    })
+
     it("drops an entry whose key canonicalizes to empty", () => {
       const map = (service as any).toMap({
         ".": [cookie({ name: "a", value: "1" })],

--- a/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
@@ -268,6 +268,15 @@ describe("CookieJarService", () => {
       )
       expect(service.cookieJar.value.size).toBe(0)
     })
+
+    it("falls back to default-path when the Path attribute does not start with /", async () => {
+      await service.extractFromResponse(
+        [{ name: "a", value: "1", path: "foo" }],
+        new URL("https://example.com/v1/users/42")
+      )
+      const stored = service.cookieJar.value.get("example.com")?.[0]
+      expect(stored?.path).toBe("/v1/users")
+    })
   })
 
   describe("serializeCookieHeader", () => {

--- a/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
@@ -216,6 +216,16 @@ describe("CookieJarService", () => {
       expect(req.headers["Cookie"]).toBeUndefined()
     })
 
+    it("strips an empty case-variant Cookie header even when the jar has no match", async () => {
+      const req = {
+        url: "https://no-match.example.com/",
+        headers: { cookie: "" } as Record<string, string>,
+      }
+      await service.applyCookiesToRequest(req)
+      expect(req.headers["cookie"]).toBeUndefined()
+      expect(req.headers["Cookie"]).toBeUndefined()
+    })
+
     it('does not send `Cookie: ""` when every matching cookie fails value validation', async () => {
       await service.upsertCookies([cookie({ name: "a", value: "has;semi" })])
       const req = {

--- a/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
@@ -180,6 +180,43 @@ describe("CookieJarService", () => {
       expect(service.cookieJar.value.size).toBe(0)
     })
 
+    it("defaults secure to false when a script-set cookie omits the flag", async () => {
+      await service.upsertCookies([
+        { name: "a", value: "1", domain: "example.com", path: "/" } as Cookie,
+      ])
+      const stored = service.cookieJar.value.get("example.com")?.[0]
+      expect(stored?.secure).toBe(false)
+    })
+
+    it("defaults httpOnly to false when a script-set cookie omits the flag", async () => {
+      await service.upsertCookies([
+        { name: "a", value: "1", domain: "example.com", path: "/" } as Cookie,
+      ])
+      const stored = service.cookieJar.value.get("example.com")?.[0]
+      expect(stored?.httpOnly).toBe(false)
+    })
+
+    it("skips a script-set cookie whose name is not a string", async () => {
+      await service.upsertCookies([
+        { name: 42 as unknown as string, value: "1", domain: "example.com" } as Cookie,
+      ])
+      expect(service.cookieJar.value.size).toBe(0)
+    })
+
+    it("produces a cookie that parseStored accepts after upsert", async () => {
+      await service.upsertCookies([
+        { name: "a", value: "1", domain: "example.com" } as Cookie,
+      ])
+      const stored = service.cookieJar.value.get("example.com")
+      expect(stored).toBeDefined()
+      // Round-trip through parseStored to confirm the upsert output
+      // satisfies the load-time shape check.
+      const payload = {
+        domains: { "example.com": stored },
+      }
+      expect(() => (service as any).parseStored(payload)).not.toThrow()
+    })
+
     it("merges by (domain, name, path) instead of duplicating", async () => {
       await service.upsertCookies([
         cookie({ name: "a", value: "old" }),

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -349,13 +349,39 @@ export class CookieJarService extends Service {
       }
     }
 
+    // RFC 6265 5.4 step 2, cookies with a longer path go first so a
+    // server that reads the first matching cookie picks the more
+    // specific value over an inherited one. Stable sort because a tie
+    // on path length keeps capture order.
+    result.sort((a, b) => (b.path?.length ?? 1) - (a.path?.length ?? 1))
+
     return result
+  }
+
+  // RFC 6265 5.4 cookie-value disallows CTL, whitespace, comma,
+  // semicolon, double-quote, and backslash. A value with any of
+  // these would corrupt the header on the wire, so the cookie is
+  // skipped and a warning logged. Most jars hit this only for
+  // server-set values that arrived already malformed; the matched
+  // cookie still exists in the in-memory jar for inspection.
+  private isCookieValueValid(value: string): boolean {
+    return !/[\x00-\x1f\x7f\s,;"\\]/.test(value)
   }
 
   // RFC 6265 5.4 Cookie header serialization, `name=value` pairs
   // joined by "; ".
   public serializeCookieHeader(cookies: Cookie[]): string {
-    return cookies.map((c) => `${c.name}=${c.value}`).join("; ")
+    const parts: string[] = []
+    for (const c of cookies) {
+      if (!this.isCookieValueValid(c.value)) {
+        console.warn(
+          `[CookieJar] Skipping cookie "${c.name}" with invalid value`
+        )
+        continue
+      }
+      parts.push(`${c.name}=${c.value}`)
+    }
+    return parts.join("; ")
   }
 
   // Returns the parsed URL, or `null` if `raw` is unparseable. A
@@ -396,6 +422,15 @@ export class CookieJarService extends Service {
 
     if (!request.headers) {
       request.headers = {}
+    }
+    // The request map is case-sensitive so a user-supplied `cookie`
+    // or `COOKIE` would survive next to our `Cookie` and ship two
+    // header lines. Strips any case-variant before setting the
+    // canonical-case name.
+    for (const key of Object.keys(request.headers)) {
+      if (key !== "Cookie" && key.toLowerCase() === "cookie") {
+        delete request.headers[key]
+      }
     }
     request.headers["Cookie"] = this.serializeCookieHeader(cookies)
   }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -2,6 +2,42 @@ import { Service } from "dioc"
 import { ref } from "vue"
 import { parseString as setCookieParse } from "set-cookie-parser-es"
 import { Cookie } from "@hoppscotch/data"
+import * as E from "fp-ts/Either"
+import { Store } from "~/kernel/store"
+
+// Cookies are per-organization state, so they persist through the
+// org-scoped `Store` (`~/kernel/store`), which resolves to
+// `{org}.hoppscotch.store` on desktop. localStorage and `UnifiedStore`
+// would merge one organization's session cookies into another because
+// every org webview shares the same `app://{bundle}/` origin.
+const STORE_NAMESPACE = "cookies.v1"
+
+const STORE_KEYS = {
+  JAR: "jar",
+} as const
+
+interface StoredCookieJar {
+  version: string
+  domains: Record<string, Cookie[]>
+  lastUpdated: string
+}
+
+// Mirror of one entry in the kernel relay response's `cookies` array
+// (`RelayResponse["cookies"]`). Typed here instead of imported so the
+// service does not depend on the kernel re-exporting the type. The
+// relay leaves domain/path optional and gives a `Date` expiry, the
+// `@hoppscotch/data` schema needs a concrete domain, path, the
+// booleans, and an ISO string expiry, so capture normalizes it.
+type ResponseCookie = {
+  name: string
+  value: string
+  domain?: string
+  path?: string
+  expires?: Date
+  secure?: boolean
+  httpOnly?: boolean
+  sameSite?: "Strict" | "Lax" | "None"
+}
 
 export class CookieJarService extends Service {
   public static readonly ID = "COOKIE_JAR_SERVICE"
@@ -9,22 +45,167 @@ export class CookieJarService extends Service {
   /**
    * The cookie jar that stores all relevant cookie info.
    * The keys correspond to the domain of the cookie.
-   * The cookie strings are stored as an array of strings corresponding to the domain
    */
   public cookieJar = ref(new Map<string, Cookie[]>())
+
+  async onServiceInit(): Promise<void> {
+    const initResult = await Store.init()
+    if (E.isLeft(initResult)) {
+      console.error(
+        "[CookieJar] Failed to initialize store:",
+        initResult.left
+      )
+      return
+    }
+
+    await this.loadJar()
+    await this.setupWatcher()
+  }
+
+  private async loadJar(): Promise<void> {
+    const loadResult = await Store.get<StoredCookieJar>(
+      STORE_NAMESPACE,
+      STORE_KEYS.JAR
+    )
+
+    if (E.isRight(loadResult) && loadResult.right) {
+      this.cookieJar.value = new Map(
+        Object.entries(loadResult.right.domains)
+      )
+      this.pruneExpired()
+    }
+  }
+
+  // Cross-process reload, another webview in the same org writes the
+  // jar and this picks it up. Matches `KernelInterceptorNativeStore`,
+  // the reload is idempotent so there is no echo guard.
+  private async setupWatcher(): Promise<void> {
+    const watcher = await Store.watch(STORE_NAMESPACE, STORE_KEYS.JAR)
+    watcher.on("change", ({ value }) => {
+      if (value) {
+        const stored = value as StoredCookieJar
+        this.cookieJar.value = new Map(Object.entries(stored.domains))
+      }
+    })
+  }
+
+  private async persistJar(): Promise<void> {
+    const stored: StoredCookieJar = {
+      version: "v1",
+      domains: Object.fromEntries(this.cookieJar.value),
+      lastUpdated: new Date().toISOString(),
+    }
+
+    const saveResult = await Store.set(
+      STORE_NAMESPACE,
+      STORE_KEYS.JAR,
+      stored
+    )
+    if (E.isLeft(saveResult)) {
+      console.error("[CookieJar] Failed to persist jar:", saveResult.left)
+    }
+  }
 
   public parseSetCookieString(setCookieString: string) {
     return setCookieParse(setCookieString)
   }
 
-  public bulkApplyCookiesToDomain(cookies: Cookie[], domain: string) {
-    const existingDomainEntries = this.cookieJar.value.get(domain) ?? []
-    existingDomainEntries.push(...cookies)
+  // The single merge path. Response capture and the post-request
+  // script both route here so they reconcile by (domain, name, path)
+  // instead of one wholesale-replacing the other. The in-memory
+  // update is synchronous so callers in the request flow do not block
+  // on disk, the write-through runs after.
+  public upsertCookies(cookies: Cookie[]): void {
+    for (const cookie of cookies) {
+      const domain = cookie.domain
+      const existing = this.cookieJar.value.get(domain) ?? []
 
-    this.cookieJar.value.set(domain, existingDomainEntries)
+      const idx = existing.findIndex(
+        (c) => c.name === cookie.name && c.path === cookie.path
+      )
+      if (idx === -1) {
+        existing.push(cookie)
+      } else {
+        existing[idx] = cookie
+      }
+
+      this.cookieJar.value.set(domain, existing)
+    }
+
+    void this.persistJar()
+  }
+
+  // Kept for existing callers, now reconciles instead of blind-pushing
+  // duplicates.
+  public bulkApplyCookiesToDomain(cookies: Cookie[], domain: string): void {
+    this.upsertCookies(cookies.map((c) => ({ ...c, domain })))
+  }
+
+  // Normalizes the kernel relay response cookies into the
+  // `@hoppscotch/data` shape and merges them. Domain falls back to the
+  // request host (host-only cookie), path to "/", the flags default
+  // off, and SameSite to "Lax" matching the browser default.
+  public extractFromResponse(
+    cookies: ResponseCookie[] | undefined,
+    requestURL: URL
+  ): void {
+    if (!cookies || cookies.length === 0) {
+      return
+    }
+
+    const normalized: Cookie[] = cookies.map((c) => ({
+      name: c.name,
+      value: c.value,
+      domain: c.domain ?? requestURL.hostname,
+      path: c.path ?? "/",
+      httpOnly: c.httpOnly ?? false,
+      secure: c.secure ?? false,
+      sameSite: c.sameSite ?? "Lax",
+      ...(c.expires
+        ? { expires: new Date(c.expires).toISOString() }
+        : {}),
+    }))
+
+    this.upsertCookies(normalized)
+  }
+
+  // Replaces the entire jar, used by the manual cookie editor. Routed
+  // through the service so the edit persists.
+  public replaceAll(jar: Map<string, Cookie[]>): void {
+    this.cookieJar.value = jar
+    void this.persistJar()
+  }
+
+  // Drops expired cookies from the jar. Called on load and before
+  // every read so a stale cookie never gets forwarded. Persists only
+  // when something was actually removed.
+  public pruneExpired(): void {
+    const now = Date.now()
+    let changed = false
+
+    for (const [domain, cookies] of this.cookieJar.value.entries()) {
+      const live = cookies.filter(
+        (c) => !c.expires || new Date(c.expires).getTime() >= now
+      )
+      if (live.length === cookies.length) {
+        continue
+      }
+      changed = true
+      if (live.length === 0) {
+        this.cookieJar.value.delete(domain)
+      } else {
+        this.cookieJar.value.set(domain, live)
+      }
+    }
+
+    if (changed) {
+      void this.persistJar()
+    }
   }
 
   public getCookiesForURL(url: URL) {
+    this.pruneExpired()
+
     const relevantDomains = Array.from(this.cookieJar.value.keys()).filter(
       (domain) => url.hostname.endsWith(domain)
     )

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -284,6 +284,41 @@ export class CookieJarService extends Service {
     this.persistJar()
   }
 
+  // Deletes the named cookies from the jar, matching by
+  // `(domain, name, path)`. The post-request script path computes
+  // a set difference between its pre-script view and the script's
+  // returned `updatedCookies` and calls this for the entries that
+  // disappeared, restoring delete-by-omission semantics without
+  // the wholesale-replace behaviour that clobbered concurrent
+  // response captures.
+  public async deleteCookies(
+    targets: Array<{ domain: string; name: string; path?: string }>
+  ): Promise<void> {
+    await this.whenReady()
+    let changed = false
+    for (const target of targets) {
+      const existing = this.cookieJar.value.get(target.domain)
+      if (!existing) {
+        continue
+      }
+      const next = existing.filter(
+        (c) => !(c.name === target.name && c.path === target.path)
+      )
+      if (next.length === existing.length) {
+        continue
+      }
+      changed = true
+      if (next.length === 0) {
+        this.cookieJar.value.delete(target.domain)
+      } else {
+        this.cookieJar.value.set(target.domain, next)
+      }
+    }
+    if (changed) {
+      this.persistJar()
+    }
+  }
+
   // Drops expired cookies from the jar. Called on load and before
   // every read so a stale cookie never gets forwarded. Persists only
   // when something was actually removed.

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -210,6 +210,21 @@ export class CookieJarService extends Service {
     await this.upsertCookies(cookies.map((c) => ({ ...c, domain })))
   }
 
+  // Canonicalizes a cookie domain per RFC 6265 5.1.2 and 5.2.3,
+  // returns null for a domain that should not be stored. Strips a
+  // leading dot the way the spec requires (the dot is wire-format
+  // history and is not part of the matching algorithm), lowercases
+  // the result, and rejects a single-label domain that would let
+  // the cookie attach to every site under that suffix.
+  private canonDomain(raw: string): string | null {
+    const stripped = raw.startsWith(".") ? raw.slice(1) : raw
+    const lower = stripped.toLowerCase()
+    if (lower.length === 0 || !lower.includes(".")) {
+      return null
+    }
+    return lower
+  }
+
   // Normalizes the kernel relay response cookies into the
   // `@hoppscotch/data` shape and merges them. Domain falls back to the
   // request host (host-only cookie), path to "/", the flags default
@@ -222,17 +237,32 @@ export class CookieJarService extends Service {
       return
     }
 
-    const normalized: Cookie[] = cookies.map((c) => ({
-      name: c.name,
-      value: c.value,
-      domain: c.domain ?? requestURL.hostname,
-      path: c.path ?? "/",
-      httpOnly: c.httpOnly ?? false,
-      secure: c.secure ?? false,
-      sameSite: c.sameSite ?? "Lax",
-      ...(c.expires ? { expires: new Date(c.expires).toISOString() } : {}),
-    }))
+    const requestHost = requestURL.hostname.toLowerCase()
+    const normalized: Cookie[] = []
+    for (const c of cookies) {
+      const domain = this.canonDomain(c.domain ?? requestHost)
+      if (domain === null) {
+        console.warn(
+          "[CookieJar] Dropped cookie with unusable domain:",
+          c.domain ?? requestHost
+        )
+        continue
+      }
+      normalized.push({
+        name: c.name,
+        value: c.value,
+        domain,
+        path: c.path ?? "/",
+        httpOnly: c.httpOnly ?? false,
+        secure: c.secure ?? false,
+        sameSite: c.sameSite ?? "Lax",
+        ...(c.expires ? { expires: new Date(c.expires).toISOString() } : {}),
+      })
+    }
 
+    if (normalized.length === 0) {
+      return
+    }
     await this.upsertCookies(normalized)
   }
 
@@ -274,9 +304,12 @@ export class CookieJarService extends Service {
   // RFC 6265 5.1.3 domain matching. The host matches a stored domain
   // when it is the domain or a subdomain of it. The old code used a
   // bare `hostname.endsWith(domain)`, which let `evil-example.com`
-  // match `example.com` because there was no label boundary.
+  // match `example.com` because there was no label boundary. Hosts
+  // are lowercased here, stored domains were lowercased on capture,
+  // so the comparison is case-insensitive per RFC 6265 5.1.2.
   private domainMatches(host: string, domain: string): boolean {
-    return host === domain || host.endsWith(`.${domain}`)
+    const h = host.toLowerCase()
+    return h === domain || h.endsWith(`.${domain}`)
   }
 
   // RFC 6265 5.1.4 path matching. The request path matches the cookie

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -142,6 +142,15 @@ export class CookieJarService extends Service {
     if (typeof v.domains !== "object" || v.domains === null) {
       throw new Error("payload missing domains record")
     }
+    // Per-domain entries must be arrays. Without this guard a
+    // malformed cross-process write (or a future schema change)
+    // gets past the surface check and then `pruneExpired` throws
+    // on `cookies.filter(...)`, which the watcher promises not to.
+    for (const cookies of Object.values(v.domains)) {
+      if (!Array.isArray(cookies)) {
+        throw new Error("payload has non-array domain entry")
+      }
+    }
     return v as StoredCookieJar
   }
 

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -276,11 +276,19 @@ export class CookieJarService extends Service {
     await this.upsertCookies(normalized)
   }
 
-  // Replaces the entire jar, used by the manual cookie editor. Routed
-  // through the service so the edit persists.
+  // Replaces the entire jar. The argument is defensive-copied so a
+  // caller that keeps the reference and continues mutating its own
+  // Map cannot inadvertently mutate the live jar after the swap.
   public async replaceAll(jar: Map<string, Cookie[]>): Promise<void> {
     await this.whenReady()
-    this.cookieJar.value = jar
+    const copy = new Map<string, Cookie[]>()
+    for (const [domain, cookies] of jar.entries()) {
+      copy.set(
+        domain,
+        cookies.map((c) => ({ ...c }))
+      )
+    }
+    this.cookieJar.value = copy
     this.persistJar()
   }
 

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -71,7 +71,14 @@ export class CookieJarService extends Service {
   // other's writes as self-echoes.
   private writePrefix = crypto.randomUUID()
   private writeCounter = 0
-  private lastWriteToken: string | null = null
+
+  // Ring buffer of recent self-write tokens. A single-slot
+  // `lastWriteToken` would lose the prior token whenever two writes
+  // landed in the same tick, so an in-process echo for the older
+  // write would be misclassified as foreign and reapply a stale
+  // snapshot. The ring tolerates burst writes up to its size.
+  private readonly recentWriteTokensCap = 100
+  private recentWriteTokens: string[] = []
 
   async onServiceInit(): Promise<void> {
     this.hydrated = (async () => {
@@ -126,7 +133,10 @@ export class CookieJarService extends Service {
         console.error("[CookieJar] Watcher rejected malformed payload:", e)
         return
       }
-      if (stored.writeToken && stored.writeToken === this.lastWriteToken) {
+      if (
+        stored.writeToken &&
+        this.recentWriteTokens.includes(stored.writeToken)
+      ) {
         return
       }
       this.cookieJar.value = this.toMap(stored.domains)
@@ -160,7 +170,10 @@ export class CookieJarService extends Service {
 
   private persistJar(): void {
     const token = `${this.writePrefix}-${++this.writeCounter}`
-    this.lastWriteToken = token
+    this.recentWriteTokens.push(token)
+    if (this.recentWriteTokens.length > this.recentWriteTokensCap) {
+      this.recentWriteTokens.shift()
+    }
 
     this.writeChain = this.writeChain
       .then(async () => {

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -367,10 +367,31 @@ export class CookieJarService extends Service {
       // duplicate jar entry alongside the canonical `/` form. The
       // explicit length check collapses both empty and undefined
       // to `/`.
+      // Scripting sandbox callers (`hopp.cookies.set(...)`) are
+      // untyped at runtime, so a `name` or `value` that comes
+      // through as a non-string would later crash
+      // `serializeCookieHeader` and the persisted-payload
+      // `parseStored` check. The cookie is skipped instead of
+      // sneaking a bad shape onto disk.
+      if (typeof cookie.name !== "string" || typeof cookie.value !== "string") {
+        console.warn(
+          `[CookieJar] Skipping cookie with non-string name or value on domain "${cookie.domain}"`
+        )
+        continue
+      }
       const normalized: Cookie = {
         ...cookie,
         domain: canonDomain,
         path: cookie.path && cookie.path.length > 0 ? cookie.path : "/",
+        // `parseStored` validates `secure` as a boolean, so a
+        // script-set cookie that omitted the flag (or sent a
+        // non-boolean) would crash the entire jar load on next
+        // launch via the load-time shape check. Default to
+        // `false` so an in-memory write survives the persist
+        // round-trip.
+        secure: typeof cookie.secure === "boolean" ? cookie.secure : false,
+        httpOnly:
+          typeof cookie.httpOnly === "boolean" ? cookie.httpOnly : false,
       }
       const existing = this.cookieJar.value.get(normalized.domain) ?? []
 

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -440,14 +440,18 @@ export class CookieJarService extends Service {
           expires = new Date(t).toISOString()
         }
       }
+      // RFC 6265 5.1.4 requires the Path attribute to begin with
+      // `/`. A response that sends `Path=foo` (or anything else
+      // not starting with the separator) falls back to the
+      // default-path so the cookie is stored under a key the
+      // request matcher can actually hit.
+      const explicitPath =
+        c.path && c.path.length > 0 && c.path.startsWith("/") ? c.path : null
       normalized.push({
         name: c.name,
         value: c.value,
         domain,
-        path:
-          c.path && c.path.length > 0
-            ? c.path
-            : this.defaultPath(requestURL.pathname),
+        path: explicitPath ?? this.defaultPath(requestURL.pathname),
         httpOnly: c.httpOnly ?? false,
         secure: c.secure ?? false,
         sameSite: c.sameSite ?? "Lax",

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -526,11 +526,19 @@ export class CookieJarService extends Service {
     if (cookies.length === 0) {
       return
     }
+    // `serializeCookieHeader` may drop every cookie if the values
+    // fail validation, returning an empty string. The Cookie header
+    // is set only when the serialized form has content, so a request
+    // never goes out with `Cookie: ""` which some servers reject.
+    const serialized = this.serializeCookieHeader(cookies)
+    if (serialized.length === 0) {
+      return
+    }
 
     if (!request.headers) {
       request.headers = {}
     }
-    request.headers["Cookie"] = this.serializeCookieHeader(cookies)
+    request.headers["Cookie"] = serialized
   }
 
   // The one shared receive path. Captures structured cookies the

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -51,10 +51,7 @@ export class CookieJarService extends Service {
   async onServiceInit(): Promise<void> {
     const initResult = await Store.init()
     if (E.isLeft(initResult)) {
-      console.error(
-        "[CookieJar] Failed to initialize store:",
-        initResult.left
-      )
+      console.error("[CookieJar] Failed to initialize store:", initResult.left)
       return
     }
 
@@ -69,9 +66,7 @@ export class CookieJarService extends Service {
     )
 
     if (E.isRight(loadResult) && loadResult.right) {
-      this.cookieJar.value = new Map(
-        Object.entries(loadResult.right.domains)
-      )
+      this.cookieJar.value = new Map(Object.entries(loadResult.right.domains))
       this.pruneExpired()
     }
   }
@@ -81,7 +76,7 @@ export class CookieJarService extends Service {
   // the reload is idempotent so there is no echo guard.
   private async setupWatcher(): Promise<void> {
     const watcher = await Store.watch(STORE_NAMESPACE, STORE_KEYS.JAR)
-    watcher.on("change", ({ value }) => {
+    watcher.on("change", ({ value }: { value?: unknown }) => {
       if (value) {
         const stored = value as StoredCookieJar
         this.cookieJar.value = new Map(Object.entries(stored.domains))
@@ -96,11 +91,7 @@ export class CookieJarService extends Service {
       lastUpdated: new Date().toISOString(),
     }
 
-    const saveResult = await Store.set(
-      STORE_NAMESPACE,
-      STORE_KEYS.JAR,
-      stored
-    )
+    const saveResult = await Store.set(STORE_NAMESPACE, STORE_KEYS.JAR, stored)
     if (E.isLeft(saveResult)) {
       console.error("[CookieJar] Failed to persist jar:", saveResult.left)
     }
@@ -161,9 +152,7 @@ export class CookieJarService extends Service {
       httpOnly: c.httpOnly ?? false,
       secure: c.secure ?? false,
       sameSite: c.sameSite ?? "Lax",
-      ...(c.expires
-        ? { expires: new Date(c.expires).toISOString() }
-        : {}),
+      ...(c.expires ? { expires: new Date(c.expires).toISOString() } : {}),
     }))
 
     this.upsertCookies(normalized)
@@ -238,8 +227,7 @@ export class CookieJarService extends Service {
         const passesPath = this.pathMatches(url.pathname, cookie.path || "/")
 
         const passesExpires =
-          !cookie.expires ||
-          new Date(cookie.expires).getTime() >= Date.now()
+          !cookie.expires || new Date(cookie.expires).getTime() >= Date.now()
 
         const passesSecure = !cookie.secure || url.protocol === "https:"
 

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -183,6 +183,16 @@ export class CookieJarService extends Service {
   public async upsertCookies(cookies: Cookie[]): Promise<void> {
     await this.whenReady()
     for (const cookie of cookies) {
+      // A script that returns a cookie without a domain (or with an
+      // empty string) would otherwise persist under the Map key
+      // `undefined` which serializes as the literal string
+      // `"undefined"`, so the entry is dropped with a warning.
+      if (!cookie.domain) {
+        console.warn(
+          `[CookieJar] Skipping cookie "${cookie.name}" with empty domain`
+        )
+        continue
+      }
       const domain = cookie.domain
       const existing = this.cookieJar.value.get(domain) ?? []
 

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -98,8 +98,19 @@ export class CookieJarService extends Service {
         return
       }
 
-      await this.loadJar()
-      await this.setupWatcher()
+      // `loadJar` and `setupWatcher` errors are caught so `hydrated`
+      // resolves either way. A rejected `hydrated` would make every
+      // later `whenReady()` reject, and the interceptors' outer
+      // try/catch would convert a successful HTTP response into
+      // `E.left` on every request, the same failure mode the
+      // `initFailed` flag exists to avoid.
+      try {
+        await this.loadJar()
+        await this.setupWatcher()
+      } catch (e) {
+        this.initFailed = true
+        console.error("[CookieJar] Failed during init:", e)
+      }
     })()
     await this.hydrated
   }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -285,13 +285,17 @@ export class CookieJarService extends Service {
     await this.upsertCookies(cookies.map((c) => ({ ...c, domain })))
   }
 
-  // Strips a leading dot the way RFC 6265 5.2.3 requires (the dot
-  // is wire-format history and is not part of the matching
-  // algorithm), then lowercases per RFC 6265 5.1.2. Used at every
-  // boundary that writes into the jar so the stored key always
-  // matches `domainMatches`'s lowercase comparison.
-  private canonStoreDomain(raw: string): string {
-    const stripped = raw.startsWith(".") ? raw.slice(1) : raw
+  // Trims, strips a leading dot the way RFC 6265 5.2.3 requires
+  // (the dot is wire-format history and is not part of the
+  // matching algorithm), then lowercases per RFC 6265 5.1.2. Used
+  // at every boundary that writes into the jar so the stored key
+  // always matches `domainMatches`'s lowercase comparison. Public
+  // so the post-request script delta in `RequestRunner` and the
+  // modal save in `AllModal` can build matching keys without
+  // re-implementing the same normalization in three places.
+  public canonStoreDomain(raw: string): string {
+    const trimmed = raw.trim()
+    const stripped = trimmed.startsWith(".") ? trimmed.slice(1) : trimmed
     return stripped.toLowerCase()
   }
 

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -223,8 +223,15 @@ export class CookieJarService extends Service {
           c === null ||
           typeof (c as { name?: unknown }).name !== "string" ||
           typeof (c as { value?: unknown }).value !== "string" ||
-          typeof (c as { domain?: unknown }).domain !== "string"
+          typeof (c as { domain?: unknown }).domain !== "string" ||
+          typeof (c as { path?: unknown }).path !== "string" ||
+          typeof (c as { secure?: unknown }).secure !== "boolean"
         ) {
+          // `path` is what `pathMatches` reads to decide whether
+          // a cookie applies, `secure` is what gates the HTTPS-only
+          // attach in `applyCookiesToRequest`, so a schema-drifted
+          // payload that smuggled a string `"false"` past either
+          // would silently mismatch path scope or attach over HTTP.
           throw new Error("payload has malformed cookie")
         }
       }
@@ -232,8 +239,36 @@ export class CookieJarService extends Service {
     return v as StoredCookieJar
   }
 
+  // Migration-aware hydration. A jar persisted before the RFC
+  // 6265 canon work could carry `.example.com` or `Example.COM`
+  // keys, and the new `domainMatches` would never line those up
+  // with an incoming `example.com` request, so the cookies would
+  // load into memory and never apply. The canon pass runs on
+  // every load (initial and watcher) so the on-disk shape
+  // upgrades on first read after the upgrade, and collisions
+  // between two non-canonical keys that map to the same canonical
+  // form merge into one entry. Each cookie's own `domain` is also
+  // canonicalized so `domainMatches` sees the canonical form on
+  // both sides.
   private toMap(domains: Record<string, Cookie[]>): Map<string, Cookie[]> {
-    return new Map(Object.entries(domains))
+    const map = new Map<string, Cookie[]>()
+    for (const [rawKey, cookies] of Object.entries(domains)) {
+      const key = this.canonStoreDomain(rawKey)
+      if (key.length === 0) {
+        continue
+      }
+      const canonized = cookies.map((c) => ({
+        ...c,
+        domain: this.canonStoreDomain(c.domain ?? key) || key,
+      }))
+      const existing = map.get(key)
+      if (existing) {
+        map.set(key, [...existing, ...canonized])
+      } else {
+        map.set(key, canonized)
+      }
+    }
+    return map
   }
 
   private persistJar(): void {

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -149,13 +149,23 @@ export class CookieJarService extends Service {
   }
 
   private async loadJar(): Promise<void> {
-    const loadResult = await Store.get<StoredCookieJar>(
-      STORE_NAMESPACE,
-      STORE_KEYS.JAR
-    )
+    const loadResult = await Store.get<unknown>(STORE_NAMESPACE, STORE_KEYS.JAR)
 
     if (E.isRight(loadResult) && loadResult.right) {
-      this.cookieJar.value = this.toMap(loadResult.right.domains)
+      // Initial load routes the on-disk payload through the same
+      // `parseStored` shape check the cross-process watcher uses,
+      // so a corrupted file or a future schema drift cannot
+      // hydrate the jar with values that later crash matching or
+      // serialization. Failure here keeps the in-memory map empty
+      // and the request flow keeps working on a fresh state.
+      let stored: StoredCookieJar
+      try {
+        stored = this.parseStored(loadResult.right)
+      } catch (e) {
+        console.error("[CookieJar] Initial load rejected payload:", e)
+        return
+      }
+      this.cookieJar.value = this.toMap(stored.domains)
       this.pruneExpired()
     }
   }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -475,6 +475,15 @@ export class CookieJarService extends Service {
     return result
   }
 
+  // RFC 6265 4.1.1 cookie-name is an RFC 7230 `token`, alphanumeric
+  // plus `!#$%&'*+-.^_` `` ` ``|~. Anything outside that set
+  // (whitespace, `=`, `;`, control chars, etc.) would either
+  // corrupt the header or be ambiguous on parse, so the cookie is
+  // skipped at serialization time.
+  private isCookieNameValid(name: string): boolean {
+    return name.length > 0 && /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(name)
+  }
+
   // RFC 6265 5.4 cookie-value disallows CTL, whitespace, comma,
   // semicolon, double-quote, and backslash. A value with any of
   // these would corrupt the header on the wire, so the cookie is
@@ -490,6 +499,12 @@ export class CookieJarService extends Service {
   public serializeCookieHeader(cookies: Cookie[]): string {
     const parts: string[] = []
     for (const c of cookies) {
+      if (!this.isCookieNameValid(c.name)) {
+        console.warn(
+          `[CookieJar] Skipping cookie with invalid name "${c.name}"`
+        )
+        continue
+      }
       if (!this.isCookieValueValid(c.value)) {
         console.warn(
           `[CookieJar] Skipping cookie "${c.name}" with invalid value`

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -508,6 +508,20 @@ export class CookieJarService extends Service {
       return
     }
 
+    // A user who set a `Cookie` header through the request panel
+    // (any case-variant) is asserting deliberate intent for this
+    // request, so the jar yields and the user's header is
+    // preserved as written. The jar still updates from response
+    // capture and the manager remains the place to inspect or
+    // edit it.
+    if (request.headers) {
+      for (const key of Object.keys(request.headers)) {
+        if (key.toLowerCase() === "cookie") {
+          return
+        }
+      }
+    }
+
     const cookies = this.getCookiesForURL(url)
     if (cookies.length === 0) {
       return
@@ -515,15 +529,6 @@ export class CookieJarService extends Service {
 
     if (!request.headers) {
       request.headers = {}
-    }
-    // The request map is case-sensitive so a user-supplied `cookie`
-    // or `COOKIE` would survive next to our `Cookie` and ship two
-    // header lines. Strips any case-variant before setting the
-    // canonical-case name.
-    for (const key of Object.keys(request.headers)) {
-      if (key !== "Cookie" && key.toLowerCase() === "cookie") {
-        delete request.headers[key]
-      }
     }
     request.headers["Cookie"] = this.serializeCookieHeader(cookies)
   }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -159,13 +159,29 @@ export class CookieJarService extends Service {
     if (typeof v.domains !== "object" || v.domains === null) {
       throw new Error("payload missing domains record")
     }
-    // Per-domain entries must be arrays. Without this guard a
-    // malformed cross-process write (or a future schema change)
-    // gets past the surface check and then `pruneExpired` throws
-    // on `cookies.filter(...)`, which the watcher promises not to.
+    // Per-domain entries must be arrays of minimally-shaped cookie
+    // objects. Without the per-cookie shape check a malformed
+    // cross-process write (cookie with non-string name or value)
+    // would survive parseStored, slip past `isCookieNameValid`'s
+    // regex when `.test` coerces undefined to the string
+    // "undefined", and ship `Cookie: undefined=undefined` on the
+    // wire. The schema-grade fields the rest of the service relies
+    // on are name, value, and domain, so those get the typeof
+    // check at the boundary.
     for (const cookies of Object.values(v.domains)) {
       if (!Array.isArray(cookies)) {
         throw new Error("payload has non-array domain entry")
+      }
+      for (const c of cookies) {
+        if (
+          typeof c !== "object" ||
+          c === null ||
+          typeof (c as { name?: unknown }).name !== "string" ||
+          typeof (c as { value?: unknown }).value !== "string" ||
+          typeof (c as { domain?: unknown }).domain !== "string"
+        ) {
+          throw new Error("payload has malformed cookie")
+        }
       }
     }
     return v as StoredCookieJar
@@ -344,6 +360,17 @@ export class CookieJarService extends Service {
         )
         continue
       }
+      // `new Date(c.expires).toISOString()` throws RangeError on an
+      // Invalid Date (kernel passes a Date built from an unparseable
+      // Expires attribute). The expires field is dropped instead so
+      // the cookie still captures, treated as a session cookie.
+      let expires: string | undefined
+      if (c.expires) {
+        const t = new Date(c.expires).getTime()
+        if (Number.isFinite(t)) {
+          expires = new Date(t).toISOString()
+        }
+      }
       normalized.push({
         name: c.name,
         value: c.value,
@@ -352,7 +379,7 @@ export class CookieJarService extends Service {
         httpOnly: c.httpOnly ?? false,
         secure: c.secure ?? false,
         sameSite: c.sameSite ?? "Lax",
-        ...(c.expires ? { expires: new Date(c.expires).toISOString() } : {}),
+        ...(expires !== undefined ? { expires } : {}),
       })
     }
 

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -358,6 +358,20 @@ export class CookieJarService extends Service {
     return cookies.map((c) => `${c.name}=${c.value}`).join("; ")
   }
 
+  // Returns the parsed URL, or `null` if `raw` is unparseable. A
+  // request reaches the interceptor with an unresolved environment
+  // template, a relative URL, or a typo-ed scheme often enough that
+  // throwing inside the cookie path would surface as a request
+  // failure when the rest of the pipeline could have produced a
+  // clearer error.
+  private parseRequestURL(raw: string): URL | null {
+    try {
+      return new URL(raw)
+    } catch {
+      return null
+    }
+  }
+
   // The one shared send path. Native, agent, and proxy all call this
   // so a request gets the same Cookie header regardless of which
   // interceptor runs it, replacing the three slightly different inline
@@ -370,8 +384,12 @@ export class CookieJarService extends Service {
     if (!request.url) {
       return
     }
+    const url = this.parseRequestURL(request.url)
+    if (url === null) {
+      return
+    }
 
-    const cookies = this.getCookiesForURL(new URL(request.url))
+    const cookies = this.getCookiesForURL(url)
     if (cookies.length === 0) {
       return
     }
@@ -391,6 +409,10 @@ export class CookieJarService extends Service {
     if (!requestUrl) {
       return
     }
-    await this.extractFromResponse(response.cookies, new URL(requestUrl))
+    const url = this.parseRequestURL(requestUrl)
+    if (url === null) {
+      return
+    }
+    await this.extractFromResponse(response.cookies, url)
   }
 }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -247,26 +247,39 @@ export class CookieJarService extends Service {
   // every load (initial and watcher) so the on-disk shape
   // upgrades on first read after the upgrade, and collisions
   // between two non-canonical keys that map to the same canonical
-  // form merge into one entry. Each cookie's own `domain` is also
-  // canonicalized so `domainMatches` sees the canonical form on
-  // both sides.
+  // form dedupe by `(name, path)` with last-occurrence wins, so
+  // `applyCookiesToRequest` never emits two cookies with the same
+  // name and path in one Cookie header. Each cookie's own
+  // `domain` is also canonicalized so `domainMatches` sees the
+  // canonical form on both sides.
   private toMap(domains: Record<string, Cookie[]>): Map<string, Cookie[]> {
-    const map = new Map<string, Cookie[]>()
+    const dedup = new Map<string, Map<string, Cookie>>()
     for (const [rawKey, cookies] of Object.entries(domains)) {
       const key = this.canonStoreDomain(rawKey)
       if (key.length === 0) {
         continue
       }
-      const canonized = cookies.map((c) => ({
-        ...c,
-        domain: this.canonStoreDomain(c.domain ?? key) || key,
-      }))
-      const existing = map.get(key)
-      if (existing) {
-        map.set(key, [...existing, ...canonized])
-      } else {
-        map.set(key, canonized)
+      let bucket = dedup.get(key)
+      if (!bucket) {
+        bucket = new Map<string, Cookie>()
+        dedup.set(key, bucket)
       }
+      for (const c of cookies) {
+        const canonized: Cookie = {
+          ...c,
+          domain: this.canonStoreDomain(c.domain ?? key) || key,
+        }
+        // NUL separator matches the `cookieKey` pattern in
+        // `RequestRunner.ts`. Empty-string path collapses to
+        // `/` so an empty and a `/` cookie dedupe onto the same
+        // key.
+        const dedupKey = `${canonized.name} ${canonized.path && canonized.path.length > 0 ? canonized.path : "/"}`
+        bucket.set(dedupKey, canonized)
+      }
+    }
+    const map = new Map<string, Cookie[]>()
+    for (const [key, bucket] of dedup) {
+      map.set(key, Array.from(bucket.values()))
     }
     return map
   }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -203,37 +203,93 @@ export class CookieJarService extends Service {
     }
   }
 
-  public getCookiesForURL(url: URL) {
+  // RFC 6265 5.1.3 domain matching. The host matches a stored domain
+  // when it is the domain or a subdomain of it. The old code used a
+  // bare `hostname.endsWith(domain)`, which let `evil-example.com`
+  // match `example.com` because there was no label boundary.
+  private domainMatches(host: string, domain: string): boolean {
+    return host === domain || host.endsWith(`.${domain}`)
+  }
+
+  // RFC 6265 5.1.4 path matching. The request path matches the cookie
+  // path when they are equal, or the cookie path is a prefix that ends
+  // at a "/" boundary.
+  private pathMatches(reqPath: string, cookiePath: string): boolean {
+    if (reqPath === cookiePath) {
+      return true
+    }
+    if (!reqPath.startsWith(cookiePath)) {
+      return false
+    }
+    return cookiePath.endsWith("/") || reqPath[cookiePath.length] === "/"
+  }
+
+  public getCookiesForURL(url: URL): Cookie[] {
     this.pruneExpired()
 
-    const relevantDomains = Array.from(this.cookieJar.value.keys()).filter(
-      (domain) => url.hostname.endsWith(domain)
-    )
+    const result: Cookie[] = []
 
-    return relevantDomains
-      .flatMap((domain) => {
-        // Assemble the list of cookie entries from all the relevant domains
+    for (const [domain, cookies] of this.cookieJar.value.entries()) {
+      if (!this.domainMatches(url.hostname, domain)) {
+        continue
+      }
 
-        const cookieStrings = this.cookieJar.value.get(domain)! // We know not nullable from how we filter above
+      for (const cookie of cookies) {
+        const passesPath = this.pathMatches(url.pathname, cookie.path || "/")
 
-        return cookieStrings.map((cookieString) =>
-          this.parseSetCookieString(cookieString.value)
-        )
-      })
-      .filter((cookie) => {
-        // Perform the required checks on the cookies
+        const passesExpires =
+          !cookie.expires ||
+          new Date(cookie.expires).getTime() >= Date.now()
 
-        const passesPathCheck = url.pathname.startsWith(cookie.path ?? "/")
+        const passesSecure = !cookie.secure || url.protocol === "https:"
 
-        const passesExpiresCheck = !cookie.expires
-          ? true
-          : cookie.expires.getTime() >= new Date().getTime()
+        if (passesPath && passesExpires && passesSecure) {
+          result.push(cookie)
+        }
+      }
+    }
 
-        const passesSecureCheck = !cookie.secure
-          ? true
-          : url.protocol === "https:"
+    return result
+  }
 
-        return passesPathCheck && passesExpiresCheck && passesSecureCheck
-      })
+  // RFC 6265 5.4 Cookie header serialization, `name=value` pairs
+  // joined by "; ".
+  public serializeCookieHeader(cookies: Cookie[]): string {
+    return cookies.map((c) => `${c.name}=${c.value}`).join("; ")
+  }
+
+  // The one shared send path. Native, agent, and proxy all call this
+  // so a request gets the same Cookie header regardless of which
+  // interceptor runs it, replacing the three slightly different inline
+  // blocks they used to carry.
+  public applyCookiesToRequest(request: {
+    url?: string
+    headers?: Record<string, string>
+  }): void {
+    if (!request.url) {
+      return
+    }
+
+    const cookies = this.getCookiesForURL(new URL(request.url))
+    if (cookies.length === 0) {
+      return
+    }
+
+    if (!request.headers) {
+      request.headers = {}
+    }
+    request.headers["Cookie"] = this.serializeCookieHeader(cookies)
+  }
+
+  // The one shared receive path. Captures structured cookies the
+  // relay parsed out of the response into the jar.
+  public captureResponseCookies(
+    response: { cookies?: ResponseCookie[] },
+    requestUrl: string | undefined
+  ): void {
+    if (!requestUrl) {
+      return
+    }
+    this.extractFromResponse(response.cookies, new URL(requestUrl))
   }
 }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -198,19 +198,23 @@ export class CookieJarService extends Service {
         )
         continue
       }
-      const domain = cookie.domain
-      const existing = this.cookieJar.value.get(domain) ?? []
+      // Path is normalized at the entry boundary so the merge key
+      // (`name`, `path`) is comparable across response captures,
+      // script returns, and modal edits. An undefined incoming path
+      // would otherwise miss a stored `"/"` and produce a duplicate.
+      const normalized: Cookie = { ...cookie, path: cookie.path ?? "/" }
+      const existing = this.cookieJar.value.get(normalized.domain) ?? []
 
       const idx = existing.findIndex(
-        (c) => c.name === cookie.name && c.path === cookie.path
+        (c) => c.name === normalized.name && c.path === normalized.path
       )
       if (idx === -1) {
-        existing.push(cookie)
+        existing.push(normalized)
       } else {
-        existing[idx] = cookie
+        existing[idx] = normalized
       }
 
-      this.cookieJar.value.set(domain, existing)
+      this.cookieJar.value.set(normalized.domain, existing)
     }
 
     this.persistJar()
@@ -329,8 +333,9 @@ export class CookieJarService extends Service {
       if (!existing) {
         continue
       }
+      const path = target.path ?? "/"
       const next = existing.filter(
-        (c) => !(c.name === target.name && c.path === target.path)
+        (c) => !(c.name === target.name && c.path === path)
       )
       if (next.length === existing.length) {
         continue

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -20,6 +20,10 @@ interface StoredCookieJar {
   version: string
   domains: Record<string, Cookie[]>
   lastUpdated: string
+  // Stamped on every write this process does, so the cross-process
+  // watcher can ignore its own echo and not overwrite concurrent
+  // in-memory mutations with a stale disk snapshot.
+  writeToken?: string
 }
 
 // Mirror of one entry in the kernel relay response's `cookies` array
@@ -48,15 +52,43 @@ export class CookieJarService extends Service {
    */
   public cookieJar = ref(new Map<string, Cookie[]>())
 
-  async onServiceInit(): Promise<void> {
-    const initResult = await Store.init()
-    if (E.isLeft(initResult)) {
-      console.error("[CookieJar] Failed to initialize store:", initResult.left)
-      return
-    }
+  // Resolves once `onServiceInit` has loaded the jar from disk
+  // and attached the cross-process watcher. Callers that read or
+  // mutate the jar in the request flow await this so a cold-start
+  // request does not see an empty in-memory map and then overwrite
+  // the persisted state with one cookie.
+  private hydrated: Promise<void> | null = null
 
-    await this.loadJar()
-    await this.setupWatcher()
+  // Writes are serialized through this chain so two concurrent
+  // mutations cannot race on `Store.set`. Each write captures the
+  // current in-memory map at the time its turn runs, so the latest
+  // state always lands on disk.
+  private writeChain: Promise<void> = Promise.resolve()
+
+  private writeCounter = 0
+  private lastWriteToken: string | null = null
+
+  async onServiceInit(): Promise<void> {
+    this.hydrated = (async () => {
+      const initResult = await Store.init()
+      if (E.isLeft(initResult)) {
+        console.error(
+          "[CookieJar] Failed to initialize store:",
+          initResult.left
+        )
+        return
+      }
+
+      await this.loadJar()
+      await this.setupWatcher()
+    })()
+    await this.hydrated
+  }
+
+  public async whenReady(): Promise<void> {
+    if (this.hydrated) {
+      await this.hydrated
+    }
   }
 
   private async loadJar(): Promise<void> {
@@ -66,35 +98,77 @@ export class CookieJarService extends Service {
     )
 
     if (E.isRight(loadResult) && loadResult.right) {
-      this.cookieJar.value = new Map(Object.entries(loadResult.right.domains))
+      this.cookieJar.value = this.toMap(loadResult.right.domains)
       this.pruneExpired()
     }
   }
 
-  // Cross-process reload, another webview in the same org writes the
-  // jar and this picks it up. Matches `KernelInterceptorNativeStore`,
-  // the reload is idempotent so there is no echo guard.
+  // Cross-process reload, another webview in the same org writes
+  // the jar and this picks it up. The watch handler ignores echoes
+  // of this process's own writes by comparing `writeToken`, and
+  // rejects malformed payloads so a future schema mismatch does
+  // not kill the listener.
   private async setupWatcher(): Promise<void> {
     const watcher = await Store.watch(STORE_NAMESPACE, STORE_KEYS.JAR)
     watcher.on("change", ({ value }: { value?: unknown }) => {
-      if (value) {
-        const stored = value as StoredCookieJar
-        this.cookieJar.value = new Map(Object.entries(stored.domains))
+      if (!value) {
+        return
       }
+      let stored: StoredCookieJar
+      try {
+        stored = this.parseStored(value)
+      } catch (e) {
+        console.error("[CookieJar] Watcher rejected malformed payload:", e)
+        return
+      }
+      if (stored.writeToken && stored.writeToken === this.lastWriteToken) {
+        return
+      }
+      this.cookieJar.value = this.toMap(stored.domains)
+      this.pruneExpired()
     })
   }
 
-  private async persistJar(): Promise<void> {
-    const stored: StoredCookieJar = {
-      version: "v1",
-      domains: Object.fromEntries(this.cookieJar.value),
-      lastUpdated: new Date().toISOString(),
+  private parseStored(value: unknown): StoredCookieJar {
+    if (typeof value !== "object" || value === null) {
+      throw new Error("payload is not an object")
     }
+    const v = value as Partial<StoredCookieJar>
+    if (typeof v.domains !== "object" || v.domains === null) {
+      throw new Error("payload missing domains record")
+    }
+    return v as StoredCookieJar
+  }
 
-    const saveResult = await Store.set(STORE_NAMESPACE, STORE_KEYS.JAR, stored)
-    if (E.isLeft(saveResult)) {
-      console.error("[CookieJar] Failed to persist jar:", saveResult.left)
-    }
+  private toMap(domains: Record<string, Cookie[]>): Map<string, Cookie[]> {
+    return new Map(Object.entries(domains))
+  }
+
+  private persistJar(): void {
+    const token = `${++this.writeCounter}`
+    this.lastWriteToken = token
+
+    this.writeChain = this.writeChain
+      .then(async () => {
+        const stored: StoredCookieJar = {
+          version: "v1",
+          domains: Object.fromEntries(this.cookieJar.value),
+          lastUpdated: new Date().toISOString(),
+          writeToken: token,
+        }
+
+        const saveResult = await Store.set(
+          STORE_NAMESPACE,
+          STORE_KEYS.JAR,
+          stored
+        )
+        if (E.isLeft(saveResult)) {
+          console.error("[CookieJar] Failed to persist jar:", saveResult.left)
+        }
+      })
+      .catch((e) => {
+        console.error("[CookieJar] Persist chain error:", e)
+      })
   }
 
   public parseSetCookieString(setCookieString: string) {
@@ -106,7 +180,8 @@ export class CookieJarService extends Service {
   // instead of one wholesale-replacing the other. The in-memory
   // update is synchronous so callers in the request flow do not block
   // on disk, the write-through runs after.
-  public upsertCookies(cookies: Cookie[]): void {
+  public async upsertCookies(cookies: Cookie[]): Promise<void> {
+    await this.whenReady()
     for (const cookie of cookies) {
       const domain = cookie.domain
       const existing = this.cookieJar.value.get(domain) ?? []
@@ -123,23 +198,26 @@ export class CookieJarService extends Service {
       this.cookieJar.value.set(domain, existing)
     }
 
-    void this.persistJar()
+    this.persistJar()
   }
 
   // Kept for existing callers, now reconciles instead of blind-pushing
   // duplicates.
-  public bulkApplyCookiesToDomain(cookies: Cookie[], domain: string): void {
-    this.upsertCookies(cookies.map((c) => ({ ...c, domain })))
+  public async bulkApplyCookiesToDomain(
+    cookies: Cookie[],
+    domain: string
+  ): Promise<void> {
+    await this.upsertCookies(cookies.map((c) => ({ ...c, domain })))
   }
 
   // Normalizes the kernel relay response cookies into the
   // `@hoppscotch/data` shape and merges them. Domain falls back to the
   // request host (host-only cookie), path to "/", the flags default
   // off, and SameSite to "Lax" matching the browser default.
-  public extractFromResponse(
+  public async extractFromResponse(
     cookies: ResponseCookie[] | undefined,
     requestURL: URL
-  ): void {
+  ): Promise<void> {
     if (!cookies || cookies.length === 0) {
       return
     }
@@ -155,14 +233,15 @@ export class CookieJarService extends Service {
       ...(c.expires ? { expires: new Date(c.expires).toISOString() } : {}),
     }))
 
-    this.upsertCookies(normalized)
+    await this.upsertCookies(normalized)
   }
 
   // Replaces the entire jar, used by the manual cookie editor. Routed
   // through the service so the edit persists.
-  public replaceAll(jar: Map<string, Cookie[]>): void {
+  public async replaceAll(jar: Map<string, Cookie[]>): Promise<void> {
+    await this.whenReady()
     this.cookieJar.value = jar
-    void this.persistJar()
+    this.persistJar()
   }
 
   // Drops expired cookies from the jar. Called on load and before
@@ -188,7 +267,7 @@ export class CookieJarService extends Service {
     }
 
     if (changed) {
-      void this.persistJar()
+      this.persistJar()
     }
   }
 
@@ -250,10 +329,11 @@ export class CookieJarService extends Service {
   // so a request gets the same Cookie header regardless of which
   // interceptor runs it, replacing the three slightly different inline
   // blocks they used to carry.
-  public applyCookiesToRequest(request: {
+  public async applyCookiesToRequest(request: {
     url?: string
     headers?: Record<string, string>
-  }): void {
+  }): Promise<void> {
+    await this.whenReady()
     if (!request.url) {
       return
     }
@@ -271,13 +351,13 @@ export class CookieJarService extends Service {
 
   // The one shared receive path. Captures structured cookies the
   // relay parsed out of the response into the jar.
-  public captureResponseCookies(
+  public async captureResponseCookies(
     response: { cookies?: ResponseCookie[] },
     requestUrl: string | undefined
-  ): void {
+  ): Promise<void> {
     if (!requestUrl) {
       return
     }
-    this.extractFromResponse(response.cookies, new URL(requestUrl))
+    await this.extractFromResponse(response.cookies, new URL(requestUrl))
   }
 }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -65,6 +65,11 @@ export class CookieJarService extends Service {
   // state always lands on disk.
   private writeChain: Promise<void> = Promise.resolve()
 
+  // The write token prefix is fresh per service instance so two
+  // processes (this org's webview and another writing the same
+  // store file) cannot collide on the counter and mis-treat each
+  // other's writes as self-echoes.
+  private writePrefix = crypto.randomUUID()
   private writeCounter = 0
   private lastWriteToken: string | null = null
 
@@ -145,7 +150,7 @@ export class CookieJarService extends Service {
   }
 
   private persistJar(): void {
-    const token = `${++this.writeCounter}`
+    const token = `${this.writePrefix}-${++this.writeCounter}`
     this.lastWriteToken = token
 
     this.writeChain = this.writeChain

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -151,23 +151,31 @@ export class CookieJarService extends Service {
   private async loadJar(): Promise<void> {
     const loadResult = await Store.get<unknown>(STORE_NAMESPACE, STORE_KEYS.JAR)
 
-    if (E.isRight(loadResult) && loadResult.right) {
-      // Initial load routes the on-disk payload through the same
-      // `parseStored` shape check the cross-process watcher uses,
-      // so a corrupted file or a future schema drift cannot
-      // hydrate the jar with values that later crash matching or
-      // serialization. Failure here keeps the in-memory map empty
-      // and the request flow keeps working on a fresh state.
-      let stored: StoredCookieJar
-      try {
-        stored = this.parseStored(loadResult.right)
-      } catch (e) {
-        console.error("[CookieJar] Initial load rejected payload:", e)
-        return
-      }
-      this.cookieJar.value = this.toMap(stored.domains)
-      this.pruneExpired()
+    // Don't degrade a read failure into "no jar yet" — that lets
+    // the next persistJar overwrite the disk with `{ domains: {} }`.
+    if (E.isLeft(loadResult)) {
+      this.initFailed = true
+      console.error(
+        "[CookieJar] Failed to read persisted jar:",
+        loadResult.left
+      )
+      return
     }
+    if (!loadResult.right) {
+      return
+    }
+    let stored: StoredCookieJar
+    try {
+      stored = this.parseStored(loadResult.right)
+    } catch (e) {
+      // Same reasoning as the read-failure path: a corrupted payload
+      // must not be silently replaced with an empty jar.
+      this.initFailed = true
+      console.error("[CookieJar] Initial load rejected payload:", e)
+      return
+    }
+    this.cookieJar.value = this.toMap(stored.domains)
+    this.pruneExpired()
   }
 
   // Cross-process reload, another webview in the same org writes

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -198,11 +198,19 @@ export class CookieJarService extends Service {
         )
         continue
       }
-      // Path is normalized at the entry boundary so the merge key
-      // (`name`, `path`) is comparable across response captures,
-      // script returns, and modal edits. An undefined incoming path
-      // would otherwise miss a stored `"/"` and produce a duplicate.
-      const normalized: Cookie = { ...cookie, path: cookie.path ?? "/" }
+      // Domain is canonicalized (strip leading dot, lowercase) at
+      // the entry boundary so script-supplied and modal-supplied
+      // entries like `.Example.COM` end up as `example.com`, the
+      // same form `domainMatches` compares against.
+      // Path is normalized too so the merge key (`name`, `path`)
+      // is comparable across response captures, script returns,
+      // and modal edits. An undefined incoming path would otherwise
+      // miss a stored `"/"` and produce a duplicate.
+      const normalized: Cookie = {
+        ...cookie,
+        domain: this.canonStoreDomain(cookie.domain),
+        path: cookie.path ?? "/",
+      }
       const existing = this.cookieJar.value.get(normalized.domain) ?? []
 
       const idx = existing.findIndex(
@@ -229,16 +237,23 @@ export class CookieJarService extends Service {
     await this.upsertCookies(cookies.map((c) => ({ ...c, domain })))
   }
 
-  // Canonicalizes a cookie domain per RFC 6265 5.1.2 and 5.2.3 when
-  // it came from a Set-Cookie `Domain` attribute. Strips a leading
-  // dot the way the spec requires (the dot is wire-format history
-  // and is not part of the matching algorithm), lowercases the
-  // result, and rejects a single-label domain that would let the
-  // cookie attach to every site under that suffix. Returns null for
-  // a domain that should not be stored.
-  private canonAttrDomain(raw: string): string | null {
+  // Strips a leading dot the way RFC 6265 5.2.3 requires (the dot
+  // is wire-format history and is not part of the matching
+  // algorithm), then lowercases per RFC 6265 5.1.2. Used at every
+  // boundary that writes into the jar so the stored key always
+  // matches `domainMatches`'s lowercase comparison.
+  private canonStoreDomain(raw: string): string {
     const stripped = raw.startsWith(".") ? raw.slice(1) : raw
-    const lower = stripped.toLowerCase()
+    return stripped.toLowerCase()
+  }
+
+  // Canonicalizes a cookie domain that came from a Set-Cookie
+  // `Domain` attribute. Calls `canonStoreDomain` then rejects a
+  // single-label domain that would let the cookie attach to every
+  // site under that suffix. Returns null for a domain that should
+  // not be stored.
+  private canonAttrDomain(raw: string): string | null {
+    const lower = this.canonStoreDomain(raw)
     if (lower.length === 0 || !lower.includes(".")) {
       return null
     }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -444,7 +444,12 @@ export class CookieJarService extends Service {
     await this.whenReady()
     let changed = false
     for (const target of targets) {
-      const existing = this.cookieJar.value.get(target.domain)
+      // Domain is canonicalized at the lookup boundary so a target
+      // built from raw user input or a script-supplied value (e.g.
+      // ".Example.COM") finds the canonical bucket the jar
+      // actually stored.
+      const domain = this.canonStoreDomain(target.domain)
+      const existing = this.cookieJar.value.get(domain)
       if (!existing) {
         continue
       }
@@ -457,9 +462,9 @@ export class CookieJarService extends Service {
       }
       changed = true
       if (next.length === 0) {
-        this.cookieJar.value.delete(target.domain)
+        this.cookieJar.value.delete(domain)
       } else {
-        this.cookieJar.value.set(target.domain, next)
+        this.cookieJar.value.set(domain, next)
       }
     }
     if (changed) {

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -74,8 +74,17 @@ export class CookieJarService extends Service {
   // The write token prefix is fresh per service instance so two
   // processes (this org's webview and another writing the same
   // store file) cannot collide on the counter and mis-treat each
-  // other's writes as self-echoes.
-  private writePrefix = crypto.randomUUID()
+  // other's writes as self-echoes. `globalThis.crypto.randomUUID`
+  // is the preferred source; a `Math.random`-based fallback keeps
+  // the service constructable in environments (test runners with
+  // older jsdom, some SSR setups) where the Web Crypto API is not
+  // exposed. The echo guard only needs uniqueness within the
+  // running process, no cryptographic property is required.
+  private writePrefix = (() => {
+    const uuid = globalThis.crypto?.randomUUID?.()
+    if (uuid) return uuid
+    return `wp-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`
+  })()
   private writeCounter = 0
 
   // Ring buffer of recent self-write tokens. A single-slot

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -82,8 +82,11 @@ export class CookieJarService extends Service {
   // `lastWriteToken` would lose the prior token whenever two writes
   // landed in the same tick, so an in-process echo for the older
   // write would be misclassified as foreign and reapply a stale
-  // snapshot. The ring tolerates burst writes up to its size.
-  private readonly recentWriteTokensCap = 100
+  // snapshot. The ring tolerates burst writes up to its size. The
+  // cap is sized well above any realistic burst (modal save, bulk
+  // import, response capture with many Set-Cookies) so a token
+  // cannot age out before its disk-write's watcher echo arrives.
+  private readonly recentWriteTokensCap = 10_000
   private recentWriteTokens: string[] = []
 
   async onServiceInit(): Promise<void> {

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -261,13 +261,24 @@ export class CookieJarService extends Service {
       // the entry boundary so script-supplied and modal-supplied
       // entries like `.Example.COM` end up as `example.com`, the
       // same form `domainMatches` compares against.
+      // A canonicalized domain that contains whitespace or comes
+      // out empty cannot match any request host, so the cookie is
+      // skipped instead of polluting the jar with an unreachable
+      // entry.
       // Path is normalized too so the merge key (`name`, `path`)
       // is comparable across response captures, script returns,
       // and modal edits. An undefined incoming path would otherwise
       // miss a stored `"/"` and produce a duplicate.
+      const canonDomain = this.canonStoreDomain(cookie.domain)
+      if (canonDomain.length === 0 || /\s/.test(canonDomain)) {
+        console.warn(
+          `[CookieJar] Skipping cookie "${cookie.name}" with invalid domain "${cookie.domain}"`
+        )
+        continue
+      }
       const normalized: Cookie = {
         ...cookie,
-        domain: this.canonStoreDomain(cookie.domain),
+        domain: canonDomain,
         path: cookie.path ?? "/",
       }
       const existing = this.cookieJar.value.get(normalized.domain) ?? []
@@ -458,15 +469,21 @@ export class CookieJarService extends Service {
 
   // Drops expired cookies from the jar. Called on load and before
   // every read so a stale cookie never gets forwarded. Persists only
-  // when something was actually removed.
+  // when something was actually removed. A cookie whose `expires`
+  // is unparseable (the kernel handed back an Invalid Date that
+  // serialized strangely, or a cross-process write stored something
+  // non-ISO) is treated as a session cookie instead of as expired,
+  // so a malformed payload cannot silently evaporate jar entries.
   public pruneExpired(): void {
     const now = Date.now()
     let changed = false
 
     for (const [domain, cookies] of this.cookieJar.value.entries()) {
-      const live = cookies.filter(
-        (c) => !c.expires || new Date(c.expires).getTime() >= now
-      )
+      const live = cookies.filter((c) => {
+        if (!c.expires) return true
+        const t = new Date(c.expires).getTime()
+        return !Number.isFinite(t) || t >= now
+      })
       if (live.length === cookies.length) {
         continue
       }
@@ -520,8 +537,11 @@ export class CookieJarService extends Service {
       for (const cookie of cookies) {
         const passesPath = this.pathMatches(url.pathname, cookie.path || "/")
 
-        const passesExpires =
-          !cookie.expires || new Date(cookie.expires).getTime() >= Date.now()
+        const passesExpires = (() => {
+          if (!cookie.expires) return true
+          const t = new Date(cookie.expires).getTime()
+          return !Number.isFinite(t) || t >= Date.now()
+        })()
 
         const passesSecure = !cookie.secure || url.protocol === "https:"
 
@@ -624,7 +644,8 @@ export class CookieJarService extends Service {
       for (const key of Object.keys(request.headers)) {
         if (
           key.toLowerCase() === "cookie" &&
-          request.headers[key].trim() !== ""
+          request.headers[key]?.trim() !== "" &&
+          request.headers[key] !== undefined
         ) {
           return
         }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -220,19 +220,29 @@ export class CookieJarService extends Service {
     await this.upsertCookies(cookies.map((c) => ({ ...c, domain })))
   }
 
-  // Canonicalizes a cookie domain per RFC 6265 5.1.2 and 5.2.3,
-  // returns null for a domain that should not be stored. Strips a
-  // leading dot the way the spec requires (the dot is wire-format
-  // history and is not part of the matching algorithm), lowercases
-  // the result, and rejects a single-label domain that would let
-  // the cookie attach to every site under that suffix.
-  private canonDomain(raw: string): string | null {
+  // Canonicalizes a cookie domain per RFC 6265 5.1.2 and 5.2.3 when
+  // it came from a Set-Cookie `Domain` attribute. Strips a leading
+  // dot the way the spec requires (the dot is wire-format history
+  // and is not part of the matching algorithm), lowercases the
+  // result, and rejects a single-label domain that would let the
+  // cookie attach to every site under that suffix. Returns null for
+  // a domain that should not be stored.
+  private canonAttrDomain(raw: string): string | null {
     const stripped = raw.startsWith(".") ? raw.slice(1) : raw
     const lower = stripped.toLowerCase()
     if (lower.length === 0 || !lower.includes(".")) {
       return null
     }
     return lower
+  }
+
+  // Canonicalizes the host used for a host-only cookie, where the
+  // response had no `Domain` attribute so the request host is the
+  // entire domain. The single-label rule does not apply here, the
+  // host is the literal endpoint the user spoke to. `localhost` and
+  // other single-label internal hostnames stay valid.
+  private canonHostOnly(host: string): string {
+    return host.toLowerCase()
   }
 
   // Normalizes the kernel relay response cookies into the
@@ -250,11 +260,16 @@ export class CookieJarService extends Service {
     const requestHost = requestURL.hostname.toLowerCase()
     const normalized: Cookie[] = []
     for (const c of cookies) {
-      const domain = this.canonDomain(c.domain ?? requestHost)
+      let domain: string | null
+      if (c.domain) {
+        domain = this.canonAttrDomain(c.domain)
+      } else {
+        domain = this.canonHostOnly(requestHost)
+      }
       if (domain === null) {
         console.warn(
           "[CookieJar] Dropped cookie with unusable domain:",
-          c.domain ?? requestHost
+          c.domain
         )
         continue
       }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -676,6 +676,16 @@ export class CookieJarService extends Service {
     if (!request.headers) {
       request.headers = {}
     }
+    // The user may have left a case-variant `cookie` / `COOKIE`
+    // key with an empty value (treated as absent above and not
+    // suppressing the jar). Removing every case-variant before
+    // writing the canonical `Cookie` ensures the request goes out
+    // with one header line, never two.
+    for (const key of Object.keys(request.headers)) {
+      if (key !== "Cookie" && key.toLowerCase() === "cookie") {
+        delete request.headers[key]
+      }
+    }
     request.headers["Cookie"] = serialized
   }
 

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -59,6 +59,12 @@ export class CookieJarService extends Service {
   // the persisted state with one cookie.
   private hydrated: Promise<void> | null = null
 
+  // Set when `Store.init` fails. The service stays alive (the
+  // request flow keeps working without cookies) but public
+  // mutators no-op so a doomed `persistJar` cannot log the same
+  // failure on every request.
+  private initFailed = false
+
   // Writes are serialized through this chain so two concurrent
   // mutations cannot race on `Store.set`. Each write captures the
   // current in-memory map at the time its turn runs, so the latest
@@ -84,6 +90,7 @@ export class CookieJarService extends Service {
     this.hydrated = (async () => {
       const initResult = await Store.init()
       if (E.isLeft(initResult)) {
+        this.initFailed = true
         console.error(
           "[CookieJar] Failed to initialize store:",
           initResult.left
@@ -169,6 +176,9 @@ export class CookieJarService extends Service {
   }
 
   private persistJar(): void {
+    if (this.initFailed) {
+      return
+    }
     const token = `${this.writePrefix}-${++this.writeCounter}`
     this.recentWriteTokens.push(token)
     if (this.recentWriteTokens.length > this.recentWriteTokensCap) {

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -281,7 +281,7 @@ export class CookieJarService extends Service {
         // `RequestRunner.ts`. Empty-string path collapses to
         // `/` so an empty and a `/` cookie dedupe onto the same
         // key.
-        const dedupKey = `${canonized.name} ${canonized.path && canonized.path.length > 0 ? canonized.path : "/"}`
+        const dedupKey = `${canonized.name}\0${canonized.path && canonized.path.length > 0 ? canonized.path : "/"}`
         bucket.set(dedupKey, canonized)
       }
     }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -687,21 +687,30 @@ export class CookieJarService extends Service {
       return
     }
 
+    // Empty or whitespace-only `Cookie` placeholders are stripped
+    // unconditionally so a leftover row from a request template
+    // never reaches the wire, regardless of whether the jar ends
+    // up contributing cookies on this request.
+    if (request.headers) {
+      for (const key of Object.keys(request.headers)) {
+        if (
+          key.toLowerCase() === "cookie" &&
+          (request.headers[key] === undefined ||
+            request.headers[key].trim() === "")
+        ) {
+          delete request.headers[key]
+        }
+      }
+    }
     // A user who set a non-empty `Cookie` header through the
     // request panel (any case-variant) is asserting deliberate
     // intent for this request, so the jar yields and the user's
     // header is preserved as written. The jar still updates from
     // response capture and the manager remains the place to
-    // inspect or edit it. An empty value is treated as absent so a
-    // leftover `Cookie: ""` from a request template does not
-    // suppress the jar.
+    // inspect or edit it.
     if (request.headers) {
       for (const key of Object.keys(request.headers)) {
-        if (
-          key.toLowerCase() === "cookie" &&
-          request.headers[key]?.trim() !== "" &&
-          request.headers[key] !== undefined
-        ) {
+        if (key.toLowerCase() === "cookie") {
           return
         }
       }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -254,6 +254,21 @@ export class CookieJarService extends Service {
     return host.toLowerCase()
   }
 
+  // RFC 6265 5.1.4 default-path. A response that omits the `Path`
+  // attribute defaults to the directory of the request URI path,
+  // i.e. the substring up to but not including the rightmost `/`.
+  // A path with no `/` or only the leading `/` defaults to `/`.
+  private defaultPath(uriPath: string): string {
+    if (uriPath.length === 0 || uriPath[0] !== "/") {
+      return "/"
+    }
+    const last = uriPath.lastIndexOf("/")
+    if (last === 0) {
+      return "/"
+    }
+    return uriPath.slice(0, last)
+  }
+
   // Normalizes the kernel relay response cookies into the
   // `@hoppscotch/data` shape and merges them. Domain falls back to the
   // request host (host-only cookie), path to "/", the flags default
@@ -286,7 +301,7 @@ export class CookieJarService extends Service {
         name: c.name,
         value: c.value,
         domain,
-        path: c.path ?? "/",
+        path: c.path ?? this.defaultPath(requestURL.pathname),
         httpOnly: c.httpOnly ?? false,
         secure: c.secure ?? false,
         sameSite: c.sameSite ?? "Lax",

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -601,15 +601,20 @@ export class CookieJarService extends Service {
       return
     }
 
-    // A user who set a `Cookie` header through the request panel
-    // (any case-variant) is asserting deliberate intent for this
-    // request, so the jar yields and the user's header is
-    // preserved as written. The jar still updates from response
-    // capture and the manager remains the place to inspect or
-    // edit it.
+    // A user who set a non-empty `Cookie` header through the
+    // request panel (any case-variant) is asserting deliberate
+    // intent for this request, so the jar yields and the user's
+    // header is preserved as written. The jar still updates from
+    // response capture and the manager remains the place to
+    // inspect or edit it. An empty value is treated as absent so a
+    // leftover `Cookie: ""` from a request template does not
+    // suppress the jar.
     if (request.headers) {
       for (const key of Object.keys(request.headers)) {
-        if (key.toLowerCase() === "cookie") {
+        if (
+          key.toLowerCase() === "cookie" &&
+          request.headers[key].trim() !== ""
+        ) {
           return
         }
       }

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -87,16 +87,20 @@ export class CookieJarService extends Service {
   })()
   private writeCounter = 0
 
-  // Ring buffer of recent self-write tokens. A single-slot
+  // Ring of recent self-write tokens. A single-slot
   // `lastWriteToken` would lose the prior token whenever two writes
-  // landed in the same tick, so an in-process echo for the older
+  // ran in the same tick, so an in-process echo for the older
   // write would be misclassified as foreign and reapply a stale
   // snapshot. The ring tolerates burst writes up to its size. The
   // cap is sized well above any realistic burst (modal save, bulk
   // import, response capture with many Set-Cookies) so a token
   // cannot age out before its disk-write's watcher echo arrives.
+  // A `Set` backs the membership check so the watcher's hot path
+  // is `O(1)` instead of `O(n)` against a 10k buffer, and `Set`
+  // iteration order is insertion order per the spec so FIFO
+  // eviction works by reading `values().next()`.
   private readonly recentWriteTokensCap = 10_000
-  private recentWriteTokens: string[] = []
+  private recentWriteTokens = new Set<string>()
 
   async onServiceInit(): Promise<void> {
     this.hydrated = (async () => {
@@ -174,10 +178,7 @@ export class CookieJarService extends Service {
         console.error("[CookieJar] Watcher rejected malformed payload:", e)
         return
       }
-      if (
-        stored.writeToken &&
-        this.recentWriteTokens.includes(stored.writeToken)
-      ) {
+      if (stored.writeToken && this.recentWriteTokens.has(stored.writeToken)) {
         return
       }
       this.cookieJar.value = this.toMap(stored.domains)
@@ -230,10 +231,13 @@ export class CookieJarService extends Service {
       return
     }
     const token = `${this.writePrefix}-${++this.writeCounter}`
-    this.recentWriteTokens.push(token)
-    if (this.recentWriteTokens.length > this.recentWriteTokensCap) {
-      this.recentWriteTokens.shift()
+    if (this.recentWriteTokens.size >= this.recentWriteTokensCap) {
+      const oldest = this.recentWriteTokens.values().next().value
+      if (oldest !== undefined) {
+        this.recentWriteTokens.delete(oldest)
+      }
     }
+    this.recentWriteTokens.add(token)
 
     this.writeChain = this.writeChain
       .then(async () => {

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -91,28 +91,39 @@ export class CookieJarService extends Service {
 
   async onServiceInit(): Promise<void> {
     this.hydrated = (async () => {
-      const initResult = await Store.init()
-      if (E.isLeft(initResult)) {
-        this.initFailed = true
-        console.error(
-          "[CookieJar] Failed to initialize store:",
-          initResult.left
-        )
-        return
-      }
-
-      // `loadJar` and `setupWatcher` errors are caught so `hydrated`
-      // resolves either way. A rejected `hydrated` would make every
-      // later `whenReady()` reject, and the interceptors' outer
-      // try/catch would convert a successful HTTP response into
-      // `E.left` on every request, the same failure mode the
-      // `initFailed` flag exists to avoid.
+      // `Store.init` resolves an `Either` for storage-layer failures
+      // but `getModule("store")` throws synchronously when the kernel
+      // is not bootstrapped, which happens in vitest specs that pull
+      // the service in transitively. Catching here keeps `hydrated`
+      // resolved, the service alive on its in-memory jar, and
+      // `initFailed` set so `persistJar` no-ops.
       try {
-        await this.loadJar()
-        await this.setupWatcher()
+        const initResult = await Store.init()
+        if (E.isLeft(initResult)) {
+          this.initFailed = true
+          console.error(
+            "[CookieJar] Failed to initialize store:",
+            initResult.left
+          )
+          return
+        }
+
+        // `loadJar` and `setupWatcher` errors are caught so `hydrated`
+        // resolves either way. A rejected `hydrated` would make every
+        // later `whenReady()` reject, and the interceptors' outer
+        // try/catch would convert a successful HTTP response into
+        // `E.left` on every request, the same failure mode the
+        // `initFailed` flag exists to avoid.
+        try {
+          await this.loadJar()
+          await this.setupWatcher()
+        } catch (e) {
+          this.initFailed = true
+          console.error("[CookieJar] Failed during init:", e)
+        }
       } catch (e) {
         this.initFailed = true
-        console.error("[CookieJar] Failed during init:", e)
+        console.error("[CookieJar] Kernel store unavailable:", e)
       }
     })()
     await this.hydrated

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -299,10 +299,16 @@ export class CookieJarService extends Service {
         )
         continue
       }
+      // An empty-string `path` falls through `??` (only `undefined`
+      // triggers it) and would otherwise produce `startsWith("")`
+      // matching every request path under the domain, plus a
+      // duplicate jar entry alongside the canonical `/` form. The
+      // explicit length check collapses both empty and undefined
+      // to `/`.
       const normalized: Cookie = {
         ...cookie,
         domain: canonDomain,
-        path: cookie.path ?? "/",
+        path: cookie.path && cookie.path.length > 0 ? cookie.path : "/",
       }
       const existing = this.cookieJar.value.get(normalized.domain) ?? []
 
@@ -424,7 +430,10 @@ export class CookieJarService extends Service {
         name: c.name,
         value: c.value,
         domain,
-        path: c.path ?? this.defaultPath(requestURL.pathname),
+        path:
+          c.path && c.path.length > 0
+            ? c.path
+            : this.defaultPath(requestURL.pathname),
         httpOnly: c.httpOnly ?? false,
         secure: c.secure ?? false,
         sameSite: c.sameSite ?? "Lax",
@@ -476,7 +485,7 @@ export class CookieJarService extends Service {
       if (!existing) {
         continue
       }
-      const path = target.path ?? "/"
+      const path = target.path && target.path.length > 0 ? target.path : "/"
       const next = existing.filter(
         (c) => !(c.name === target.name && c.path === path)
       )

--- a/packages/hoppscotch-desktop/plugin-workspace/relay/Cargo.lock
+++ b/packages/hoppscotch-desktop/plugin-workspace/relay/Cargo.lock
@@ -150,6 +150,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +735,7 @@ name = "relay"
 version = "0.1.1"
 dependencies = [
  "bytes",
+ "cookie",
  "curl",
  "dashmap",
  "env_logger",
@@ -903,6 +914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -1051,6 +1063,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "windows-sys"

--- a/packages/hoppscotch-desktop/plugin-workspace/relay/Cargo.toml
+++ b/packages/hoppscotch-desktop/plugin-workspace/relay/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 curl = { git = "https://github.com/CuriousCorrelation/curl-rust.git", features = ["ntlm"] }
+cookie = "0.18"
 tokio-util = "0.7.12"
 lazy_static = "1.5.0"
 time = { version = "0.3.37", features = ["serde"] }

--- a/packages/hoppscotch-desktop/plugin-workspace/relay/devenv.lock
+++ b/packages/hoppscotch-desktop/plugin-workspace/relay/devenv.lock
@@ -3,10 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1732585607,
+        "lastModified": 1776802132,
+        "narHash": "sha256-2yO2SGA7zVFYKe0qyJjdg7WHuMOKNwTQmigL7ydD8hI=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "a520f05c40ebecaf5e17064b27e28ba8e70c49fb",
+        "rev": "91affc7a7b6646852a0079678eadf12ac5029d9d",
         "type": "github"
       },
       "original": {
@@ -24,59 +25,26 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1732602776,
+        "lastModified": 1776845169,
+        "narHash": "sha256-Ya6Ba5oC0+PK1TSU4Rkjpoca73mUp6FoHQV5QGnqbx0=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "e0d44b70dcd2b98dd77857b4c5c7b1dc6b1ef56d",
+        "rev": "f0b5be1fa2891221ba8b48784f8fded5ef15301f",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732238832,
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8edf06bea5bcbee082df1b7369ff973b91618b8d",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
@@ -86,58 +54,21 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1731797254,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
-      },
-      "locked": {
-        "lastModified": 1732021966,
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "devenv": "devenv",
         "fenix": "fenix",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "nixpkgs": "nixpkgs"
       }
     },
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1732562640,
+        "lastModified": 1776800521,
+        "narHash": "sha256-f8YJfwAOsLFpIoqZuX3yF69UvMLrkx7iVzMH1pJU7cM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "157c7d01149e9be7179c5724b89d8d073e923bd8",
+        "rev": "8954b66d43225e62c92e8bbcc8500191b5cceb1e",
         "type": "github"
       },
       "original": {

--- a/packages/hoppscotch-desktop/plugin-workspace/relay/src/interop.rs
+++ b/packages/hoppscotch-desktop/plugin-workspace/relay/src/interop.rs
@@ -386,6 +386,7 @@ pub struct Cookie {
     pub value: String,
     pub domain: Option<String>,
     pub path: Option<String>,
+    #[serde(with = "time::serde::rfc3339::option")]
     pub expires: Option<OffsetDateTime>,
     pub secure: Option<bool>,
     #[serde(rename = "httpOnly")]

--- a/packages/hoppscotch-desktop/plugin-workspace/relay/src/response.rs
+++ b/packages/hoppscotch-desktop/plugin-workspace/relay/src/response.rs
@@ -3,10 +3,13 @@ use std::{collections::HashMap, str::FromStr, time::SystemTime};
 use bytes::Bytes;
 use http::{StatusCode, Version};
 use mime::Mime;
+use time::OffsetDateTime;
 
 use crate::{
     error::{RelayError, Result},
-    interop::{MediaType, Response, ResponseBody, ResponseMeta, SizeInfo, TimingInfo},
+    interop::{
+        Cookie, MediaType, Response, ResponseBody, ResponseMeta, SameSite, SizeInfo, TimingInfo,
+    },
 };
 
 pub(crate) struct ResponseHandler {
@@ -63,6 +66,8 @@ impl ResponseHandler {
             "Response built successfully"
         );
 
+        let cookies = self.parse_cookies();
+
         let body = ResponseBody {
             body: self.body,
             media_type,
@@ -73,11 +78,74 @@ impl ResponseHandler {
             status: self.status,
             status_text: self.status.to_string(),
             version: self.version,
+            cookies,
             headers: self.headers,
-            cookies: None,
             meta: ResponseMeta { timing, size },
             body,
         })
+    }
+
+    /// Parses the response's `Set-Cookie` header(s) into structured cookies.
+    ///
+    /// The relay used to return `cookies: None` because nothing downstream
+    /// consumed structured cookies, and `transfer.rs` joins multiple
+    /// `Set-Cookie` headers into one value with `\n`. This splits on that
+    /// same delimiter and parses each line with the `cookie` crate so the
+    /// jar service gets a real contract instead of re-parsing the joined
+    /// header string. The joined header is left in `headers` untouched so
+    /// the existing header path does not regress.
+    fn parse_cookies(&self) -> Option<Vec<Cookie>> {
+        let raw = self
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("set-cookie"))
+            .map(|(_, v)| v.as_str())?;
+
+        let cookies: Vec<Cookie> = raw
+            .split('\n')
+            .filter_map(|line| {
+                let line = line.trim();
+                if line.is_empty() {
+                    return None;
+                }
+                match cookie::Cookie::parse(line) {
+                    Ok(parsed) => Some(Self::to_interop_cookie(&parsed)),
+                    Err(e) => {
+                        tracing::warn!(error = %e, raw = %line, "Skipping unparseable Set-Cookie");
+                        None
+                    }
+                }
+            })
+            .collect();
+
+        (!cookies.is_empty()).then_some(cookies)
+    }
+
+    fn to_interop_cookie(c: &cookie::Cookie<'_>) -> Cookie {
+        // RFC 6265 5.2.2, Max-Age takes precedence over Expires when both
+        // are present. `checked_add` so an absurd Max-Age cannot panic the
+        // relay, it just drops the expiry and the cookie reads as session.
+        let expires = c
+            .max_age()
+            .and_then(|age| OffsetDateTime::now_utc().checked_add(age))
+            .or_else(|| c.expires_datetime());
+
+        let same_site = c.same_site().map(|s| match s {
+            cookie::SameSite::Strict => SameSite::Strict,
+            cookie::SameSite::Lax => SameSite::Lax,
+            cookie::SameSite::None => SameSite::None,
+        });
+
+        Cookie {
+            name: c.name().to_owned(),
+            value: c.value().to_owned(),
+            domain: c.domain().map(str::to_owned),
+            path: c.path().map(str::to_owned),
+            expires,
+            secure: c.secure(),
+            http_only: c.http_only(),
+            same_site,
+        }
     }
 
     fn determine_media_type(&self) -> MediaType {

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/devenv.lock
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/devenv.lock
@@ -3,10 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1733525154,
+        "lastModified": 1778705971,
+        "narHash": "sha256-n0LjnKBAjJ5/mgNzOCeVvAeHUrNMUZ3fBQx/UDCkHtQ=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "d74232153d60ccdeba6f41eec8ce8b2be0b33ac6",
+        "rev": "64d4353a3628c4138c84d8ba10987da2ba27fddd",
         "type": "github"
       },
       "original": {
@@ -24,80 +25,26 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1733553297,
+        "lastModified": 1778748763,
+        "narHash": "sha256-x4dC4C/GtyOGlgIAPml8SfXeHwLkG/66r7zk7ueL0OM=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "8519a70a1a81db2dd22316f94c25d7510218169e",
+        "rev": "67a701a5cb6507815a33d8f7b3466c78a7d724e7",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "fenix",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1765121682,
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1765911976,
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "b68b780b69702a090c8bb1b973bab13756cc7a27",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1762808025,
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733330745,
+        "lastModified": 1778672786,
+        "narHash": "sha256-Blg88K1jwG+P0Mr27+rKMFCufdrWkV3wWh9AdYtz0FQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f9d395f057a50f8076f633c10519035fce8d773",
+        "rev": "eef00dfd8a712b34af845f9350bac681b1228bd1",
         "type": "github"
       },
       "original": {
@@ -111,26 +58,44 @@
       "inputs": {
         "devenv": "devenv",
         "fenix": "fenix",
-        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ]
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1733499879,
+        "lastModified": 1778703600,
+        "narHash": "sha256-EpgXYEuDyqWKcyhO4EP/nRY+7ZnQwNDBYMVb/k06ME4=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "17720acb90105cbd736d3e78d736eb5d41af89a5",
+        "rev": "77db6109f0952f64ffc94d2e4215aa20b3d703bf",
         "type": "github"
       },
       "original": {
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778728594,
+        "narHash": "sha256-+gIOsOzqWNfn+ThCXBQGcLHVEnaGQW59XjghE9JUIYk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "83a17ebffcfacb17b49e1b5e9dc15eed07936648",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
         "type": "github"
       }
     }

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/devenv.yaml
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/devenv.yaml
@@ -1,23 +1,14 @@
-# yaml-language-server: $schema=https://devenv.sh/devenv.schema.json
 inputs:
-  # For NodeJS-22 and above
-  nixpkgs:
-    url: github:NixOS/nixpkgs/nixpkgs-unstable
-  # nixpkgs:
-  #   url: github:cachix/devenv-nixpkgs/rolling
   fenix:
     url: github:nix-community/fenix
     inputs:
       nixpkgs:
         follows: nixpkgs
-
-# If you're using non-OSS software, you can set allowUnfree to true.
+  nixpkgs:
+    url: github:NixOS/nixpkgs/nixpkgs-unstable
+  rust-overlay:
+    url: github:oxalica/rust-overlay
+    inputs:
+      nixpkgs:
+        follows: nixpkgs
 allowUnfree: true
-
-# If you're willing to use a package that's vulnerable
-# permittedInsecurePackages:
-#  - "openssl-1.1.1w"
-
-# If you have more than one devenv you can merge them
-#imports:
-# - ./backend

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/package.json
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.3.0",
-    "rollup": "^4.54.0",
+    "rollup": "^4.59.0",
     "tslib": "^2.8.1",
     "typescript": "5.9.3"
   }

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/package.json
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.3.0",
-    "rollup": "^4.59.0",
+    "rollup": "^4.54.0",
     "tslib": "^2.8.1",
     "typescript": "5.9.3"
   }

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/Cargo.lock
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/Cargo.lock
@@ -3,25 +3,16 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -42,12 +33,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -73,44 +58,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "atk"
@@ -136,25 +121,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "backtrace"
-version = "0.3.74"
+name = "autocfg"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -169,6 +145,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,11 +167,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -194,27 +185,18 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "block2"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d59b4c170e16f0405a2e95aff44432a0d41aa97675f3d52623effe95792a037"
-dependencies = [
- "objc2 0.6.0",
+ "objc2",
 ]
 
 [[package]]
 name = "brotli"
-version = "7.0.0"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -223,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -233,15 +215,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -251,9 +233,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -264,7 +246,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -285,11 +267,11 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -312,25 +294,26 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "cargo_toml"
-version = "0.21.0"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbd1fe9db3ebf71b89060adaf7b0504c2d6a425cf061313099547e382c2e472"
+checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -363,34 +346,27 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -420,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -436,11 +412,11 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -453,7 +429,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "core-foundation",
  "libc",
 ]
@@ -469,18 +445,18 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -493,9 +469,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -503,19 +479,32 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.27.2"
+version = "0.29.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "754b69d351cdc2d8ee09ae203db831e005560fc6030da058f86ad60c92a9cb0a"
+checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
- "itoa 0.4.8",
+ "itoa",
  "matches",
- "phf 0.8.0",
+ "phf 0.10.1",
  "proc-macro2",
  "quote",
  "smallvec",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
 ]
 
 [[package]]
@@ -525,7 +514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -535,7 +524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -547,7 +536,7 @@ dependencies = [
  "libc",
  "openssl-probe",
  "openssl-sys",
- "socket2",
+ "socket2 0.5.10",
 ]
 
 [[package]]
@@ -565,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -575,27 +564,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -614,25 +602,46 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
+version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.100",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -663,14 +672,20 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "dispatch"
-version = "0.2.0"
+name = "dispatch2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "libc",
+ "objc2",
+]
 
 [[package]]
 name = "displaydoc"
@@ -680,14 +695,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "dlopen2"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1297103d2bbaea85724fcee6294c2d50b1081f9ad47d0f6f6f61eda65315a6"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
 dependencies = [
  "dlopen2_derive",
  "libc",
@@ -697,29 +712,44 @@ dependencies = [
 
 [[package]]
 name = "dlopen2_derive"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b99bf03862d7f545ebc28ddd33a665b50865f4dfd84031a393823879bd4c54"
+checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "dom_query"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
+dependencies = [
+ "bit-set",
+ "cssparser 0.36.0",
+ "foldhash 0.2.0",
+ "html5ever 0.38.0",
+ "precomputed-hash",
+ "selectors 0.36.1",
+ "tendril 0.5.0",
 ]
 
 [[package]]
 name = "dpi"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "dtoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dtoa-short"
@@ -738,20 +768,20 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "embed-resource"
-version = "3.0.2"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbc6e0d8e0c03a655b53ca813f0463d2c956bc4db8138dbc89f120b066551e3"
+checksum = "63a1d0de4f2249aa0ff5884d7080814f446bb241a559af6c170a41e878ed2d45"
 dependencies = [
  "cc",
  "memchr",
  "rustc_version",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "vswhom",
  "winreg",
 ]
@@ -764,9 +794,9 @@ checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
 name = "env_filter"
-version = "0.1.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -774,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.7"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -793,13 +823,20 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.6"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
 dependencies = [
  "serde",
+ "serde_core",
  "typeid",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fdeflate"
@@ -821,10 +858,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.1.0"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -835,6 +878,18 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -863,7 +918,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -880,9 +935,9 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -899,24 +954,24 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -925,38 +980,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -965,7 +1020,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1100,36 +1154,39 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "wasm-bindgen",
- "windows-targets 0.52.6",
+ "r-efi 5.3.0",
+ "wasip2",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
+name = "getrandom"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
+]
 
 [[package]]
 name = "gio"
@@ -1169,7 +1226,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1193,11 +1250,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 2.0.2",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1212,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "gobject-sys"
@@ -1276,7 +1333,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1293,9 +1350,18 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1317,27 +1383,34 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "html5ever"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea68cab48b8459f17cf1c944c67ddc572d272d9f2b274140f223ecb1da4a3b7"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "markup5ever 0.14.1",
+ "match_token",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
+dependencies = [
+ "log",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
- "itoa 1.0.15",
+ "itoa",
 ]
 
 [[package]]
@@ -1381,17 +1454,18 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "httparse",
- "itoa 1.0.15",
+ "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -1399,37 +1473,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
-dependencies = [
- "futures-util",
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1437,16 +1497,17 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1460,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "ico"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc50b891e4acf8fe0e71ef88ec43ad82ee07b3810ad09de10f1d01f072ed4b98"
+checksum = "3e795dff5605e0f04bff85ca41b51a96b83e80b281e96231bcaaf1ac35103371"
 dependencies = [
  "byteorder",
  "png",
@@ -1470,21 +1531,23 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
+ "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1494,97 +1557,65 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
+name = "id-arena"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1594,9 +1625,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1605,9 +1636,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1626,13 +1657,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.17.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1655,27 +1687,31 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "javascriptcore-rs"
@@ -1702,26 +1738,26 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.4"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.4"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1733,7 +1769,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1742,16 +1778,40 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1784,22 +1844,21 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "serde",
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "kuchikiki"
-version = "0.8.2"
+version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e4755b7b995046f510a7520c42b2fed58b77bd94d5a87a8eb43d2fd126da8"
+checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
- "cssparser",
- "html5ever",
- "indexmap 1.9.3",
- "matches",
- "selectors",
+ "cssparser 0.29.6",
+ "html5ever 0.29.1",
+ "indexmap 2.14.0",
+ "selectors 0.24.0",
 ]
 
 [[package]]
@@ -1807,6 +1866,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libappindicator"
@@ -1834,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -1850,19 +1915,18 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.9.0",
  "libc",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.21"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -1872,31 +1936,24 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mac"
@@ -1906,16 +1963,38 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markup5ever"
-version = "0.11.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
 dependencies = [
  "log",
- "phf 0.10.1",
- "phf_codegen 0.10.0",
- "string_cache",
- "string_cache_codegen",
- "tendril",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
+ "web_atoms",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1926,9 +2005,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
@@ -1947,9 +2026,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -1957,34 +2036,34 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "muda"
-version = "0.16.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de14a9b5d569ca68d7c891d613b390cf5ab4f851c77aaa2f9e435555d3d9492"
+checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
 dependencies = [
  "crossbeam-channel",
  "dpi",
  "gtk",
  "keyboard-types",
- "objc2 0.6.0",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.0",
+ "objc2-foundation",
  "once_cell",
  "png",
  "serde",
- "thiserror 2.0.12",
- "windows-sys 0.59.0",
+ "thiserror 2.0.18",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1993,8 +2072,8 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.9.0",
- "jni-sys",
+ "bitflags 2.11.1",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys",
  "num_enum",
@@ -2014,7 +2093,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -2031,9 +2110,9 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -2046,46 +2125,31 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.3.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "objc-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-
-[[package]]
-name = "objc2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
-dependencies = [
- "objc-sys",
- "objc2-encode",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "objc2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
  "objc2-exception-helper",
@@ -2093,75 +2157,39 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5906f93257178e2f7ae069efb89fbd6ee94f0592740b5f8a1512ca498814d0fb"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.9.0",
- "block2 0.6.0",
- "libc",
- "objc2 0.6.0",
- "objc2-cloud-kit",
- "objc2-core-data",
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
  "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-core-image",
- "objc2-foundation 0.3.0",
- "objc2-quartz-core 0.3.0",
-]
-
-[[package]]
-name = "objc2-cloud-kit"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c1948a9be5f469deadbd6bcb86ad7ff9e47b4f632380139722f7d9840c0d42c"
-dependencies = [
- "bitflags 2.9.0",
- "objc2 0.6.0",
- "objc2-foundation 0.3.0",
-]
-
-[[package]]
-name = "objc2-core-data"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f860f8e841f6d32f754836f51e6bc7777cd7e7053cf18528233f6811d3eceb4"
-dependencies = [
- "bitflags 2.9.0",
- "objc2 0.6.0",
- "objc2-foundation 0.3.0",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-core-foundation"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.9.0",
- "objc2 0.6.0",
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
 ]
 
 [[package]]
 name = "objc2-core-graphics"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dca602628b65356b6513290a21a6405b4d4027b8b250f0b98dddbb28b7de02"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.9.0",
- "objc2 0.6.0",
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-core-image"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffa6bea72bf42c78b0b34e89c0bafac877d5f80bf91e159a5d96ea7f693ca56"
-dependencies = [
- "objc2 0.6.0",
- "objc2-foundation 0.3.0",
 ]
 
 [[package]]
@@ -2181,124 +2209,84 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.9.0",
- "block2 0.5.1",
- "libc",
- "objc2 0.5.2",
-]
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
-dependencies = [
- "bitflags 2.9.0",
- "block2 0.6.0",
- "libc",
- "objc2 0.6.0",
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
  "objc2-core-foundation",
 ]
 
 [[package]]
 name = "objc2-io-surface"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161a8b87e32610086e1a7a9e9ec39f84459db7b3a0881c1f16ca5a2605581c19"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.9.0",
- "objc2 0.6.0",
+ "bitflags 2.11.1",
+ "objc2",
  "objc2-core-foundation",
 ]
 
 [[package]]
-name = "objc2-metal"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
-dependencies = [
- "bitflags 2.9.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
-]
-
-[[package]]
 name = "objc2-quartz-core"
-version = "0.2.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.9.0",
- "block2 0.5.1",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-metal",
-]
-
-[[package]]
-name = "objc2-quartz-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb3794501bb1bee12f08dcad8c61f2a5875791ad1c6f47faa71a0f033f20071"
-dependencies = [
- "bitflags 2.9.0",
- "objc2 0.6.0",
- "objc2-foundation 0.3.0",
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-ui-kit"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777a571be14a42a3990d4ebedaeb8b54cd17377ec21b92e8200ac03797b3bee1"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.9.0",
- "objc2 0.6.0",
+ "bitflags 2.11.1",
+ "objc2",
  "objc2-core-foundation",
- "objc2-foundation 0.3.0",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "objc2-web-kit"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b717127e4014b0f9f3e8bba3d3f2acec81f1bde01f656823036e823ed2c94dce"
+checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.9.0",
- "block2 0.6.0",
- "objc2 0.6.0",
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.0",
-]
-
-[[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
+ "objc2-foundation",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.1"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -2315,7 +2303,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2326,18 +2314,18 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.2+3.4.1"
+version = "300.6.0+3.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2379,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2389,22 +2377,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -2412,9 +2400,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
 dependencies = [
- "phf_macros 0.8.0",
  "phf_shared 0.8.0",
- "proc-macro-hack",
 ]
 
 [[package]]
@@ -2423,7 +2409,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
+ "phf_macros 0.10.0",
  "phf_shared 0.10.0",
+ "proc-macro-hack",
 ]
 
 [[package]]
@@ -2434,6 +2422,17 @@ checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -2448,12 +2447,22 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
-version = "0.10.0"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -2473,7 +2482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2483,17 +2492,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fde18ff429ffc8fe78e2bf7f8b7a5a5a6e2a8b58bc5a9ac69198bbda9189c"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
 dependencies = [
- "phf_generator 0.8.0",
- "phf_shared 0.8.0",
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -2510,7 +2529,20 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2537,35 +2569,38 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.1",
+ "siphasher 1.0.2",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.2",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cf17e9a1800f5f396bc67d193dc9411b59012a5876445ef450d449881e1016"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.8.0",
+ "indexmap 2.14.0",
  "quick-xml",
  "serde",
  "time",
@@ -2586,17 +2621,26 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2621,6 +2665,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2632,20 +2686,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
 dependencies = [
- "toml_edit 0.20.7",
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.22.24",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -2680,83 +2735,42 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.32.0"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.12",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "bytes",
- "getrandom 0.3.1",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.12",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -2774,23 +2788,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2814,16 +2818,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,16 +2832,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2876,29 +2861,49 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2908,9 +2913,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2919,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "relay"
@@ -2954,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.14"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2966,62 +2971,31 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pemfile",
- "rustls-pki-types",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
  "tokio-util",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
- "windows-registry",
 ]
-
-[[package]]
-name = "ring"
-version = "0.17.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom 0.2.15",
- "libc",
- "untrusted",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3033,59 +3007,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
-dependencies = [
- "once_cell",
- "ring",
- "rustls-pki-types",
- "rustls-webpki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "rustls-pki-types"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
-dependencies = [
- "web-time",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
-
-[[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "same-file"
@@ -3112,6 +3037,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3120,7 +3069,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3131,62 +3080,91 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "selectors"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df320f1889ac4ba6bc0cdc9c9af7af4bd64bb927bccdf32d81140dc1f9be12fe"
+checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
- "cssparser",
- "derive_more",
+ "cssparser 0.29.6",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
- "matches",
  "phf 0.8.0",
  "phf_codegen 0.8.0",
  "precomputed-hash",
- "servo_arc",
+ "servo_arc 0.2.0",
  "smallvec",
- "thin-slice",
+]
+
+[[package]]
+name = "selectors"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+dependencies = [
+ "bitflags 2.11.1",
+ "cssparser 0.36.0",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc 0.4.3",
+ "smallvec",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
 [[package]]
 name = "serde-untagged"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
 dependencies = [
  "erased-serde",
  "serde",
+ "serde_core",
  "typeid",
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3197,19 +3175,20 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "itoa 1.0.15",
+ "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3220,43 +3199,41 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
+name = "serde_spanned"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "form_urlencoded",
- "itoa 1.0.15",
- "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
- "serde",
- "serde_derive",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -3264,21 +3241,21 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serialize-to-javascript"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9823f2d3b6a81d98228151fdeaf848206a7855a7a042bbf9bf870449a66cafb"
+checksum = "04f3666a07a197cdb77cdf306c32be9b7f598d7060d50cfd4d5aa04bfd92f6c5"
 dependencies = [
  "serde",
  "serde_json",
@@ -3287,30 +3264,39 @@ dependencies = [
 
 [[package]]
 name = "serialize-to-javascript-impl"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74064874e9f6a15f04c1f3cb627902d0e6b410abbf36668afa873c61889f1763"
+checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "servo_arc"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
+checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
 dependencies = [
  "nodrop",
  "stable_deref_trait",
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.8"
+name = "servo_arc"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3325,9 +3311,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "siphasher"
@@ -3337,55 +3323,62 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "softbuffer"
-version = "0.4.6"
+name = "socket2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "softbuffer"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "bytemuck",
- "cfg_aliases",
- "core-graphics",
- "foreign-types 0.5.0",
  "js-sys",
- "log",
- "objc2 0.5.2",
- "objc2-foundation 0.2.2",
- "objc2-quartz-core 0.2.2",
+ "ndk",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "objc2-quartz-core",
  "raw-window-handle",
  "redox_syscall",
+ "tracing",
  "wasm-bindgen",
  "web-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3416,21 +3409,33 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "string_cache"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938d512196766101d333398efde81bc1f37b00cb42c2f8350e5df639f040bbbe"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
  "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
 ]
 
 [[package]]
@@ -3441,6 +3446,18 @@ checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -3470,14 +3487,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3503,9 +3514,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3523,13 +3534,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3541,45 +3552,44 @@ dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml",
+ "toml 0.8.2",
  "version-compare",
 ]
 
 [[package]]
 name = "tao"
-version = "0.32.8"
+version = "0.34.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63c8b1020610b9138dd7b1e06cf259ae91aa05c30f3bd0d6b42a03997b92dec1"
+checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.11.1",
+ "block2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
- "dispatch",
+ "dispatch2",
  "dlopen2",
  "dpi",
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
  "jni",
- "lazy_static",
  "libc",
  "log",
  "ndk",
  "ndk-context",
  "ndk-sys",
- "objc2 0.6.0",
+ "objc2",
  "objc2-app-kit",
- "objc2-foundation 0.3.0",
+ "objc2-foundation",
  "once_cell",
  "parking_lot",
  "raw-window-handle",
- "scopeguard",
  "tao-macros",
  "unicode-segmentation",
  "url",
  "windows",
- "windows-core 0.60.1",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -3592,7 +3602,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3603,17 +3613,17 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.3.1"
+version = "2.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be747b26bf28674977fac47bdf6963fd9c7578271c3fbeb25d8686de6596f35"
+checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
 dependencies = [
  "anyhow",
  "bytes",
+ "cookie",
  "dirs",
  "dunce",
  "embed_plist",
- "futures-util",
- "getrandom 0.2.15",
+ "getrandom 0.3.4",
  "glob",
  "gtk",
  "heck 0.5.0",
@@ -3623,9 +3633,11 @@ dependencies = [
  "log",
  "mime",
  "muda",
- "objc2 0.6.0",
+ "objc2",
  "objc2-app-kit",
- "objc2-foundation 0.3.0",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "objc2-web-kit",
  "percent-encoding",
  "plist",
  "raw-window-handle",
@@ -3640,11 +3652,10 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tokio",
  "tray-icon",
  "url",
- "urlpattern",
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
@@ -3653,9 +3664,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.0.6"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a2e96f3c0baa0581656bb58e6fdd0f7c9c31eaf6721a0c08689d938fe85f2d"
+checksum = "4bbc990d1dbf57a8e1c7fa2327f2a614d8b757805603c1b9ba5c81bade09fd4d"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -3663,21 +3674,21 @@ dependencies = [
  "glob",
  "heck 0.5.0",
  "json-patch",
- "schemars",
+ "schemars 0.8.22",
  "semver",
  "serde",
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.0.5"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e357ec3daf8faad1029bc7109e7f5b308ceb63b6073d110d7388923a4cce5e55"
+checksum = "d4a24476afd977c5d5d169f72425868613d82747916dd29e0a357c84c4bd6d29"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -3691,9 +3702,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.100",
+ "syn 2.0.117",
  "tauri-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "time",
  "url",
  "uuid",
@@ -3702,32 +3713,32 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.0.5"
+version = "2.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447ee4dd94690d77f1422f2b57e783c654ba75c535ad6f6e727887330804fff2"
+checksum = "d39b349a98dadaffebb73f0a40dcd1f23c999211e5a2e744403db384d0c33de7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
  "tauri-codegen",
  "tauri-utils",
 ]
 
 [[package]]
 name = "tauri-plugin"
-version = "2.0.5"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad3021d8e60ec7672f51ecb67c5e1a514a4d7a9a5ffc9d85090739378047502"
+checksum = "ddde7d51c907b940fb573006cdda9a642d6a7c8153657e88f8a5c3c9290cd4aa"
 dependencies = [
  "anyhow",
  "glob",
  "plist",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "tauri-utils",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
@@ -3739,42 +3750,47 @@ dependencies = [
  "serde",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "tauri-runtime"
-version = "2.4.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e758a405ab39e25f4d1235c5f06fe563f44b01ee18bbe38ddec5356d4f581908"
+checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
 dependencies = [
+ "cookie",
  "dpi",
  "gtk",
  "http",
  "jni",
+ "objc2",
+ "objc2-ui-kit",
+ "objc2-web-kit",
  "raw-window-handle",
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "url",
+ "webkit2gtk",
+ "webview2-com",
  "windows",
 ]
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.4.1"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2beb90decade4c71e8b09c9e4a9245837a8a97693f945b77e32baf13f51fec"
+checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
 dependencies = [
  "gtk",
  "http",
  "jni",
  "log",
- "objc2 0.6.0",
+ "objc2",
  "objc2-app-kit",
- "objc2-foundation 0.3.0",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -3791,16 +3807,17 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.2.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107a959dbd5ff53d89a98f6f2e3e987c611334141a43630caae1d80e79446dd6"
+checksum = "219a1f983a2af3653f75b5747f76733b0da7ff03069c7a41901a5eb3ace4557d"
 dependencies = [
+ "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
  "dunce",
  "glob",
- "html5ever",
+ "html5ever 0.29.1",
  "http",
  "infer 0.19.0",
  "json-patch",
@@ -3811,15 +3828,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "schemars",
+ "schemars 0.8.22",
  "semver",
  "serde",
  "serde-untagged",
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.12",
- "toml",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -3828,12 +3845,13 @@ dependencies = [
 
 [[package]]
 name = "tauri-winres"
-version = "0.3.0"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56eaa45f707bedf34d19312c26d350bc0f3c59a47e58e8adbeecdc850d2c13a0"
+checksum = "1087b111fe2b005e42dbdc1990fc18593234238d47453b0c99b7de1c9ab2c1e0"
 dependencies = [
+ "dunce",
  "embed-resource",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -3848,10 +3866,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "thin-slice"
-version = "0.1.1"
+name = "tendril"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
+]
 
 [[package]]
 name = "thiserror"
@@ -3864,11 +3886,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3879,46 +3901,46 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.39"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
- "itoa 1.0.15",
+ "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.3"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.20"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3926,59 +3948,33 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
-dependencies = [
- "rustls",
- "tokio",
+ "socket2 0.6.3",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3989,23 +3985,56 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.22.24",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -4014,46 +4043,80 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.8.0",
- "toml_datetime",
+ "indexmap 2.14.0",
+ "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.20.7"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.8.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
-dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.14.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow 0.7.4",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -4072,9 +4135,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4083,44 +4146,44 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "tray-icon"
-version = "0.20.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d433764348e7084bad2c5ea22c96c71b61b17afe3a11645710f533bd72b6a2b5"
+checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
 dependencies = [
  "crossbeam-channel",
  "dirs",
  "libappindicator",
  "muda",
- "objc2 0.6.0",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation 0.3.0",
+ "objc2-foundation",
  "once_cell",
  "png",
  "serde",
- "thiserror 2.0.12",
- "windows-sys 0.59.0",
+ "thiserror 2.0.18",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4137,9 +4200,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unic-char-property"
@@ -4184,32 +4247,33 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "untrusted"
-version = "0.9.0"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4246,12 +4310,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4265,12 +4323,14 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.3.1",
- "serde",
+ "getrandom 0.4.2",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4281,9 +4341,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -4338,63 +4398,56 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4402,31 +4455,53 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.2"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -4436,30 +4511,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wasmparser"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
+name = "web_atoms"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]
 name = "webkit2gtk"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b1bc1e54c581da1e9f179d0b38512ba358fb1af2d634a1affe42e37172361a"
+checksum = "a1027150013530fb2eaf806408df88461ae4815a45c541c8975e61d6f2fc4793"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-rs",
@@ -4481,9 +4570,9 @@ dependencies = [
 
 [[package]]
 name = "webkit2gtk-sys"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62daa38afc514d1f8f12b8693d30d5993ff77ced33ce30cd04deebc267a6d57c"
+checksum = "916a5f65c2ef0dfe12fff695960a2ec3d4565359fdbb2e9943c974e06c734ea5"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-sys-rs",
@@ -4500,48 +4589,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webview2-com"
-version = "0.36.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d606f600e5272b514dbb66539dd068211cc20155be8d3958201b4b5bd79ed3"
+checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows",
- "windows-core 0.60.1",
+ "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
 ]
 
 [[package]]
 name = "webview2-com-macros"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
+checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "webview2-com-sys"
-version = "0.36.0"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb27fccd3c27f68e9a6af1bcf48c2d82534b8675b83608a4d81446d095a17ac"
+checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "windows",
- "windows-core 0.60.1",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4562,11 +4642,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4581,10 +4661,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2 0.6.0",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.0",
+ "objc2-foundation",
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
@@ -4592,123 +4672,141 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.60.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddf874e74c7a99773e62b1c671427abf01a425e77c3d3fb9fb1e4883ea934529"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.60.1",
+ "windows-core 0.61.2",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5467f79cc1ba3f52ebb2ed41dbb459b8e7db636cc3429458d9a852e15bc24dec"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.60.1",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.60.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca21a92a9cae9bf4ccae5cf8368dce0837100ddf6e6d57936749e85f152f6247"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a787db4595e7eb80239b74ce8babfb1363d8e343ab072f2ffe901400c03349f0"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.60.1",
- "windows-link",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.59.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.0"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26fd936d991781ea39e87c3a27285081e3c0da5ca0fcbc02d368cc6f52ff01"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005dea54e2f6499f2cee279b8f703b3cf3b5734a2d8d21867c8f44003182eeed"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.60.1",
- "windows-link",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.53.0",
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4718,15 +4816,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4748,6 +4837,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4760,21 +4867,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4795,27 +4887,37 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
 name = "windows-version"
-version = "0.1.3"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfbcc4996dd183ff1376a20ade1242da0d2dcaff83cc76710a588d24fd4c5db"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4826,21 +4928,15 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4850,21 +4946,15 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4874,21 +4964,15 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -4898,9 +4982,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4910,21 +4994,15 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4934,21 +5012,15 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4958,21 +5030,15 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4982,21 +5048,15 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -5009,69 +5069,154 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "winreg"
-version = "0.52.0"
+version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
- "bitflags 2.9.0",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
+name = "wit-bindgen"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.50.4"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804a7d1613bd699beccaa60f3b3c679acee21cebba1945a693f5eab95c08d1fa"
+checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
 dependencies = [
  "base64 0.22.1",
- "block2 0.6.0",
+ "block2",
  "cookie",
  "crossbeam-channel",
+ "dirs",
+ "dom_query",
  "dpi",
  "dunce",
  "gdkx11",
  "gtk",
- "html5ever",
  "http",
  "javascriptcore-rs",
  "jni",
- "kuchikiki",
  "libc",
  "ndk",
- "objc2 0.6.0",
+ "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation 0.3.0",
+ "objc2-foundation",
  "objc2-ui-kit",
  "objc2-web-kit",
  "once_cell",
@@ -5080,13 +5225,13 @@ dependencies = [
  "sha2",
  "soup3",
  "tao-macros",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
  "windows",
- "windows-core 0.60.1",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -5114,11 +5259,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -5126,68 +5270,73 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
  "synstructure",
 ]
 
 [[package]]
-name = "zeroize"
-version = "1.8.1"
+name = "zerotrie"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5196,11 +5345,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/Cargo.toml
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/Cargo.toml
@@ -16,4 +16,4 @@ tracing = "0.1.41"
 relay = { git = "https://github.com/CuriousCorrelation/relay.git" }
 
 [build-dependencies]
-tauri-plugin = { version = "2.0.2", features = ["build"] }
+tauri-plugin = { version = "2.5.4", features = ["build"] }

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/package.json
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/package.json
@@ -29,5 +29,10 @@
     "rollup": "^4.59.0",
     "tslib": "^2.6.2",
     "typescript": "5.9.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "picomatch@<4.0.4": "^4.0.4"
+    }
   }
 }

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/permissions/autogenerated/reference.md
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/permissions/autogenerated/reference.md
@@ -2,6 +2,8 @@
 
 Default permissions for the plugin
 
+#### This default permission set includes the following:
+
 - `allow-execute`
 - `allow-cancel`
 

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/permissions/schemas/schema.json
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/permissions/schemas/schema.json
@@ -49,7 +49,7 @@
           "minimum": 1.0
         },
         "description": {
-          "description": "Human-readable description of what the permission does. Tauri convention is to use <h4> headings in markdown content for Tauri documentation generation purposes.",
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
           "type": [
             "string",
             "null"
@@ -111,7 +111,7 @@
           "type": "string"
         },
         "description": {
-          "description": "Human-readable description of what the permission does. Tauri internal convention is to use <h4> headings in markdown content for Tauri documentation generation purposes.",
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
           "type": [
             "string",
             "null"
@@ -297,47 +297,56 @@
         {
           "description": "Enables the cancel command without any pre-configured scope.",
           "type": "string",
-          "const": "allow-cancel"
+          "const": "allow-cancel",
+          "markdownDescription": "Enables the cancel command without any pre-configured scope."
         },
         {
           "description": "Denies the cancel command without any pre-configured scope.",
           "type": "string",
-          "const": "deny-cancel"
+          "const": "deny-cancel",
+          "markdownDescription": "Denies the cancel command without any pre-configured scope."
         },
         {
           "description": "Enables the execute command without any pre-configured scope.",
           "type": "string",
-          "const": "allow-execute"
+          "const": "allow-execute",
+          "markdownDescription": "Enables the execute command without any pre-configured scope."
         },
         {
           "description": "Denies the execute command without any pre-configured scope.",
           "type": "string",
-          "const": "deny-execute"
+          "const": "deny-execute",
+          "markdownDescription": "Denies the execute command without any pre-configured scope."
         },
         {
           "description": "Enables the run command without any pre-configured scope.",
           "type": "string",
-          "const": "allow-run"
+          "const": "allow-run",
+          "markdownDescription": "Enables the run command without any pre-configured scope."
         },
         {
           "description": "Denies the run command without any pre-configured scope.",
           "type": "string",
-          "const": "deny-run"
+          "const": "deny-run",
+          "markdownDescription": "Denies the run command without any pre-configured scope."
         },
         {
           "description": "Enables the subscribe command without any pre-configured scope.",
           "type": "string",
-          "const": "allow-subscribe"
+          "const": "allow-subscribe",
+          "markdownDescription": "Enables the subscribe command without any pre-configured scope."
         },
         {
           "description": "Denies the subscribe command without any pre-configured scope.",
           "type": "string",
-          "const": "deny-subscribe"
+          "const": "deny-subscribe",
+          "markdownDescription": "Denies the subscribe command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-execute`\n- `allow-cancel`",
           "type": "string",
-          "const": "default"
+          "const": "default",
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-execute`\n- `allow-cancel`"
         }
       ]
     }

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/pnpm-lock.yaml
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  picomatch@<4.0.4: ^4.0.4
+
 importers:
 
   .:
@@ -14,10 +17,10 @@ importers:
     devDependencies:
       '@rollup/plugin-typescript':
         specifier: ^11.1.6
-        version: 11.1.6(rollup@4.27.4)(tslib@2.8.1)(typescript@5.9.2)
+        version: 11.1.6(rollup@4.60.2)(tslib@2.8.1)(typescript@5.9.2)
       rollup:
-        specifier: ^4.9.6
-        version: 4.27.4
+        specifier: ^4.59.0
+        version: 4.60.2
       tslib:
         specifier: ^2.6.2
         version: 2.8.1
@@ -49,93 +52,141 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.27.4':
-    resolution: {integrity: sha512-2Y3JT6f5MrQkICUyRVCw4oa0sutfAsgaSsb0Lmmy1Wi2y7X5vT9Euqw4gOsCyy0YfKURBg35nhUKZS4mDcfULw==}
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.27.4':
-    resolution: {integrity: sha512-wzKRQXISyi9UdCVRqEd0H4cMpzvHYt1f/C3CoIjES6cG++RHKhrBj2+29nPF0IB5kpy9MS71vs07fvrNGAl/iA==}
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.27.4':
-    resolution: {integrity: sha512-PlNiRQapift4LNS8DPUHuDX/IdXiLjf8mc5vdEmUR0fF/pyy2qWwzdLjB+iZquGr8LuN4LnUoSEvKRwjSVYz3Q==}
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.27.4':
-    resolution: {integrity: sha512-o9bH2dbdgBDJaXWJCDTNDYa171ACUdzpxSZt+u/AAeQ20Nk5x+IhA+zsGmrQtpkLiumRJEYef68gcpn2ooXhSQ==}
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.27.4':
-    resolution: {integrity: sha512-NBI2/i2hT9Q+HySSHTBh52da7isru4aAAo6qC3I7QFVsuhxi2gM8t/EI9EVcILiHLj1vfi+VGGPaLOUENn7pmw==}
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.27.4':
-    resolution: {integrity: sha512-wYcC5ycW2zvqtDYrE7deary2P2UFmSh85PUpAx+dwTCO9uw3sgzD6Gv9n5X4vLaQKsrfTSZZ7Z7uynQozPVvWA==}
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.27.4':
-    resolution: {integrity: sha512-9OwUnK/xKw6DyRlgx8UizeqRFOfi9mf5TYCw1uolDaJSbUmBxP85DE6T4ouCMoN6pXw8ZoTeZCSEfSaYo+/s1w==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.27.4':
-    resolution: {integrity: sha512-Vgdo4fpuphS9V24WOV+KwkCVJ72u7idTgQaBoLRD0UxBAWTF9GWurJO9YD9yh00BzbkhpeXtm6na+MvJU7Z73A==}
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.27.4':
-    resolution: {integrity: sha512-pleyNgyd1kkBkw2kOqlBx+0atfIIkkExOTiifoODo6qKDSpnc6WzUY5RhHdmTdIJXBdSnh6JknnYTtmQyobrVg==}
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.27.4':
-    resolution: {integrity: sha512-caluiUXvUuVyCHr5DxL8ohaaFFzPGmgmMvwmqAITMpV/Q+tPoaHZ/PWa3t8B2WyoRcIIuu1hkaW5KkeTDNSnMA==}
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.27.4':
-    resolution: {integrity: sha512-FScrpHrO60hARyHh7s1zHE97u0KlT/RECzCKAdmI+LEoC1eDh/RDji9JgFqyO+wPDb86Oa/sXkily1+oi4FzJQ==}
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.27.4':
-    resolution: {integrity: sha512-qyyprhyGb7+RBfMPeww9FlHwKkCXdKHeGgSqmIXw9VSUtvyFZ6WZRtnxgbuz76FK7LyoN8t/eINRbPUcvXB5fw==}
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-s390x-gnu@4.27.4':
-    resolution: {integrity: sha512-PFz+y2kb6tbh7m3A7nA9++eInGcDVZUACulf/KzDtovvdTizHpZaJty7Gp0lFwSQcrnebHOqxF1MaKZd7psVRg==}
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.27.4':
-    resolution: {integrity: sha512-Ni8mMtfo+o/G7DVtweXXV/Ol2TFf63KYjTtoZ5f078AUgJTmaIJnj4JFU7TK/9SVWTaSJGxPi5zMDgK4w+Ez7Q==}
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.27.4':
-    resolution: {integrity: sha512-5AeeAF1PB9TUzD+3cROzFTnAJAcVUGLuR8ng0E0WXGkYhp6RD6L+6szYVX+64Rs0r72019KHZS1ka1q+zU/wUw==}
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@rollup/rollup-win32-arm64-msvc@4.27.4':
-    resolution: {integrity: sha512-yOpVsA4K5qVwu2CaS3hHxluWIK5HQTjNV4tWjQXluMiiiu4pJj4BN98CvxohNCpcjMeTXk/ZMJBRbgRg8HBB6A==}
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.27.4':
-    resolution: {integrity: sha512-KtwEJOaHAVJlxV92rNYiG9JQwQAdhBlrjNRp7P9L8Cb4Rer3in+0A+IPhJC9y68WAi9H0sX4AiG2NTsVlmqJeQ==}
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.27.4':
-    resolution: {integrity: sha512-3j4jx1TppORdTAoBJRd+/wJRGCPC0ETWkXOecJ6PPZLj6SptXkrXcNqdj0oclbKML6FkQltdz7bBA3rUSirZug==}
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
 
@@ -144,6 +195,9 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -167,16 +221,16 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  picomatch@4.0.2:
-    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
 
-  rollup@4.27.4:
-    resolution: {integrity: sha512-RLKxqHEMjh/RGLsDxAEsaLO3mWgyoU6x9w6n1ikAzet4B3gI2/3yP6PWY2p9QzRTh6MfEIXB3MwsOY0Iv3vNrw==}
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -194,80 +248,103 @@ packages:
 
 snapshots:
 
-  '@rollup/plugin-typescript@11.1.6(rollup@4.27.4)(tslib@2.8.1)(typescript@5.9.2)':
+  '@rollup/plugin-typescript@11.1.6(rollup@4.60.2)(tslib@2.8.1)(typescript@5.9.2)':
     dependencies:
-      '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.3(rollup@4.60.2)
       resolve: 1.22.8
       typescript: 5.9.2
     optionalDependencies:
-      rollup: 4.27.4
+      rollup: 4.60.2
       tslib: 2.8.1
 
-  '@rollup/pluginutils@5.1.3(rollup@4.27.4)':
+  '@rollup/pluginutils@5.1.3(rollup@4.60.2)':
     dependencies:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
-      picomatch: 4.0.2
+      picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.27.4
+      rollup: 4.60.2
 
-  '@rollup/rollup-android-arm-eabi@4.27.4':
+  '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.27.4':
+  '@rollup/rollup-android-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.27.4':
+  '@rollup/rollup-darwin-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.27.4':
+  '@rollup/rollup-darwin-x64@4.60.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.27.4':
+  '@rollup/rollup-freebsd-arm64@4.60.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.27.4':
+  '@rollup/rollup-freebsd-x64@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.27.4':
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.27.4':
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.27.4':
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.27.4':
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.27.4':
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.27.4':
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.27.4':
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.27.4':
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.27.4':
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.27.4':
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.27.4':
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.27.4':
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
   '@tauri-apps/api@2.1.1': {}
 
   '@types/estree@1.0.6': {}
+
+  '@types/estree@1.0.8': {}
 
   estree-walker@2.0.2: {}
 
@@ -286,7 +363,7 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  picomatch@4.0.2: {}
+  picomatch@4.0.4: {}
 
   resolve@1.22.8:
     dependencies:
@@ -294,28 +371,35 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rollup@4.27.4:
+  rollup@4.60.2:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.27.4
-      '@rollup/rollup-android-arm64': 4.27.4
-      '@rollup/rollup-darwin-arm64': 4.27.4
-      '@rollup/rollup-darwin-x64': 4.27.4
-      '@rollup/rollup-freebsd-arm64': 4.27.4
-      '@rollup/rollup-freebsd-x64': 4.27.4
-      '@rollup/rollup-linux-arm-gnueabihf': 4.27.4
-      '@rollup/rollup-linux-arm-musleabihf': 4.27.4
-      '@rollup/rollup-linux-arm64-gnu': 4.27.4
-      '@rollup/rollup-linux-arm64-musl': 4.27.4
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.27.4
-      '@rollup/rollup-linux-riscv64-gnu': 4.27.4
-      '@rollup/rollup-linux-s390x-gnu': 4.27.4
-      '@rollup/rollup-linux-x64-gnu': 4.27.4
-      '@rollup/rollup-linux-x64-musl': 4.27.4
-      '@rollup/rollup-win32-arm64-msvc': 4.27.4
-      '@rollup/rollup-win32-ia32-msvc': 4.27.4
-      '@rollup/rollup-win32-x64-msvc': 4.27.4
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
   supports-preserve-symlinks-flag@1.0.0: {}

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.lock
@@ -4470,9 +4470,10 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "relay"
 version = "0.1.1"
-source = "git+https://github.com/CuriousCorrelation/relay.git#ed2329e4ebb71bb984c4705aa950cb9c3f9ff931"
+source = "git+https://github.com/CuriousCorrelation/relay.git#1c4f1e16106ed48983926ea6ddb114c1dbb2f688"
 dependencies = [
  "bytes",
+ "cookie",
  "curl",
  "dashmap",
  "env_logger",
@@ -5721,7 +5722,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-relay"
 version = "0.1.0"
-source = "git+https://github.com/CuriousCorrelation/tauri-plugin-relay?rev=42f449e1c5657679fecf0374b0ce5047ad03c069#42f449e1c5657679fecf0374b0ce5047ad03c069"
+source = "git+https://github.com/CuriousCorrelation/tauri-plugin-relay?rev=273488c8f50a22ee707af6b50ccd5570851f8bc9#273488c8f50a22ee707af6b50ccd5570851f8bc9"
 dependencies = [
  "relay",
  "serde",

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ tauri-plugin-dialog = "2.2.0"
 tauri-plugin-fs = "2.2.0"
 tauri-plugin-deep-link = "2.2.0"
 tauri-plugin-appload = { git = "https://github.com/CuriousCorrelation/tauri-plugin-appload", rev = "9d4528be4f385bccbe46859631d31aa2ee1ec0b6" }
-tauri-plugin-relay = { git = "https://github.com/CuriousCorrelation/tauri-plugin-relay", rev = "42f449e1c5657679fecf0374b0ce5047ad03c069" }
+tauri-plugin-relay = { git = "https://github.com/CuriousCorrelation/tauri-plugin-relay", rev = "273488c8f50a22ee707af6b50ccd5570851f8bc9" }
 axum = "0.8.1"
 tower-http = { version = "0.6.2", features = ["cors"] }
 random-port = "0.1.1"

--- a/packages/hoppscotch-kernel/package.json
+++ b/packages/hoppscotch-kernel/package.json
@@ -58,7 +58,7 @@
     }
   },
   "dependencies": {
-    "@hoppscotch/plugin-relay": "github:CuriousCorrelation/tauri-plugin-relay#42f449e1c5657679fecf0374b0ce5047ad03c069",
+    "@hoppscotch/plugin-relay": "github:CuriousCorrelation/tauri-plugin-relay#273488c8f50a22ee707af6b50ccd5570851f8bc9",
     "@tauri-apps/plugin-dialog": "2.0.1",
     "@tauri-apps/plugin-fs": "2.0.2",
     "@tauri-apps/plugin-shell": "2.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1314,8 +1314,8 @@ importers:
   packages/hoppscotch-kernel:
     dependencies:
       '@hoppscotch/plugin-relay':
-        specifier: github:CuriousCorrelation/tauri-plugin-relay#42f449e1c5657679fecf0374b0ce5047ad03c069
-        version: '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/42f449e1c5657679fecf0374b0ce5047ad03c069'
+        specifier: github:CuriousCorrelation/tauri-plugin-relay#273488c8f50a22ee707af6b50ccd5570851f8bc9
+        version: '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/273488c8f50a22ee707af6b50ccd5570851f8bc9'
       '@tauri-apps/api':
         specifier: 2.1.1
         version: 2.1.1
@@ -1772,11 +1772,11 @@ packages:
         optional: true
 
   '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/9d4528be4f385bccbe46859631d31aa2ee1ec0b6':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/9d4528be4f385bccbe46859631d31aa2ee1ec0b6}
+    resolution: {gitHosted: true, integrity: sha512-fH4riUTO4+6/Pr87Q4PTV7EqGXEnSuLl01g3ws54V2k+A3LDzbCrSa+50XBbmPgroHxnhefkXig8q8qL099f0g==, tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/9d4528be4f385bccbe46859631d31aa2ee1ec0b6}
     version: 0.1.0
 
-  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/42f449e1c5657679fecf0374b0ce5047ad03c069':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/42f449e1c5657679fecf0374b0ce5047ad03c069}
+  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/273488c8f50a22ee707af6b50ccd5570851f8bc9':
+    resolution: {gitHosted: true, integrity: sha512-ipTfU7ci4UGP5+lpR2oDQGfVY3PvF3p5OtqKBVoNoRyIogHoqlpw6VsK+IfvsNbNN+LmAGKpQFyiZaRKErB2Lg==, tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/273488c8f50a22ee707af6b50ccd5570851f8bc9}
     version: 0.1.0
 
   '@acemir/cssom@0.9.31':
@@ -13707,7 +13707,7 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.9.1
 
-  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/42f449e1c5657679fecf0374b0ce5047ad03c069':
+  '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/273488c8f50a22ee707af6b50ccd5570851f8bc9':
     dependencies:
       '@tauri-apps/api': 2.1.1
 


### PR DESCRIPTION
Adds end-to-end cookie support on the desktop client. The relay
returns parsed Set-Cookie data, the jar persists per organization
through the kernel store, RFC 6265 matching replaces a too-loose
suffix check, and one shared send-receive path replaces three
near-identical interceptor blocks. The cookie manager renders an
HttpOnly indicator and now shows response-captured cookies
because the shared capture path writes into that same jar.

This is FE-1265 through FE-1267 plus the resolved portion of
FE-1268, under parent epic FE-1264. The `tauri-plugin-relay`
pin advances in lockstep, inheriting the rollup path-traversal
CVE fix (FE-1137) and a partial Tauri runtime bump (FE-1271)
that were already deployed in the plugin repo but not yet
linked to a desktop release. Cross-org isolation, RFC 6265
matching, and the shared send-receive path together address
the cross-org session leak that every prior attempt in the
issue thread had to confine itself to `hoppscotch-common` and
so could not reach.

Closes FE-1265
Closes FE-1266
Closes FE-1267
Closes FE-1137
Closes #5864
Closes #3532
Closes #4013
Part of FE-1264
Part of FE-1268
Part of FE-968
Part of FE-1271
Supersedes #5853
Supersedes #5865 

## Receive side via the relay

`Response.cookies` previously returned `None` from
`relay/src/response.rs`, with Set-Cookie data only reachable
through a `\n`-joined string in `headers` that was marked
experimental at the relay layer. The relay now parses Set-Cookie
into the `interop::Cookie` type already declared on `Response`,
with Max-Age taking precedence over Expires per RFC 6265 and
`checked_add` so an oversized Max-Age cannot panic the relay.

The desktop kernel relay impl already maps the structured field
through, so the change on the hoppscotch side is one Cargo.toml
and one `package.json` pin bump to pick up the new behaviour.
The joined `set-cookie` header stays untouched, so any code path
still reading the header form continues to work.

## Per-org persistence and write reconciliation

`CookieJarService` binds to the org-scoped kernel `Store` on
`onServiceInit`, hydrates from disk, watches for cross-process
changes, and writes through on every mutation. This mirrors the
`KernelInterceptorNativeStore` pattern used elsewhere in common,
so each org gets its own `{org}.hoppscotch.store` file and a
cookie set on one org never reads back on another. Hydrate-time
canon (initial load and watcher) upgrades a jar persisted
before the RFC 6265 work, so the on-disk keys collapse onto
canonical form on first read after the release and never get
stranded by `domainMatches`.

A single `upsertCookies` merge by `(domain, name, path)`
replaces the wholesale jar replace in `RequestRunner.ts`, so
response-captured and post-request-script cookies reconcile
through the merge. A post-script delta against the pre-script
snapshot makes `hopp.cookies.delete(...)` from a script take
effect through omission, and preserves concurrent captures
that the prior wholesale replace would have dropped.

Persisting through localStorage was considered and ruled out
for the same cross-org reason. Every webview on desktop shares
one `app://` origin because Tauri v2 validates the origin for
IPC, so a localStorage write merges every org's cookies into
one store. The org-scoped `Store` is the only boundary that
prevents the cross-org merge.

## RFC 6265 matching and one shared path

`getCookiesForURL` used `url.hostname.endsWith(domain)` and a
`startsWith` path check, which was adequate while the jar only
held script-set cookies. With response capture and arbitrary
domains, `evil-example.com` then matched a cookie stored for
`example.com`. `getCookiesForURL` now applies RFC 6265 §5.1.3
domain-suffix and §5.1.4 path-prefix matching, returns the
stored `Cookie` objects directly without re-parsing them, and
emits the §5.4 `name=value; ...` header through
`serializeCookieHeader`, which skips any cookie whose name
fails the RFC 7230 token grammar or whose value contains a
§5.4 forbidden character so a malformed entry never produces
a malformed Cookie header.

`applyCookiesToRequest` and `captureResponseCookies` are the one
shared send and receive path. The native, agent, and proxy
interceptors all call them, replacing three near-identical
inline blocks. The proxy interceptor forwards stored cookies
for the first time as part of this consolidation.

## HttpOnly indicator in the cookie manager

The manager already grouped by domain, supported manual add,
edit, and delete, and read from `CookieJarService`. It now
also renders response-captured cookies because the shared
capture path writes into that same jar, and it shows an
HttpOnly badge on each row through `IconLockedCookie`, with a
tooltip explaining the flag. HttpOnly cookies are forwarded in
outgoing requests, matching never filters on the flag. Modal
save is a per-row delta against the baseline snapshot the
modal opened with, so a response-captured cookie that arrives
between open and save is not wiped on save and a Clear All
only removes domains the user saw.

## Relay pin bump

The `tauri-plugin-relay` Cargo rev advances from `42f449e1` to
`273488c8` so the desktop client picks up the receive-side
parsing described above. The same rev range contains the
rollup `^4.59.0` bump that closes the FE-1137 CVE and a Tauri
runtime declaration bump in the plugin's `Cargo.toml` that
addresses the FE-1271 source-side mismatch. Both were already
deployed in the prior plugin pin, this PR is what links them
to FE-968 and to the desktop release.

## Notes for reviewers

Proxy receive-side capture is the one item of the original
scope deferred to a follow-up. The shared capture path expects
structured cookies, which the relay-backed native and agent
interceptors do deliver. The proxy interceptor goes through
proxyscotch, which returns Set-Cookie only through a header
string, so adding receive capture there is a separate change
in `proxyscotch` plus a header-parse step on the common side.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end cookie support on the desktop app with per‑org persistence, RFC 6265 matching, a shared apply/capture path, and structured cookies from the relay. Addresses FE‑1265–FE‑1268 under FE‑1264, fixing the cross‑org session leak.

- **New Features**
  - Persist cookie jar per organization via the kernel `Store` with a hydration gate, serialized writes, cross‑process watch with echo guards, expiry pruning, on‑disk validation/migration/dedup, and graceful degrade when storage/read fails.
  - One shared path to apply and capture cookies across `native`/`agent`/`proxy`; proxy now forwards stored cookies and advertises cookie support. Relay returns structured `Set‑Cookie` on `Response.cookies` (RFC 3339 `expires`, Max‑Age over Expires) via a bumped `@hoppscotch/plugin-relay` and synced plugin mirror.
  - RFC 6265 compliance: canonical domain/path matching, default‑path algorithm, longest‑path ordering, guarded URL parsing, and name/value validation; accepts host‑only cookies on single‑label hosts and rejects bad `Domain`/`Path`.
  - Cookie manager updates: HttpOnly badges with a tooltip, per‑cookie deltas on save scoped to baseline‑visible domains, canonicalize/validate domains on add (error toast), auto‑name rows to avoid collisions, and preserve concurrent captures.
  - Added unit tests for `CookieJarService`.

- **Bug Fixes**
  - Respect a user‑set non‑empty `Cookie` header; otherwise serialize matching jar cookies only when non‑empty and strip all case‑variants and empty placeholders so `Cookie: ""` never ships.
  - Safer capture/load: tolerate invalid dates (treat as session cookies), relay serializes `expires` as RFC 3339, canonicalize/validate domains and paths on hydrate/watch, validate and dedupe on‑disk payloads, and normalize empty/undefined paths to `/`.
  - Post‑script and modal reconciliation: clone the sandbox view, compute deltas keyed by `(domain, name, path)`, skip entirely on platforms without cookies (web), avoid in‑place mutation pitfalls, and ensure deletes hit the right cookie.
  - Misc stability: guarded URL parsing in interceptors, globally unique write tokens with a bounded recent‑token set, write queue to serialize persists, use `\0` for the internal dedup key, and dependency hardening (`@hoppscotch/plugin-relay` bump and mirror sync; keep `rollup@^4.59.0`; pnpm override `picomatch@<4.0.4`).

<sup>Written for commit 3526bf341b4840fc18cba90ec8e5d10d6392444b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



