### PR TITLE
fix(cli): preserve pre-request-script env mutations on later failures

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/unit/process-request-envs.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/process-request-envs.spec.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test, vi, beforeEach } from "vitest";
+
+// Mock modules before imports - NO external variable references in factory
+// (mirrors the pattern used in hopp-fetch.spec.ts). `axios` needs to be
+// callable directly (used by `requestRunner`) as well as expose `create`/
+// `isAxiosError` (used by `createHoppFetchHook` inside the scripting sandbox).
+vi.mock("axios", () => {
+  const mockAxios: any = vi.fn();
+  mockAxios.create = vi.fn();
+  mockAxios.isAxiosError = vi.fn().mockReturnValue(false);
+  return { default: mockAxios };
+});
+
+vi.mock("axios-cookiejar-support", () => ({
+  wrapper: (instance: any) => instance,
+}));
+
+vi.mock("tough-cookie", () => ({
+  CookieJar: vi.fn(),
+}));
+
+import { makeRESTRequest } from "@hoppscotch/data";
+import axios from "axios";
+
+import { processRequest } from "../../utils/request";
+import { HoppEnvs } from "../../types/request";
+
+const mockAxios = axios as unknown as ReturnType<typeof vi.fn> & {
+  create: ReturnType<typeof vi.fn>;
+};
+
+const SAMPLE_REQUEST = makeRESTRequest({
+  name: "request",
+  method: "GET",
+  endpoint: "https://example.com",
+  params: [],
+  headers: [],
+  preRequestScript: "",
+  testScript: "",
+  auth: { authActive: false, authType: "none" },
+  body: { contentType: null, body: null },
+  requestVariables: [],
+  description: null,
+  responses: {},
+});
+
+describe("processRequest - envs propagation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockAxios.mockResolvedValue({
+      data: {},
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config: { url: "https://example.com", method: "GET" },
+    });
+    mockAxios.create.mockReturnValue(vi.fn());
+  });
+
+  // Regression: a pre-request script's env mutations were discarded from the
+  // value handed back to the collection runner whenever the *test* script
+  // that ran afterwards failed (e.g. a runtime error). `processRequest` only
+  // wrote `result.envs` from the test-runner's success branch, so a failing
+  // test script (or any error after the pre-request step) silently rolled
+  // the visible envs back to their pre-pre-request-script state. Downstream
+  // requests in the same collection run would then never see variables set
+  // by this request, even though the pre-request script itself succeeded.
+  test("propagates pre-request-script env mutations even when the test script errors", async () => {
+    const request = makeRESTRequest({
+      ...SAMPLE_REQUEST,
+      preRequestScript: `pw.env.set("FROM_PRE", "set-by-pre-request");`,
+      testScript: `nonExistentFn();`, // throws a ReferenceError at runtime
+    });
+
+    const envs: HoppEnvs = { global: [], selected: [] };
+
+    const result = await processRequest({
+      request,
+      envs,
+      path: "fake/path",
+      delay: 0,
+    })();
+
+    expect(result.report.result).toBe(false);
+    expect(
+      result.report.errors.some((e) => e.code === "TEST_SCRIPT_ERROR")
+    ).toBe(true);
+
+    const fromPre = result.envs.selected.find((v) => v.key === "FROM_PRE");
+    expect(fromPre?.currentValue).toBe("set-by-pre-request");
+  });
+
+  test("propagates pre-request-script env mutations even when the request itself errors", async () => {
+    mockAxios.mockRejectedValue(new Error("network down"));
+
+    const request = makeRESTRequest({
+      ...SAMPLE_REQUEST,
+      preRequestScript: `pw.env.set("FROM_PRE", "set-by-pre-request");`,
+    });
+
+    const envs: HoppEnvs = { global: [], selected: [] };
+
+    const result = await processRequest({
+      request,
+      envs,
+      path: "fake/path",
+      delay: 0,
+    })();
+
+    expect(result.report.result).toBe(false);
+
+    const fromPre = result.envs.selected.find((v) => v.key === "FROM_PRE");
+    expect(fromPre?.currentValue).toBe("set-by-pre-request");
+  });
+
+  test("still reflects the test-script's own env mutations when it succeeds", async () => {
+    const request = makeRESTRequest({
+      ...SAMPLE_REQUEST,
+      preRequestScript: `pw.env.set("FROM_PRE", "set-by-pre-request");`,
+      testScript: `pw.env.set("FROM_TEST", "set-by-test-script");`,
+    });
+
+    const envs: HoppEnvs = { global: [], selected: [] };
+
+    const result = await processRequest({
+      request,
+      envs,
+      path: "fake/path",
+      delay: 0,
+    })();
+
+    expect(result.report.result).toBe(true);
+
+    const fromPre = result.envs.selected.find((v) => v.key === "FROM_PRE");
+    const fromTest = result.envs.selected.find((v) => v.key === "FROM_TEST");
+    expect(fromPre?.currentValue).toBe("set-by-pre-request");
+    expect(fromTest?.currentValue).toBe("set-by-test-script");
+  });
+});

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -295,6 +295,18 @@ export const processRequest =
       ({ effectiveRequest, updatedEnvs } = preRequestRes.right);
     }
 
+    // Keep the reported envs in sync with the latest known-good state (post
+    // pre-request-script). Without this, a test-script execution error
+    // (handled below, which leaves `result.envs` untouched) would cause
+    // `processCollection` to carry forward the envs as they were *before*
+    // this request's pre-request script ran, silently discarding any
+    // variables it set/updated. That state is then unavailable to every
+    // subsequent request in the collection, which is exactly the kind of
+    // leak/ordering bug this guards against. The test-runner success branch
+    // below still has the final say, overwriting this with the post-test
+    // envs once that step completes successfully.
+    result.envs = updatedEnvs;
+
     // Creating request-config for request-runner.
     const requestConfig = createRequest(effectiveRequest);
 


### PR DESCRIPTION
## Problem

In the CLI collection runner, `processRequest()` only wrote the envs it
returns (`result.envs`) from the test-runner's **success** branch:

```ts
} else {
  const { envs, testsReport, duration } = testRunnerRes.right;
  ...
  result.envs = envs;   // only assigned here
}
```

`result.envs` was otherwise initialized once, at the top of the function,
to the envs **from before this request's pre-request script ran**. If the
test/post-request script errored (e.g. a thrown `ReferenceError`), or if
the HTTP request itself failed, `result.envs` was never reassigned and
fell back to that stale pre-pre-request-script snapshot.

`processCollection` copies `result.envs` straight into the shared `envs`
object threaded into every subsequent request:

```ts
const { global, selected } = result.envs;
envs.global = global;
envs.selected = selected;
```

So any variable a request's pre-request script set or mutated was
silently discarded for the rest of the collection run the moment that
request's test script (or the HTTP call) failed — even though the script
that set the variable ran successfully. In a collection with multiple
folders/requests relying on shared environment values, this surfaces as
variables "disappearing" for later requests depending on unrelated
failures earlier in the run.

Note: collection-variable inheritance and the pre-request/test script
cascade ordering (root → folder → request for pre-request scripts,
request → folder → root for test scripts) were already correct — this is
specifically an envs-propagation gap on the error path.

## Fix

One line (plus comment) in `processRequest`, right after the pre-request
step resolves:

```ts
result.envs = updatedEnvs;
```

This keeps `result.envs` in sync with the latest known-good state. The
test-runner's existing success-path assignment still has the final say
when it completes normally, so the happy path is byte-for-byte unchanged
— only the previously-undefined error paths (test-script error, request
failure) are now well-defined.

## Testing

Added `packages/hoppscotch-cli/src/__tests__/unit/process-request-envs.spec.ts`
covering:
- pre-request env mutation survives a test-script runtime error
- pre-request env mutation survives an HTTP request failure
- a successful test-script's own mutations still take final precedence

Verified each case flips from failing to passing against the fix (and
that the third case passes both before and after, confirming the happy
path is untouched).

Ran for `hoppscotch-cli`:
- `pnpm exec tsc --noEmit` — clean
- `vitest run` — same pass/fail counts as on `main` plus the 3 new tests
  passing (the one pre-existing failure is an e2e test hitting the live
  `echo.hoppscotch.io`, unrelated to this change)

Also ran repo-wide `pnpm -r do-lint` and `pnpm -r do-typecheck` — both
clean (only pre-existing lint warnings, no errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes env propagation in the CLI collection runner. Pre-request script env changes now persist to later requests even if the test script or HTTP call fails.

- **Bug Fixes**
  - In `processRequest`, set `result.envs = updatedEnvs` right after the pre-request step to keep envs consistent on error paths; success path remains unchanged.
  - Added unit tests in `packages/hoppscotch-cli/src/__tests__/unit/process-request-envs.spec.ts` covering test-script error, request failure, and successful test-script precedence.

<sup>Written for commit dd4b5d96d32f3045a421a49957ff11a8cbc7c02d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

