### PR TITLE
fix(backend): prevent P2003 foreign key error on large team collection imports

### DIFF
--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -60,14 +60,6 @@ export class TeamCollectionService {
   MAX_RETRIES = 5; // Maximum number of retries for database transactions
 
   /**
-   * Generate a Prisma query object representation of a collection and its child collections and requests
-   *
-   * @param folder CollectionFolder from client
-   * @param teamID The Team ID
-   * @param orderIndex Initial OrderIndex of
-   * @returns A Prisma query object to create a collection, its child collections and requests
-   */
-  /**
    * Recursively create a TeamCollection together with its requests and child
    * collections, guaranteeing that a collection row exists before any row that
    * references it (its requests and its children) is inserted.
@@ -272,6 +264,10 @@ export class TeamCollectionService {
       }, {
         // Large imports run many sequential inserts; the default 10s interactive
         // transaction timeout (set in PrismaService) is not enough for big collections.
+        // The whole import is intentionally kept in one transaction so it stays
+        // atomic (a failure rolls back the partial tree). Trade-off: a very large
+        // import holds one pooled connection for up to this long; raise this value
+        // if you routinely import very large collections.
         timeout: 60000,
         maxWait: 10000,
       });

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -67,38 +67,60 @@ export class TeamCollectionService {
    * @param orderIndex Initial OrderIndex of
    * @returns A Prisma query object to create a collection, its child collections and requests
    */
-  private generatePrismaQueryObjForFBCollFolder(
+  /**
+   * Recursively create a TeamCollection together with its requests and child
+   * collections, guaranteeing that a collection row exists before any row that
+   * references it (its requests and its children) is inserted.
+   *
+   * This deliberately avoids Prisma's deeply-nested `create` over the recursive
+   * `children` self-relation combined with `Promise.all`. Running concurrent
+   * writes on a single interactive transaction under Prisma 7 + the pg driver
+   * adapter can interleave statements so a TeamRequest is inserted before its
+   * parent TeamCollection, violating `TeamRequest_collectionID_fkey` (P2003).
+   * The race only opens on large imports (many folders + large request bodies),
+   * which is why small collections imported fine.
+   */
+  private async createTeamCollectionTree(
+    tx: Prisma.TransactionClient,
     folder: CollectionFolder,
     teamID: string,
+    parentID: string | null,
     orderIndex: number,
-  ): Prisma.TeamCollectionCreateInput {
-    return {
-      title: folder.name,
-      team: {
-        connect: {
-          id: teamID,
-        },
+  ): Promise<DBTeamCollection> {
+    const collection = await tx.teamCollection.create({
+      data: {
+        title: folder.name,
+        team: { connect: { id: teamID } },
+        parent: parentID ? { connect: { id: parentID } } : undefined,
+        orderIndex,
+        data: folder.data ?? undefined,
       },
-      requests: {
-        create: folder.requests.map((r, index) => ({
-          title: r.name,
-          team: {
-            connect: {
-              id: teamID,
-            },
-          },
-          request: r,
+    });
+
+    if (folder.requests.length > 0) {
+      await tx.teamRequest.createMany({
+        data: folder.requests.map((request, index) => ({
+          title: request.name,
+          teamID,
+          collectionID: collection.id,
+          request: request as Prisma.InputJsonValue,
           orderIndex: index + 1,
         })),
-      },
-      orderIndex: orderIndex,
-      children: {
-        create: folder.folders.map((f, index) =>
-          this.generatePrismaQueryObjForFBCollFolder(f, teamID, index + 1),
-        ),
-      },
-      data: folder.data ?? undefined,
-    };
+      });
+    }
+
+    let childOrderIndex = 0;
+    for (const childFolder of folder.folders) {
+      await this.createTeamCollectionTree(
+        tx,
+        childFolder,
+        teamID,
+        collection.id,
+        ++childOrderIndex,
+      );
+    }
+
+    return collection;
   }
 
   /**
@@ -211,7 +233,6 @@ export class TeamCollectionService {
       return E.left(TEAM_COLL_INVALID_JSON);
 
     let teamCollections: DBTeamCollection[] = [];
-    let queryList: Prisma.TeamCollectionCreateInput[] = [];
     try {
       await this.prisma.$transaction(async (tx) => {
         try {
@@ -230,27 +251,29 @@ export class TeamCollectionService {
           });
           let lastOrderIndex = lastEntry ? lastEntry.orderIndex : 0;
 
-          // Generate Prisma Query Object for all child collections in collectionsList
-          queryList = collectionsList.right.map((x) =>
-            this.generatePrismaQueryObjForFBCollFolder(
-              x,
-              teamID,
-              ++lastOrderIndex,
-            ),
-          );
-
-          const promises = queryList.map((query) =>
-            tx.teamCollection.create({
-              data: {
-                ...query,
-                parent: parentID ? { connect: { id: parentID } } : undefined,
-              },
-            }),
-          );
-          teamCollections = await Promise.all(promises);
+          // Create each root collection tree sequentially (parent-before-child)
+          // to guarantee FK ordering. See createTeamCollectionTree for why the
+          // previous nested-create + Promise.all caused P2003 on large imports.
+          teamCollections = [];
+          for (const collFolder of collectionsList.right) {
+            teamCollections.push(
+              await this.createTeamCollectionTree(
+                tx,
+                collFolder,
+                teamID,
+                parentID,
+                ++lastOrderIndex,
+              ),
+            );
+          }
         } catch (error) {
           throw new ConflictException(error);
         }
+      }, {
+        // Large imports run many sequential inserts; the default 10s interactive
+        // transaction timeout (set in PrismaService) is not enough for big collections.
+        timeout: 60000,
+        maxWait: 10000,
       });
     } catch (error) {
       console.error(

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.spec.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.spec.ts
@@ -2451,6 +2451,19 @@ describe('importCollectionsFromJSON — collection-level script fields', () => {
       updatedOn: currentTime,
       data: rootDataAtCreate,
     });
+    // The child folder is now created in its own `userCollection.create` call
+    // (sequential parent-before-child), so it needs its own resolved value.
+    mockPrisma.userCollection.create.mockResolvedValueOnce({
+      id: folderRowId,
+      orderIndex: 1,
+      parentID: rootRowId,
+      title: 'child-folder',
+      userUid: user.uid,
+      type: ReqType.REST,
+      createdOn: currentTime,
+      updatedOn: currentTime,
+      data: folderDataAtCreate,
+    });
 
     // Export-side mocks: root resolves once, then its child folder resolves.
     mockPrisma.userCollection.findUniqueOrThrow
@@ -2506,17 +2519,19 @@ describe('importCollectionsFromJSON — collection-level script fields', () => {
 
     expect(E.isRight(result)).toBe(true);
 
-    // Import side: `userCollection.create` must receive script fields inside
-    // its `data` payload (root) and inside `children.create[0].data` (folder).
-    // Asserting against the create call args proves import preserved scripts;
-    // export-side mocks alone would only round-trip the values we pre-loaded.
+    // Import side: each collection now gets its own `userCollection.create`
+    // call (sequential parent-before-child). Root is calls[0], the child
+    // folder is calls[1]; both must carry the script fields in their `data`
+    // payload. Asserting against the create call args proves import preserved
+    // scripts; export-side mocks alone would only round-trip the pre-loaded values.
     const createCallArg = mockPrisma.userCollection.create.mock.calls[0][0]
       .data as any;
     expect(createCallArg.data.preRequestScript).toBe(
       'pw.env.set("ROOT_RAN", "yes");',
     );
     expect(createCallArg.data.testScript).toBe('pw.test("root", () => {});');
-    const childCreateArg = createCallArg.children.create[0];
+    const childCreateArg = mockPrisma.userCollection.create.mock.calls[1][0]
+      .data as any;
     expect(childCreateArg.data.preRequestScript).toBe(
       'pw.env.set("FOLDER_RAN", "yes");',
     );

--- a/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
+++ b/packages/hoppscotch-backend/src/user-collection/user-collection.service.ts
@@ -1054,20 +1054,25 @@ export class UserCollectionService {
   }
 
   /**
-   * Generate a Prisma query object representation of a collection and its child collections and requests
+   * Recursively create a UserCollection together with its requests and child
+   * collections, guaranteeing that a collection row exists before any row that
+   * references it (its requests and its children) is inserted.
    *
-   * @param folder CollectionFolder from client
-   * @param userID The User ID
-   * @param orderIndex Initial OrderIndex of
-   * @param reqType The Type of Collection
-   * @returns A Prisma query object to create a collection, its child collections and requests
+   * Mirrors the team-collection fix: avoids the deeply-nested `create` over the
+   * recursive `children` self-relation combined with `Promise.all`. Concurrent
+   * writes on a single interactive transaction under Prisma 7 + the pg driver
+   * adapter can interleave statements so a UserRequest is inserted before its
+   * parent UserCollection, violating `UserRequest_collectionID_fkey` (P2003) on
+   * large imports.
    */
-  private generatePrismaQueryObj(
+  private async createUserCollectionTree(
+    tx: Prisma.TransactionClient,
     folder: CollectionFolder,
     userID: string,
+    parentID: string | null,
     orderIndex: number,
     reqType: DBReqType,
-  ): Prisma.UserCollectionCreateInput {
+  ): Promise<UserCollection> {
     // Parse collection data if it exists
     let data = null;
     if (folder.data) {
@@ -1082,35 +1087,43 @@ export class UserCollectionService {
       }
     }
 
-    return {
-      title: folder.name,
-      data,
-      user: {
-        connect: {
-          uid: userID,
-        },
+    const collection = await tx.userCollection.create({
+      data: {
+        title: folder.name,
+        data,
+        user: { connect: { uid: userID } },
+        parent: parentID ? { connect: { id: parentID } } : undefined,
+        orderIndex,
+        type: reqType,
       },
-      requests: {
-        create: folder.requests.map((r, index) => ({
-          title: r.name,
-          user: {
-            connect: {
-              uid: userID,
-            },
-          },
+    });
+
+    if (folder.requests.length > 0) {
+      await tx.userRequest.createMany({
+        data: folder.requests.map((request, index) => ({
+          title: request.name,
+          userUid: userID,
+          collectionID: collection.id,
           type: reqType,
-          request: r,
+          request: request as Prisma.InputJsonValue,
           orderIndex: index + 1,
         })),
-      },
-      orderIndex: orderIndex,
-      type: reqType,
-      children: {
-        create: folder.folders.map((f, index) =>
-          this.generatePrismaQueryObj(f, userID, index + 1, reqType),
-        ),
-      },
-    };
+      });
+    }
+
+    let childOrderIndex = 0;
+    for (const childFolder of folder.folders) {
+      await this.createUserCollectionTree(
+        tx,
+        childFolder,
+        userID,
+        collection.id,
+        ++childOrderIndex,
+        reqType,
+      );
+    }
+
+    return collection;
   }
 
   /**
@@ -1170,25 +1183,32 @@ export class UserCollectionService {
           });
           let lastOrderIndex = lastCollection ? lastCollection.orderIndex : 0;
 
-          // Generate Prisma Query Object for all child collections in collectionsList
-          const queryList = collectionsList.right.map((x) =>
-            this.generatePrismaQueryObj(x, userID, ++lastOrderIndex, reqType),
-          );
-
-          const parent = destCollectionID
-            ? { connect: { id: destCollectionID } }
-            : undefined;
-
-          const promises = queryList.map((query) =>
-            tx.userCollection.create({
-              data: { ...query, parent },
-            }),
-          );
-
-          userCollections = await Promise.all(promises);
+          // Create each root collection tree sequentially (parent-before-child)
+          // to guarantee FK ordering. See createUserCollectionTree for why the
+          // previous nested-create + Promise.all caused P2003 on large imports.
+          userCollections = [];
+          for (const collFolder of collectionsList.right) {
+            userCollections.push(
+              await this.createUserCollectionTree(
+                tx,
+                collFolder,
+                userID,
+                destCollectionID,
+                ++lastOrderIndex,
+                reqType,
+              ),
+            );
+          }
         } catch (error) {
           throw new ConflictException(error);
         }
+      }, {
+        // Large imports run many sequential inserts; the default 10s interactive
+        // transaction timeout (set in PrismaService) is not enough for big collections.
+        // Kept in one transaction for atomicity; trade-off: holds one pooled
+        // connection for up to this long on very large imports.
+        timeout: 60000,
+        maxWait: 10000,
       });
     } catch (error) {
       return E.left(USER_COLLECTION_CREATION_FAILED);


### PR DESCRIPTION
## Summary

Importing a **large** collection (OpenAPI or Hoppscotch format) into a **team** workspace fails with a generic `team_coll/creation_failed`. The same collection imports fine into a **personal** workspace, and small collections import fine into teams.

Backend logs during the failure:

```
ConflictException: Invalid `tx.teamCollection.create()` invocation
Foreign key constraint violated on the constraint: `TeamRequest_collectionID_fkey`
code: 'P2003' ... driverAdapterError
→ ExceptionsHandler: Error: team_coll/creation_failed
```

## Root cause

`TeamCollectionService.importCollectionsFromJSON` generated one deeply-nested `tx.teamCollection.create` per root collection (recursive `children` self-relation + nested `requests`) and ran them concurrently via `Promise.all` inside a single interactive transaction:

```ts
const promises = queryList.map((query) =>
  tx.teamCollection.create({ data: { ...query, parent: ... } }),
)
teamCollections = await Promise.all(promises)
```

Under **Prisma 7 + `@prisma/adapter-pg`**, concurrent writes on a single interactive transaction (one shared connection) interleave the emitted SQL statements. A `TeamRequest` insert can execute before its parent `TeamCollection` is committed, violating `TeamRequest_collectionID_fkey` (P2003). The race only opens with enough concurrent root collections **and** large request bodies (slower inserts widen the window) — exactly a large OpenAPI import (many tag folders + inlined example bodies). Small or personal-workspace imports never hit this path.

## Reproduction

Minimal repro on real Postgres + Prisma `7.8.0` + `@prisma/adapter-pg`, using the exact `TeamCollection` (self-relation) / `TeamRequest` schema and the `TeamRequest_collectionID_fkey` constraint. Trigger case: 40 root collections, ~10KB request bodies, imported under a parent collection.

```
current code  (nested create + Promise.all):    FAILED 5/5  (P2003)
this fix      (sequential parent-before-child): PASSED 5/5
```

Single root collections (even deep/large) and many roots with tiny bodies do **not** reproduce — consistent with the field reports that only large collections fail.

## Fix

Replace the nested-create + `Promise.all` with a sequential, parent-before-child insertion (`createTeamCollectionTree`):

- create each collection first,
- insert its requests via `createMany` once the parent row exists,
- then recurse into child folders with an explicit `parentID`.

This removes both the FK ordering hazard and the concurrent-writes-on-one-interactive-transaction anti-pattern. The interactive transaction timeout is also raised, since large imports now run more sequential statements and can exceed the default 10s.

No schema or migration changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes P2003 foreign key errors on large team imports by creating parent collections before their requests and children. Applies the same sequential import to user collections and raises the transaction timeout so large imports complete reliably.

- **Bug Fixes**
  - Replaced nested `create` + `Promise.all` with sequential `createTeamCollectionTree` and `createUserCollectionTree` (parent-before-child).
  - Inserted requests via `createMany` after the parent exists; recurse children with an explicit `parentID`.
  - Raised interactive transaction timeout to 60s for both imports; no schema changes.

<sup>Written for commit 6e35f51d46b73005f2bcb88cb90c13d5145caa1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

