### PR TITLE
feat(common): support custom OAuth2 redirect URLs

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -239,6 +239,7 @@
       "label_code_challenge_method": "Code Challenge Method",
       "label_code_verifier": "Code Verifier",
       "label_scopes": "Scopes",
+      "label_redirect_uri": "Redirect URI",
       "label_token_endpoint": "Token Endpoint",
       "label_use_pkce": "Use PKCE",
       "label_implicit": "Implicit",

--- a/packages/hoppscotch-common/src/components/http/authorization/OAuth2.vue
+++ b/packages/hoppscotch-common/src/components/http/authorization/OAuth2.vue
@@ -591,6 +591,7 @@ const getPlaceholderForField = (fieldId: string): string => {
     clientId: "your_client_id_here",
     clientSecret: "your_client_secret_here",
     scopes: "read write",
+    redirectURI: "https://example.com/oauth/callback",
     username: "your_username",
     password: "your_password",
   }
@@ -807,6 +808,16 @@ const generateOAuthToken = async () => {
       const errorMessages = {
         VALIDATION_FAILED: t("authorization.oauth.validation_failed"),
         OAUTH_TOKEN_FETCH_FAILED: t("authorization.oauth.token_fetch_failed"),
+        AUTH_SERVER_RETURNED_ERROR: t(
+          "authorization.oauth.redirect_auth_server_returned_error"
+        ),
+        AUTH_TOKEN_REQUEST_FAILED: t(
+          "authorization.oauth.redirect_auth_token_request_failed"
+        ),
+        AUTH_TOKEN_REQUEST_INVALID_RESPONSE: t(
+          "authorization.oauth.redirect_auth_token_request_invalid_response"
+        ),
+        INVALID_STATE: t("authorization.oauth.redirect_invalid_state"),
       }
       if (res.left in errorMessages) {
         // @ts-expect-error - not possible to have a key that doesn't exist

--- a/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
+++ b/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
@@ -27,6 +27,7 @@ import passwordFlow, {
   getDefaultPasswordFlowParams,
 } from "~/services/oauth/flows/password"
 import { AuthRequestParam, TokenRequestParam } from "./useOAuth2AdvancedParams"
+import { platform } from "~/platform"
 
 export type GrantTypes = z.infer<
   typeof HoppRESTAuthOAuth2
@@ -46,6 +47,7 @@ export const useOAuth2GrantTypes = (
 ) => {
   const t = useI18n()
   const toast = useToast()
+  const supportsDesktopOAuth2Flow = !!platform.auth.oauth2
 
   // Helper function to prepare request parameters
   const prepareRequestParams = (
@@ -160,6 +162,20 @@ export const useOAuth2GrantTypes = (
           }
         )
 
+        const redirectURI = refWithCallbackOnChange(
+          grantType?.redirectURI,
+          (value) => {
+            if (auth.value.grantTypeInfo.grantType !== "AUTHORIZATION_CODE") {
+              return
+            }
+
+            auth.value.grantTypeInfo = {
+              ...auth.value.grantTypeInfo,
+              redirectURI: value,
+            }
+          }
+        )
+
         const isPKCE = refWithCallbackOnChange(
           auth.value.grantTypeInfo.isPKCE,
           (value) => {
@@ -259,6 +275,7 @@ export const useOAuth2GrantTypes = (
             clientID: clientID.value,
             clientSecret: clientSecret.value,
             scopes: scopes.value,
+            redirectURI: redirectURI.value,
             isPKCE: isPKCE.value,
             // Ensure older collections without `codeVerifierMethod` get a default
             // so schema validation does not fail. Default to 'plain' when PKCE
@@ -283,6 +300,15 @@ export const useOAuth2GrantTypes = (
 
           if (E.isLeft(res)) {
             return res
+          }
+
+          if (res.right?.access_token) {
+            setAccessTokenInActiveContext(
+              res.right.access_token,
+              res.right.refresh_token
+            )
+
+            toast.success(t("authorization.oauth.token_fetched_successfully"))
           }
 
           return E.right(undefined)
@@ -358,6 +384,16 @@ export const useOAuth2GrantTypes = (
               type: "text" as const,
               ref: scopes,
             },
+            ...(supportsDesktopOAuth2Flow
+              ? [
+                  {
+                    id: "redirectURI",
+                    label: t("authorization.oauth.label_redirect_uri"),
+                    type: "text" as const,
+                    ref: redirectURI,
+                  },
+                ]
+              : []),
           ]
         })
 
@@ -727,12 +763,29 @@ export const useOAuth2GrantTypes = (
           }
         )
 
-        const runAction = () => {
+        const redirectURI = refWithCallbackOnChange(
+          "redirectURI" in grantTypeInfo
+            ? grantTypeInfo.redirectURI
+            : undefined,
+          (value) => {
+            if (auth.value.grantTypeInfo.grantType !== "IMPLICIT") {
+              return
+            }
+
+            auth.value.grantTypeInfo = {
+              ...auth.value.grantTypeInfo,
+              redirectURI: value,
+            }
+          }
+        )
+
+        const runAction = async () => {
           const values: ImplicitOauthFlowParams =
             replaceTemplateStringsInObjectValues({
               authEndpoint: authEndpoint.value,
               clientID: clientID.value,
               scopes: scopes.value,
+              redirectURI: redirectURI.value,
               authRequestParams: preparedAuthRequestParams.value,
               refreshRequestParams: preparedRefreshRequestParams.value,
             })
@@ -745,7 +798,17 @@ export const useOAuth2GrantTypes = (
             return E.left("VALIDATION_FAILED" as const)
           }
 
-          implicit.init(parsedArgs.data)
+          const res = await implicit.init(parsedArgs.data)
+
+          if (E.isLeft(res)) {
+            return res
+          }
+
+          if (res.right?.access_token) {
+            setAccessTokenInActiveContext(res.right.access_token)
+
+            toast.success(t("authorization.oauth.token_fetched_successfully"))
+          }
 
           return E.right(undefined)
         }
@@ -770,6 +833,16 @@ export const useOAuth2GrantTypes = (
               type: "text" as const,
               ref: scopes,
             },
+            ...(supportsDesktopOAuth2Flow
+              ? [
+                  {
+                    id: "redirectURI",
+                    label: t("authorization.oauth.label_redirect_uri"),
+                    type: "text" as const,
+                    ref: redirectURI,
+                  },
+                ]
+              : []),
           ]
         })
 

--- a/packages/hoppscotch-common/src/platform/auth.ts
+++ b/packages/hoppscotch-common/src/platform/auth.ts
@@ -288,4 +288,12 @@ export type AuthPlatformDef = {
    * @returns True if tokens were refreshed successfully, false otherwise
    */
   refreshAuthToken?: () => Promise<boolean>
+
+  /**
+   * Desktop-only OAuth2 request auth bridge. Web platforms leave this undefined
+   * and continue using the in-app `/oauth` route.
+   */
+  oauth2?: {
+    startFlow: (authUrl: string, redirectURI: string) => Promise<string>
+  }
 }

--- a/packages/hoppscotch-common/src/services/oauth/__tests__/oauth.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/oauth/__tests__/oauth.service.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { getOAuthRedirectURI } from "../redirect"
+
+describe("getOAuthRedirectURI", () => {
+  it("returns the default /oauth redirect URI when no custom URI is set", () => {
+    expect(getOAuthRedirectURI()).toBe(`${window.location.origin}/oauth`)
+  })
+
+  it("returns the custom redirect URI when one is set", () => {
+    expect(
+      getOAuthRedirectURI({
+        redirectURI: "https://example.com/oauth/callback",
+      })
+    ).toBe("https://example.com/oauth/callback")
+  })
+
+  it("falls back to the default /oauth redirect URI for a blank custom URI", () => {
+    expect(getOAuthRedirectURI({ redirectURI: "   " })).toBe(
+      `${window.location.origin}/oauth`
+    )
+  })
+})

--- a/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
@@ -1,10 +1,11 @@
 import { PersistenceService } from "~/services/persistence"
 import {
-  OauthAuthService,
   PersistedOAuthConfig,
   createFlowConfig,
   decodeResponseAsJSON,
   generateRandomString,
+  getOAuthRedirectURI,
+  startOAuthFlow,
 } from "../oauth.service"
 import { z } from "zod"
 import { getService } from "~/modules/dioc"
@@ -67,6 +68,7 @@ export const getDefaultAuthCodeOauthFlowParams =
     clientID: "",
     clientSecret: "",
     scopes: undefined,
+    redirectURI: getOAuthRedirectURI(),
     isPKCE: false,
     codeVerifierMethod: "S256",
     authRequestParams: [],
@@ -80,6 +82,7 @@ const initAuthCodeOauthFlow = async ({
   clientSecret,
   scopes,
   authEndpoint,
+  redirectURI: customRedirectURI,
   isPKCE,
   codeVerifierMethod,
   authRequestParams,
@@ -87,6 +90,7 @@ const initAuthCodeOauthFlow = async ({
   tokenRequestParams,
 }: AuthCodeOauthFlowParams) => {
   const state = generateRandomString()
+  const redirectURI = getOAuthRedirectURI({ redirectURI: customRedirectURI })
 
   let codeVerifier: string | undefined
   let codeChallenge: string | undefined
@@ -118,6 +122,7 @@ const initAuthCodeOauthFlow = async ({
     codeVerifier?: string
     codeVerifierMethod?: string
     codeChallenge?: string
+    redirectURI: string
     scopes?: string
     authRequestParams?: Array<{
       key: string
@@ -144,6 +149,7 @@ const initAuthCodeOauthFlow = async ({
     tokenEndpoint,
     clientSecret,
     clientID,
+    redirectURI,
     isPKCE,
     // Persist the normalized method so subsequent redirect handling has a value
     codeVerifierMethod: codeVerifierMethodNormalized,
@@ -192,7 +198,7 @@ const initAuthCodeOauthFlow = async ({
   url.searchParams.set("client_id", clientID)
   url.searchParams.set("state", state)
   url.searchParams.set("response_type", "code")
-  url.searchParams.set("redirect_uri", OauthAuthService.redirectURI)
+  url.searchParams.set("redirect_uri", redirectURI)
 
   if (scopes) url.searchParams.set("scope", scopes)
 
@@ -209,15 +215,38 @@ const initAuthCodeOauthFlow = async ({
     })
   }
 
-  // Redirect to the authorization server
-  window.location.assign(url.toString())
+  const callbackURL = await startOAuthFlow(url.toString(), redirectURI)
+
+  if (callbackURL) {
+    const updatedLocalOAuthTempConfig =
+      await persistenceService.getLocalConfig("oauth_temp_config")
+
+    if (!updatedLocalOAuthTempConfig) {
+      return E.left("INVALID_LOCAL_CONFIG")
+    }
+
+    const result = await handleRedirectForAuthCodeOauthFlow(
+      updatedLocalOAuthTempConfig,
+      callbackURL
+    )
+
+    if (E.isRight(result)) {
+      await persistenceService.removeLocalConfig("oauth_temp_config")
+    }
+
+    return result
+  }
 
   return E.right(undefined)
 }
 
-const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
+const handleRedirectForAuthCodeOauthFlow = async (
+  localConfig: string,
+  callbackURL?: string
+) => {
   // parse the query string
-  const params = new URLSearchParams(window.location.search)
+  const callback = callbackURL ? new URL(callbackURL) : window.location
+  const params = new URLSearchParams(callback.search)
 
   const code = params.get("code")
   const state = params.get("state")
@@ -239,6 +268,7 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
     clientID: z.string(),
     codeVerifier: z.string().optional(),
     codeChallenge: z.string().optional(),
+    redirectURI: z.string().optional(),
   })
 
   const decodedLocalConfig = expectedSchema.safeParse(
@@ -269,7 +299,9 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
       grant_type: "authorization_code",
       client_id: decodedLocalConfig.data.clientID,
       client_secret: decodedLocalConfig.data.clientSecret,
-      redirect_uri: OauthAuthService.redirectURI,
+      redirect_uri: getOAuthRedirectURI({
+        redirectURI: decodedLocalConfig.data.redirectURI,
+      }),
       ...(decodedLocalConfig.data.codeVerifier && {
         code_verifier: decodedLocalConfig.data.codeVerifier,
       }),
@@ -292,7 +324,7 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
     .object({
       access_token: z.string().optional(),
       id_token: z.string().optional(),
-      refresh_token: z.string().optional(),
+      refresh_token: z.string().nullable().optional(),
     })
     .refine((data) => data.access_token || data.id_token, {
       message: "Either access_token or id_token must be present",
@@ -311,7 +343,7 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
       parsedTokenResponse.data.access_token ||
       parsedTokenResponse.data.id_token ||
       "",
-    refresh_token: parsedTokenResponse.data.refresh_token,
+    refresh_token: parsedTokenResponse.data.refresh_token ?? undefined,
   })
 }
 

--- a/packages/hoppscotch-common/src/services/oauth/flows/implicit.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/implicit.ts
@@ -1,9 +1,10 @@
 import { PersistenceService } from "~/services/persistence"
 import {
-  OauthAuthService,
   PersistedOAuthConfig,
   createFlowConfig,
   generateRandomString,
+  getOAuthRedirectURI,
+  startOAuthFlow,
 } from "../oauth.service"
 import { z } from "zod"
 import { getService } from "~/modules/dioc"
@@ -43,6 +44,7 @@ export const getDefaultImplicitOauthFlowParams =
     authEndpoint: "",
     clientID: "",
     scopes: undefined,
+    redirectURI: getOAuthRedirectURI(),
     authRequestParams: [],
     refreshRequestParams: [],
   })
@@ -51,9 +53,11 @@ const initImplicitOauthFlow = async ({
   clientID,
   scopes,
   authEndpoint,
+  redirectURI: customRedirectURI,
   authRequestParams,
 }: ImplicitOauthFlowParams) => {
   const state = generateRandomString()
+  const redirectURI = getOAuthRedirectURI({ redirectURI: customRedirectURI })
 
   const localOAuthTempConfig =
     await persistenceService.getLocalConfig("oauth_temp_config")
@@ -72,6 +76,7 @@ const initImplicitOauthFlow = async ({
         authEndpoint,
         scopes,
         state,
+        redirectURI,
         authRequestParams,
       },
       grant_type: "IMPLICIT",
@@ -89,7 +94,7 @@ const initImplicitOauthFlow = async ({
   url.searchParams.set("client_id", clientID)
   url.searchParams.set("state", state)
   url.searchParams.set("response_type", "token")
-  url.searchParams.set("redirect_uri", OauthAuthService.redirectURI)
+  url.searchParams.set("redirect_uri", redirectURI)
 
   if (scopes) url.searchParams.set("scope", scopes)
 
@@ -102,16 +107,39 @@ const initImplicitOauthFlow = async ({
       })
   }
 
-  // Redirect to the authorization server
-  window.location.assign(url.toString())
+  const callbackURL = await startOAuthFlow(url.toString(), redirectURI)
+
+  if (callbackURL) {
+    const updatedLocalOAuthTempConfig =
+      await persistenceService.getLocalConfig("oauth_temp_config")
+
+    if (!updatedLocalOAuthTempConfig) {
+      return E.left("INVALID_LOCAL_CONFIG")
+    }
+
+    const result = await handleRedirectForAuthCodeOauthFlow(
+      updatedLocalOAuthTempConfig,
+      callbackURL
+    )
+
+    if (E.isRight(result)) {
+      await persistenceService.removeLocalConfig("oauth_temp_config")
+    }
+
+    return result
+  }
 
   return E.right(undefined)
 }
 
-const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
+const handleRedirectForAuthCodeOauthFlow = async (
+  localConfig: string,
+  callbackURL?: string
+) => {
   // parse the query string
-  const params = new URLSearchParams(window.location.search)
-  const paramsFromHash = new URLSearchParams(window.location.hash.substring(1))
+  const callback = callbackURL ? new URL(callbackURL) : window.location
+  const params = new URLSearchParams(callback.search)
+  const paramsFromHash = new URLSearchParams(callback.hash.substring(1))
 
   const accessToken =
     params.get("access_token") || paramsFromHash.get("access_token")

--- a/packages/hoppscotch-common/src/services/oauth/oauth.service.ts
+++ b/packages/hoppscotch-common/src/services/oauth/oauth.service.ts
@@ -11,6 +11,10 @@ import { HoppCollection } from "@hoppscotch/data"
 import { TeamCollection } from "~/helpers/backend/graphql"
 import { parseBytesToJSON } from "~/helpers/functional/json"
 import { MediaType } from "@hoppscotch/kernel"
+import { platform } from "~/platform"
+import { getDefaultOAuthRedirectURI } from "./redirect"
+
+export { getOAuthRedirectURI } from "./redirect"
 
 const persistenceService = getService(PersistenceService)
 
@@ -33,7 +37,19 @@ export type PersistedOAuthConfig = {
 
 export const grantTypesInvolvingRedirect = ["AUTHORIZATION_CODE", "IMPLICIT"]
 
-export const routeOAuthRedirect = async () => {
+export const startOAuthFlow = async (
+  authUrl: string,
+  redirectURI: string
+): Promise<string | undefined> => {
+  if (platform.auth.oauth2?.startFlow) {
+    return platform.auth.oauth2.startFlow(authUrl, redirectURI)
+  }
+
+  window.location.assign(authUrl)
+  return undefined
+}
+
+export const routeOAuthRedirect = async (callbackURL?: string) => {
   // get the temp data from the local storage
   const localOAuthTempConfig =
     await persistenceService.getLocalConfig("oauth_temp_config")
@@ -64,7 +80,7 @@ export const routeOAuthRedirect = async () => {
     return E.left("INVALID_STATE")
   }
 
-  return flowConfig?.onRedirectReceived(localOAuthTempConfig)
+  return flowConfig?.onRedirectReceived(localOAuthTempConfig, callbackURL)
 }
 
 export function createFlowConfig<
@@ -78,11 +94,12 @@ export function createFlowConfig<
   init: (
     params: AuthParams
   ) =>
-    | E.Either<string, InitFuncReturnObject>
-    | Promise<E.Either<string, InitFuncReturnObject>>
-    | E.Either<string, undefined>
-    | Promise<E.Either<string, undefined>>,
-  onRedirectReceived: (localConfig: string) => Promise<
+    | E.Either<string, InitFuncReturnObject | undefined>
+    | Promise<E.Either<string, InitFuncReturnObject | undefined>>,
+  onRedirectReceived: (
+    localConfig: string,
+    callbackURL?: string
+  ) => Promise<
     E.Either<
       string,
       {
@@ -121,7 +138,9 @@ export const decodeResponseAsJSON = (response: {
 export class OauthAuthService extends Service {
   public static readonly ID = "OAUTH_AUTH_SERVICE"
 
-  static redirectURI = `${window.location.origin}/oauth`
+  static get redirectURI() {
+    return getDefaultOAuthRedirectURI()
+  }
 }
 
 export const generateRandomString = () => {

--- a/packages/hoppscotch-common/src/services/oauth/redirect.ts
+++ b/packages/hoppscotch-common/src/services/oauth/redirect.ts
@@ -1,0 +1,5 @@
+export const getDefaultOAuthRedirectURI = () =>
+  `${window.location.origin}/oauth`
+
+export const getOAuthRedirectURI = (flowConfig?: { redirectURI?: string }) =>
+  flowConfig?.redirectURI?.trim() || getDefaultOAuthRedirectURI()

--- a/packages/hoppscotch-common/src/types/post-request.d.ts
+++ b/packages/hoppscotch-common/src/types/post-request.d.ts
@@ -121,6 +121,7 @@ type OAuth2GrantTypeInfo =
       clientID: string
       clientSecret?: string
       scopes?: string
+      redirectURI?: string
       isPKCE?: boolean
       codeVerifierMethod?: "plain" | "S256"
       token?: string
@@ -147,6 +148,7 @@ type OAuth2GrantTypeInfo =
       authEndpoint: string
       clientID: string
       scopes?: string
+      redirectURI?: string
     }
 interface HoppRESTAuthAWSSignature {
   authType: "aws-signature"

--- a/packages/hoppscotch-common/src/types/pre-request.d.ts
+++ b/packages/hoppscotch-common/src/types/pre-request.d.ts
@@ -109,6 +109,7 @@ type OAuth2GrantTypeInfo =
       clientID: string
       clientSecret?: string
       scopes?: string
+      redirectURI?: string
       isPKCE?: boolean
       codeVerifierMethod?: "plain" | "S256"
       token?: string
@@ -135,6 +136,7 @@ type OAuth2GrantTypeInfo =
       authEndpoint: string
       clientID: string
       scopes?: string
+      redirectURI?: string
     }
 
 interface HoppRESTAuthOAuth2 {

--- a/packages/hoppscotch-data/src/rest/v/15/auth.ts
+++ b/packages/hoppscotch-data/src/rest/v/15/auth.ts
@@ -34,6 +34,7 @@ export const OAuth2AdvancedParam = z.object({
 export const OAuth2AuthRequestParam = OAuth2AdvancedParam.omit({ sendIn: true })
 
 export const AuthCodeGrantTypeParams = AuthCodeGrantTypeParamsOld.extend({
+  redirectURI: z.string().optional(),
   authRequestParams: z.array(OAuth2AuthRequestParam).optional().default([]),
   tokenRequestParams: z.array(OAuth2AdvancedParam).optional().default([]),
   refreshRequestParams: z.array(OAuth2AdvancedParam).optional().default([]),
@@ -51,6 +52,7 @@ export const PasswordGrantTypeParams = PasswordGrantTypeParamsOld.extend({
 })
 
 export const ImplicitOauthFlowParams = ImplicitOauthFlowParamsOld.extend({
+  redirectURI: z.string().optional(),
   authRequestParams: z.array(OAuth2AuthRequestParam).optional().default([]),
   refreshRequestParams: z.array(OAuth2AdvancedParam).optional().default([]),
 })

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.lock
@@ -2355,6 +2355,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "url",
  "winreg 0.52.0",
 ]
 

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.toml
@@ -43,6 +43,7 @@ native-dialog = { version = "0.7.0" }
 tauri-plugin-http = { version = "2.0.1", features = ["gzip"] }
 tauri-plugin-opener = "2"
 semver = "1.0"
+url = "2.5"
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/packages/hoppscotch-desktop/src-tauri/src/lib.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/lib.rs
@@ -11,9 +11,10 @@ pub mod webview;
 
 use std::sync::OnceLock;
 
-use tauri::Emitter;
+use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_window_state::StateFlags;
+use url::Url;
 
 use random_port::{PortPicker, Protocol};
 
@@ -33,6 +34,87 @@ fn hopp_auth_port() -> u16 {
         .get()
         .copied()
         .expect("Server port not initialized")
+}
+
+fn oauth_redirect_url_matches(candidate_url: &str, redirect_uri: &str) -> bool {
+    let Ok(candidate) = Url::parse(candidate_url) else {
+        return false;
+    };
+    let Ok(redirect) = Url::parse(redirect_uri) else {
+        return false;
+    };
+
+    if candidate.scheme() != redirect.scheme()
+        || candidate.username() != redirect.username()
+        || candidate.password() != redirect.password()
+        || candidate.host_str() != redirect.host_str()
+        || candidate.port_or_known_default() != redirect.port_or_known_default()
+        || candidate.path() != redirect.path()
+    {
+        return false;
+    }
+
+    if let Some(redirect_fragment) = redirect.fragment() {
+        if candidate.fragment() != Some(redirect_fragment) {
+            return false;
+        }
+    }
+
+    redirect
+        .query_pairs()
+        .all(|(redirect_key, redirect_value)| {
+            candidate
+                .query_pairs()
+                .any(|(candidate_key, candidate_value)| {
+                    candidate_key == redirect_key && candidate_value == redirect_value
+                })
+        })
+}
+
+#[tauri::command]
+async fn start_oauth2_flow(
+    app: tauri::AppHandle,
+    auth_url: String,
+    redirect_uri: String,
+) -> Result<(), String> {
+    let parsed_auth_url = Url::parse(&auth_url).map_err(|_| "Invalid OAuth authorization URL")?;
+    Url::parse(&redirect_uri).map_err(|_| "Invalid OAuth redirect URI")?;
+
+    let _ = app
+        .get_webview_window("oauth2-auth")
+        .map(|window| window.close());
+
+    let app_handle = app.clone();
+    let redirect_uri_for_navigation = redirect_uri.clone();
+
+    WebviewWindowBuilder::new(&app, "oauth2-auth", WebviewUrl::External(parsed_auth_url))
+        .title("OAuth 2.0 Authorization")
+        .inner_size(520.0, 720.0)
+        .on_navigation(move |url| {
+            let url = url.to_string();
+
+            if !oauth_redirect_url_matches(&url, &redirect_uri_for_navigation) {
+                return true;
+            }
+
+            if let Err(e) = app_handle.emit("oauth2-callback-received", url) {
+                tracing::error!(
+                    error.message = %e,
+                    error.type = %std::any::type_name_of_val(&e),
+                    "OAuth2 callback event emission failed"
+                );
+            }
+
+            if let Some(window) = app_handle.get_webview_window("oauth2-auth") {
+                let _ = window.close();
+            }
+
+            false
+        })
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    Ok(())
 }
 
 fn setup_deep_link_handler(app: &tauri::App) -> Result<(), HoppError> {
@@ -246,6 +328,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             is_portable,
             hopp_auth_port,
+            start_oauth2_flow,
             quit_app,
             backup::check_and_backup_on_version_change,
             config::set_desktop_config,
@@ -269,5 +352,50 @@ pub fn run() {
 
     if let Err(e) = app {
         tracing::error!(error = %e, "Error while running Hoppscotch Desktop");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::oauth_redirect_url_matches;
+
+    #[test]
+    fn oauth_redirect_matches_exact_redirect_uri() {
+        assert!(oauth_redirect_url_matches(
+            "https://example.com/oauth/callback?code=abc&state=xyz",
+            "https://example.com/oauth/callback"
+        ));
+    }
+
+    #[test]
+    fn oauth_redirect_matches_redirect_uri_with_query_params() {
+        assert!(oauth_redirect_url_matches(
+            "https://example.com/oauth/callback?tenant=dev&code=abc&state=xyz",
+            "https://example.com/oauth/callback?tenant=dev"
+        ));
+    }
+
+    #[test]
+    fn oauth_redirect_matches_implicit_callback_hash() {
+        assert!(oauth_redirect_url_matches(
+            "https://example.com/oauth/callback#access_token=abc&state=xyz",
+            "https://example.com/oauth/callback"
+        ));
+    }
+
+    #[test]
+    fn oauth_redirect_rejects_unrelated_url() {
+        assert!(!oauth_redirect_url_matches(
+            "https://example.net/oauth/callback?code=abc&state=xyz",
+            "https://example.com/oauth/callback"
+        ));
+    }
+
+    #[test]
+    fn oauth_redirect_rejects_missing_configured_query_param() {
+        assert!(!oauth_redirect_url_matches(
+            "https://example.com/oauth/callback?code=abc&state=xyz",
+            "https://example.com/oauth/callback?tenant=dev"
+        ));
     }
 }

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
@@ -6,6 +6,7 @@ import { Ref, ref, watch } from "vue"
 import { content } from "@hoppscotch/kernel"
 
 import { Io } from "@hoppscotch/common/kernel/io"
+import { invoke } from "@tauri-apps/api/core"
 import { listen } from "@tauri-apps/api/event"
 import { getService } from "@hoppscotch/common/modules/dioc"
 import { parseBodyAsJSON } from "@hoppscotch/common/helpers/functional/json"
@@ -524,6 +525,36 @@ export const def: AuthPlatformDef = {
   async refreshAuthToken() {
     const refreshed = await refreshToken()
     return refreshed
+  },
+
+  oauth2: {
+    startFlow(authUrl, redirectURI) {
+      return new Promise<string>((resolve, reject) => {
+        let unlisten: (() => void) | undefined
+
+        const openOAuthWindow = async () => {
+          try {
+            unlisten = await listen<string>(
+              "oauth2-callback-received",
+              (event) => {
+                unlisten?.()
+                resolve(event.payload)
+              }
+            )
+
+            await invoke("start_oauth2_flow", {
+              authUrl,
+              redirectUri: redirectURI,
+            })
+          } catch (error) {
+            unlisten?.()
+            reject(error)
+          }
+        }
+
+        void openOAuthWindow()
+      })
+    },
   },
 
   /**


### PR DESCRIPTION
Closes #5954

This PR adds support for custom OAuth2 redirect URLs in request authorization flows. It keeps the existing `/oauth` redirect behavior for web while allowing the desktop app to complete Authorization Code and Implicit flows through a dedicated OAuth window.

### What's changed

- Added an optional Redirect URI field for OAuth2 Authorization Code and Implicit grants when the platform supports the desktop OAuth2 bridge.
- Added `redirectURI` support to OAuth2 auth schemas and pre-request/post-request typings.
- Updated OAuth2 redirect handling to use a custom redirect URI when provided, while falling back to the existing `{origin}/oauth` redirect.
- Added a desktop OAuth2 bridge that opens the authorization URL in a Tauri webview window and returns the matching callback URL to the shared OAuth flow.
- Added validation for desktop OAuth callback URL matching, including configured query parameters and implicit-flow hash callbacks.
- Added tests for redirect URI fallback/custom handling and desktop callback URL matching.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for custom OAuth2 redirect URLs and a desktop OAuth bridge so Authorization Code and Implicit flows can complete in a dedicated window. Web keeps using the existing `/oauth` route; desktop opens the provider page and returns the callback for token exchange.

- **New Features**
  - Added Redirect URI field for Authorization Code and Implicit (shown only when the desktop OAuth2 bridge is available).
  - OAuth2 schemas/typings now support `redirectURI`; flows use the custom URI or fall back to `{origin}/oauth`.
  - Desktop OAuth2 bridge (Tauri) opens the auth URL and validates the callback URL (path, query params, and hash for implicit) before continuing.
  - Added tests for redirect fallback/custom handling and desktop callback matching.

- **Migration**
  - No changes needed for web; existing redirects continue to `{origin}/oauth`.
  - To use a custom redirect, set the Redirect URI in OAuth2 settings and allow it in your OAuth provider (desktop supported).

<sup>Written for commit d66240f37b97a65a06fcd08a8cfec8926b0be725. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

