### PR TITLE
fix: keep environment variables header visible while scrolling

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/my/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/my/Details.vue
@@ -108,7 +108,9 @@
               :key="tab.id"
               :label="tab.label"
             >
-              <div class="divide-y divide-dividerLight">
+              <div
+                class="divide-y divide-dividerLight overflow-y-auto max-h-[50vh]"
+              >
                 <HoppSmartPlaceholder
                   v-if="tab.variables.length === 0"
                   :src="`/images/states/${colorMode.value}/blockchain.svg`"

--- a/packages/hoppscotch-common/src/components/environments/teams/Details.vue
+++ b/packages/hoppscotch-common/src/components/environments/teams/Details.vue
@@ -111,7 +111,9 @@
               :key="tab.id"
               :label="tab.label"
             >
-              <div class="divide-y divide-dividerLight">
+              <div
+                class="divide-y divide-dividerLight overflow-y-auto max-h-[50vh]"
+              >
                 <HoppSmartPlaceholder
                   v-if="tab.variables.length === 0"
                   :src="`/images/states/${colorMode.value}/blockchain.svg`"


### PR DESCRIPTION
Closes #6421

## Summary

Keeps the environment variables header visible when working with large environment variable lists.

Previously, when many variables were present, users had to scroll back to the top of the modal to access actions such as Add, Clear, and More. This change makes only the variable list scrollable while keeping the header visible.

## What's changed

- Added `overflow-y-auto` to the variables/secrets list container
- Added `max-h-[50vh]` to constrain the scrollable area
- Preserved existing layout and functionality
- Applied to both Variables and Secrets tabs

## Testing

- [x] Verified Variables tab with 30+ entries
- [x] Verified Secrets tab with 30+ entries
- [x] Confirmed Add button remains accessible while scrolling
- [x] Confirmed existing actions continue to work as expected

## Notes to reviewers

This is a minimal UI-only change limited to the environment editor modal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the environment variables header visible while scrolling long lists in the environment editor modal. The variables/secrets list now scrolls (max 50vh), so Add, Clear, and More stay accessible on both Variables and Secrets tabs in personal and team environments.

<sup>Written for commit 94de0ef37687a36775ce5656a9a4d1fdb86d9027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

