### PR TITLE
fix: preserve header values containing colon-space in cURL import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1057,6 +1057,91 @@ data2: {"type":"test2","typeId":"123"}`,
       description: null,
     }),
   },
+  {
+    command: `curl -H 'X-Note: hello: world' https://example.com`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://example.com/",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      headers: [
+        {
+          active: true,
+          key: "X-Note",
+          value: "hello: world",
+          description: "",
+        },
+      ],
+      params: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+      description: null,
+    }),
+  },
+  {
+    command: `curl -H 'Authorization: Bearer token:extra' https://example.com`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://example.com/",
+      auth: {
+        authType: "bearer",
+        authActive: true,
+        token: "token:extra",
+      },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      headers: [
+        {
+          active: true,
+          key: "Authorization",
+          value: "Bearer token:extra",
+          description: "",
+        },
+      ],
+      params: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+      description: null,
+    }),
+  },
+  {
+    command: `curl -H 'Custom-Header: value: with: multiple: colons' https://example.com`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://example.com/",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      headers: [
+        {
+          active: true,
+          key: "Custom-Header",
+          value: "value: with: multiple: colons",
+          description: "",
+        },
+      ],
+      params: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+      description: null,
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -11,11 +11,16 @@ import {
 import { tupleToRecord } from "~/helpers/functional/record"
 
 const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
+  // Split on the first colon (with optional surrounding whitespace) only,
+  // so that header values containing ": " are preserved intact.
+  // e.g. "X-Note: hello: world" → ["X-Note", "hello: world"]
+  (s: string) => {
+    const idx = s.indexOf(":");
+    if (idx === -1) return O.none;
+    const key = s.slice(0, idx).trim();
+    const value = s.slice(idx + 1).trim();
+    return key.length > 0 ? O.some([key, value] as [string, string]) : O.none;
+  }
 )
 
 export function getHeaders(parsedArguments: parser.Arguments) {


### PR DESCRIPTION
## Problem

When importing a cURL command, any header whose value contains  (colon followed by a space) is silently dropped. Only headers with  in the value are affected.

Example:  — the header vanishes from the imported request.

## Root cause

 in  used  which splits on ALL occurrences of . For , this produces  (3 parts). The predicate  fails, so the header is dropped.

## Fix

Split only on the first colon using  + . This preserves the full value:  → key=, value=.

## Testing

Verified with:
- <!doctype html><html lang="en"><head><title>Example Domain</title><link rel="icon" href="data:,"><meta name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href="https://iana.org/domains/example">Learn more</a></p></div></body></html> — header preserved
- <!doctype html><html lang="en"><head><title>Example Domain</title><link rel="icon" href="data:,"><meta name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href="https://iana.org/domains/example">Learn more</a></p></div></body></html> — header preserved
- <!doctype html><html lang="en"><head><title>Example Domain</title><link rel="icon" href="data:,"><meta name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href="https://iana.org/domains/example">Learn more</a></p></div></body></html> — still works
- <!doctype html><html lang="en"><head><title>Example Domain</title><link rel="icon" href="data:,"><meta name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style></head><body><div><h1>Example Domain</h1><p>This domain is for use in documentation examples without needing permission. Avoid use in operations.</p><p><a href="https://iana.org/domains/example">Learn more</a></p></div></body></html> — still works

Per RFC 9110, a header is  where the name is everything before the first colon and the value may itself contain colons and spaces.

Fixes #6400

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cURL import header parsing by splitting on the first ':' only and trimming key/value, so values with colons are preserved. Adds regression tests (incl. 'Authorization: Bearer token:extra' and multi-colon values), preventing drops like 'X-Note: hello: world' and aligning with RFC 9110.

<sup>Written for commit a13a17183657c90f446f54d80ce80270c38f292d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

