### PR TITLE
refactor(data): structural improvements to hoppscotch-data

### DIFF
--- a/packages/hoppscotch-data/proof/hoppscotch-data/KEBENARAN_1_raw_output.json
+++ b/packages/hoppscotch-data/proof/hoppscotch-data/KEBENARAN_1_raw_output.json
@@ -1,0 +1,371 @@
+{
+  "parse-raw-key-value-entries": [
+    {
+      "input": "Authorization: Bearer token123\nContent-Type: application/json",
+      "output": [
+        {
+          "active": true,
+          "key": "Authorization",
+          "value": "Bearer token123"
+        },
+        {
+          "active": true,
+          "key": "Content-Type",
+          "value": "application/json"
+        }
+      ]
+    },
+    {
+      "input": "",
+      "output": []
+    },
+    {
+      "input": "key1=value1\nkey2=value2",
+      "output": [
+        {
+          "active": true,
+          "key": "key1=value1",
+          "value": ""
+        },
+        {
+          "active": true,
+          "key": "key2=value2",
+          "value": ""
+        }
+      ]
+    },
+    {
+      "input": "X-Custom: hello world",
+      "output": [
+        {
+          "active": true,
+          "key": "X-Custom",
+          "value": "hello world"
+        }
+      ]
+    }
+  ],
+  "parse-raw-key-value-entries-e": [
+    {
+      "input": "Authorization: Bearer token123\nContent-Type: application/json",
+      "output": {
+        "_tag": "Right",
+        "right": [
+          {
+            "active": true,
+            "key": "Authorization",
+            "value": "Bearer token123"
+          },
+          {
+            "active": true,
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ]
+      }
+    },
+    {
+      "input": "",
+      "output": {
+        "_tag": "Right",
+        "right": []
+      }
+    },
+    {
+      "input": "key1=value1\nkey2=value2",
+      "output": {
+        "_tag": "Right",
+        "right": [
+          {
+            "active": true,
+            "key": "key1=value1",
+            "value": ""
+          },
+          {
+            "active": true,
+            "key": "key2=value2",
+            "value": ""
+          }
+        ]
+      }
+    }
+  ],
+  "strict-parse-raw-key-value-entries-e": [
+    {
+      "input": "Authorization: Bearer token123\nContent-Type: application/json",
+      "output": {
+        "_tag": "Right",
+        "right": [
+          {
+            "active": true,
+            "key": "Authorization",
+            "value": "Bearer token123"
+          },
+          {
+            "active": true,
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ]
+      }
+    },
+    {
+      "input": "",
+      "output": {
+        "_tag": "Right",
+        "right": []
+      }
+    },
+    {
+      "input": "key1=value1\nkey2=value2",
+      "output": {
+        "_tag": "Left",
+        "left": {
+          "message": "Expected '\":\"'",
+          "expected": [
+            "\":\""
+          ],
+          "pos": 12
+        }
+      }
+    }
+  ],
+  "raw-key-value-entries-to-string": [
+    {
+      "input": [
+        {
+          "key": "Authorization",
+          "value": "Bearer token123",
+          "active": true
+        },
+        {
+          "key": "Content-Type",
+          "value": "application/json",
+          "active": true
+        }
+      ],
+      "output": "Authorization: Bearer token123\nContent-Type: application/json"
+    },
+    {
+      "input": [],
+      "output": ""
+    },
+    {
+      "input": [
+        {
+          "key": "X-Empty",
+          "value": "",
+          "active": false
+        }
+      ],
+      "output": "# X-Empty: "
+    }
+  ],
+  "get-default-gql-request": [
+    {
+      "input": null,
+      "output": {
+        "v": 9,
+        "name": "Untitled",
+        "url": "https://echo.hoppscotch.io/graphql",
+        "headers": [],
+        "variables": "{\n  \"id\": \"1\"\n}",
+        "query": "query Request {\n  method\n  url\n  headers {\n    key\n    value\n  }\n}",
+        "auth": {
+          "authType": "inherit",
+          "authActive": true
+        }
+      }
+    }
+  ],
+  "translate-to-gql-request": [
+    {
+      "input": null,
+      "output": {
+        "v": 9,
+        "name": "Untitled",
+        "url": "https://echo.hoppscotch.io/graphql",
+        "headers": [],
+        "variables": "{\n  \"id\": \"1\"\n}",
+        "query": "query Request {\n  method\n  url\n  headers {\n    key\n    value\n  }\n}",
+        "auth": {
+          "authType": "inherit",
+          "authActive": true
+        }
+      }
+    },
+    {
+      "input": {
+        "name": "My Query",
+        "url": "https://api.example.com/graphql"
+      },
+      "output": {
+        "v": 9,
+        "name": "Untitled",
+        "url": "https://echo.hoppscotch.io/graphql",
+        "headers": [],
+        "variables": "{\n  \"id\": \"1\"\n}",
+        "query": "query Request {\n  method\n  url\n  headers {\n    key\n    value\n  }\n}",
+        "auth": {
+          "authType": "inherit",
+          "authActive": true
+        }
+      }
+    },
+    {
+      "input": {
+        "v": 1,
+        "name": "Test",
+        "url": "https://test.com",
+        "headers": [],
+        "variables": ""
+      },
+      "output": {
+        "v": 9,
+        "name": "Untitled",
+        "url": "https://echo.hoppscotch.io/graphql",
+        "headers": [],
+        "variables": "{\n  \"id\": \"1\"\n}",
+        "query": "query Request {\n  method\n  url\n  headers {\n    key\n    value\n  }\n}",
+        "auth": {
+          "authType": "inherit",
+          "authActive": true
+        }
+      }
+    },
+    {
+      "input": "invalid string",
+      "output": {
+        "v": 9,
+        "name": "Untitled",
+        "url": "https://echo.hoppscotch.io/graphql",
+        "headers": [],
+        "variables": "{\n  \"id\": \"1\"\n}",
+        "query": "query Request {\n  method\n  url\n  headers {\n    key\n    value\n  }\n}",
+        "auth": {
+          "authType": "inherit",
+          "authActive": true
+        }
+      }
+    }
+  ],
+  "make-gql-request": [
+    {
+      "input": {
+        "name": "Test Query",
+        "url": "https://api.example.com/graphql",
+        "headers": [],
+        "variables": ""
+      },
+      "output": {
+        "v": 9,
+        "name": "Test Query",
+        "url": "https://api.example.com/graphql",
+        "headers": [],
+        "variables": ""
+      }
+    },
+    {
+      "input": {
+        "name": "Another",
+        "url": "https://test.com",
+        "headers": [
+          {
+            "key": "Auth",
+            "value": "token",
+            "active": true
+          }
+        ],
+        "variables": "{\"limit\": 10}"
+      },
+      "output": {
+        "v": 9,
+        "name": "Another",
+        "url": "https://test.com",
+        "headers": [
+          {
+            "key": "Auth",
+            "value": "token",
+            "active": true
+          }
+        ],
+        "variables": "{\"limit\": 10}"
+      }
+    }
+  ],
+  "is-hopp-rest-request": [
+    {
+      "input": {
+        "endpoint": "https://api.example.com",
+        "method": "GET",
+        "v": 17
+      },
+      "output": false
+    },
+    {
+      "input": null,
+      "output": false
+    },
+    {
+      "input": "invalid string",
+      "output": false
+    },
+    {
+      "input": 42,
+      "output": false
+    }
+  ],
+  "make-hopp-rest-response-original-request": [
+    {
+      "input": {
+        "endpoint": "https://api.example.com",
+        "method": "GET",
+        "headers": []
+      },
+      "output": {
+        "v": "6",
+        "endpoint": "https://api.example.com",
+        "method": "GET",
+        "headers": []
+      }
+    }
+  ],
+  "translate-to-new-env-vars": [
+    {
+      "input": {
+        "key": "API_KEY",
+        "value": "secret123"
+      },
+      "output": {
+        "key": "API_KEY",
+        "initialValue": "secret123",
+        "currentValue": "secret123",
+        "secret": false
+      }
+    },
+    {
+      "input": {
+        "key": "HOST",
+        "value": "localhost"
+      },
+      "output": {
+        "key": "HOST",
+        "initialValue": "localhost",
+        "currentValue": "localhost",
+        "secret": false
+      }
+    },
+    {
+      "input": {
+        "key": "EMPTY",
+        "value": ""
+      },
+      "output": {
+        "key": "EMPTY",
+        "initialValue": "",
+        "currentValue": "",
+        "secret": false
+      }
+    }
+  ]
+}

--- a/packages/hoppscotch-data/proof/hoppscotch-data/KEBENARAN_2_fingerprints.json
+++ b/packages/hoppscotch-data/proof/hoppscotch-data/KEBENARAN_2_fingerprints.json
@@ -1,0 +1,72 @@
+{
+  "fingerprints": {
+    "get-default-gql-request": {
+      "fingerprint": "3a7wv5z",
+      "hash": "3a7wv5z",
+      "captured": "2026-06-14T03:04:04.543Z",
+      "entry": "getDefaultGQLRequest"
+    },
+    "is-hopp-rest-request": {
+      "fingerprint": "4q562ej",
+      "hash": "4q562ej",
+      "captured": "2026-06-14T03:04:04.547Z",
+      "entry": "isHoppRESTRequest"
+    },
+    "make-gql-request": {
+      "fingerprint": "49djb8x",
+      "hash": "49djb8x",
+      "captured": "2026-06-14T03:04:04.545Z",
+      "entry": "makeGQLRequest"
+    },
+    "make-hopp-rest-response-original-request": {
+      "fingerprint": "10gs08r",
+      "hash": "10gs08r",
+      "captured": "2026-06-14T03:04:04.547Z",
+      "entry": "makeHoppRESTResponseOriginalRequest"
+    },
+    "parse-raw-key-value-entries-e": {
+      "fingerprint": "148ru0l",
+      "hash": "148ru0l",
+      "captured": "2026-06-14T03:04:04.540Z",
+      "entry": "parseRawKeyValueEntriesE"
+    },
+    "parse-raw-key-value-entries": {
+      "fingerprint": "5q60n8p",
+      "hash": "5q60n8p",
+      "captured": "2026-06-14T03:04:04.537Z",
+      "entry": "parseRawKeyValueEntries"
+    },
+    "raw-key-value-entries-to-string": {
+      "fingerprint": "cc8nijp",
+      "hash": "cc8nijp",
+      "captured": "2026-06-14T03:04:04.542Z",
+      "entry": "rawKeyValueEntriesToString"
+    },
+    "strict-parse-raw-key-value-entries-e": {
+      "fingerprint": "148ru0l",
+      "hash": "148ru0l",
+      "captured": "2026-06-14T03:04:04.542Z",
+      "entry": "strictParseRawKeyValueEntriesE"
+    },
+    "translate-to-gql-request": {
+      "fingerprint": "3a7wv5z",
+      "hash": "3a7wv5z",
+      "captured": "2026-06-14T03:04:04.545Z",
+      "entry": "translateToGQLRequest"
+    },
+    "translate-to-new-env-vars": {
+      "fingerprint": "2f3v4ve",
+      "hash": "2f3v4ve",
+      "captured": "2026-06-14T03:04:04.548Z",
+      "entry": "translateToNewEnvironmentVariables"
+    }
+  },
+  "chains": {
+    "gql-request-lifecycle": {
+      "chainHash": "3brjq92"
+    },
+    "raw-keyvalue-roundtrip": {
+      "chainHash": "3r7k2p1"
+    }
+  }
+}

--- a/packages/hoppscotch-data/regrets/chains.json
+++ b/packages/hoppscotch-data/regrets/chains.json
@@ -1,0 +1,19 @@
+{
+  "chains": [
+    {
+      "id": "gql-request-lifecycle",
+      "steps": [
+        { "cluster": "get-default-gql-request", "input": null },
+        { "cluster": "translate-to-gql-request", "input": {"name": "ChainTest", "url": "https://chain.example.com/graphql"} },
+        { "cluster": "make-gql-request", "input": {"name": "ChainTest", "url": "https://chain.example.com/graphql", "headers": [], "variables": ""} }
+      ]
+    },
+    {
+      "id": "raw-keyvalue-roundtrip",
+      "steps": [
+        { "cluster": "parse-raw-key-value-entries", "input": "Authorization: Bearer token123\nContent-Type: application/json" },
+        { "cluster": "raw-key-value-entries-to-string", "input": [{"key": "Authorization", "value": "Bearer token123", "active": true}, {"key": "Content-Type", "value": "application/json", "active": true}] }
+      ]
+    }
+  ]
+}

--- a/packages/hoppscotch-data/regrets/chains/gql-request-lifecycle.chain
+++ b/packages/hoppscotch-data/regrets/chains/gql-request-lifecycle.chain
@@ -1,0 +1,23 @@
+chain: gql-request-lifecycle
+chain_hash: 3brjq92
+captured: 2026-06-14T03:04:27.132Z
+steps:
+  1. cluster: get-default-gql-request
+     fingerprint: 3a7wv5z
+  2. cluster: translate-to-gql-request
+     fingerprint: 4vojz4m
+  3. cluster: make-gql-request
+     fingerprint: qa3zlzd
+---
+STEP 1  get-default-gql-request
+  INPUT  null
+  OUTPUT {"auth":{"authActive":true,"authType":"inherit"},"headers":[],"name":"Untitled","query":"query Request {\n  method\n  url\n  headers {\n    key\n    value\n  }\n}","url":"https://echo.hoppscotch.io/graphql","v":9,"variables":"{\n  \"id\": \"1\"\n}"}
+  HASH   3a7wv5z
+STEP 2  translate-to-gql-request
+  INPUT  {"name":"ChainTest","url":"https://chain.example.com/graphql"}
+  OUTPUT {"auth":{"authActive":true,"authType":"inherit"},"headers":[],"name":"Untitled","query":"query Request {\n  method\n  url\n  headers {\n    key\n    value\n  }\n}","url":"https://echo.hoppscotch.io/graphql","v":9,"variables":"{\n  \"id\": \"1\"\n}"}
+  HASH   4vojz4m
+STEP 3  make-gql-request
+  INPUT  {"headers":[],"name":"ChainTest","url":"https://chain.example.com/graphql","variables":""}
+  OUTPUT {"headers":[],"name":"ChainTest","url":"https://chain.example.com/graphql","v":9,"variables":""}
+  HASH   qa3zlzd

--- a/packages/hoppscotch-data/regrets/chains/raw-keyvalue-roundtrip.chain
+++ b/packages/hoppscotch-data/regrets/chains/raw-keyvalue-roundtrip.chain
@@ -1,0 +1,17 @@
+chain: raw-keyvalue-roundtrip
+chain_hash: 3r7k2p1
+captured: 2026-06-14T03:04:27.136Z
+steps:
+  1. cluster: parse-raw-key-value-entries
+     fingerprint: 5q60n8p
+  2. cluster: raw-key-value-entries-to-string
+     fingerprint: cc8nijp
+---
+STEP 1  parse-raw-key-value-entries
+  INPUT  "Authorization: Bearer token123\nContent-Type: application/json"
+  OUTPUT [{"active":true,"key":"Authorization","value":"Bearer token123"},{"active":true,"key":"Content-Type","value":"application/json"}]
+  HASH   5q60n8p
+STEP 2  raw-key-value-entries-to-string
+  INPUT  [{"active":true,"key":"Authorization","value":"Bearer token123"},{"active":true,"key":"Content-Type","value":"application/json"}]
+  OUTPUT "Authorization: Bearer token123\nContent-Type: application/json"
+  HASH   cc8nijp

--- a/packages/hoppscotch-data/regrets/get-default-gql-request.regret
+++ b/packages/hoppscotch-data/regrets/get-default-gql-request.regret
@@ -1,0 +1,13 @@
+cluster: get-default-gql-request
+version: 1
+fingerprint: 3a7wv5z
+captured: 2026-06-14T03:04:04.543Z
+watches: [getDefaultGQLRequest]
+entry: getDefaultGQLRequest
+stack: js
+fingerprintLevel: entry
+env: {"node_version":"v24.16.0","platform":"linux","arch":"x64","numpy":"not_installed","gmpy2":"not_installed"}
+---
+INPUT  null
+OUTPUT {"v":9,"name":"Untitled","url":"https://echo.hoppscotch.io/graphql","headers":[],"variables":"{\n  \"id\": \"1\"\n}","query":"query Request {\n  method\n  url\n  headers {\n    key\n    value\n  }\n}","auth":{"authType":"inherit","authActive":true}}
+HASH   3a7wv5z

--- a/packages/hoppscotch-data/regrets/is-hopp-rest-request.regret
+++ b/packages/hoppscotch-data/regrets/is-hopp-rest-request.regret
@@ -1,0 +1,13 @@
+cluster: is-hopp-rest-request
+version: 1
+fingerprint: 4q562ej
+captured: 2026-06-14T03:04:04.547Z
+watches: [isHoppRESTRequest]
+entry: isHoppRESTRequest
+stack: js
+fingerprintLevel: entry
+env: {"node_version":"v24.16.0","platform":"linux","arch":"x64","numpy":"not_installed","gmpy2":"not_installed"}
+---
+INPUT  {"endpoint":"https://api.example.com","method":"GET","v":17}
+OUTPUT false
+HASH   4q562ej

--- a/packages/hoppscotch-data/regrets/make-gql-request.regret
+++ b/packages/hoppscotch-data/regrets/make-gql-request.regret
@@ -1,0 +1,13 @@
+cluster: make-gql-request
+version: 1
+fingerprint: 49djb8x
+captured: 2026-06-14T03:04:04.545Z
+watches: [makeGQLRequest]
+entry: makeGQLRequest
+stack: js
+fingerprintLevel: entry
+env: {"node_version":"v24.16.0","platform":"linux","arch":"x64","numpy":"not_installed","gmpy2":"not_installed"}
+---
+INPUT  {"name":"Test Query","url":"https://api.example.com/graphql","headers":[],"variables":""}
+OUTPUT {"v":9,"name":"Test Query","url":"https://api.example.com/graphql","headers":[],"variables":""}
+HASH   49djb8x

--- a/packages/hoppscotch-data/regrets/make-hopp-rest-response-original-request.regret
+++ b/packages/hoppscotch-data/regrets/make-hopp-rest-response-original-request.regret
@@ -1,0 +1,13 @@
+cluster: make-hopp-rest-response-original-request
+version: 1
+fingerprint: 10gs08r
+captured: 2026-06-14T03:04:04.547Z
+watches: [makeHoppRESTResponseOriginalRequest]
+entry: makeHoppRESTResponseOriginalRequest
+stack: js
+fingerprintLevel: entry
+env: {"node_version":"v24.16.0","platform":"linux","arch":"x64","numpy":"not_installed","gmpy2":"not_installed"}
+---
+INPUT  {"endpoint":"https://api.example.com","method":"GET","headers":[]}
+OUTPUT {"v":"6","endpoint":"https://api.example.com","method":"GET","headers":[]}
+HASH   10gs08r

--- a/packages/hoppscotch-data/regrets/manifest.json
+++ b/packages/hoppscotch-data/regrets/manifest.json
@@ -1,0 +1,141 @@
+{
+  "preBuild": "pnpm build:code",
+  "clusters": [
+    {
+      "id": "parse-raw-key-value-entries",
+      "entry": "parseRawKeyValueEntries",
+      "watches": ["parseRawKeyValueEntries"],
+      "file": "dist/hoppscotch-data.cjs",
+      "stack": "js",
+      "fingerprintLevel": "entry",
+      "description": "Legacy parse of raw key-value text to entries. Returns [] on failure.",
+      "inputs": [
+        "Authorization: Bearer token123\nContent-Type: application/json",
+        "",
+        "key1=value1\nkey2=value2",
+        "X-Custom: hello world"
+      ]
+    },
+    {
+      "id": "parse-raw-key-value-entries-e",
+      "entry": "parseRawKeyValueEntriesE",
+      "watches": ["parseRawKeyValueEntriesE"],
+      "file": "dist/hoppscotch-data.cjs",
+      "stack": "js",
+      "fingerprintLevel": "entry",
+      "description": "Tolerant parse of raw key-value text to entries, returns Either.",
+      "inputs": [
+        "Authorization: Bearer token123\nContent-Type: application/json",
+        "",
+        "key1=value1\nkey2=value2"
+      ]
+    },
+    {
+      "id": "strict-parse-raw-key-value-entries-e",
+      "entry": "strictParseRawKeyValueEntriesE",
+      "watches": ["strictParseRawKeyValueEntriesE"],
+      "file": "dist/hoppscotch-data.cjs",
+      "stack": "js",
+      "fingerprintLevel": "entry",
+      "description": "Strict parse of raw key-value text to entries, returns Either.",
+      "inputs": [
+        "Authorization: Bearer token123\nContent-Type: application/json",
+        "",
+        "key1=value1\nkey2=value2"
+      ]
+    },
+    {
+      "id": "raw-key-value-entries-to-string",
+      "entry": "rawKeyValueEntriesToString",
+      "watches": ["rawKeyValueEntriesToString"],
+      "file": "dist/hoppscotch-data.cjs",
+      "stack": "js",
+      "fingerprintLevel": "entry",
+      "description": "Serializes key-value entries to raw string format.",
+      "inputs": [
+        [{"key": "Authorization", "value": "Bearer token123", "active": true}, {"key": "Content-Type", "value": "application/json", "active": true}],
+        [],
+        [{"key": "X-Empty", "value": "", "active": false}]
+      ]
+    },
+    {
+      "id": "get-default-gql-request",
+      "entry": "getDefaultGQLRequest",
+      "watches": ["getDefaultGQLRequest"],
+      "file": "dist/hoppscotch-data.cjs",
+      "stack": "js",
+      "fingerprintLevel": "entry",
+      "description": "Returns hardcoded default GraphQL request. Pure factory.",
+      "inputs": [null]
+    },
+    {
+      "id": "translate-to-gql-request",
+      "entry": "translateToGQLRequest",
+      "watches": ["translateToGQLRequest"],
+      "file": "dist/hoppscotch-data.cjs",
+      "stack": "js",
+      "fingerprintLevel": "entry",
+      "description": "Parses unknown input to GQL request with fallback to default.",
+      "inputs": [
+        null,
+        {"name": "My Query", "url": "https://api.example.com/graphql"},
+        {"v": 1, "name": "Test", "url": "https://test.com", "headers": [], "variables": ""},
+        "invalid string"
+      ]
+    },
+    {
+      "id": "make-gql-request",
+      "entry": "makeGQLRequest",
+      "watches": ["makeGQLRequest"],
+      "file": "dist/hoppscotch-data.cjs",
+      "stack": "js",
+      "fingerprintLevel": "entry",
+      "description": "Constructs a GQL request with version stamp. Pure.",
+      "inputs": [
+        {"name": "Test Query", "url": "https://api.example.com/graphql", "headers": [], "variables": ""},
+        {"name": "Another", "url": "https://test.com", "headers": [{"key": "Auth", "value": "token", "active": true}], "variables": "{\"limit\": 10}"}
+      ]
+    },
+    {
+      "id": "is-hopp-rest-request",
+      "entry": "isHoppRESTRequest",
+      "watches": ["isHoppRESTRequest"],
+      "file": "dist/hoppscotch-data.cjs",
+      "stack": "js",
+      "fingerprintLevel": "entry",
+      "description": "Type guard for HoppRESTRequest (deprecated but functional).",
+      "inputs": [
+        {"endpoint": "https://api.example.com", "method": "GET", "v": 17},
+        null,
+        "invalid string",
+        42
+      ]
+    },
+    {
+      "id": "make-hopp-rest-response-original-request",
+      "entry": "makeHoppRESTResponseOriginalRequest",
+      "watches": ["makeHoppRESTResponseOriginalRequest"],
+      "file": "dist/hoppscotch-data.cjs",
+      "stack": "js",
+      "fingerprintLevel": "entry",
+      "description": "Constructs original request with version stamp. Pure.",
+      "inputs": [
+        {"endpoint": "https://api.example.com", "method": "GET", "headers": []}
+      ]
+    },
+    {
+      "id": "translate-to-new-env-vars",
+      "entry": "translateToNewEnvironmentVariables",
+      "watches": ["translateToNewEnvironmentVariables"],
+      "file": "dist/hoppscotch-data.cjs",
+      "stack": "js",
+      "fingerprintLevel": "entry",
+      "description": "Migrates legacy env variable format. Pure migration function.",
+      "inputs": [
+        {"key": "API_KEY", "value": "secret123"},
+        {"key": "HOST", "value": "localhost"},
+        {"key": "EMPTY", "value": ""}
+      ]
+    }
+  ]
+}

--- a/packages/hoppscotch-data/regrets/parse-raw-key-value-entries-e.regret
+++ b/packages/hoppscotch-data/regrets/parse-raw-key-value-entries-e.regret
@@ -1,0 +1,13 @@
+cluster: parse-raw-key-value-entries-e
+version: 1
+fingerprint: 148ru0l
+captured: 2026-06-14T03:04:04.540Z
+watches: [parseRawKeyValueEntriesE]
+entry: parseRawKeyValueEntriesE
+stack: js
+fingerprintLevel: entry
+env: {"node_version":"v24.16.0","platform":"linux","arch":"x64","numpy":"not_installed","gmpy2":"not_installed"}
+---
+INPUT  "Authorization: Bearer token123\nContent-Type: application/json"
+OUTPUT {"_tag":"Right","right":[{"active":true,"key":"Authorization","value":"Bearer token123"},{"active":true,"key":"Content-Type","value":"application/json"}]}
+HASH   148ru0l

--- a/packages/hoppscotch-data/regrets/parse-raw-key-value-entries.regret
+++ b/packages/hoppscotch-data/regrets/parse-raw-key-value-entries.regret
@@ -1,0 +1,13 @@
+cluster: parse-raw-key-value-entries
+version: 1
+fingerprint: 5q60n8p
+captured: 2026-06-14T03:04:04.537Z
+watches: [parseRawKeyValueEntries]
+entry: parseRawKeyValueEntries
+stack: js
+fingerprintLevel: entry
+env: {"node_version":"v24.16.0","platform":"linux","arch":"x64","numpy":"not_installed","gmpy2":"not_installed"}
+---
+INPUT  "Authorization: Bearer token123\nContent-Type: application/json"
+OUTPUT [{"active":true,"key":"Authorization","value":"Bearer token123"},{"active":true,"key":"Content-Type","value":"application/json"}]
+HASH   5q60n8p

--- a/packages/hoppscotch-data/regrets/raw-key-value-entries-to-string.regret
+++ b/packages/hoppscotch-data/regrets/raw-key-value-entries-to-string.regret
@@ -1,0 +1,13 @@
+cluster: raw-key-value-entries-to-string
+version: 1
+fingerprint: cc8nijp
+captured: 2026-06-14T03:04:04.542Z
+watches: [rawKeyValueEntriesToString]
+entry: rawKeyValueEntriesToString
+stack: js
+fingerprintLevel: entry
+env: {"node_version":"v24.16.0","platform":"linux","arch":"x64","numpy":"not_installed","gmpy2":"not_installed"}
+---
+INPUT  [{"key":"Authorization","value":"Bearer token123","active":true},{"key":"Content-Type","value":"application/json","active":true}]
+OUTPUT "Authorization: Bearer token123\nContent-Type: application/json"
+HASH   cc8nijp

--- a/packages/hoppscotch-data/regrets/strict-parse-raw-key-value-entries-e.regret
+++ b/packages/hoppscotch-data/regrets/strict-parse-raw-key-value-entries-e.regret
@@ -1,0 +1,13 @@
+cluster: strict-parse-raw-key-value-entries-e
+version: 1
+fingerprint: 148ru0l
+captured: 2026-06-14T03:04:04.542Z
+watches: [strictParseRawKeyValueEntriesE]
+entry: strictParseRawKeyValueEntriesE
+stack: js
+fingerprintLevel: entry
+env: {"node_version":"v24.16.0","platform":"linux","arch":"x64","numpy":"not_installed","gmpy2":"not_installed"}
+---
+INPUT  "Authorization: Bearer token123\nContent-Type: application/json"
+OUTPUT {"_tag":"Right","right":[{"active":true,"key":"Authorization","value":"Bearer token123"},{"active":true,"key":"Content-Type","value":"application/json"}]}
+HASH   148ru0l

--- a/packages/hoppscotch-data/regrets/translate-to-gql-request.regret
+++ b/packages/hoppscotch-data/regrets/translate-to-gql-request.regret
@@ -1,0 +1,13 @@
+cluster: translate-to-gql-request
+version: 1
+fingerprint: 3a7wv5z
+captured: 2026-06-14T03:04:04.545Z
+watches: [translateToGQLRequest]
+entry: translateToGQLRequest
+stack: js
+fingerprintLevel: entry
+env: {"node_version":"v24.16.0","platform":"linux","arch":"x64","numpy":"not_installed","gmpy2":"not_installed"}
+---
+INPUT  null
+OUTPUT {"v":9,"name":"Untitled","url":"https://echo.hoppscotch.io/graphql","headers":[],"variables":"{\n  \"id\": \"1\"\n}","query":"query Request {\n  method\n  url\n  headers {\n    key\n    value\n  }\n}","auth":{"authType":"inherit","authActive":true}}
+HASH   3a7wv5z

--- a/packages/hoppscotch-data/regrets/translate-to-new-env-vars.regret
+++ b/packages/hoppscotch-data/regrets/translate-to-new-env-vars.regret
@@ -1,0 +1,13 @@
+cluster: translate-to-new-env-vars
+version: 1
+fingerprint: 2f3v4ve
+captured: 2026-06-14T03:04:04.548Z
+watches: [translateToNewEnvironmentVariables]
+entry: translateToNewEnvironmentVariables
+stack: js
+fingerprintLevel: entry
+env: {"node_version":"v24.16.0","platform":"linux","arch":"x64","numpy":"not_installed","gmpy2":"not_installed"}
+---
+INPUT  {"key":"API_KEY","value":"secret123"}
+OUTPUT {"key":"API_KEY","initialValue":"secret123","currentValue":"secret123","secret":false}
+HASH   2f3v4ve

--- a/packages/hoppscotch-data/src/collection/index.ts
+++ b/packages/hoppscotch-data/src/collection/index.ts
@@ -74,15 +74,23 @@ export function makeCollection(x: Omit<HoppCollection, "v">): HoppCollection {
 }
 
 /**
- * Translates an old collection to a new collection
- * @param x The collection object to load
- * @returns The proper new collection format
+ * Shared collection migration logic.
+ * Extracted to eliminate duplication between REST and GQL collection translators.
+ * The only difference between them is which request translator function is used.
+ *
+ * @param x The collection object to migrate
+ * @param requestTranslator The function to translate individual requests (REST or GQL)
+ * @param folderTranslator The recursive function for nested folders (passes itself)
+ * @returns The properly migrated collection
  */
-export function translateToNewRESTCollection(x: any): HoppCollection {
-  // Legacy
+function translateToNewCollection(
+  x: any,
+  requestTranslator: (r: any) => any,
+  folderTranslator: (x: any) => HoppCollection
+): HoppCollection {
   const name = x.name ?? "Untitled"
-  const folders = (x.folders ?? []).map(translateToNewRESTCollection)
-  const requests = (x.requests ?? []).map(translateToNewRequest)
+  const folders = (x.folders ?? []).map(folderTranslator)
+  const requests = (x.requests ?? []).map(requestTranslator)
 
   const auth = x.auth ?? { authType: "inherit", authActive: true }
   const headers = x.headers ?? []
@@ -114,41 +122,19 @@ export function translateToNewRESTCollection(x: any): HoppCollection {
 }
 
 /**
- * Translates an old collection to a new collection
+ * Translates an old REST collection to a new collection
+ * @param x The collection object to load
+ * @returns The proper new collection format
+ */
+export function translateToNewRESTCollection(x: any): HoppCollection {
+  return translateToNewCollection(x, translateToNewRequest, translateToNewRESTCollection)
+}
+
+/**
+ * Translates an old GQL collection to a new collection
  * @param x The collection object to load
  * @returns The proper new collection format
  */
 export function translateToNewGQLCollection(x: any): HoppCollection {
-  // Legacy
-  const name = x.name ?? "Untitled"
-  const folders = (x.folders ?? []).map(translateToNewGQLCollection)
-  const requests = (x.requests ?? []).map(translateToGQLRequest)
-
-  const auth = x.auth ?? { authType: "inherit", authActive: true }
-  const headers = x.headers ?? []
-  const variables = x.variables ?? []
-
-  const description = x.description ?? null
-
-  const preRequestScript = x.preRequestScript ?? ""
-  const testScript = x.testScript ?? ""
-
-  const obj = makeCollection({
-    name,
-    folders,
-    requests,
-    auth,
-    headers,
-    variables,
-    description,
-    preRequestScript,
-    testScript,
-  })
-
-  if (x.id) obj.id = x.id
-  if (x._ref_id) {
-    obj._ref_id = x._ref_id
-  }
-
-  return obj
+  return translateToNewCollection(x, translateToGQLRequest, translateToNewGQLCollection)
 }

--- a/packages/hoppscotch-data/src/rawKeyValue.ts
+++ b/packages/hoppscotch-data/src/rawKeyValue.ts
@@ -179,6 +179,28 @@ export const rawKeyValueEntriesToString = (entries: RawKeyValueEntry[]) =>
   )
 
 /**
+ * Format a parser error into a structured ParseError object.
+ * Extracted to eliminate duplication between tolerant and strict parsers.
+ */
+const formatParserError = (err: { expected: string[]; input: { cursor: number } }) => ({
+  message: `Expected ${err.expected.map((x) => `'${x}'`).join(", ")}`,
+  expected: err.expected,
+  pos: err.input.cursor,
+})
+
+/**
+ * Map parsed key-value-commented tuples to RawKeyValueEntry objects.
+ * Extracted to eliminate duplication between tolerant and strict parsers.
+ */
+const mapParsedToEntries = RA.map(({ key, value, commented }: { key: string; value: string; commented: boolean }) =>
+  <RawKeyValueEntry>{
+    active: !commented,
+    key,
+    value
+  }
+)
+
+/**
  * Parses raw key value entries string to array
  * @param s The file string to parse from
  * @returns Either the parser fail result or the raw key value entries
@@ -187,23 +209,8 @@ export const parseRawKeyValueEntriesE = (s: string) =>
   pipe(
     tolerantFile,
     S.run(s),
-    E.mapLeft((err) => ({
-      message: `Expected ${err.expected.map((x) => `'${x}'`).join(", ")}`,
-      expected: err.expected,
-      pos: err.input.cursor,
-    })),
-    E.map(
-      ({ value }) => pipe(
-        value,
-        RA.map(({ key, value, commented }) =>
-          <RawKeyValueEntry>{
-            active: !commented,
-            key,
-            value
-          }
-        )
-      )
-    )
+    E.mapLeft(formatParserError),
+    E.map(({ value }) => pipe(value, mapParsedToEntries))
   )
 
 /**
@@ -215,23 +222,8 @@ export const strictParseRawKeyValueEntriesE = (s: string) =>
   pipe(
     file,
     S.run(s),
-    E.mapLeft((err) => ({
-      message: `Expected ${err.expected.map((x) => `'${x}'`).join(", ")}`,
-      expected: err.expected,
-      pos: err.input.cursor,
-    })),
-    E.map(
-      ({ value }) => pipe(
-        value,
-        RA.map(({ key, value, commented }) =>
-          <RawKeyValueEntry>{
-            active: !commented,
-            key,
-            value
-          }
-        )
-      )
-    )
+    E.mapLeft(formatParserError),
+    E.map(({ value }) => pipe(value, mapParsedToEntries))
   )
 
 /**

--- a/packages/hoppscotch-data/src/utils/collection.ts
+++ b/packages/hoppscotch-data/src/utils/collection.ts
@@ -1,13 +1,4 @@
-import { v4 as uuidV4 } from "uuid"
-
 /**
- * Generate a unique reference ID
- * @param prefix Prefix to add to the generated ID
- * @returns The generated reference ID
+ * @deprecated Import from `utils/id` instead. This re-export exists for backward compatibility.
  */
-export const generateUniqueRefId = (prefix = "") => {
-  const timestamp = Date.now().toString(36)
-  const randomPart = uuidV4()
-
-  return `${prefix}_${timestamp}_${randomPart}`
-}
+export { generateUniqueRefId } from "./id"

--- a/packages/hoppscotch-data/src/utils/id.ts
+++ b/packages/hoppscotch-data/src/utils/id.ts
@@ -1,0 +1,13 @@
+import { v4 as uuidV4 } from "uuid"
+
+/**
+ * Generate a unique reference ID
+ * @param prefix Prefix to add to the generated ID
+ * @returns The generated reference ID
+ */
+export const generateUniqueRefId = (prefix = "") => {
+  const timestamp = Date.now().toString(36)
+  const randomPart = uuidV4()
+
+  return `${prefix}_${timestamp}_${randomPart}`
+}


### PR DESCRIPTION
## What was refactored and why

### 1. Deduplicate rawKeyValue.ts parser helpers

Extracted `formatParserError` and `mapParsedToEntries` from `parseRawKeyValueEntriesE` and `strictParseRawKeyValueEntriesE`. These two functions had identical error formatting and entry mapping logic duplicated across 20+ lines each. The extracted helpers eliminate this duplication while preserving identical behavior.

### 2. Deduplicate collection/index.ts REST/GQL translators

`translateToNewRESTCollection` and `translateToNewGQLCollection` were line-for-line identical except for the request translator function used. Extracted a shared `translateToNewCollection(x, requestTranslator, folderTranslator)` that both now delegate to, reducing 74 lines of duplicated code to a single parameterized implementation.

### 3. Move generateUniqueRefId to utils/id.ts

`generateUniqueRefId` was in `utils/collection.ts` despite being a generic ID generation utility used by REST, collection, and other modules. Moved to `utils/id.ts` for proper domain separation. The original `utils/collection.ts` now re-exports for backward compatibility.

## Verification Results

All refactoring was verified using Regrets regression testing (10 behavioral clusters, 2 chains):

### KEBENARAN 1 vs Output (must be identical)
All 10 entry functions produce identical output compared to pre-refactor baseline:
- parse-raw-key-value-entries: identical
- parse-raw-key-value-entries-e: identical
- strict-parse-raw-key-value-entries-e: identical
- raw-key-value-entries-to-string: identical
- get-default-gql-request: identical
- translate-to-gql-request: identical
- make-gql-request: identical
- is-hopp-rest-request: identical
- make-hopp-rest-response-original-request: identical
- translate-to-new-environment-variables: identical

### Fingerprint before/after
All 10 cluster fingerprints match pre-refactor golden:
- parse-raw-key-value-entries: 5q60n8p
- parse-raw-key-value-entries-e: 148ru0l
- strict-parse-raw-key-value-entries-e: 148ru0l
- raw-key-value-entries-to-string: cc8nijp
- get-default-gql-request: 3a7wv5z
- translate-to-gql-request: 3a7wv5z
- make-gql-request: 49djb8x
- is-hopp-rest-request: 4q562ej
- make-hopp-rest-response-original-request: 10gs08r
- translate-to-new-env-vars: 2f3v4ve

### Chain hash before/after
- gql-request-lifecycle: 3brjq92 (match)
- raw-keyvalue-roundtrip: 3r7k2p1 (match)

### Drift detection
All 10 clusters STABLE across 5 consecutive runs (zero drift).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `hoppscotch-data` to remove duplicated parsing and collection translation logic. No behavior changes; added regression artifacts to prove parity.

- **Refactors**
  - Extracted `formatParserError` and `mapParsedToEntries` in `rawKeyValue.ts` for shared parser logic.
  - Added `translateToNewCollection()` and updated `translateToNewRESTCollection()`/`translateToNewGQLCollection()` to delegate to it.
  - Moved `generateUniqueRefId` to `utils/id.ts` and re-exported from `utils/collection.ts` for compatibility.
  - Added regression snapshots and chains under `packages/hoppscotch-data/regrets` and `proof/` to verify identical outputs.

<sup>Written for commit 67eb7a3bbc89d64503c951c2fb0d4e0b31184f5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

