### PR TITLE
fix: add CORS hint to browser interceptor network error message

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -672,7 +672,8 @@
   "error": {
     "network": {
       "heading": "Network Error",
-      "description": "Network connection failed. {message}: {cause}"
+      "description": "Network connection failed. {message}: {cause}",
+      "browser_cors_hint": "This is often caused by CORS (Cross-Origin Resource Sharing) restrictions. Install the Hoppscotch browser extension to send requests without CORS limitations."
     },
     "timeout": {
       "heading": "Timeout Error",

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/browser/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/browser/index.ts
@@ -88,10 +88,13 @@ export class BrowserKernelInterceptorService
               description: (t: ReturnType<typeof getI18n>) => {
                 switch (error.kind) {
                   case "network":
-                    return t("error.network.description", {
-                      message: error.message,
-                      cause: error.cause ?? t("error.unknown.cause"),
-                    })
+                    return [
+                      t("error.network.description", {
+                        message: error.message,
+                        cause: error.cause ?? t("error.unknown.cause"),
+                      }),
+                      t("error.network.browser_cors_hint"),
+                    ].join(" ")
                   case "timeout":
                     return t("error.timeout.description", {
                       message: error.message,


### PR DESCRIPTION
## What

When a request fails in browser interceptor mode, the error message now includes a hint that CORS restrictions may be the cause and suggests installing the browser extension.

## Why

Browsers intentionally hide CORS failure details from JavaScript — a CORS block and a real network failure both surface as a generic `Failed to fetch`. First-time users have no way to tell the difference and often don't know the browser extension exists. The added hint closes that gap.

## Changes

- `locales/en.json` — new locale key for the CORS hint message
- `kernel-interceptors/browser/index.ts` — append CORS hint to network error description

Closes #1376

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CORS hint to network errors in the browser interceptor and suggests installing the Hoppscotch browser extension. Helps users distinguish CORS blocks from real network failures that both show as "Failed to fetch".

<sup>Written for commit 0986a8e0019a5e1813143d9f69768536b8c72732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

