### PR TITLE
fix: preserve header value when it contains colon-space in cURL import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -845,6 +845,39 @@ const samples = [
     }),
   },
   {
+    // Regression: headers whose value contains ": " were silently dropped
+    // because the parser split on every occurrence of ": " instead of only
+    // the first one (see RFC 9110 §5.1).
+    command: `curl https://api.example.com -H "X-Note: hello: world" -H "X-Simple: value"`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://api.example.com/",
+      auth: { authType: "inherit", authActive: true },
+      body: { contentType: null, body: null },
+      params: [],
+      headers: [
+        {
+          active: true,
+          key: "X-Note",
+          value: "hello: world",
+          description: "",
+        },
+        {
+          active: true,
+          key: "X-Simple",
+          value: "value",
+          description: "",
+        },
+      ],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+      description: null,
+    }),
+  },
+  {
     command: `curl google.com -u userx`,
     response: makeRESTRequest({
       method: "GET",

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -2,7 +2,6 @@ import { HoppRESTHeader } from "@hoppscotch/data"
 import * as A from "fp-ts/Array"
 import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
 import parser from "yargs-parser"
 import {
   objHasArrayProperty,
@@ -10,13 +9,26 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
-const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
-)
+const getHeaderPair = (header: string): O.Option<[string, string]> => {
+  // Normalize headers that omit the space after the colon (e.g. "X-Foo:bar" → "X-Foo: bar")
+  // before looking for the separator. Only add a space when none follows the colon.
+  const normalized = /^[^:]+:(?! )/.test(header)
+    ? header.replace(":", ": ")
+    : header
+
+  // Per RFC 9110 §5.1, the field name is everything before the FIRST colon and
+  // the field value is everything after. Splitting on the first ": " preserves
+  // colons that appear inside the value (e.g. "X-Note: hello: world").
+  const separatorIndex = normalized.indexOf(": ")
+  if (separatorIndex === -1) return O.none
+
+  const key = normalized.slice(0, separatorIndex).trim()
+  const value = normalized.slice(separatorIndex + 2).trim()
+
+  if (!key) return O.none
+
+  return O.some([key, value] as [string, string])
+}
 
 export function getHeaders(parsedArguments: parser.Arguments) {
   let headers: Record<string, string> = {}


### PR DESCRIPTION
If a header value contains `": "` — like `X-Note: hello: world` — it gets silently dropped on import. `getHeaderPair` was using `S.split(": ")` which splits on every occurrence, producing an array of length 3 instead of 2, so the guard discards it.

RFC 9110 says the field name is everything before the first colon, and the value is everything after. Fixed by using `indexOf` to find only the first separator and slicing from there.

Closes #6400