### PR TITLE
fix(common): handle non-string values in Postman collection import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/postman-import.spec.ts
@@ -1,0 +1,60 @@
+import * as E from "fp-ts/Either"
+import { describe, expect, it } from "vitest"
+
+import { hoppPostmanImporter } from "../import-export/import/postman"
+
+const postmanCollectionWithArrayHeader = JSON.stringify({
+  info: {
+    name: "Array Header Import",
+    schema:
+      "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+  },
+  item: [
+    {
+      name: "Import Array Header",
+      request: {
+        method: "GET",
+        header: [
+          {
+            key: "Authorization",
+            value: ["Basic xxxxx", "Basic xxxxxxxxxxxx="],
+          },
+          {
+            key: "Content-Type",
+            value: "application/x-www-form-urlencoded",
+          },
+        ],
+        url: "https://echo.hoppscotch.io/get",
+      },
+    },
+  ],
+})
+
+describe("Postman importer", () => {
+  it("coerces array header values instead of crashing during import", async () => {
+    const result = await hoppPostmanImporter([
+      postmanCollectionWithArrayHeader,
+    ])()
+
+    expect(E.isRight(result)).toBe(true)
+
+    if (E.isLeft(result)) {
+      throw new Error("Expected Postman import to succeed")
+    }
+
+    expect(result.right[0].requests[0].headers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "Authorization",
+          value: "Basic xxxxx,Basic xxxxxxxxxxxx=",
+          active: true,
+        }),
+        expect.objectContaining({
+          key: "Content-Type",
+          value: "application/x-www-form-urlencoded",
+          active: true,
+        }),
+      ])
+    )
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -63,10 +63,10 @@ const getCollectionSchema = (jsonStr: string): string | null => {
   }
 }
 
-export const replacePMVarTemplating = flow(
-  S.replace(/{{\s*/g, "<<"),
-  S.replace(/\s*}}/g, ">>")
-)
+export const replacePMVarTemplating = (value: unknown): string => {
+  const str = typeof value === "string" ? value : String(value ?? "")
+  return pipe(str, S.replace(/{{\s*/g, "<<"), S.replace(/\s*}}/g, ">>"))
+}
 
 const PMRawLanguageOptionsToContentTypeMap: Record<
   PMRawLanguage,


### PR DESCRIPTION
## What

Importing a Postman collection where headers, query params, or variables contain non-string values (numbers, arrays, objects) crashed with a `TypeError`.

## Why

`replacePMVarTemplating` pipes values through `fp-ts S.replace`, which calls `.replace()` on its input. Postman's spec allows non-string field values, so `.replace()` throws when it receives a number or array.

## Changes

- `import/postman.ts` — coerce values to string before passing to `replacePMVarTemplating`; `null`/`undefined` fall back to an empty string

Closes #5755

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when importing Postman collections with non-string header/query/variable values. Values are now safely stringified before templating, so arrays, numbers, and objects import without errors.

- **Bug Fixes**
  - Stringify input in `replacePMVarTemplating`; `null`/`undefined` become an empty string.
  - Add test covering array header values (imported as comma-separated strings).

<sup>Written for commit 48578df6cae3cd49dbd414076b7e42750f3a1b8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

