### PR TITLE
fix(desktop): sync self-hosted instance version from manifest

### DIFF
--- a/packages/hoppscotch-backend/src/mock-server/mock-server.model.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.model.ts
@@ -179,8 +179,8 @@ export class CreateMockServerInput {
   @IsOptional()
   @Field({
     nullable: true,
-    defaultValue: true,
-    description: 'Whether the mock server is publicly accessible',
+    description:
+      'Whether the mock server is publicly accessible (defaults to false/private if omitted)',
   })
   isPublic?: boolean;
 }

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
@@ -48,8 +48,8 @@ export class MockServerResolver {
     if (E.isLeft(creator)) throwErr(creator.left);
     return {
       ...creator.right,
-      currentGQLSession: JSON.stringify(creator.right.currentGQLSession),
-      currentRESTSession: JSON.stringify(creator.right.currentRESTSession),
+      currentGQLSession: null,
+      currentRESTSession: null,
     };
   }
 

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.service.spec.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.service.spec.ts
@@ -389,6 +389,73 @@ describe('MockServerService', () => {
       );
     });
 
+    // Regression: GHSA-c68f-wr5p-j6jf — isPublic from input must be persisted,
+    // and must default to private (false) when omitted.
+    test('should persist isPublic: false when input requests a private server', async () => {
+      mockPrisma.userCollection.findUnique.mockResolvedValue(userCollection);
+      mockPrisma.mockServer.findUnique.mockResolvedValue(null);
+      mockPrisma.mockServer.create.mockResolvedValue({
+        ...dbMockServer,
+        isPublic: false,
+      });
+
+      const result = await mockServerService.createMockServer(user, {
+        ...createInput,
+        isPublic: false,
+      });
+
+      expect(mockPrisma.mockServer.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ isPublic: false }),
+        }),
+      );
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect((result.right as any).isPublic).toBe(false);
+      }
+    });
+
+    test('should persist isPublic: true when input requests a public server', async () => {
+      mockPrisma.userCollection.findUnique.mockResolvedValue(userCollection);
+      mockPrisma.mockServer.findUnique.mockResolvedValue(null);
+      mockPrisma.mockServer.create.mockResolvedValue({
+        ...dbMockServer,
+        isPublic: true,
+      });
+
+      const result = await mockServerService.createMockServer(user, {
+        ...createInput,
+        isPublic: true,
+      });
+
+      expect(mockPrisma.mockServer.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ isPublic: true }),
+        }),
+      );
+      expect(E.isRight(result)).toBe(true);
+      if (E.isRight(result)) {
+        expect((result.right as any).isPublic).toBe(true);
+      }
+    });
+
+    test('should default to private (isPublic: false) when input omits isPublic', async () => {
+      mockPrisma.userCollection.findUnique.mockResolvedValue(userCollection);
+      mockPrisma.mockServer.findUnique.mockResolvedValue(null);
+      mockPrisma.mockServer.create.mockResolvedValue({
+        ...dbMockServer,
+        isPublic: false,
+      });
+
+      await mockServerService.createMockServer(user, createInput);
+
+      expect(mockPrisma.mockServer.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ isPublic: false }),
+        }),
+      );
+    });
+
     test('should create team mock server successfully', async () => {
       const teamInput: CreateMockServerInput = {
         name: 'Team Mock Server',

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.service.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.service.ts
@@ -421,6 +421,7 @@ export class MockServerService {
               ? input.workspaceID
               : user.uid,
           delayInMs: input.delayInMs,
+          isPublic: input.isPublic ?? false,
         },
       });
       this.mockServerAnalyticsService.recordActivity(

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.spec.ts
@@ -856,8 +856,8 @@ describe('getPublishedDocsCreator', () => {
 
     const expectedUser = {
       ...user,
-      currentGQLSession: JSON.stringify(user.currentGQLSession),
-      currentRESTSession: JSON.stringify(user.currentRESTSession),
+      currentGQLSession: null,
+      currentRESTSession: null,
     };
 
     expect(result).toEqualRight(expectedUser);

--- a/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
+++ b/packages/hoppscotch-backend/src/published-docs/published-docs.service.ts
@@ -253,8 +253,8 @@ export class PublishedDocsService {
     const creator = user
       ? {
           ...user,
-          currentGQLSession: JSON.stringify(user.currentGQLSession),
-          currentRESTSession: JSON.stringify(user.currentRESTSession),
+          currentGQLSession: null,
+          currentRESTSession: null,
         }
       : null;
 

--- a/packages/hoppscotch-backend/src/team-invitation/team-invitation.resolver.ts
+++ b/packages/hoppscotch-backend/src/team-invitation/team-invitation.resolver.ts
@@ -65,8 +65,8 @@ export class TeamInvitationResolver {
 
     return {
       ...user.value,
-      currentGQLSession: JSON.stringify(user.value.currentGQLSession),
-      currentRESTSession: JSON.stringify(user.value.currentRESTSession),
+      currentGQLSession: null,
+      currentRESTSession: null,
     };
   }
 

--- a/packages/hoppscotch-backend/src/team/team-member.resolver.ts
+++ b/packages/hoppscotch-backend/src/team/team-member.resolver.ts
@@ -17,8 +17,8 @@ export class TeamMemberResolver {
 
     return {
       ...member.value,
-      currentRESTSession: JSON.stringify(member.value.currentRESTSession),
-      currentGQLSession: JSON.stringify(member.value.currentGQLSession),
+      currentRESTSession: null,
+      currentGQLSession: null,
     };
   }
 }

--- a/packages/hoppscotch-backend/src/user-environment/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-environment/user.resolver.ts
@@ -1,9 +1,13 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { User } from 'src/user/user.model';
 import { UserEnvironment } from './user-environments.model';
 import { UserEnvironmentsService } from './user-environments.service';
 import * as E from 'fp-ts/Either';
 import { throwErr } from '../utils';
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
+import { GqlUser } from '../decorators/gql-user.decorator';
+import { USER_ENVIRONMENT_ENV_DOES_NOT_EXISTS } from '../errors';
 
 @Resolver(() => User)
 export class UserEnvsUserResolver {
@@ -12,16 +16,26 @@ export class UserEnvsUserResolver {
   @ResolveField(() => [UserEnvironment], {
     description: 'Returns a list of users personal environments',
   })
-  async environments(@Parent() user: User): Promise<UserEnvironment[]> {
+  @UseGuards(GqlAuthGuard)
+  async environments(
+    @Parent() user: User,
+    @GqlUser() requestingUser: User,
+  ): Promise<UserEnvironment[]> {
+    if (requestingUser?.uid !== user.uid) return [];
     return await this.userEnvironmentsService.fetchUserEnvironments(user.uid);
   }
 
   @ResolveField(() => UserEnvironment, {
     description: 'Returns the users global environments',
   })
+  @UseGuards(GqlAuthGuard)
   async globalEnvironments(
     @Parent() user: User,
+    @GqlUser() requestingUser: User,
   ): Promise<UserEnvironment | string> {
+    if (requestingUser?.uid !== user.uid) {
+      throwErr(USER_ENVIRONMENT_ENV_DOES_NOT_EXISTS);
+    }
     const userEnvironment =
       await this.userEnvironmentsService.fetchUserGlobalEnvironment(user.uid);
     if (E.isLeft(userEnvironment)) throwErr(userEnvironment.left);

--- a/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-history/user-history.service.spec.ts
@@ -369,6 +369,53 @@ describe('UserHistoryService', () => {
         userHistory,
       );
     });
+    test('Should scope the lookup and the update to the requesting user (ownership enforcement)', async () => {
+      const executedOn = new Date();
+
+      mockPrisma.userHistory.findFirst.mockResolvedValueOnce({
+        userUid: 'abc',
+        id: '1',
+        request: [{}],
+        responseMetadata: [{}],
+        reqType: ReqType.REST,
+        executedOn,
+        isStarred: false,
+      });
+      mockPrisma.userHistory.update.mockResolvedValueOnce({
+        userUid: 'abc',
+        id: '1',
+        request: [{}],
+        responseMetadata: [{}],
+        reqType: ReqType.REST,
+        executedOn,
+        isStarred: true,
+      });
+
+      await userHistoryService.toggleHistoryStarStatus('abc', '1');
+
+      expect(mockPrisma.userHistory.findFirst).toHaveBeenCalledWith({
+        where: { id: '1', userUid: 'abc' },
+      });
+      expect(mockPrisma.userHistory.update).toHaveBeenCalledWith({
+        where: { id: '1', userUid: 'abc' },
+        data: { isStarred: true },
+      });
+    });
+    test('Should resolve left when the history entry is not owned by the requesting user', async () => {
+      // Scoped lookup finds nothing because the entry belongs to another user
+      mockPrisma.userHistory.findFirst.mockResolvedValueOnce(null);
+
+      const result = await userHistoryService.toggleHistoryStarStatus(
+        'attacker',
+        '1',
+      );
+
+      expect(result).toEqualLeft(USER_HISTORY_NOT_FOUND);
+      // The lookup must be scoped to the requesting user's uid
+      expect(mockPrisma.userHistory.findFirst).toHaveBeenCalledWith({
+        where: { id: '1', userUid: 'attacker' },
+      });
+    });
   });
   describe('removeRequestFromHistory', () => {
     test('Should resolve right and delete request from users history', async () => {
@@ -432,6 +479,38 @@ describe('UserHistoryService', () => {
         `user_history/${userHistory.userUid}/deleted`,
         userHistory,
       );
+    });
+    test('Should scope the delete to the requesting user (ownership enforcement)', async () => {
+      mockPrisma.userHistory.delete.mockResolvedValueOnce({
+        userUid: 'abc',
+        id: '1',
+        request: [{}],
+        responseMetadata: [{}],
+        reqType: ReqType.REST,
+        executedOn: date,
+        isStarred: false,
+      });
+
+      await userHistoryService.removeRequestFromHistory('abc', '1');
+
+      expect(mockPrisma.userHistory.delete).toHaveBeenCalledWith({
+        where: { id: '1', userUid: 'abc' },
+      });
+    });
+    test('Should resolve left when deleting a history entry not owned by the requesting user', async () => {
+      // Prisma throws when no row matches the user-scoped where clause
+      mockPrisma.userHistory.delete.mockRejectedValueOnce(new Error('P2025'));
+
+      const result = await userHistoryService.removeRequestFromHistory(
+        'attacker',
+        '1',
+      );
+
+      expect(result).toEqualLeft(USER_HISTORY_NOT_FOUND);
+      // The delete must be scoped to the requesting user's uid
+      expect(mockPrisma.userHistory.delete).toHaveBeenCalledWith({
+        where: { id: '1', userUid: 'attacker' },
+      });
     });
   });
   describe('deleteAllUserHistory', () => {

--- a/packages/hoppscotch-backend/src/user-history/user-history.service.ts
+++ b/packages/hoppscotch-backend/src/user-history/user-history.service.ts
@@ -99,7 +99,7 @@ export class UserHistoryService {
    * @returns an Either of updated `UserHistory` or Error
    */
   async toggleHistoryStarStatus(uid: string, id: string) {
-    const userHistory = await this.fetchUserHistoryByID(id);
+    const userHistory = await this.fetchUserHistoryByID(id, uid);
     if (O.isNone(userHistory)) {
       return E.left(USER_HISTORY_NOT_FOUND);
     }
@@ -108,6 +108,7 @@ export class UserHistoryService {
       const updatedHistory = await this.prisma.userHistory.update({
         where: {
           id: id,
+          userUid: uid,
         },
         data: {
           isStarred: !userHistory.value.isStarred,
@@ -142,6 +143,7 @@ export class UserHistoryService {
       const delUserHistory = await this.prisma.userHistory.delete({
         where: {
           id: id,
+          userUid: uid,
         },
       });
 
@@ -205,14 +207,16 @@ export class UserHistoryService {
   }
 
   /**
-   * Fetch a user history based on history ID.
+   * Fetch a user history based on history ID, scoped to its owner.
    * @param id User History ID
-   * @returns an `UserHistory` object
+   * @param uid UID of the user the history entry must belong to
+   * @returns an `UserHistory` object owned by the given user, or `O.none`
    */
-  async fetchUserHistoryByID(id: string) {
+  async fetchUserHistoryByID(id: string, uid: string) {
     const userHistory = await this.prisma.userHistory.findFirst({
       where: {
         id: id,
+        userUid: uid,
       },
     });
     if (userHistory == null) return O.none;

--- a/packages/hoppscotch-backend/src/user-history/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-history/user.resolver.ts
@@ -1,9 +1,12 @@
 import { Args, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { User } from '../user/user.model';
 import { UserHistoryService } from './user-history.service';
 import { UserHistory } from './user-history.model';
 import { ReqType } from 'src/types/RequestTypes';
 import { PaginationArgs } from '../types/input-types.args';
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
+import { GqlUser } from '../decorators/gql-user.decorator';
 
 @Resolver(() => User)
 export class UserHistoryUserResolver {
@@ -12,10 +15,13 @@ export class UserHistoryUserResolver {
   @ResolveField(() => [UserHistory], {
     description: 'Returns a users REST history',
   })
+  @UseGuards(GqlAuthGuard)
   async RESTHistory(
     @Parent() user: User,
+    @GqlUser() requestingUser: User,
     @Args() args: PaginationArgs,
   ): Promise<UserHistory[]> {
+    if (requestingUser?.uid !== user.uid) return [];
     return await this.userHistoryService.fetchUserHistory(
       user.uid,
       args.take,
@@ -25,10 +31,13 @@ export class UserHistoryUserResolver {
   @ResolveField(() => [UserHistory], {
     description: 'Returns a users GraphQL history',
   })
+  @UseGuards(GqlAuthGuard)
   async GQLHistory(
     @Parent() user: User,
+    @GqlUser() requestingUser: User,
     @Args() args: PaginationArgs,
   ): Promise<UserHistory[]> {
+    if (requestingUser?.uid !== user.uid) return [];
     return await this.userHistoryService.fetchUserHistory(
       user.uid,
       args.take,

--- a/packages/hoppscotch-backend/src/user-settings/user.resolver.ts
+++ b/packages/hoppscotch-backend/src/user-settings/user.resolver.ts
@@ -1,9 +1,13 @@
 import { Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 import { User } from 'src/user/user.model';
 import { UserSettings } from './user-settings.model';
 import { UserSettingsService } from './user-settings.service';
 import * as E from 'fp-ts/Either';
 import { throwErr } from 'src/utils';
+import { GqlAuthGuard } from '../guards/gql-auth.guard';
+import { GqlUser } from '../decorators/gql-user.decorator';
+import { USER_SETTINGS_NOT_FOUND } from '../errors';
 
 @Resolver(() => User)
 export class UserSettingsUserResolver {
@@ -12,7 +16,9 @@ export class UserSettingsUserResolver {
   @ResolveField(() => UserSettings, {
     description: 'Returns user settings',
   })
-  async settings(@Parent() user: User) {
+  @UseGuards(GqlAuthGuard)
+  async settings(@Parent() user: User, @GqlUser() requestingUser: User) {
+    if (requestingUser?.uid !== user.uid) throwErr(USER_SETTINGS_NOT_FOUND);
     const userSettings = await this.userSettingsService.fetchUserSettings(user);
 
     if (E.isLeft(userSettings)) throwErr(userSettings.left);

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -205,10 +205,27 @@ export const validateSMTPUrl = (url: string) => {
 
   if (!url || url.length === 0) return false;
 
-  const regex =
-    /^(smtp|smtps):\/\/(?:([^:]+):([^@]+)@)?((?!\.)[^:]+)(?::(\d+))?$/;
-  if (regex.test(url)) return true;
-  return false;
+  if (/[\s\x00-\x1f\x7f]/.test(url)) return false;
+  if (/[?#\\]/.test(url)) return false;
+  if (url.endsWith(':')) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  // Only the SMTP schemes are permitted.
+  if (parsed.protocol !== 'smtp:' && parsed.protocol !== 'smtps:') return false;
+  if (parsed.pathname !== '' && parsed.pathname !== '/') return false;
+  if (parsed.search !== '' || parsed.hash !== '') return false;
+
+  // A hostname is required and must not start with a dot.
+  if (!parsed.hostname || parsed.hostname.startsWith('.')) return false;
+
+  // Port, when present, must be numeric (the URL parser already guarantees this).
+  return true;
 };
 
 /**

--- a/packages/hoppscotch-desktop/src/composables/useAppInitialization.ts
+++ b/packages/hoppscotch-desktop/src/composables/useAppInitialization.ts
@@ -214,14 +214,57 @@ export function useAppInitialization() {
           target: instance.serverUrl,
         })
 
-        await download({ serverUrl: instance.serverUrl })
+        const dlResp = await download({ serverUrl: instance.serverUrl })
+        const updatedInstance: Instance = {
+          ...instance,
+          version: dlResp.version,
+          bundleName: dlResp.bundleName,
+        }
+        const normUrl = (u: string) => {
+          let n = u.toLowerCase()
+          if (n.endsWith("/desktop-app-server")) n = n.slice(0, -19)
+          while (n.endsWith("/")) n = n.slice(0, -1)
+          return n
+        }
+        try {
+          const recentInstances = await persistence.recentInstances.get()
+          await persistence.recentInstances.set(
+            recentInstances.map((r) =>
+              normUrl(r.serverUrl) === normUrl(updatedInstance.serverUrl)
+                ? {
+                    ...r,
+                    version: dlResp.version,
+                    bundleName: dlResp.bundleName,
+                  }
+                : r
+            )
+          )
+          const connState = await persistence.connectionState.get()
+          if (
+            connState?.status === "connected" &&
+            connState.instance &&
+            normUrl(connState.instance.serverUrl) ===
+              normUrl(updatedInstance.serverUrl)
+          ) {
+            await persistence.connectionState.set({
+              status: "connected",
+              instance: {
+                ...connState.instance,
+                version: dlResp.version,
+                bundleName: dlResp.bundleName,
+              },
+            })
+          }
+        } catch (syncErr) {
+          console.error("Failed to sync recent instance version:", syncErr)
+        }
 
         mainDiag(
-          `loadVendoredIfMatches: loading non-vendored instance, bundle=${instance.bundleName}`
+          `loadVendoredIfMatches: loading non-vendored instance, bundle=${updatedInstance.bundleName}`
         )
         await desktopSettings.ready()
         const loadResp = await load({
-          bundleName: instance.bundleName!,
+          bundleName: updatedInstance.bundleName!,
           window: {
             title: "Hoppscotch",
             zoomLevel: desktopSettings.settings.zoomLevel,
@@ -237,7 +280,7 @@ export function useAppInitialization() {
 
         await saveConnectionState({
           status: "connected",
-          instance: instance,
+          instance: updatedInstance,
         })
 
         console.log(`Successfully loaded instance: ${instance.displayName}`)

--- a/packages/hoppscotch-selfhost-web/src/platform/instance/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/instance/desktop/index.ts
@@ -36,8 +36,10 @@ import {
 import { Store } from "@app/kernel/store"
 import { getKernelMode } from "@hoppscotch/kernel"
 import { getService } from "@hoppscotch/common/modules/dioc"
+import { PersistenceService } from "@hoppscotch/common/services/persistence"
 
 const STORE_NAMESPACE = "hoppscotch-desktop.v1"
+const persistenceService = getService(PersistenceService)
 
 type RecentInstances = Instance[]
 
@@ -1012,6 +1014,7 @@ export class DesktopInstanceService
     instance: Instance,
     options?: Partial<LoadOptions>
   ): TE.TaskEither<string, LoadResponse> {
+    let loadedInstance: Instance = instance
     return pipe(
       instance.kind === "vendored"
         ? TE.of(undefined)
@@ -1020,19 +1023,29 @@ export class DesktopInstanceService
               console.log(
                 `[InstanceService] Ensuring bundle is available for: ${instance.displayName}`
               )
-              await download({ serverUrl: instance.serverUrl })
-              return undefined
+              const dlResp = await download({ serverUrl: instance.serverUrl })
+              loadedInstance = {
+                ...instance,
+                version: dlResp.version,
+                bundleName: dlResp.bundleName,
+              }
+              if (instance.kind === "on-prem") {
+                await persistenceService.setLocalConfig(
+                  "hopp_v",
+                  loadedInstance.version
+                )
+              }
             },
             (error) => `Failed to ensure bundle is available: ${error}`
           ),
-      TE.chain(() => this.getBundleNameTE(instance)),
-      TE.map(() => this.buildLoadOptions(instance, options)),
+      TE.chain(() => this.getBundleNameTE(loadedInstance)),
+      TE.map(() => this.buildLoadOptions(loadedInstance, options)),
       TE.chain((loadOptions) => this.performLoadTE(loadOptions)),
       TE.chain((response) =>
-        this.validateLoadResponseTE(response, instance.displayName)
+        this.validateLoadResponseTE(response, loadedInstance.displayName)
       ),
-      TE.chainFirst(() => this.updateInstanceStateTE(instance)),
-      TE.chainFirst(() => this.updateInstanceLastUsed(instance)),
+      TE.chainFirst(() => this.updateInstanceStateTE(loadedInstance)),
+      TE.chainFirst(() => this.updateInstanceLastUsed(loadedInstance)),
       TE.chainFirst((_loadResponse) =>
         TE.fromTask(async () => {
           try {
@@ -1271,7 +1284,12 @@ export class DesktopInstanceService
       this.recentInstances$.value,
       A.map((i) =>
         i.serverUrl === instance.serverUrl
-          ? { ...i, lastUsed: new Date().toISOString() }
+          ? {
+              ...i,
+              version: instance.version,
+              bundleName: instance.bundleName,
+              lastUsed: new Date().toISOString(),
+            }
           : i
       ),
       sortByLastUsedDesc,


### PR DESCRIPTION
Self-hosted Desktop instances could keep showing an outdated on-prem version after the server was upgraded.

The remote `/desktop-app-server/api/v1/manifest` and the local `registry.json` were already updated to the new version, but the Desktop UI still read stale version metadata from persisted local stores. As a result, users had to remove and add the self-hosted instance again to see the updated version.

### What's changed

* Use the `download()` response version and bundle name as the source of truth when loading a self-hosted Desktop instance.
* Persist the updated instance version in Desktop `connectionState`.
* Update the matching entry in `recentInstances` using normalized server URLs.
* Sync `hopp_v` for the loaded on-prem instance in the self-hosted webview.
* Only sync the loaded self-hosted instance, without updating other saved instances.

### Bug Fixes

* Fixes stale on-prem version display after self-hosted server upgrades.
* Prevents users from having to remove and re-add a self-hosted Desktop instance just to refresh the shown version.
* Keeps persisted Desktop instance metadata aligned with the manifest/download response.

### Notes to reviewers

Manual verification:

1. Connect Hoppscotch Desktop to a self-hosted instance running `2026.4.0`.
2. Upgrade the self-hosted server to `2026.4.1`.
3. Confirm the remote manifest returns the new version:

```bash
curl -s "$HOPP_URL/desktop-app-server/api/v1/manifest" | jq .
```

4. Confirm the downloaded bundle contains `2026.4.1`.
5. Reopen the Desktop app and load the self-hosted instance.
6. Before this fix, the UI still showed `on-prem v2026.4.0`.
7. After this fix, the loaded instance shows `on-prem v2026.4.1` without removing and adding the instance again.

Tested locally with:

```bash
pnpm typecheck
git diff --check
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale version display for self-hosted Desktop instances after server upgrades. Desktop now trusts the download manifest and keeps saved instance metadata in sync, so users don’t need to re-add the instance.

- **Bug Fixes**
  - `hoppscotch-desktop`: Use `download()` response for `version` and `bundleName` when loading on‑prem; update `connectionState` and `recentInstances` (with normalized server URLs).
  - `hoppscotch-selfhost-web`: Sync `hopp_v` for the loaded on‑prem instance; update only the active instance.
  - `hoppscotch-backend`: Persist `isPublic` on mock server creation and default to private when omitted.
  - `hoppscotch-backend`: Gate private user resolvers to the owner and scope history star/delete by `userUid`; stop returning current session blobs in member/creator payloads.
  - `hoppscotch-backend`: Harden SMTP URL validation to reject paths, queries, fragments, control chars, and invalid schemes.

<sup>Written for commit de7fef38c37be1172a62f34992628d2b12468ab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

