### PR TITLE
fix(desktop): sync self-hosted instance version from manifest

### DIFF
--- a/packages/hoppscotch-desktop/src/composables/useAppInitialization.ts
+++ b/packages/hoppscotch-desktop/src/composables/useAppInitialization.ts
@@ -220,9 +220,12 @@ export function useAppInitialization() {
           version: dlResp.version,
           bundleName: dlResp.bundleName,
         }
+        const DESKTOP_APP_SERVER_PATH = "/desktop-app-server"
         const normUrl = (u: string) => {
           let n = u.toLowerCase()
-          if (n.endsWith("/desktop-app-server")) n = n.slice(0, -19)
+          while (n.endsWith("/")) n = n.slice(0, -1)
+          if (n.endsWith(DESKTOP_APP_SERVER_PATH))
+            n = n.slice(0, -DESKTOP_APP_SERVER_PATH.length)
           while (n.endsWith("/")) n = n.slice(0, -1)
           return n
         }
@@ -239,22 +242,6 @@ export function useAppInitialization() {
                 : r
             )
           )
-          const connState = await persistence.connectionState.get()
-          if (
-            connState?.status === "connected" &&
-            connState.instance &&
-            normUrl(connState.instance.serverUrl) ===
-              normUrl(updatedInstance.serverUrl)
-          ) {
-            await persistence.connectionState.set({
-              status: "connected",
-              instance: {
-                ...connState.instance,
-                version: dlResp.version,
-                bundleName: dlResp.bundleName,
-              },
-            })
-          }
         } catch (syncErr) {
           console.error("Failed to sync recent instance version:", syncErr)
         }

--- a/packages/hoppscotch-desktop/src/composables/useAppInitialization.ts
+++ b/packages/hoppscotch-desktop/src/composables/useAppInitialization.ts
@@ -214,14 +214,57 @@ export function useAppInitialization() {
           target: instance.serverUrl,
         })
 
-        await download({ serverUrl: instance.serverUrl })
+        const dlResp = await download({ serverUrl: instance.serverUrl })
+        const updatedInstance: Instance = {
+          ...instance,
+          version: dlResp.version,
+          bundleName: dlResp.bundleName,
+        }
+        const normUrl = (u: string) => {
+          let n = u.toLowerCase()
+          if (n.endsWith("/desktop-app-server")) n = n.slice(0, -19)
+          while (n.endsWith("/")) n = n.slice(0, -1)
+          return n
+        }
+        try {
+          const recentInstances = await persistence.recentInstances.get()
+          await persistence.recentInstances.set(
+            recentInstances.map((r) =>
+              normUrl(r.serverUrl) === normUrl(updatedInstance.serverUrl)
+                ? {
+                    ...r,
+                    version: dlResp.version,
+                    bundleName: dlResp.bundleName,
+                  }
+                : r
+            )
+          )
+          const connState = await persistence.connectionState.get()
+          if (
+            connState?.status === "connected" &&
+            connState.instance &&
+            normUrl(connState.instance.serverUrl) ===
+              normUrl(updatedInstance.serverUrl)
+          ) {
+            await persistence.connectionState.set({
+              status: "connected",
+              instance: {
+                ...connState.instance,
+                version: dlResp.version,
+                bundleName: dlResp.bundleName,
+              },
+            })
+          }
+        } catch (syncErr) {
+          console.error("Failed to sync recent instance version:", syncErr)
+        }
 
         mainDiag(
-          `loadVendoredIfMatches: loading non-vendored instance, bundle=${instance.bundleName}`
+          `loadVendoredIfMatches: loading non-vendored instance, bundle=${updatedInstance.bundleName}`
         )
         await desktopSettings.ready()
         const loadResp = await load({
-          bundleName: instance.bundleName!,
+          bundleName: updatedInstance.bundleName!,
           window: {
             title: "Hoppscotch",
             zoomLevel: desktopSettings.settings.zoomLevel,
@@ -237,7 +280,7 @@ export function useAppInitialization() {
 
         await saveConnectionState({
           status: "connected",
-          instance: instance,
+          instance: updatedInstance,
         })
 
         console.log(`Successfully loaded instance: ${instance.displayName}`)

--- a/packages/hoppscotch-selfhost-web/src/platform/instance/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/instance/desktop/index.ts
@@ -36,8 +36,10 @@ import {
 import { Store } from "@app/kernel/store"
 import { getKernelMode } from "@hoppscotch/kernel"
 import { getService } from "@hoppscotch/common/modules/dioc"
+import { PersistenceService } from "@hoppscotch/common/services/persistence"
 
 const STORE_NAMESPACE = "hoppscotch-desktop.v1"
+const persistenceService = getService(PersistenceService)
 
 type RecentInstances = Instance[]
 
@@ -1012,6 +1014,7 @@ export class DesktopInstanceService
     instance: Instance,
     options?: Partial<LoadOptions>
   ): TE.TaskEither<string, LoadResponse> {
+    let loadedInstance: Instance = instance
     return pipe(
       instance.kind === "vendored"
         ? TE.of(undefined)
@@ -1020,19 +1023,29 @@ export class DesktopInstanceService
               console.log(
                 `[InstanceService] Ensuring bundle is available for: ${instance.displayName}`
               )
-              await download({ serverUrl: instance.serverUrl })
-              return undefined
+              const dlResp = await download({ serverUrl: instance.serverUrl })
+              loadedInstance = {
+                ...instance,
+                version: dlResp.version,
+                bundleName: dlResp.bundleName,
+              }
+              if (instance.kind === "on-prem") {
+                await persistenceService.setLocalConfig(
+                  "hopp_v",
+                  loadedInstance.version
+                )
+              }
             },
             (error) => `Failed to ensure bundle is available: ${error}`
           ),
-      TE.chain(() => this.getBundleNameTE(instance)),
-      TE.map(() => this.buildLoadOptions(instance, options)),
+      TE.chain(() => this.getBundleNameTE(loadedInstance)),
+      TE.map(() => this.buildLoadOptions(loadedInstance, options)),
       TE.chain((loadOptions) => this.performLoadTE(loadOptions)),
       TE.chain((response) =>
-        this.validateLoadResponseTE(response, instance.displayName)
+        this.validateLoadResponseTE(response, loadedInstance.displayName)
       ),
-      TE.chainFirst(() => this.updateInstanceStateTE(instance)),
-      TE.chainFirst(() => this.updateInstanceLastUsed(instance)),
+      TE.chainFirst(() => this.updateInstanceStateTE(loadedInstance)),
+      TE.chainFirst(() => this.updateInstanceLastUsed(loadedInstance)),
       TE.chainFirst((_loadResponse) =>
         TE.fromTask(async () => {
           try {
@@ -1271,7 +1284,12 @@ export class DesktopInstanceService
       this.recentInstances$.value,
       A.map((i) =>
         i.serverUrl === instance.serverUrl
-          ? { ...i, lastUsed: new Date().toISOString() }
+          ? {
+              ...i,
+              version: instance.version,
+              bundleName: instance.bundleName,
+              lastUsed: new Date().toISOString(),
+            }
           : i
       ),
       sortByLastUsedDesc,

--- a/packages/hoppscotch-selfhost-web/src/platform/instance/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/instance/desktop/index.ts
@@ -36,10 +36,8 @@ import {
 import { Store } from "@app/kernel/store"
 import { getKernelMode } from "@hoppscotch/kernel"
 import { getService } from "@hoppscotch/common/modules/dioc"
-import { PersistenceService } from "@hoppscotch/common/services/persistence"
 
 const STORE_NAMESPACE = "hoppscotch-desktop.v1"
-const persistenceService = getService(PersistenceService)
 
 type RecentInstances = Instance[]
 
@@ -1028,12 +1026,6 @@ export class DesktopInstanceService
                 ...instance,
                 version: dlResp.version,
                 bundleName: dlResp.bundleName,
-              }
-              if (instance.kind === "on-prem") {
-                await persistenceService.setLocalConfig(
-                  "hopp_v",
-                  loadedInstance.version
-                )
               }
             },
             (error) => `Failed to ensure bundle is available: ${error}`


### PR DESCRIPTION
Closes # https://github.com/hoppscotch/hoppscotch/issues/6432

The remote `/desktop-app-server/api/v1/manifest` and the local `registry.json` were already updated to the new version, but the Desktop UI still read stale version metadata from persisted local stores. As a result, users had to remove and add the self-hosted instance again to see the updated version.

### What's changed

* Use the download() response version and bundle name as the source of truth when loading a self-hosted Desktop instance.
* Persist the updated instance version in Desktop connectionState.
* Update the matching entry in recentInstances using normalized server URLs.
* Update the matching entry in `recentInstances` using normalized server URLs.
* Only sync the loaded self-hosted instance, without updating other saved instances.
* Keep What's New version tracking untouched.

### Bug Fixes

* Fixes stale on-prem version display after self-hosted server upgrades.
* Prevents users from having to remove and re-add a self-hosted Desktop instance just to refresh the shown version.
* Keeps persisted Desktop instance metadata aligned with the manifest/download response.

### Notes to reviewers

Manual verification:

1. Connect Hoppscotch Desktop to a self-hosted instance running `2026.4.0`.
2. Upgrade the self-hosted server to `2026.4.1`.
3. Confirm the remote manifest returns the new version:

```bash
curl -s "$HOPP_URL/desktop-app-server/api/v1/manifest" | jq .
```

4. Confirm the downloaded bundle contains `2026.4.1`.
5. Reopen the Desktop app and load the self-hosted instance.
6. Before this fix, the UI still showed `on-prem v2026.4.0`.
7. After this fix, the loaded instance shows `on-prem v2026.4.1` without removing and adding the instance again.

Tested locally with:

```bash
pnpm typecheck
git diff --check
```






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale version display for self-hosted Desktop instances after server upgrades. Desktop now trusts the download manifest and keeps saved instance metadata in sync, so users don’t need to re-add the instance.

- **Bug Fixes**
  - `hoppscotch-desktop`: Use `download()` response to set `version`/`bundleName`; load with these values and persist in `connectionState`; update the matching `recentInstances` entry with the new `version`/`bundleName` (normalize URLs and trim `/desktop-app-server`).
  - `hoppscotch-selfhost-web`: On load, use the downloaded on‑prem `version`/`bundleName` for the active instance; update its `recentInstances` entry with `version`/`bundleName` and `lastUsed`; keep `hopp_v` in sync.

<sup>Written for commit c05d5704328beb51e2eb5b1784f8806e65b08cbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6423?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



