### PR TITLE
feat(common): add OAuth2 token type selector for `id_token` support

### DIFF
--- a/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
+++ b/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
@@ -47,6 +47,18 @@ export const useOAuth2GrantTypes = (
   const t = useI18n()
   const toast = useToast()
 
+  // Token type dropdown options (shared across all grant types). The OAuth2
+  // dropdown component reads `ref.value.{id,label}` and assigns the whole
+  // option object on click, so the ref must hold an `{id,label}` object — not
+  // the raw string union.
+  const tokenTypeOptions = [
+    { id: "access_token" as const, label: "Access Token" },
+    { id: "id_token" as const, label: "ID Token" },
+  ]
+
+  const tokenTypeOptionFor = (value: string | undefined) =>
+    tokenTypeOptions.find((o) => o.id === value) ?? tokenTypeOptions[0]
+
   // Helper function to prepare request parameters
   const prepareRequestParams = (
     params: Ref<AuthRequestParam[] | TokenRequestParam[]>
@@ -211,7 +223,7 @@ export const useOAuth2GrantTypes = (
         )
 
         const tokenType = refWithCallbackOnChange(
-          auth.value.grantTypeInfo.tokenType || "access_token",
+          tokenTypeOptionFor(auth.value.grantTypeInfo.tokenType),
           (value) => {
             if (!("tokenType" in auth.value.grantTypeInfo)) {
               return
@@ -219,7 +231,7 @@ export const useOAuth2GrantTypes = (
 
             auth.value.grantTypeInfo = {
               ...auth.value.grantTypeInfo,
-              tokenType: value,
+              tokenType: value.id,
             }
           }
         )
@@ -283,7 +295,7 @@ export const useOAuth2GrantTypes = (
             authRequestParams: preparedAuthRequestParams.value,
             tokenRequestParams: preparedTokenRequestParams.value,
             refreshRequestParams: preparedRefreshRequestParams.value,
-            tokenType: tokenType.value,
+            tokenType: tokenType.value.id,
           }
 
           const unwrappedParams = replaceTemplateStringsInObjectValues(params)
@@ -380,16 +392,7 @@ export const useOAuth2GrantTypes = (
               ref: tokenType,
               tippyRefName: "tokenTypeTippyActions",
               tippyRef: { value: null },
-              options: [
-                {
-                  id: "access_token" as const,
-                  label: "Access Token",
-                },
-                {
-                  id: "id_token" as const,
-                  label: "ID Token",
-                },
-              ],
+              options: tokenTypeOptions,
             },
           ]
         })
@@ -483,7 +486,7 @@ export const useOAuth2GrantTypes = (
         )
 
         const tokenType = refWithCallbackOnChange(
-          (auth.value.grantTypeInfo as any).tokenType || "access_token",
+          tokenTypeOptionFor(auth.value.grantTypeInfo.tokenType),
           (value) => {
             if (!("tokenType" in auth.value.grantTypeInfo)) {
               return
@@ -491,7 +494,7 @@ export const useOAuth2GrantTypes = (
 
             auth.value.grantTypeInfo = {
               ...auth.value.grantTypeInfo,
-              tokenType: value,
+              tokenType: value.id,
             }
           }
         )
@@ -506,7 +509,7 @@ export const useOAuth2GrantTypes = (
               clientAuthentication: clientAuthentication.value.id,
               tokenRequestParams: preparedTokenRequestParams.value,
               refreshRequestParams: preparedRefreshRequestParams.value,
-              tokenType: tokenType.value,
+              tokenType: tokenType.value.id,
             })
 
           const parsedArgs = clientCredentials.params.safeParse(values)
@@ -579,16 +582,7 @@ export const useOAuth2GrantTypes = (
               ref: tokenType,
               tippyRefName: "tokenTypeTippyActions",
               tippyRef: { value: null },
-              options: [
-                {
-                  id: "access_token" as const,
-                  label: "Access Token",
-                },
-                {
-                  id: "id_token" as const,
-                  label: "ID Token",
-                },
-              ],
+              options: tokenTypeOptions,
             },
           ]
         })
@@ -679,7 +673,7 @@ export const useOAuth2GrantTypes = (
         )
 
         const tokenType = refWithCallbackOnChange(
-          auth.value.grantTypeInfo.tokenType || "access_token",
+          tokenTypeOptionFor(auth.value.grantTypeInfo.tokenType),
           (value) => {
             if (!("tokenType" in auth.value.grantTypeInfo)) {
               return
@@ -687,7 +681,7 @@ export const useOAuth2GrantTypes = (
 
             auth.value.grantTypeInfo = {
               ...auth.value.grantTypeInfo,
-              tokenType: value,
+              tokenType: value.id,
             }
           }
         )
@@ -703,7 +697,7 @@ export const useOAuth2GrantTypes = (
               password: password.value,
               tokenRequestParams: preparedTokenRequestParams.value,
               refreshRequestParams: preparedRefreshRequestParams.value,
-              tokenType: tokenType.value,
+              tokenType: tokenType.value.id,
             })
 
           const parsedArgs = passwordFlow.params.safeParse(values)
@@ -770,16 +764,7 @@ export const useOAuth2GrantTypes = (
               ref: tokenType,
               tippyRefName: "tokenTypeTippyActions",
               tippyRef: { value: null },
-              options: [
-                {
-                  id: "access_token" as const,
-                  label: "Access Token",
-                },
-                {
-                  id: "id_token" as const,
-                  label: "ID Token",
-                },
-              ],
+              options: tokenTypeOptions,
             },
           ]
         })
@@ -827,7 +812,7 @@ export const useOAuth2GrantTypes = (
         )
 
         const tokenType = refWithCallbackOnChange(
-          auth.value.grantTypeInfo.tokenType || "access_token",
+          tokenTypeOptionFor(auth.value.grantTypeInfo.tokenType),
           (value) => {
             if (!("tokenType" in auth.value.grantTypeInfo)) {
               return
@@ -835,7 +820,7 @@ export const useOAuth2GrantTypes = (
 
             auth.value.grantTypeInfo = {
               ...auth.value.grantTypeInfo,
-              tokenType: value,
+              tokenType: value.id,
             }
           }
         )
@@ -848,7 +833,7 @@ export const useOAuth2GrantTypes = (
               scopes: scopes.value,
               authRequestParams: preparedAuthRequestParams.value,
               refreshRequestParams: preparedRefreshRequestParams.value,
-              tokenType: tokenType.value,
+              tokenType: tokenType.value.id,
             })
 
           const unwrappedValues = replaceTemplateStringsInObjectValues(values)
@@ -891,16 +876,7 @@ export const useOAuth2GrantTypes = (
               ref: tokenType,
               tippyRefName: "tokenTypeTippyActions",
               tippyRef: { value: null },
-              options: [
-                {
-                  id: "access_token" as const,
-                  label: "Access Token",
-                },
-                {
-                  id: "id_token" as const,
-                  label: "ID Token",
-                },
-              ],
+              options: tokenTypeOptions,
             },
           ]
         })

--- a/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
+++ b/packages/hoppscotch-common/src/composables/oauth2/useOAuth2GrantTypes.ts
@@ -210,6 +210,20 @@ export const useOAuth2GrantTypes = (
           }
         )
 
+        const tokenType = refWithCallbackOnChange(
+          auth.value.grantTypeInfo.tokenType || "access_token",
+          (value) => {
+            if (!("tokenType" in auth.value.grantTypeInfo)) {
+              return
+            }
+
+            auth.value.grantTypeInfo = {
+              ...auth.value.grantTypeInfo,
+              tokenType: value,
+            }
+          }
+        )
+
         const refreshToken = async () => {
           const grantTypeInfo = auth.value.grantTypeInfo
 
@@ -269,6 +283,7 @@ export const useOAuth2GrantTypes = (
             authRequestParams: preparedAuthRequestParams.value,
             tokenRequestParams: preparedTokenRequestParams.value,
             refreshRequestParams: preparedRefreshRequestParams.value,
+            tokenType: tokenType.value,
           }
 
           const unwrappedParams = replaceTemplateStringsInObjectValues(params)
@@ -357,6 +372,24 @@ export const useOAuth2GrantTypes = (
               label: t("authorization.oauth.label_scopes"),
               type: "text" as const,
               ref: scopes,
+            },
+            {
+              id: "tokenType",
+              label: "Token Type",
+              type: "dropdown" as const,
+              ref: tokenType,
+              tippyRefName: "tokenTypeTippyActions",
+              tippyRef: { value: null },
+              options: [
+                {
+                  id: "access_token" as const,
+                  label: "Access Token",
+                },
+                {
+                  id: "id_token" as const,
+                  label: "ID Token",
+                },
+              ],
             },
           ]
         })
@@ -449,6 +482,20 @@ export const useOAuth2GrantTypes = (
           }
         )
 
+        const tokenType = refWithCallbackOnChange(
+          (auth.value.grantTypeInfo as any).tokenType || "access_token",
+          (value) => {
+            if (!("tokenType" in auth.value.grantTypeInfo)) {
+              return
+            }
+
+            auth.value.grantTypeInfo = {
+              ...auth.value.grantTypeInfo,
+              tokenType: value,
+            }
+          }
+        )
+
         const runAction = async () => {
           const values: ClientCredentialsFlowParams =
             replaceTemplateStringsInObjectValues({
@@ -459,6 +506,7 @@ export const useOAuth2GrantTypes = (
               clientAuthentication: clientAuthentication.value.id,
               tokenRequestParams: preparedTokenRequestParams.value,
               refreshRequestParams: preparedRefreshRequestParams.value,
+              tokenType: tokenType.value,
             })
 
           const parsedArgs = clientCredentials.params.safeParse(values)
@@ -521,6 +569,24 @@ export const useOAuth2GrantTypes = (
                 {
                   id: "AS_BASIC_AUTH_HEADERS" as const,
                   label: t("authorization.oauth.label_send_as_basic_auth"),
+                },
+              ],
+            },
+            {
+              id: "tokenType",
+              label: "Token Type",
+              type: "dropdown" as const,
+              ref: tokenType,
+              tippyRefName: "tokenTypeTippyActions",
+              tippyRef: { value: null },
+              options: [
+                {
+                  id: "access_token" as const,
+                  label: "Access Token",
+                },
+                {
+                  id: "id_token" as const,
+                  label: "ID Token",
                 },
               ],
             },
@@ -612,6 +678,20 @@ export const useOAuth2GrantTypes = (
           }
         )
 
+        const tokenType = refWithCallbackOnChange(
+          auth.value.grantTypeInfo.tokenType || "access_token",
+          (value) => {
+            if (!("tokenType" in auth.value.grantTypeInfo)) {
+              return
+            }
+
+            auth.value.grantTypeInfo = {
+              ...auth.value.grantTypeInfo,
+              tokenType: value,
+            }
+          }
+        )
+
         const runAction = async () => {
           const values: PasswordFlowParams =
             replaceTemplateStringsInObjectValues({
@@ -623,6 +703,7 @@ export const useOAuth2GrantTypes = (
               password: password.value,
               tokenRequestParams: preparedTokenRequestParams.value,
               refreshRequestParams: preparedRefreshRequestParams.value,
+              tokenType: tokenType.value,
             })
 
           const parsedArgs = passwordFlow.params.safeParse(values)
@@ -682,6 +763,24 @@ export const useOAuth2GrantTypes = (
               type: "text" as const,
               ref: scopes,
             },
+            {
+              id: "tokenType",
+              label: "Token Type",
+              type: "dropdown" as const,
+              ref: tokenType,
+              tippyRefName: "tokenTypeTippyActions",
+              tippyRef: { value: null },
+              options: [
+                {
+                  id: "access_token" as const,
+                  label: "Access Token",
+                },
+                {
+                  id: "id_token" as const,
+                  label: "ID Token",
+                },
+              ],
+            },
           ]
         })
 
@@ -727,6 +826,20 @@ export const useOAuth2GrantTypes = (
           }
         )
 
+        const tokenType = refWithCallbackOnChange(
+          auth.value.grantTypeInfo.tokenType || "access_token",
+          (value) => {
+            if (!("tokenType" in auth.value.grantTypeInfo)) {
+              return
+            }
+
+            auth.value.grantTypeInfo = {
+              ...auth.value.grantTypeInfo,
+              tokenType: value,
+            }
+          }
+        )
+
         const runAction = () => {
           const values: ImplicitOauthFlowParams =
             replaceTemplateStringsInObjectValues({
@@ -735,6 +848,7 @@ export const useOAuth2GrantTypes = (
               scopes: scopes.value,
               authRequestParams: preparedAuthRequestParams.value,
               refreshRequestParams: preparedRefreshRequestParams.value,
+              tokenType: tokenType.value,
             })
 
           const unwrappedValues = replaceTemplateStringsInObjectValues(values)
@@ -769,6 +883,24 @@ export const useOAuth2GrantTypes = (
               label: t("authorization.oauth.label_scopes"),
               type: "text" as const,
               ref: scopes,
+            },
+            {
+              id: "tokenType",
+              label: "Token Type",
+              type: "dropdown" as const,
+              ref: tokenType,
+              tippyRefName: "tokenTypeTippyActions",
+              tippyRef: { value: null },
+              options: [
+                {
+                  id: "access_token" as const,
+                  label: "Access Token",
+                },
+                {
+                  id: "id_token" as const,
+                  label: "ID Token",
+                },
+              ],
             },
           ]
         })

--- a/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
@@ -30,6 +30,7 @@ const AuthCodeOauthFlowParamsSchema = AuthCodeGrantTypeParams.omit({
     authRequestParams: z.array(OAuth2AuthRequestParam),
     tokenRequestParams: z.array(OAuth2ParamSchema),
     refreshRequestParams: z.array(OAuth2ParamSchema),
+    tokenType: z.enum(["access_token", "id_token"]).optional(),
   })
   .refine(
     (params) => {
@@ -72,6 +73,7 @@ export const getDefaultAuthCodeOauthFlowParams =
     authRequestParams: [],
     refreshRequestParams: [],
     tokenRequestParams: [],
+    tokenType: "access_token",
   })
 
 const initAuthCodeOauthFlow = async ({
@@ -85,6 +87,7 @@ const initAuthCodeOauthFlow = async ({
   authRequestParams,
   refreshRequestParams,
   tokenRequestParams,
+  tokenType,
 }: AuthCodeOauthFlowParams) => {
   const state = generateRandomString()
 
@@ -137,6 +140,7 @@ const initAuthCodeOauthFlow = async ({
       active: boolean
       sendIn?: string
     }>
+    tokenType?: "access_token" | "id_token"
   } = {
     state,
     grant_type: "AUTHORIZATION_CODE",
@@ -151,6 +155,7 @@ const initAuthCodeOauthFlow = async ({
     authRequestParams,
     refreshRequestParams,
     tokenRequestParams,
+    tokenType,
   }
 
   if (codeVerifier && codeChallenge) {
@@ -239,6 +244,7 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
     clientID: z.string(),
     codeVerifier: z.string().optional(),
     codeChallenge: z.string().optional(),
+    tokenType: z.enum(["access_token", "id_token"]).optional(),
   })
 
   const decodedLocalConfig = expectedSchema.safeParse(
@@ -306,11 +312,18 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
     return E.left("AUTH_TOKEN_REQUEST_INVALID_RESPONSE" as const)
   }
 
+  // Get the token type preference from the persisted config
+  const tokenTypePreference = (decodedLocalConfig.data as any).tokenType || "access_token"
+
   return E.right({
     access_token:
-      parsedTokenResponse.data.access_token ||
-      parsedTokenResponse.data.id_token ||
-      "",
+      tokenTypePreference === "id_token"
+        ? parsedTokenResponse.data.id_token ||
+          parsedTokenResponse.data.access_token ||
+          ""
+        : parsedTokenResponse.data.access_token ||
+          parsedTokenResponse.data.id_token ||
+          "",
     refresh_token: parsedTokenResponse.data.refresh_token,
   })
 }

--- a/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/authCode.ts
@@ -313,7 +313,8 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
   }
 
   // Get the token type preference from the persisted config
-  const tokenTypePreference = (decodedLocalConfig.data as any).tokenType || "access_token"
+  const tokenTypePreference =
+    decodedLocalConfig.data.tokenType || "access_token"
 
   return E.right({
     access_token:

--- a/packages/hoppscotch-common/src/services/oauth/flows/clientCredentials.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/clientCredentials.ts
@@ -28,6 +28,7 @@ const ClientCredentialsFlowParamsSchema = ClientCredentialsGrantTypeParams.omit(
     // Override optional arrays to be required for the service layer
     tokenRequestParams: z.array(OAuth2ParamSchema),
     refreshRequestParams: z.array(OAuth2ParamSchema),
+    tokenType: z.enum(["access_token", "id_token"]).optional(),
   })
   .refine(
     (params) => {
@@ -55,6 +56,7 @@ export const getDefaultClientCredentialsFlowParams =
     clientAuthentication: "IN_BODY",
     tokenRequestParams: [],
     refreshRequestParams: [],
+    tokenType: "access_token",
   })
 
 const initClientCredentialsOAuthFlow = async (
@@ -80,7 +82,8 @@ const initClientCredentialsOAuthFlow = async (
   if (E.isLeft(jsonResponse)) return E.left("AUTH_TOKEN_REQUEST_FAILED")
 
   const withAccessTokenSchema = z.object({
-    access_token: z.string(),
+    access_token: z.string().optional(),
+    id_token: z.string().optional(),
   })
 
   const parsedTokenResponse = withAccessTokenSchema.safeParse(
@@ -91,9 +94,21 @@ const initClientCredentialsOAuthFlow = async (
     toast.error("AUTH_TOKEN_REQUEST_INVALID_RESPONSE")
   }
 
-  return parsedTokenResponse.success
-    ? E.right(parsedTokenResponse.data)
-    : E.left("AUTH_TOKEN_REQUEST_INVALID_RESPONSE" as const)
+  if (parsedTokenResponse.success) {
+    // Return the preferred token type
+    const token =
+      payload.tokenType === "id_token"
+        ? parsedTokenResponse.data.id_token ||
+          parsedTokenResponse.data.access_token
+        : parsedTokenResponse.data.access_token ||
+          parsedTokenResponse.data.id_token
+
+    if (token) {
+      return E.right({ access_token: token })
+    }
+  }
+
+  return E.left("AUTH_TOKEN_REQUEST_INVALID_RESPONSE" as const)
 }
 
 const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {

--- a/packages/hoppscotch-common/src/services/oauth/flows/clientCredentials.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/clientCredentials.ts
@@ -81,10 +81,14 @@ const initClientCredentialsOAuthFlow = async (
 
   if (E.isLeft(jsonResponse)) return E.left("AUTH_TOKEN_REQUEST_FAILED")
 
-  const withAccessTokenSchema = z.object({
-    access_token: z.string().optional(),
-    id_token: z.string().optional(),
-  })
+  const withAccessTokenSchema = z
+    .object({
+      access_token: z.string().optional(),
+      id_token: z.string().optional(),
+    })
+    .refine((data) => data.access_token || data.id_token, {
+      message: "Either access_token or id_token must be present",
+    })
 
   const parsedTokenResponse = withAccessTokenSchema.safeParse(
     jsonResponse.right

--- a/packages/hoppscotch-common/src/services/oauth/flows/implicit.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/implicit.ts
@@ -148,7 +148,8 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
   }
 
   // Get the token type preference from the persisted config
-  const tokenTypePreference = decodedLocalConfig.data.tokenType || "access_token"
+  const tokenTypePreference =
+    decodedLocalConfig.data.tokenType || "access_token"
 
   // Return the preferred token type
   const token =

--- a/packages/hoppscotch-common/src/services/oauth/flows/implicit.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/implicit.ts
@@ -25,6 +25,7 @@ const ImplicitOauthFlowParamsSchema = ImplicitOauthFlowParamsData.omit({
     // Override optional arrays to be required for the service layer
     authRequestParams: z.array(OAuth2AuthRequestParam),
     refreshRequestParams: z.array(OAuth2ParamSchema),
+    tokenType: z.enum(["access_token", "id_token"]).optional(),
   })
   .refine((params) => {
     return (
@@ -45,6 +46,7 @@ export const getDefaultImplicitOauthFlowParams =
     scopes: undefined,
     authRequestParams: [],
     refreshRequestParams: [],
+    tokenType: "access_token",
   })
 
 const initImplicitOauthFlow = async ({
@@ -52,6 +54,7 @@ const initImplicitOauthFlow = async ({
   scopes,
   authEndpoint,
   authRequestParams,
+  tokenType,
 }: ImplicitOauthFlowParams) => {
   const state = generateRandomString()
 
@@ -73,6 +76,7 @@ const initImplicitOauthFlow = async ({
         scopes,
         state,
         authRequestParams,
+        tokenType,
       },
       grant_type: "IMPLICIT",
     })
@@ -115,6 +119,7 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
 
   const accessToken =
     params.get("access_token") || paramsFromHash.get("access_token")
+  const idToken = params.get("id_token") || paramsFromHash.get("id_token")
   const state = params.get("state") || paramsFromHash.get("state")
   const error = params.get("error") || paramsFromHash.get("error")
 
@@ -122,14 +127,11 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
     return E.left("AUTH_SERVER_RETURNED_ERROR")
   }
 
-  if (!accessToken) {
-    return E.left("AUTH_TOKEN_REQUEST_FAILED")
-  }
-
   const expectedSchema = z.object({
     source: z.optional(z.string()),
     state: z.string(),
     clientID: z.string(),
+    tokenType: z.enum(["access_token", "id_token"]).optional(),
   })
 
   const decodedLocalConfig = expectedSchema.safeParse(
@@ -145,8 +147,21 @@ const handleRedirectForAuthCodeOauthFlow = async (localConfig: string) => {
     return E.left("INVALID_STATE")
   }
 
+  // Get the token type preference from the persisted config
+  const tokenTypePreference = decodedLocalConfig.data.tokenType || "access_token"
+
+  // Return the preferred token type
+  const token =
+    tokenTypePreference === "id_token"
+      ? idToken || accessToken
+      : accessToken || idToken
+
+  if (!token) {
+    return E.left("AUTH_TOKEN_REQUEST_FAILED")
+  }
+
   return E.right({
-    access_token: accessToken,
+    access_token: token,
   })
 }
 

--- a/packages/hoppscotch-common/src/services/oauth/flows/password.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/password.ts
@@ -25,6 +25,7 @@ const PasswordFlowParamsSchema = PasswordGrantTypeParams.omit({
     // Override optional arrays to be required for the service layer
     tokenRequestParams: z.array(OAuth2ParamSchema),
     refreshRequestParams: z.array(OAuth2ParamSchema),
+    tokenType: z.enum(["access_token", "id_token"]).optional(),
   })
   .refine(
     (params) => {
@@ -52,6 +53,7 @@ export const getDefaultPasswordFlowParams = (): PasswordFlowParams => ({
   password: "",
   tokenRequestParams: [],
   refreshRequestParams: [],
+  tokenType: "access_token",
 })
 
 const initPasswordOauthFlow = async ({
@@ -62,6 +64,7 @@ const initPasswordOauthFlow = async ({
   scopes,
   authEndpoint,
   tokenRequestParams,
+  tokenType,
 }: PasswordFlowParams) => {
   const toast = useToast()
 
@@ -123,10 +126,11 @@ const initPasswordOauthFlow = async ({
   }
 
   const withAccessTokenSchema = z.object({
-    access_token: z.string(),
+    access_token: z.string().optional(),
+    id_token: z.string().optional(),
   })
 
-  const responsePayload = parseBytesToJSON<{ access_token: string }>(
+  const responsePayload = parseBytesToJSON<{ access_token?: string; id_token?: string }>(
     res.right.body.body
   )
 
@@ -134,9 +138,20 @@ const initPasswordOauthFlow = async ({
     const parsedTokenResponse = withAccessTokenSchema.safeParse(
       responsePayload.value
     )
-    return parsedTokenResponse.success
-      ? E.right(parsedTokenResponse.data)
-      : E.left("AUTH_TOKEN_REQUEST_INVALID_RESPONSE" as const)
+
+    if (parsedTokenResponse.success) {
+      // Return the preferred token type
+      const token =
+        tokenType === "id_token"
+          ? parsedTokenResponse.data.id_token ||
+            parsedTokenResponse.data.access_token
+          : parsedTokenResponse.data.access_token ||
+            parsedTokenResponse.data.id_token
+
+      if (token) {
+        return E.right({ access_token: token })
+      }
+    }
   }
 
   return E.left("AUTH_TOKEN_REQUEST_INVALID_RESPONSE" as const)

--- a/packages/hoppscotch-common/src/services/oauth/flows/password.ts
+++ b/packages/hoppscotch-common/src/services/oauth/flows/password.ts
@@ -125,14 +125,19 @@ const initPasswordOauthFlow = async ({
     return E.left("AUTH_TOKEN_REQUEST_FAILED" as const)
   }
 
-  const withAccessTokenSchema = z.object({
-    access_token: z.string().optional(),
-    id_token: z.string().optional(),
-  })
+  const withAccessTokenSchema = z
+    .object({
+      access_token: z.string().optional(),
+      id_token: z.string().optional(),
+    })
+    .refine((data) => data.access_token || data.id_token, {
+      message: "Either access_token or id_token must be present",
+    })
 
-  const responsePayload = parseBytesToJSON<{ access_token?: string; id_token?: string }>(
-    res.right.body.body
-  )
+  const responsePayload = parseBytesToJSON<{
+    access_token?: string
+    id_token?: string
+  }>(res.right.body.body)
 
   if (O.isSome(responsePayload)) {
     const parsedTokenResponse = withAccessTokenSchema.safeParse(

--- a/packages/hoppscotch-data/src/rest/v/15/auth.ts
+++ b/packages/hoppscotch-data/src/rest/v/15/auth.ts
@@ -37,22 +37,26 @@ export const AuthCodeGrantTypeParams = AuthCodeGrantTypeParamsOld.extend({
   authRequestParams: z.array(OAuth2AuthRequestParam).optional().default([]),
   tokenRequestParams: z.array(OAuth2AdvancedParam).optional().default([]),
   refreshRequestParams: z.array(OAuth2AdvancedParam).optional().default([]),
+  tokenType: z.enum(["access_token", "id_token"]).optional().catch("access_token"),
 })
 
 export const ClientCredentialsGrantTypeParams =
   ClientCredentialsGrantTypeParamsOld.extend({
     tokenRequestParams: z.array(OAuth2AdvancedParam).optional().default([]),
     refreshRequestParams: z.array(OAuth2AdvancedParam).optional().default([]),
+    tokenType: z.enum(["access_token", "id_token"]).optional().catch("access_token"),
   })
 
 export const PasswordGrantTypeParams = PasswordGrantTypeParamsOld.extend({
   tokenRequestParams: z.array(OAuth2AdvancedParam).optional().default([]),
   refreshRequestParams: z.array(OAuth2AdvancedParam).optional().default([]),
+  tokenType: z.enum(["access_token", "id_token"]).optional().catch("access_token"),
 })
 
 export const ImplicitOauthFlowParams = ImplicitOauthFlowParamsOld.extend({
   authRequestParams: z.array(OAuth2AuthRequestParam).optional().default([]),
   refreshRequestParams: z.array(OAuth2AdvancedParam).optional().default([]),
+  tokenType: z.enum(["access_token", "id_token"]).optional().catch("access_token"),
 })
 
 // Extend OAuth2 with advanced parameters


### PR DESCRIPTION
Closes FE-1282 #3490

### What's changed
 Adds support for selecting between access_token and id_token in OAuth2 token responses, addressing the needs of OpenID Connect implementations that require ID tokens.
