### PR TITLE
fix(common): skip Vue sync during IME composition in CodeMirror editors

### DIFF
--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -436,7 +436,21 @@ export function useCodemirror(
               cachedValue.value = update.state.doc
                 .toJSON()
                 .join(update.state.lineBreak)
-              if (!options.extendedEditorConfig.readOnly) {
+
+              // Do not propagate intermediate composition changes to the Vue
+              // reactive value. During IME composition (e.g. Chinese via Sogou
+              // Pinyin), CodeMirror emits docChanged updates with the
+              // "input.type.compose" userEvent for every intermediate keystroke.
+              // Pushing these back through Vue's watch(value) watcher causes
+              // view.dispatch() to replace the entire document mid-composition,
+              // which resets the IME session and forces the user to type the
+              // character a second time. We wait for compositionend (when no
+              // transaction is a compose event) before syncing back.
+              const isComposing = update.transactions.some((tr) =>
+                tr.isUserEvent("input.type.compose")
+              )
+
+              if (!options.extendedEditorConfig.readOnly && !isComposing) {
                 // Only update if the value is actually different to prevent circular updates
                 if (value.value !== cachedValue.value) {
                   value.value = cachedValue.value


### PR DESCRIPTION
In the JSON body editor, intermediate IME composition updates were being flushed back to the Vue reactive value on every keystroke during composition. This triggered the `watch(value)` watcher, which called `view.dispatch()` to replace the entire document — interrupting the active IME session. Chinese IME users (e.g. Sogou Pinyin) had to type characters twice to get them to stick.

Fixed by checking `update.transactions` for the `"input.type.compose"` userEvent in the CodeMirror ViewPlugin update handler. During active composition, the Vue reactive sync is skipped. The final `compositionend` update arrives without the compose tag and syncs the finished character normally.

Closes #6439

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop interrupting IME composition in CodeMirror editors by skipping Vue sync during active composition. We detect `input.type.compose` transactions and hold updates so `watch(value)` doesn’t dispatch full document replacements; the final compositionend syncs normally, fixing double-typing with Chinese IMEs (closes #6439).

<sup>Written for commit d3769e91f4c26e8168a2d34719908c3df78c6ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

