### PR TITLE
fix(curl-import): preserve header values containing colon+space after colon

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -10,9 +10,20 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
+/**
+ * Splits a string on the first occurrence of the separator.
+ * Unlike S.split, this returns at most 2 parts, which ensures
+ * header values containing ": " (colon + space) are not split
+ * into more than 2 segments.
+ */
+const splitAtFirst = (sep: string) => (s: string): string[] => {
+  const idx = s.indexOf(sep)
+  return idx === -1 ? [s] : [s.slice(0, idx), s.slice(idx + sep.length)]
+}
+
 const getHeaderPair = flow(
   S.replace(":", ": "),
-  S.split(": "),
+  splitAtFirst(": "),
   // must have a key and a value
   O.fromPredicate((arr) => arr.length === 2),
   O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])


### PR DESCRIPTION
Closes #6400

## Problem

The cURL import helper in `getHeaderPair` splits headers on **every** occurrence of `": "`, which silently drops headers whose values contain a colon followed by a space (e.g. `X-Note: hello: world`).

Per RFC 9110, a header field is `name: value` where only the first colon separates the name from the value.

## Fix
Added a `splitAtFirst` helper that splits on the first occurrence of the separator only, and used it in `getHeaderPair` instead of `S.split`.

## Before
```
curl -H "X-Note: hello: world" -H "Accept: application/json"
```
`X-Note` header silently dropped (3 parts after `split` → fails `length === 2` check)

## After
Both `X-Note: hello: world` and `Accept: application/json` are correctly preserved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cURL import header parsing to only split on the first colon, preserving header values that contain ": " (e.g., X-Note: hello: world). Follows RFC 9110 so header values are no longer dropped.

- **Bug Fixes**
  - Added `splitAtFirst` and used it in `getHeaderPair` to split on the first ": " only.
  - Prevents dropping headers when values include ": ".

<sup>Written for commit 298afd817a6bce7261007f9862e29852cb62ffda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

