### PR TITLE
fix(cli): prevent folder array mutation and env loss on test-script failure

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/unit/collections-folder-mutation.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/collections-folder-mutation.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression tests for the folder-array mutation bug in processCollection.
+ *
+ * Root cause (fixed in utils/collections.ts):
+ *   `const updatedFolder = { ...folder }` was a shallow copy, so
+ *   `updatedFolder.headers` and `updatedFolder.variables` pointed at the
+ *   *same* arrays as the original folder.  The subsequent `.push()` calls
+ *   permanently mutated the source collection object.  On a second traversal
+ *   (multi-iteration run, or any re-use of the same collection objects) the
+ *   folder already had the parent's headers/variables pre-appended, causing
+ *   duplicates and wrong-precedence resolution.
+ *
+ * Fix: shallow-copy `headers` and `variables` arrays before pushing.
+ */
+
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { makeCollection } from "@hoppscotch/data";
+
+// vi.hoisted runs before module import hoisting so the variable is available
+// inside vi.mock factory closures.
+const { mockAxiosCallable } = vi.hoisted(() => {
+  const mockAxiosCallable = vi.fn();
+  return { mockAxiosCallable };
+});
+
+// `requestRunner` in utils/request.ts calls `axios(config)` directly, so the
+// default export must be a callable function.  hopp-fetch.ts calls
+// `axios.create()`, so that method must also exist.
+vi.mock("axios", () => ({
+  default: Object.assign(mockAxiosCallable, {
+    create: vi.fn().mockReturnValue(vi.fn()),
+    isAxiosError: vi.fn().mockReturnValue(false),
+  }),
+}));
+
+vi.mock("axios-cookiejar-support", () => ({
+  wrapper: (instance: any) => instance,
+}));
+
+vi.mock("tough-cookie", () => ({
+  CookieJar: vi.fn(),
+}));
+
+import axios, { AxiosResponse } from "axios";
+import { collectionsRunner } from "../../utils/collections";
+import { HoppEnvs } from "../../types/request";
+
+const MOCK_200: AxiosResponse = {
+  data: {},
+  status: 200,
+  statusText: "OK",
+  config: { url: "https://example.com", method: "GET" } as any,
+  headers: {},
+  request: {},
+};
+
+const makeRequest = (name: string, overrides: Record<string, unknown> = {}) => ({
+  v: "1",
+  name,
+  method: "GET",
+  endpoint: "https://example.com",
+  params: [],
+  headers: [],
+  preRequestScript: "",
+  testScript: "",
+  auth: { authActive: false, authType: "none" as const },
+  body: { contentType: null, body: null },
+  requestVariables: [],
+  ...overrides,
+});
+
+const EMPTY_ENVS: HoppEnvs = { global: [], selected: [] };
+
+describe("collectionsRunner – folder mutation regression", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAxiosCallable.mockResolvedValue(MOCK_200);
+    (axios as any).create.mockReturnValue(vi.fn());
+    (axios as any).isAxiosError.mockReturnValue(false);
+  });
+
+  test("folder.headers is not mutated after a single run", async () => {
+    const folder = makeCollection({
+      name: "folder",
+      folders: [],
+      requests: [makeRequest("req") as any],
+      headers: [{ key: "X-Folder", value: "yes", active: true, description: "" }],
+      auth: { authActive: false, authType: "none" },
+      variables: [],
+    });
+
+    const collection = makeCollection({
+      name: "col",
+      folders: [folder],
+      requests: [],
+      headers: [{ key: "X-Parent", value: "parent", active: true, description: "" }],
+      auth: { authActive: false, authType: "none" },
+      variables: [],
+    });
+
+    const originalFolderHeaderCount = folder.headers.length;
+
+    await collectionsRunner({
+      collections: [collection],
+      envs: EMPTY_ENVS,
+    });
+
+    // The folder's header array must remain unchanged
+    expect(folder.headers.length).toBe(originalFolderHeaderCount);
+    expect(folder.headers.some((h) => h.key === "X-Parent")).toBe(false);
+  });
+
+  test("folder.variables is not mutated after a single run", async () => {
+    const folder = makeCollection({
+      name: "folder",
+      folders: [],
+      requests: [makeRequest("req") as any],
+      headers: [],
+      auth: { authActive: false, authType: "none" },
+      variables: [{ key: "folderVar", initialValue: "folder", currentValue: "folder", secret: false }],
+    });
+
+    const collection = makeCollection({
+      name: "col",
+      folders: [folder],
+      requests: [],
+      headers: [],
+      auth: { authActive: false, authType: "none" },
+      variables: [{ key: "parentVar", initialValue: "parent", currentValue: "parent", secret: false }],
+    });
+
+    const originalFolderVariableCount = folder.variables.length;
+
+    await collectionsRunner({
+      collections: [collection],
+      envs: EMPTY_ENVS,
+    });
+
+    expect(folder.variables.length).toBe(originalFolderVariableCount);
+    expect(folder.variables.some((v) => v.key === "parentVar")).toBe(false);
+  });
+
+  test("multi-iteration run produces consistent folder header count across iterations", async () => {
+    const folder = makeCollection({
+      name: "folder",
+      folders: [],
+      requests: [makeRequest("req") as any],
+      headers: [{ key: "X-Folder", value: "yes", active: true, description: "" }],
+      auth: { authActive: false, authType: "none" },
+      variables: [],
+    });
+
+    const collection = makeCollection({
+      name: "col",
+      folders: [folder],
+      requests: [],
+      headers: [
+        { key: "X-Parent-1", value: "a", active: true, description: "" },
+        { key: "X-Parent-2", value: "b", active: true, description: "" },
+      ],
+      auth: { authActive: false, authType: "none" },
+      variables: [],
+    });
+
+    const originalFolderHeaderCount = folder.headers.length;
+
+    // Run twice with iterationCount=2 to exercise the iteration reset path
+    await collectionsRunner({
+      collections: [collection],
+      envs: EMPTY_ENVS,
+      iterationCount: 2,
+    });
+
+    // The original folder must remain clean — pre-fix it grew by 2 on every pass
+    expect(folder.headers.length).toBe(originalFolderHeaderCount);
+    expect(folder.headers.some((h) => h.key === "X-Parent-1")).toBe(false);
+    expect(folder.headers.some((h) => h.key === "X-Parent-2")).toBe(false);
+  });
+});

--- a/packages/hoppscotch-cli/src/__tests__/unit/env-propagation-on-test-error.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/env-propagation-on-test-error.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression tests for the env-propagation bug in processRequest.
+ *
+ * Root cause (fixed in utils/request.ts):
+ *   `result.envs` was initialised to the raw `params.envs` and only
+ *   overwritten inside the test-runner *success* branch.  When the test
+ *   script threw (E.isLeft), `result.envs` was never updated, so env
+ *   mutations written by the pre-request script were silently discarded.
+ *   The *next* request in the collection therefore received the stale,
+ *   pre-run environment.
+ *
+ * Fix: assign `result.envs = updatedEnvs` immediately after the
+ * pre-request script succeeds, before the test runner runs.
+ */
+
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { makeCollection, makeRESTRequest } from "@hoppscotch/data";
+
+// vi.hoisted runs before module import hoisting so the variable is available
+// inside vi.mock factory closures.
+const { mockAxiosCallable } = vi.hoisted(() => {
+  const mockAxiosCallable = vi.fn();
+  return { mockAxiosCallable };
+});
+
+// `requestRunner` in utils/request.ts calls `axios(config)` directly, so the
+// default export must be a callable function.  hopp-fetch.ts calls
+// `axios.create()`, so that method must also exist.
+vi.mock("axios", () => ({
+  default: Object.assign(mockAxiosCallable, {
+    create: vi.fn().mockReturnValue(vi.fn()),
+    isAxiosError: vi.fn().mockReturnValue(false),
+  }),
+}));
+
+vi.mock("axios-cookiejar-support", () => ({
+  wrapper: (instance: any) => instance,
+}));
+
+vi.mock("tough-cookie", () => ({
+  CookieJar: vi.fn(),
+}));
+
+import axios, { AxiosResponse } from "axios";
+import { collectionsRunner } from "../../utils/collections";
+import { processRequest } from "../../utils/request";
+import { HoppEnvs } from "../../types/request";
+
+const MOCK_200: AxiosResponse = {
+  data: {},
+  status: 200,
+  statusText: "OK",
+  config: { url: "https://example.com", method: "GET" } as any,
+  headers: {},
+  request: {},
+};
+
+const EMPTY_ENVS: HoppEnvs = { global: [], selected: [] };
+
+describe("processRequest – env propagation on test-script failure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAxiosCallable.mockResolvedValue(MOCK_200);
+    (axios as any).create.mockReturnValue(vi.fn());
+    (axios as any).isAxiosError.mockReturnValue(false);
+  });
+
+  test("env variable set in pre-request script is present in result.envs even when test script fails", async () => {
+    const request = makeRESTRequest({
+      name: "req",
+      method: "GET",
+      endpoint: "https://example.com",
+      params: [],
+      headers: [],
+      // pre-request sets a variable
+      preRequestScript: `pw.env.set("TOKEN", "abc123");`,
+      // test script references an undeclared variable — should throw ReferenceError
+      testScript: `undeclaredVariableThatDoesNotExist;`,
+      auth: { authActive: false, authType: "none" },
+      body: { contentType: null, body: null },
+      requestVariables: [],
+      description: null,
+      responses: {},
+    });
+
+    const result = await processRequest({
+      request,
+      envs: EMPTY_ENVS,
+      path: "test/req",
+      delay: 0,
+      legacySandbox: false,
+    })();
+
+    // The request itself fails (test error), but the pre-request env mutation
+    // must still be visible so the next request in the collection can use it.
+    const tokenVar = result.envs.selected.find((v) => v.key === "TOKEN");
+    expect(tokenVar).toBeDefined();
+    expect(tokenVar?.currentValue).toBe("abc123");
+  });
+
+  test("env variable from pre-request propagates to next sequential request even when the first request's test script fails", async () => {
+    // Request 1: sets TOKEN via pre-request, has a broken test script
+    const req1 = makeRESTRequest({
+      name: "set-token",
+      method: "GET",
+      endpoint: "https://example.com",
+      params: [],
+      headers: [],
+      preRequestScript: `pw.env.set("TOKEN", "secret");`,
+      testScript: `undeclaredVariableThatDoesNotExist;`,  // fails
+      auth: { authActive: false, authType: "none" },
+      body: { contentType: null, body: null },
+      requestVariables: [],
+      description: null,
+      responses: {},
+    });
+
+    // Request 2: uses TOKEN in a passing test — only passes if TOKEN propagated
+    const req2 = makeRESTRequest({
+      name: "use-token",
+      method: "GET",
+      endpoint: "https://example.com",
+      params: [],
+      headers: [],
+      preRequestScript: "",
+      testScript: `
+        pw.test("TOKEN is propagated from previous request", () => {
+          pw.expect(pw.env.get("TOKEN")).toBe("secret");
+        });
+      `,
+      auth: { authActive: false, authType: "none" },
+      body: { contentType: null, body: null },
+      requestVariables: [],
+      description: null,
+      responses: {},
+    });
+
+    const collection = makeCollection({
+      name: "col",
+      folders: [],
+      requests: [req1 as any, req2 as any],
+      headers: [],
+      auth: { authActive: false, authType: "none" },
+      variables: [],
+    });
+
+    const reports = await collectionsRunner({
+      collections: [collection],
+      envs: EMPTY_ENVS,
+    });
+
+    expect(reports).toHaveLength(2);
+
+    const req1Report = reports[0];
+    const req2Report = reports[1];
+
+    // First request fails because of the broken test script
+    expect(req1Report.result).toBe(false);
+
+    // Second request's test should pass — TOKEN must have propagated despite req1 failing
+    expect(req2Report.result).toBe(true);
+    expect(req2Report.errors).toHaveLength(0);
+    expect(
+      req2Report.tests.some(
+        (t) =>
+          t.descriptor === "TOKEN is propagated from previous request" &&
+          t.failed === 0 &&
+          t.passed === 1
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/hoppscotch-cli/src/utils/collections.ts
+++ b/packages/hoppscotch-cli/src/utils/collections.ts
@@ -163,7 +163,15 @@ const processCollection = async (
 
   // Process each folder in the collection
   for (const folder of collection.folders) {
-    const updatedFolder: HoppCollection = { ...folder };
+    // Copy headers and variables into new arrays so that the push calls below
+    // never mutate the original folder data.  Without this, multi-iteration
+    // runs (or any second traversal of the same collection tree) accumulate
+    // parent entries on each pass, producing duplicate / wrong-order values.
+    const updatedFolder: HoppCollection = {
+      ...folder,
+      headers: [...folder.headers],
+      variables: [...folder.variables],
+    };
 
     if (updatedFolder.auth.authType === "inherit") {
       updatedFolder.auth = collection.auth;

--- a/packages/hoppscotch-cli/src/utils/request.ts
+++ b/packages/hoppscotch-cli/src/utils/request.ts
@@ -243,8 +243,11 @@ export const processRequest =
       inheritedTestScripts = [],
     } = params;
 
-    // Initialising updatedEnvs with given parameter envs, will eventually get updated.
-    const result = {
+    // Initialising result envs with given parameter envs; updated after the
+    // pre-request stage (so env mutations from pre-request scripts always
+    // propagate to the next request even when the test script fails) and
+    // again after a successful test-runner run.
+    const result: { envs: HoppEnvs; report: RequestReport } = {
       envs: <HoppEnvs>envs,
       report: <RequestReport>{},
     };
@@ -293,6 +296,10 @@ export const processRequest =
     } else {
       // Updating effective-request and consuming updated envs after pre-request script execution
       ({ effectiveRequest, updatedEnvs } = preRequestRes.right);
+      // Commit pre-request env mutations immediately so that if the test
+      // script later fails, the next request in the collection still sees the
+      // variables set here rather than the stale pre-run state.
+      result.envs = updatedEnvs;
     }
 
     // Creating request-config for request-runner.


### PR DESCRIPTION
## Problem

Two bugs in the CLI collection runner caused non-deterministic variable resolution when collections had nested folders or when pre-request scripts wrote variables that a subsequent failing test script would accidentally discard.

### Bug 1 — `folder.headers` / `folder.variables` mutated across iterations

`processCollection` built the per-pass merged folder with a shallow spread:

```ts
const updatedFolder: HoppCollection = { ...folder };
updatedFolder.headers.push(...filteredHeaders); // mutates folder.headers directly
```

`{ ...folder }` copies the top-level reference but `updatedFolder.headers` and `updatedFolder.variables` remain the **same array instances** as the original folder. The `.push()` calls therefore permanently modify the source collection tree.

On a second pass (e.g. `--iteration-count > 1`) the folder already contains the parent's entries from the prior pass, causing:
- **Duplicate headers** sent to the server on every iteration after the first
- **Broken header-override precedence** — folder headers are supposed to take priority over parent headers when the same key exists

### Bug 2 — Pre-request env mutations discarded when the test script fails

`result.envs` was initialised to the raw `params.envs` and only reassigned inside the test-runner **success** branch:

```ts
const result = { envs: <HoppEnvs>envs, ... }; // starts as raw input

// pre-request script runs and writes TOKEN to updatedEnvs ...

if (E.isLeft(testRunnerRes)) {
  report.errors.push(...);
  // result.envs is never updated → TOKEN is lost
} else {
  result.envs = envs; // only reached on success
}
```

When a test script throws, `result.envs` stays as the original pre-run environment. Any variable written by the pre-request script is silently dropped, so the next request in the collection gets stale state.

## Fix

**Bug 1** — copy the arrays before pushing:

```ts
const updatedFolder: HoppCollection = {
  ...folder,
  headers:   [...folder.headers],
  variables: [...folder.variables],
};
```

**Bug 2** — commit pre-request mutations to `result.envs` immediately after the pre-request stage succeeds, before the test runner runs:

```ts
} else {
  ({ effectiveRequest, updatedEnvs } = preRequestRes.right);
  result.envs = updatedEnvs; // committed now; test-runner success overwrites with its own output
}
```

## Tests added

- `collections-folder-mutation.spec.ts` — verifies `folder.headers` and `folder.variables` are unchanged after a single run and after multiple iterations
- `env-propagation-on-test-error.spec.ts` — verifies a variable set by request N's pre-request script is present in `result.envs` when request N's test script fails, and that request N+1 can read it

All 118 unit tests pass. `tsc --noEmit` exits clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two state bugs in the CLI collection runner: prevents folder header/variable arrays from being mutated across iterations and preserves env changes from pre-request scripts even when a test script fails.

- **Bug Fixes**
  - `collections.ts`: clone `headers` and `variables` when merging folders to stop in-place mutation, duplicate headers, and broken precedence in multi-iteration runs.
  - `request.ts`: persist `updatedEnvs` right after the pre-request stage so env writes are kept even if the test script throws.
  - Tests: added regression suites for folder mutation and env propagation on test error.

<sup>Written for commit 48870762555318bf1a052f70933cf8ea8845c38a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

