### PR TITLE
Fix JSONC float serialization preserving trailing decimals

### DIFF
--- a/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/__tests__/jsonc.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+
+import { stripComments } from "../jsonc"
+
+describe("stripComments", () => {
+  it("preserves the original representation of JSON numbers", () => {
+    const input = `{
+      "decimal": 70.0,
+      "negativeZero": -0.0,
+      "exponent": 1.0e+3
+    }`
+
+    expect(stripComments(input)).toBe(
+      '{"decimal":70.0,"negativeZero":-0.0,"exponent":1.0e+3}'
+    )
+  })
+
+  it("still removes comments and trailing commas", () => {
+    const input = `{
+      // Keep the decimal spelling while cleaning JSONC syntax.
+      "value": 70.0,
+    }`
+
+    expect(stripComments(input)).toBe('{"value":70.0}')
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/linting/jsonc.ts
@@ -35,7 +35,7 @@ class InvalidJSONCNodeError extends Error {
  * @throws {InvalidJSONCNodeError} if the node is in an invalid configuration
  * @returns The JSON string without comments and trailing commas
  */
-function convertNodeToJSON(node: Node): string {
+function convertNodeToJSON(node: Node, source: string): string {
   switch (node.type) {
     case "string":
       return JSON.stringify(node.value)
@@ -47,10 +47,12 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `[${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, source))
         .join(",")}]`
     case "number":
-      return JSON.stringify(node.value)
+      // JSON.parse/JSON.stringify normalizes 70.0 to 70. Keep the user's
+      // numeric token so request payloads preserve its original representation.
+      return source.slice(node.offset, node.offset + node.length)
     case "boolean":
       return JSON.stringify(node.value)
     case "object":
@@ -59,7 +61,7 @@ function convertNodeToJSON(node: Node): string {
       }
 
       return `{${node.children
-        .map((child) => convertNodeToJSON(child))
+        .map((child) => convertNodeToJSON(child, source))
         .join(",")}}`
     case "property":
       if (!node.children || node.children.length !== 2) {
@@ -72,7 +74,7 @@ function convertNodeToJSON(node: Node): string {
       // Attempting to JSON.stringify(keyNode) directly would throw
       // "Converting circular structure to JSON" error.
       // If the valueNode configuration is wrong, this will return an error, which will propagate up
-      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(valueNode)}`
+      return `${JSON.stringify(keyNode.value)}:${convertNodeToJSON(valueNode, source)}`
   }
 }
 
@@ -89,7 +91,7 @@ function stripCommentsAndCommas(text: string): string {
 
   // convertNodeToJSON can throw an error if the tree is invalid
   try {
-    return convertNodeToJSON(tree)
+    return convertNodeToJSON(tree, text)
   } catch (_) {
     return text
   }


### PR DESCRIPTION
## Summary

This PR fixes an issue where JSONC numeric literals such as `70.0` were serialized as `70`, causing loss of the original representation.

## Changes

- Preserve original numeric token representation during JSONC serialization.
- Added regression tests covering:
  - Decimal values
  - Negative zero
  - Exponent notation
  - Comments
  - Trailing commas

## Testing

- Reproduced the original issue.
- Verified that `70.0` remains `70.0` after serialization.
- Added regression tests to prevent future regressions.

Closes #6317

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves original number formatting in JSONC serialization so values like 70.0, -0.0, and 1.0e+3 are kept as written while comments and trailing commas are removed. This prevents unintended numeric normalization in request payloads.

- **Bug Fixes**
  - `stripComments` now returns the original numeric token from the source, keeping decimals, exponents, and -0.0 intact.
  - Added regression tests for decimals, negative zero, exponent notation, and JSONC cleanup.

<sup>Written for commit 1e3a8b4a83c5e5c6fcb0e0a6f1d9a6bf62a534a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

