### PR TITLE
fix: preserve asterisk (*) in URL query params during cURL import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1028,6 +1028,38 @@ data2: {"type":"test2","typeId":"123"}`,
       responses: {},
     }),
   },
+  {
+    command: `curl 'https://api.example.com/search?q=test*&wildcard=*value*'`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://api.example.com/search",
+      auth: { authType: "inherit", authActive: true },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      params: [
+        {
+          active: true,
+          key: "q",
+          value: "test*",
+          description: "",
+        },
+        {
+          active: true,
+          key: "wildcard",
+          value: "*value*",
+          description: "",
+        },
+      ],
+      headers: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
@@ -53,7 +53,7 @@ const parseURL = (urlText: string | number) =>
       u
         .toString()
         .replace(/^'|'$/g, "")
-        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>\s]/g, "")
+        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>*\s]/g, "")
     ),
     O.filter((u) => u.length > 0),
     O.chain((u) =>


### PR DESCRIPTION
## What

Query parameter values containing `*` (or URL-encoded `%2A`) were silently dropped when importing cURL commands.

## Why

The URL preprocessing regex used a character whitelist that did not include `*`. Any character outside the whitelist was stripped, so `?q=foo*bar` would import as `?q=foobar`.

## Changes

- `sub_helpers/url.ts` — add `*` to the URL preprocessing regex whitelist
- `curlparser.spec.js` — test cases covering bare `*` and `%2A` in query param values

Fixes #6249

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cURL import dropping asterisks in query params. We now preserve `*` (and `%2A`) so queries like `?q=foo*bar` import correctly. Fixes #6249.

- **Bug Fixes**
  - Whitelisted `*` in the URL preprocessing regex in `sub_helpers/url.ts`.
  - Added tests for `*` and `%2A` in query param values in `curlparser.spec.js`.

<sup>Written for commit c1ff3a76240c044adf33fbe9bcd28511fc5a3564. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

