### PR TITLE
fix(common): resolve environment variables in inherited collection headers

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/Properties.vue
+++ b/packages/hoppscotch-common/src/components/collections/Properties.vue
@@ -264,6 +264,9 @@ export type EditingProperties = {
   isRootCollection: boolean
   path: string
   inheritedProperties?: HoppInheritedProperty
+  // Key the collection's secret/current values are stored under, computed
+  // authoritatively by `editProperties` (team → `id`, personal → `_ref_id`).
+  collectionStoreKey?: string
 }
 type HoppCollectionAuth = HoppRESTAuth | HoppGQLAuth
 type HoppCollectionHeaders = HoppRESTHeaders | GQLHeader[]
@@ -321,16 +324,12 @@ const aggregateEnvs = useReadonlyStream(
   getAggregateEnvsWithCurrentValue()
 )
 
-// Mirror the read/write keying in collections `editProperties`: personal
-// collections are keyed by `_ref_id`, team collections by `id` (falling back
-// to the last path segment). The env tooltip uses sourceEnvID to resolve the
-// collection's stored secret/current values.
+// The store key (team → `id`, personal → `_ref_id`) is computed authoritatively
+// by `editProperties` and passed through here, so it can't diverge from the
+// save-side keying. The env tooltip uses it (as sourceEnvID) to resolve the
+// collection's own stored secret/current values.
 const collectionStoreKey = computed(
-  () =>
-    props.editingProperties.collection?._ref_id ??
-    props.editingProperties.collection?.id ??
-    props.editingProperties.path.split("/").pop() ??
-    ""
+  () => props.editingProperties.collectionStoreKey ?? ""
 )
 
 const envs = computed(() => {

--- a/packages/hoppscotch-common/src/components/collections/Properties.vue
+++ b/packages/hoppscotch-common/src/components/collections/Properties.vue
@@ -324,10 +324,8 @@ const aggregateEnvs = useReadonlyStream(
   getAggregateEnvsWithCurrentValue()
 )
 
-// The store key (team → `id`, personal → `_ref_id`) is computed authoritatively
-// by `editProperties` and passed through here, so it can't diverge from the
-// save-side keying. The env tooltip uses it (as sourceEnvID) to resolve the
-// collection's own stored secret/current values.
+// Surfaces the prop's already-keyed store ID so `envs` can pass it as
+// `sourceEnvID` — lets the env tooltip resolve the collection's own secrets.
 const collectionStoreKey = computed(
   () => props.editingProperties.collectionStoreKey ?? ""
 )
@@ -421,6 +419,7 @@ const persistUnsavedChanges = async (
       isRootCollection: props.editingProperties.isRootCollection ?? false,
       path: props.editingProperties.path,
       inheritedProperties: props.editingProperties.inheritedProperties,
+      collectionStoreKey: props.editingProperties.collectionStoreKey,
     })
   )
 }

--- a/packages/hoppscotch-common/src/components/collections/Properties.vue
+++ b/packages/hoppscotch-common/src/components/collections/Properties.vue
@@ -63,6 +63,7 @@
             v-model="editableCollection.variables"
             :inherited-properties="editingProperties.inheritedProperties"
             :has-team-write-access="hasTeamWriteAccess"
+            :collection-store-key="collectionStoreKey"
           />
         </HoppSmartTab>
 
@@ -320,12 +321,25 @@ const aggregateEnvs = useReadonlyStream(
   getAggregateEnvsWithCurrentValue()
 )
 
+// Mirror the read/write keying in collections `editProperties`: personal
+// collections are keyed by `_ref_id`, team collections by `id` (falling back
+// to the last path segment). The env tooltip uses sourceEnvID to resolve the
+// collection's stored secret/current values.
+const collectionStoreKey = computed(
+  () =>
+    props.editingProperties.collection?._ref_id ??
+    props.editingProperties.collection?.id ??
+    props.editingProperties.path.split("/").pop() ??
+    ""
+)
+
 const envs = computed(() => {
   const collectionVars = editableCollection.value.variables.map((v) => ({
     key: v.key,
     currentValue: v.currentValue,
     initialValue: v.initialValue,
     sourceEnv: "CollectionVariable",
+    sourceEnvID: collectionStoreKey.value,
     secret: v.secret,
   }))
 

--- a/packages/hoppscotch-common/src/components/collections/Properties.vue
+++ b/packages/hoppscotch-common/src/components/collections/Properties.vue
@@ -336,7 +336,7 @@ const envs = computed(() => {
 
   // Note: request-level variables are intentionally NOT merged here since
   // there is no single active request in scope when editing collection-level
-  // properties. See PR #6447 review discussion.
+  // properties.
   return [...collectionVars, ...inheritedVars, ...aggregateEnvs.value]
 })
 

--- a/packages/hoppscotch-common/src/components/collections/Properties.vue
+++ b/packages/hoppscotch-common/src/components/collections/Properties.vue
@@ -21,6 +21,7 @@
           <HttpHeaders
             v-model="editableCollection"
             :is-collection-property="true"
+            :envs="envs"
             @change-tab="changeOptionTab"
           />
           <div
@@ -41,6 +42,7 @@
             :is-collection-property="true"
             :is-root-collection="editingProperties.isRootCollection"
             :inherited-properties="editingProperties.inheritedProperties"
+            :envs="envs"
             :source="source"
           />
           <div
@@ -228,6 +230,12 @@ import preRequestLinter from "~/helpers/editor/linting/preRequest"
 import testScriptLinter from "~/helpers/editor/linting/testScript"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import { useService } from "dioc/vue"
+import { useReadonlyStream } from "@composables/stream"
+import {
+  aggregateEnvsWithCurrentValue$,
+  getAggregateEnvsWithCurrentValue,
+} from "~/newstore/environments"
+import { transformInheritedCollectionVariablesToAggregateEnv } from "~/helpers/utils/inheritedCollectionVarTransformer"
 
 import {
   HoppCollection,
@@ -306,6 +314,28 @@ const copyIcon = refAutoReset<typeof IconCopy | typeof IconCheck>(
 )
 const activeTab = useVModel(props, "modelValue", emit)
 const activeScriptsTab = ref<"pre-request" | "test-script">("pre-request")
+
+const aggregateEnvs = useReadonlyStream(
+  aggregateEnvsWithCurrentValue$,
+  getAggregateEnvsWithCurrentValue()
+)
+
+const envs = computed(() => {
+  const collectionVars = editableCollection.value.variables.map((v) => ({
+    key: v.key,
+    currentValue: v.currentValue,
+    initialValue: v.initialValue,
+    sourceEnv: "CollectionVariable",
+    secret: v.secret,
+  }))
+
+  const inheritedVars = transformInheritedCollectionVariablesToAggregateEnv(
+    props.editingProperties.inheritedProperties?.variables ?? [],
+    true
+  )
+
+  return [...collectionVars, ...inheritedVars, ...aggregateEnvs.value]
+})
 
 const activeTabIsDetails = computed(() => activeTab.value === "details")
 

--- a/packages/hoppscotch-common/src/components/collections/Properties.vue
+++ b/packages/hoppscotch-common/src/components/collections/Properties.vue
@@ -334,6 +334,9 @@ const envs = computed(() => {
     true
   )
 
+  // Note: request-level variables are intentionally NOT merged here since
+  // there is no single active request in scope when editing collection-level
+  // properties. See PR #6447 review discussion.
   return [...collectionVars, ...inheritedVars, ...aggregateEnvs.value]
 })
 

--- a/packages/hoppscotch-common/src/components/collections/Variables.vue
+++ b/packages/hoppscotch-common/src/components/collections/Variables.vue
@@ -223,6 +223,9 @@ const props = defineProps<{
   modelValue: HoppCollectionVariable[]
   inheritedProperties?: HoppInheritedProperty
   hasTeamWriteAccess: boolean
+  // Store key this collection's secret/current values are saved under; lets the
+  // env tooltip resolve own-collection secrets (set by Properties.vue).
+  collectionStoreKey?: string
 }>()
 
 type SelectedEnv = "variables" | "secret"
@@ -290,6 +293,7 @@ const liveEnvs = computed(() => {
     A.map((env) => ({
       ...env,
       sourceEnv: "CollectionVariable",
+      sourceEnvID: props.collectionStoreKey ?? "",
     }))
   )
   const parentInheritedVariables =

--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -3442,10 +3442,11 @@ const editProperties = async (payload: {
       )
     }
 
+    const storeID = (collection as HoppCollection)._ref_id ?? collectionId!
+
     const collectionVariables = pipe(
       (collection as HoppCollection).variables ?? [],
       A.mapWithIndex((index, e) => {
-        const storeID = (collection as HoppCollection)._ref_id ?? collectionId!
         const stored = getSecretValues(e.secret, index, storeID)
         return {
           ...e,
@@ -3466,6 +3467,10 @@ const editProperties = async (payload: {
       isRootCollection: isAlreadyInRoot(collectionIndex),
       path: collectionIndex,
       inheritedProperties,
+      // Persist the exact key secrets/current values were read under, so the
+      // properties modal resolves them without re-deriving (and diverging from)
+      // this keying.
+      collectionStoreKey: storeID,
     }
   } else {
     const parentIndex = collectionIndex.split("/").slice(0, -1).join("/") // remove last folder to get parent folder
@@ -3539,6 +3544,8 @@ const editProperties = async (payload: {
       isRootCollection: isAlreadyInRoot(collectionIndex),
       path: collectionIndex,
       inheritedProperties,
+      // Team collections are keyed by `id` (mirrors the save-side keying).
+      collectionStoreKey: collectionId ?? "",
     }
   }
 

--- a/packages/hoppscotch-common/src/components/embeds/Request.vue
+++ b/packages/hoppscotch-common/src/components/embeds/Request.vue
@@ -65,6 +65,7 @@ import { HoppRESTResponse } from "~/helpers/types/HoppRESTResponse"
 import { runRESTRequest$ } from "~/helpers/RequestRunner"
 import { HoppTab } from "~/services/tab"
 import { HoppRequestDocument } from "~/helpers/rest/document"
+import { transformRequestVariablesToAggregateEnv } from "~/helpers/utils/environments"
 
 const toast = useToast()
 const t = useI18n()
@@ -80,14 +81,11 @@ const requestCancelFunc: Ref<(() => void) | null> = ref(null)
 
 const loading = ref(false)
 
-const tabRequestVariables = computed(() => {
-  return tab.value.document.request.requestVariables.map(({ key, value }) => ({
-    key,
-    value,
-    secret: false,
-    sourceEnv: "RequestVariable",
-  }))
-})
+const tabRequestVariables = computed(() =>
+  transformRequestVariablesToAggregateEnv(
+    tab.value.document.request.requestVariables
+  )
+)
 
 const { subscribeToStream } = useStreamSubscriber()
 

--- a/packages/hoppscotch-common/src/components/embeds/index.vue
+++ b/packages/hoppscotch-common/src/components/embeds/index.vue
@@ -36,6 +36,7 @@ import { HoppTab } from "~/services/tab"
 import { HoppRequestDocument } from "~/helpers/rest/document"
 import { platform } from "~/platform"
 import { RESTOptionTabs } from "../http/RequestOptions.vue"
+import { transformRequestVariablesToAggregateEnv } from "~/helpers/utils/environments"
 
 const props = defineProps<{
   modelTab: HoppTab<HoppRequestDocument>
@@ -55,14 +56,11 @@ const sharedRequestURL = computed(() => {
   return `${shortcodeBaseURL.value}/r/${props.sharedRequestID}`
 })
 
-const tabRequestVariables = computed(() => {
-  return tab.value.document.request.requestVariables.map(({ key, value }) => ({
-    key,
-    value,
-    secret: false,
-    sourceEnv: "RequestVariable",
-  }))
-})
+const tabRequestVariables = computed(() =>
+  transformRequestVariablesToAggregateEnv(
+    tab.value.document.request.requestVariables
+  )
+)
 
 const showCustomEmbedsView = computed(() => {
   const { organization, ui } = platform

--- a/packages/hoppscotch-common/src/components/http/Codegen.vue
+++ b/packages/hoppscotch-common/src/components/http/Codegen.vue
@@ -131,10 +131,7 @@ import {
   getEffectiveRESTRequest,
   resolvesEnvsInBody,
 } from "~/helpers/utils/EffectiveURL"
-import {
-  AggregateEnvironment,
-  getAggregateEnvsWithCurrentValue,
-} from "~/newstore/environments"
+import { getAggregateEnvsWithCurrentValue } from "~/newstore/environments"
 import { getEffectiveVariablesForRequest } from "~/helpers/utils/environments"
 
 import { useService } from "dioc/vue"
@@ -148,14 +145,11 @@ import IconCheck from "~icons/lucide/check"
 import IconWrapText from "~icons/lucide/wrap-text"
 import { asyncComputed } from "@vueuse/core"
 import { getDefaultRESTRequest } from "~/helpers/rest/default"
-import { CurrentValueService } from "~/services/current-environment-value.service"
-import { getCurrentEnvironment } from "../../newstore/environments"
 import { filterNonEmptyEnvironmentVariables } from "~/helpers/RequestRunner"
 
 const t = useI18n()
 
 const tabs = useService(RESTTabService)
-const currentEnvironmentValueService = useService(CurrentValueService)
 
 // Get the current active request if the current active tab is a request else get the original request from the response tab
 const currentActiveRequest = computed(() => {
@@ -194,8 +188,6 @@ defineProps({
 const emit = defineEmits<{
   (e: "request-code", value: string): void
 }>()
-
-
 
 const getFinalURL = (input: string): string => {
   // If the URL is empty, return "https://"

--- a/packages/hoppscotch-common/src/components/http/Codegen.vue
+++ b/packages/hoppscotch-common/src/components/http/Codegen.vue
@@ -135,6 +135,7 @@ import {
   AggregateEnvironment,
   getAggregateEnvsWithCurrentValue,
 } from "~/newstore/environments"
+import { getEffectiveVariablesForRequest } from "~/helpers/utils/environments"
 
 import { useService } from "dioc/vue"
 import cloneDeep from "lodash-es/cloneDeep"
@@ -149,7 +150,6 @@ import { asyncComputed } from "@vueuse/core"
 import { getDefaultRESTRequest } from "~/helpers/rest/default"
 import { CurrentValueService } from "~/services/current-environment-value.service"
 import { getCurrentEnvironment } from "../../newstore/environments"
-import { transformInheritedCollectionVariablesToAggregateEnv } from "~/helpers/utils/inheritedCollectionVarTransformer"
 import { filterNonEmptyEnvironmentVariables } from "~/helpers/RequestRunner"
 
 const t = useI18n()
@@ -195,17 +195,7 @@ const emit = defineEmits<{
   (e: "request-code", value: string): void
 }>()
 
-const getCurrentValue = (env: AggregateEnvironment) => {
-  const currentSelectedEnvironment = getCurrentEnvironment()
 
-  if (env && env.secret) {
-    return env.currentValue
-  }
-  return currentEnvironmentValueService.getEnvironmentByKey(
-    env?.sourceEnv !== "Global" ? currentSelectedEnvironment.id : "Global",
-    env?.key ?? ""
-  )?.currentValue
-}
 
 const getFinalURL = (input: string): string => {
   // If the URL is empty, return "https://"
@@ -244,39 +234,13 @@ const buildFinalEnvironment = (): Environment => {
   const inheritedVariables =
     currentActiveTabDocument.value.inheritedProperties?.variables || []
 
-  const requestVariables = (currentActiveRequest.value?.requestVariables || [])
-    .filter((variable) => variable.active)
-    .map((variable) => ({
-      key: variable.key,
-      initialValue: variable.value,
-      currentValue: variable.value,
-      secret: false,
-    }))
+  const resolvedEnvs = getEffectiveVariablesForRequest(
+    currentActiveRequest.value?.requestVariables,
+    inheritedVariables,
+    aggregateEnvs
+  )
 
-  const collectionVariables =
-    transformInheritedCollectionVariablesToAggregateEnv(inheritedVariables).map(
-      ({ key, initialValue, currentValue, secret }) => ({
-        key,
-        initialValue,
-        currentValue,
-        secret,
-      })
-    )
-
-  const environmentVariables = aggregateEnvs.map((env) => ({
-    key: env.key,
-    secret: env.secret,
-    initialValue: env.initialValue,
-    currentValue: getCurrentValue(env) || env.initialValue,
-  }))
-
-  const allVariables = [
-    ...requestVariables,
-    ...collectionVariables,
-    ...environmentVariables,
-  ]
-
-  const filteredVariables = filterNonEmptyEnvironmentVariables(allVariables)
+  const filteredVariables = filterNonEmptyEnvironmentVariables(resolvedEnvs)
 
   return {
     v: 2,

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -279,6 +279,7 @@ import {
   getComputedHeaders,
 } from "~/helpers/utils/EffectiveURL"
 import { isDragDropAllowed, DragDropEvent } from "~/helpers/dragDropValidation"
+import { filterNonEmptyEnvironmentVariables } from "~/helpers/RequestRunner"
 import {
   AggregateEnvironment,
   aggregateEnvsWithCurrentValue$,
@@ -553,7 +554,10 @@ const clearContent = () => {
   bulkHeaders.value = ""
 }
 
-const aggregateEnvs = useReadonlyStream(aggregateEnvsWithCurrentValue$, getAggregateEnvsWithCurrentValue())
+const aggregateEnvs = useReadonlyStream(
+  aggregateEnvsWithCurrentValue$,
+  getAggregateEnvsWithCurrentValue()
+)
 
 const computedHeaders: Ref<
   {
@@ -572,10 +576,9 @@ const inheritedProperty = ref<
   }[]
 >([])
 
-const currentSelectedEnvironment = getCurrentEnvironment()
-
 const resolvedEnvs = computed(() => {
   if (props.envs) return props.envs
+  const currentSelectedEnvironment = getCurrentEnvironment()
   return aggregateEnvs.value.map((env) => {
     return {
       ...env,
@@ -600,7 +603,10 @@ watch(
       isStale = true
     })
 
-    const headers = await getComputedHeaders(props.modelValue, resolvedEnvs.value)
+    const headers = await getComputedHeaders(
+      props.modelValue,
+      filterNonEmptyEnvironmentVariables(resolvedEnvs.value)
+    )
     if (isStale) return
 
     computedHeaders.value = headers.map((header, index) => ({
@@ -630,7 +636,7 @@ watch(
         )
     )
     const headersList = inheritedHeaders.map((header, index) => ({
-      inheritedFrom: props.inheritedProperties!.headers[index].parentName!,
+      inheritedFrom: header.parentName,
       source: "headers" as const,
       id: `header-${index}`,
       header: header.inheritedHeader,
@@ -646,7 +652,7 @@ watch(
       )
     ) {
       const [computedAuthHeader] = await getComputedAuthHeaders(
-        resolvedEnvs.value,
+        filterNonEmptyEnvironmentVariables(resolvedEnvs.value),
         request.value,
         props.inheritedProperties.auth.inheritedAuth,
         false
@@ -661,8 +667,6 @@ watch(
           header: computedAuthHeader,
         })
       }
-    } else {
-      if (isStale) return
     }
 
     inheritedProperty.value = headersList

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -592,18 +592,33 @@ const resolvedEnvs = computed(() => {
   })
 })
 
-watch([() => props.modelValue, resolvedEnvs], async () => {
-  computedHeaders.value = (
-    await getComputedHeaders(props.modelValue, resolvedEnvs.value)
-  ).map((header, index) => ({
-    id: `header-${index}`,
-    ...header,
-  }))
-}, { immediate: true, deep: true })
+watch(
+  [() => props.modelValue, resolvedEnvs],
+  async (_newVals, _oldVals, onCleanup) => {
+    let isStale = false
+    onCleanup(() => {
+      isStale = true
+    })
+
+    const headers = await getComputedHeaders(props.modelValue, resolvedEnvs.value)
+    if (isStale) return
+
+    computedHeaders.value = headers.map((header, index) => ({
+      id: `header-${index}`,
+      ...header,
+    }))
+  },
+  { immediate: true, deep: true }
+)
 
 watch(
-  () => [props.inheritedProperties, request.value, resolvedEnvs.value],
-  async () => {
+  [() => props.inheritedProperties, request, resolvedEnvs],
+  async (_newVals, _oldVals, onCleanup) => {
+    let isStale = false
+    onCleanup(() => {
+      isStale = true
+    })
+
     if (!props.inheritedProperties) return
 
     const inheritedHeaders = props.inheritedProperties.headers.filter(
@@ -614,9 +629,9 @@ watch(
             requestHeader.active
         )
     )
-    inheritedProperty.value = inheritedHeaders.map((header, index) => ({
+    const headersList = inheritedHeaders.map((header, index) => ({
       inheritedFrom: props.inheritedProperties!.headers[index].parentName!,
-      source: "headers",
+      source: "headers" as const,
       id: `header-${index}`,
       header: header.inheritedHeader,
     }))
@@ -636,15 +651,21 @@ watch(
         props.inheritedProperties.auth.inheritedAuth,
         false
       )
+      if (isStale) return
+
       if (computedAuthHeader) {
-        inheritedProperty.value.push({
+        headersList.push({
           inheritedFrom: props.inheritedProperties.auth.parentName,
-          source: "auth",
+          source: "auth" as const,
           id: `header-auth`,
           header: computedAuthHeader,
         })
       }
+    } else {
+      if (isStale) return
     }
+
+    inheritedProperty.value = headersList
   },
   { immediate: true, deep: true }
 )

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -280,6 +280,7 @@ import {
 } from "~/helpers/utils/EffectiveURL"
 import { isDragDropAllowed, DragDropEvent } from "~/helpers/dragDropValidation"
 import { filterNonEmptyEnvironmentVariables } from "~/helpers/RequestRunner"
+import { normalizeAggregateEnvs } from "~/helpers/utils/environments"
 import {
   AggregateEnvironment,
   aggregateEnvsWithCurrentValue$,
@@ -577,7 +578,9 @@ const inheritedProperty = ref<
 >([])
 
 const resolvedEnvs = computed(() => {
-  if (props.envs) return props.envs
+  // Normalize to the v2 env shape so any legacy `{ key, value }` rows still
+  // resolve correctly in the computed headers/auth below.
+  if (props.envs) return normalizeAggregateEnvs(props.envs)
   const currentSelectedEnvironment = getCurrentEnvironment()
   return aggregateEnvs.value.map((env) => {
     return {

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -625,7 +625,12 @@ watch(
       isStale = true
     })
 
-    if (!props.inheritedProperties) return
+    if (!props.inheritedProperties) {
+      // Clear any previously-computed inherited rows so they don't linger when
+      // the request switches to one without inherited collection settings.
+      inheritedProperty.value = []
+      return
+    }
 
     const inheritedHeaders = props.inheritedProperties.headers.filter(
       (header) =>

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -281,8 +281,8 @@ import {
 import { isDragDropAllowed, DragDropEvent } from "~/helpers/dragDropValidation"
 import {
   AggregateEnvironment,
-  aggregateEnvs$,
-  getAggregateEnvs,
+  aggregateEnvsWithCurrentValue$,
+  getAggregateEnvsWithCurrentValue,
   getCurrentEnvironment,
 } from "~/newstore/environments"
 import { toggleNestedSetting } from "~/newstore/settings"
@@ -553,7 +553,7 @@ const clearContent = () => {
   bulkHeaders.value = ""
 }
 
-const aggregateEnvs = useReadonlyStream(aggregateEnvs$, getAggregateEnvs())
+const aggregateEnvs = useReadonlyStream(aggregateEnvsWithCurrentValue$, getAggregateEnvsWithCurrentValue())
 
 const computedHeaders: Ref<
   {
@@ -599,7 +599,7 @@ watch([() => props.modelValue, resolvedEnvs], async () => {
     id: `header-${index}`,
     ...header,
   }))
-}, { immediate: true })
+}, { immediate: true, deep: true })
 
 watch(
   () => [props.inheritedProperties, request.value, resolvedEnvs.value],

--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -263,7 +263,7 @@ import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
 import * as RA from "fp-ts/ReadonlyArray"
 import { cloneDeep, isEqual } from "lodash-es"
-import { reactive, Ref, ref, toRef, watch } from "vue"
+import { computed, reactive, Ref, ref, toRef, watch } from "vue"
 import draggable from "vuedraggable-es"
 
 import { useVModel } from "@vueuse/core"
@@ -574,8 +574,9 @@ const inheritedProperty = ref<
 
 const currentSelectedEnvironment = getCurrentEnvironment()
 
-watch([props.modelValue, aggregateEnvs], async () => {
-  const resolvedEnvs = aggregateEnvs.value.map((env) => {
+const resolvedEnvs = computed(() => {
+  if (props.envs) return props.envs
+  return aggregateEnvs.value.map((env) => {
     return {
       ...env,
       currentValue:
@@ -589,20 +590,22 @@ watch([props.modelValue, aggregateEnvs], async () => {
             )?.currentValue ?? ""),
     }
   })
+})
+
+watch([() => props.modelValue, resolvedEnvs], async () => {
   computedHeaders.value = (
-    await getComputedHeaders(props.modelValue, resolvedEnvs)
+    await getComputedHeaders(props.modelValue, resolvedEnvs.value)
   ).map((header, index) => ({
     id: `header-${index}`,
     ...header,
   }))
-})
+}, { immediate: true })
 
 watch(
-  () => [props.inheritedProperties, request.value],
+  () => [props.inheritedProperties, request.value, resolvedEnvs.value],
   async () => {
     if (!props.inheritedProperties) return
 
-    //filter out headers that are already in the request headers
     const inheritedHeaders = props.inheritedProperties.headers.filter(
       (header) =>
         !request.value.headers.some(
@@ -628,7 +631,7 @@ watch(
       )
     ) {
       const [computedAuthHeader] = await getComputedAuthHeaders(
-        aggregateEnvs.value,
+        resolvedEnvs.value,
         request.value,
         props.inheritedProperties.auth.inheritedAuth,
         false

--- a/packages/hoppscotch-common/src/components/http/RequestTab.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestTab.vue
@@ -6,7 +6,7 @@
         v-model="tab.document.request"
         v-model:option-tab="tab.document.optionTabPreference!"
         v-model:inherited-properties="tab.document.inheritedProperties"
-        :envs="envs"
+        :envs="resolvedEnvs"
       />
     </template>
     <template #secondary>
@@ -20,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-import { watch } from "vue"
+import { watch, computed } from "vue"
 import { useVModel } from "@vueuse/core"
 import { cloneDeep } from "lodash-es"
 import { isEqualHoppRESTRequest } from "@hoppscotch/data"
@@ -31,6 +31,7 @@ import {
   aggregateEnvsWithCurrentValue$,
   getAggregateEnvsWithCurrentValue,
 } from "~/newstore/environments"
+import { getEffectiveVariablesForRequest } from "~/helpers/utils/environments"
 
 const props = defineProps<{ modelValue: HoppTab<HoppRequestDocument> }>()
 
@@ -44,6 +45,14 @@ const envs = useReadonlyStream(
   aggregateEnvsWithCurrentValue$,
   getAggregateEnvsWithCurrentValue()
 )
+
+const resolvedEnvs = computed(() => {
+  return getEffectiveVariablesForRequest(
+    tab.value.document.request.requestVariables,
+    tab.value.document.inheritedProperties?.variables,
+    envs.value
+  )
+})
 
 // TODO: Come up with a better dirty check
 let oldRequest = cloneDeep(tab.value.document.request)

--- a/packages/hoppscotch-common/src/components/http/RequestTab.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestTab.vue
@@ -6,6 +6,7 @@
         v-model="tab.document.request"
         v-model:option-tab="tab.document.optionTabPreference!"
         v-model:inherited-properties="tab.document.inheritedProperties"
+        :envs="envs"
       />
     </template>
     <template #secondary>
@@ -25,8 +26,11 @@ import { cloneDeep } from "lodash-es"
 import { isEqualHoppRESTRequest } from "@hoppscotch/data"
 import { HoppTab } from "~/services/tab"
 import { HoppRequestDocument } from "~/helpers/rest/document"
-
-// TODO: Move Response and Request execution code to over here
+import { useReadonlyStream } from "@composables/stream"
+import {
+  aggregateEnvsWithCurrentValue$,
+  getAggregateEnvsWithCurrentValue,
+} from "~/newstore/environments"
 
 const props = defineProps<{ modelValue: HoppTab<HoppRequestDocument> }>()
 
@@ -35,6 +39,11 @@ const emit = defineEmits<{
 }>()
 
 const tab = useVModel(props, "modelValue", emit)
+
+const envs = useReadonlyStream(
+  aggregateEnvsWithCurrentValue$,
+  getAggregateEnvsWithCurrentValue()
+)
 
 // TODO: Come up with a better dirty check
 let oldRequest = cloneDeep(tab.value.document.request)

--- a/packages/hoppscotch-common/src/components/http/example/ResponseTab.vue
+++ b/packages/hoppscotch-common/src/components/http/example/ResponseTab.vue
@@ -5,6 +5,8 @@
       <HttpRequestOptions
         v-model="tab.document.response.originalRequest"
         v-model:option-tab="optionTabPreference"
+        v-model:inherited-properties="tab.document.inheritedProperties"
+        :envs="envs"
       />
     </template>
     <template #secondary>
@@ -21,6 +23,11 @@ import { HoppTab } from "~/services/tab"
 import { HoppSavedExampleDocument } from "~/helpers/rest/document"
 import { RESTOptionTabs } from "../RequestOptions.vue"
 import { isEqual } from "lodash-es"
+import { useReadonlyStream } from "@composables/stream"
+import {
+  aggregateEnvsWithCurrentValue$,
+  getAggregateEnvsWithCurrentValue,
+} from "~/newstore/environments"
 
 const props = defineProps<{ modelValue: HoppTab<HoppSavedExampleDocument> }>()
 
@@ -31,6 +38,11 @@ const emit = defineEmits<{
 const tab = useVModel(props, "modelValue", emit)
 
 const optionTabPreference = ref<RESTOptionTabs>("params")
+
+const envs = useReadonlyStream(
+  aggregateEnvsWithCurrentValue$,
+  getAggregateEnvsWithCurrentValue()
+)
 
 // TODO: Come up with a better dirty check
 let oldResponse = cloneDeep(tab.value.document.response)

--- a/packages/hoppscotch-common/src/components/http/example/ResponseTab.vue
+++ b/packages/hoppscotch-common/src/components/http/example/ResponseTab.vue
@@ -6,7 +6,7 @@
         v-model="tab.document.response.originalRequest"
         v-model:option-tab="optionTabPreference"
         v-model:inherited-properties="tab.document.inheritedProperties"
-        :envs="envs"
+        :envs="resolvedEnvs"
       />
     </template>
     <template #secondary>
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { watch, ref } from "vue"
+import { watch, ref, computed } from "vue"
 import { useVModel } from "@vueuse/core"
 import { cloneDeep, isEqual } from "lodash-es"
 import { HoppTab } from "~/services/tab"
@@ -27,6 +27,7 @@ import {
   aggregateEnvsWithCurrentValue$,
   getAggregateEnvsWithCurrentValue,
 } from "~/newstore/environments"
+import { getEffectiveVariablesForRequest } from "~/helpers/utils/environments"
 
 const props = defineProps<{ modelValue: HoppTab<HoppSavedExampleDocument> }>()
 
@@ -42,6 +43,14 @@ const envs = useReadonlyStream(
   aggregateEnvsWithCurrentValue$,
   getAggregateEnvsWithCurrentValue()
 )
+
+const resolvedEnvs = computed(() => {
+  return getEffectiveVariablesForRequest(
+    tab.value.document.response.originalRequest.requestVariables,
+    tab.value.document.inheritedProperties?.variables,
+    envs.value
+  )
+})
 
 // TODO: Come up with a better dirty check
 let oldResponse = cloneDeep(tab.value.document.response)

--- a/packages/hoppscotch-common/src/components/http/example/ResponseTab.vue
+++ b/packages/hoppscotch-common/src/components/http/example/ResponseTab.vue
@@ -18,11 +18,10 @@
 <script setup lang="ts">
 import { watch, ref } from "vue"
 import { useVModel } from "@vueuse/core"
-import { cloneDeep } from "lodash-es"
+import { cloneDeep, isEqual } from "lodash-es"
 import { HoppTab } from "~/services/tab"
 import { HoppSavedExampleDocument } from "~/helpers/rest/document"
 import { RESTOptionTabs } from "../RequestOptions.vue"
-import { isEqual } from "lodash-es"
 import { useReadonlyStream } from "@composables/stream"
 import {
   aggregateEnvsWithCurrentValue$,

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -392,14 +392,24 @@ const aggregateEnvs = useReadonlyStream(
 const tabs = useService(RESTTabService)
 
 const envVars = computed(() => {
-  // If envs are passed directly as props, mask secrets and return them
+  // If envs are passed directly as props, mask secrets and return them.
+  // Keep sourceEnvID: the env tooltip uses it to look up secret/current values
+  // for collection-scoped variables (otherwise they show as "Empty").
   if (props.envs?.length) {
     return props.envs.map(
-      ({ key, currentValue, initialValue, secret, sourceEnv }) => ({
+      ({
+        key,
+        currentValue,
+        initialValue,
+        secret,
+        sourceEnv,
+        sourceEnvID,
+      }) => ({
         key,
         currentValue: secret ? "********" : currentValue,
         initialValue: secret ? "********" : initialValue,
         sourceEnv: sourceEnv ?? "",
+        sourceEnvID,
         secret,
       })
     )

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -101,7 +101,7 @@ import { useService } from "dioc/vue"
 import { RESTTabService } from "~/services/tab/rest"
 import { syntaxTree } from "@codemirror/language"
 import { uniqueID } from "~/helpers/utils/uniqueID"
-import { transformInheritedCollectionVariablesToAggregateEnv } from "~/helpers/utils/inheritedCollectionVarTransformer"
+import { getEffectiveVariablesForRequest } from "~/helpers/utils/environments"
 
 const t = useI18n()
 
@@ -410,34 +410,25 @@ const envVars = computed(() => {
   const isRequest = document.type === "request"
   const isExample = document.type === "example-response"
 
-  // variables inherited from the collection if we're in a request or example
-  const collectionVariables =
-    isRequest || isExample
-      ? transformInheritedCollectionVariablesToAggregateEnv(
-          document.inheritedProperties?.variables ?? [],
-          false
-        )
-      : []
-
-  // request-level variables
-  const rawRequestVars = isRequest
+  // request-level variables for the active request/example
+  const requestVariables = isRequest
     ? document.request.requestVariables
     : isExample
       ? document.response.originalRequest.requestVariables
       : []
 
-  // formated request variables
-  const requestVariables = rawRequestVars
-    .filter((v) => v.active)
-    .map(({ key, value }) => ({
-      key,
-      currentValue: value,
-      initialValue: value,
-      sourceEnv: "RequestVariable",
-      secret: false,
-    }))
+  // variables inherited from the collection if we're in a request or example
+  const inheritedVariables =
+    isRequest || isExample ? document.inheritedProperties?.variables : []
 
-  return [...requestVariables, ...collectionVariables, ...aggregateEnvs.value]
+  // Merge in precedence order (request → collection → environment).
+  // Collection secrets stay masked here (showSecretCollectionValues = false).
+  return getEffectiveVariablesForRequest(
+    requestVariables,
+    inheritedVariables,
+    aggregateEnvs.value,
+    false
+  )
 })
 
 function envAutoCompletion(context: CompletionContext) {

--- a/packages/hoppscotch-common/src/components/smart/EnvInput.vue
+++ b/packages/hoppscotch-common/src/components/smart/EnvInput.vue
@@ -420,14 +420,12 @@ const envVars = computed(() => {
   const isRequest = document.type === "request"
   const isExample = document.type === "example-response"
 
-  // request-level variables for the active request/example
   const requestVariables = isRequest
     ? document.request.requestVariables
     : isExample
       ? document.response.originalRequest.requestVariables
       : []
 
-  // variables inherited from the collection if we're in a request or example
   const inheritedVariables =
     isRequest || isExample ? document.inheritedProperties?.variables : []
 

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -7,10 +7,7 @@ import {
   hoverTooltip,
 } from "@codemirror/view"
 import { StreamSubscriberFunc } from "@composables/stream"
-import {
-  parseTemplateStringE,
-  HoppRESTRequestVariables,
-} from "@hoppscotch/data"
+import { parseTemplateStringE } from "@hoppscotch/data"
 import * as E from "fp-ts/Either"
 import { Ref, watch } from "vue"
 
@@ -35,8 +32,7 @@ import IconVariable from "~icons/lucide/variable?raw"
 import IconLibrary from "~icons/lucide/library?raw"
 
 import { isComment } from "./helpers"
-import { transformInheritedCollectionVariablesToAggregateEnv } from "~/helpers/utils/inheritedCollectionVarTransformer"
-import { HoppInheritedProperty } from "~/helpers/types/HoppInheritedProperties"
+import { getEffectiveVariablesForRequest } from "~/helpers/utils/environments"
 import {
   ENV_VAR_NAME_REGEX,
   HOPP_ENVIRONMENT_REGEX,
@@ -370,34 +366,6 @@ export const environmentHighlightStyle = (
   )
 }
 
-/**
- * Function to get the request variables and collection variables in AggregateEnvironment type
- * @param requestVariables Request Variables defined in the request
- * @param collectionVariables Inherited Collection Variables
- * @returns Transforms the request and collection variables to AggregateEnvironment type
- */
-const getRequestAndCollectionVariables = (
-  requestVariables: HoppRESTRequestVariables,
-  collectionVariables: HoppInheritedProperty["variables"]
-) => {
-  const reqVars = requestVariables
-    .filter((v) => v.active)
-    .map(({ key, value }) => ({
-      key,
-      currentValue: value,
-      initialValue: value,
-      sourceEnv: "RequestVariable",
-      secret: false,
-    }))
-
-  const collVars = transformInheritedCollectionVariablesToAggregateEnv(
-    collectionVariables,
-    false
-  )
-
-  return [...reqVars, ...collVars]
-}
-
 export class HoppEnvironmentPlugin {
   private compartment = new Compartment()
   private envs: AggregateEnvironment[] = []
@@ -429,13 +397,12 @@ export class HoppEnvironmentPlugin {
             ? request.requestVariables
             : []
 
-        const requestAndCollVars = getRequestAndCollectionVariables(
+        this.envs = getEffectiveVariablesForRequest(
           requestVariables,
-          collectionVariables
+          collectionVariables,
+          getAggregateEnvsWithCurrentValue(),
+          false
         )
-
-        const currentAggregateEnvs = getAggregateEnvsWithCurrentValue()
-        this.envs = [...requestAndCollVars, ...currentAggregateEnvs]
 
         this.editorView.value?.dispatch({
           effects: this.compartment.reconfigure([
@@ -460,12 +427,12 @@ export class HoppEnvironmentPlugin {
       const requestVariables =
         request && "requestVariables" in request ? request.requestVariables : []
 
-      const freshRequestAndCollVars = getRequestAndCollectionVariables(
+      this.envs = getEffectiveVariablesForRequest(
         requestVariables,
-        inheritedProperties?.variables ?? []
+        inheritedProperties?.variables ?? [],
+        envs,
+        false
       )
-
-      this.envs = [...freshRequestAndCollVars, ...envs]
 
       this.editorView.value?.dispatch({
         effects: this.compartment.reconfigure([

--- a/packages/hoppscotch-common/src/helpers/utils/__tests__/variablePrecedence.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/__tests__/variablePrecedence.spec.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest"
+import { HoppRESTAuth, HoppRESTRequestVariable } from "@hoppscotch/data"
+import { getEffectiveVariablesForRequest } from "../environments"
+import { getComputedAuthHeaders } from "../EffectiveURL"
+import { AggregateEnvironment } from "~/newstore/environments"
+import { HoppInheritedProperty } from "../../types/HoppInheritedProperties"
+
+describe("inherited collection auth — variable precedence in preview", () => {
+  it("resolves request variable over environment variable with the same key", async () => {
+    // Arrange
+    const collectionAuth: HoppRESTAuth = {
+      authType: "basic",
+      authActive: true,
+      username: "<<token>>",
+      password: "irrelevant",
+    }
+
+    const environmentVars: AggregateEnvironment[] = [
+      {
+        key: "token",
+        currentValue: "env-token",
+        initialValue: "env-token",
+        secret: false,
+        sourceEnv: "Test Env",
+      },
+    ]
+
+    const requestVariables: HoppRESTRequestVariable[] = [
+      { key: "token", value: "request-token", active: true },
+    ]
+
+    // Act — build the same merged list the preview path now produces
+    const resolvedList = getEffectiveVariablesForRequest(
+      requestVariables,
+      [], // no collection vars in this case
+      environmentVars
+    )
+
+    const computedHeaders = await getComputedAuthHeaders(
+      resolvedList,
+      undefined,
+      collectionAuth
+    )
+
+    // Assert
+    const authHeader = computedHeaders.find((h) => h.key === "Authorization")
+    const expectedEncoded = btoa("request-token:irrelevant")
+    expect(authHeader?.value).toBe(`Basic ${expectedEncoded}`)
+    // NOT btoa("env-token:irrelevant") — that would mean the bug regressed
+  })
+
+  it("falls back to environment variable when no request variable exists", async () => {
+    // Arrange
+    const collectionAuth: HoppRESTAuth = {
+      authType: "basic",
+      authActive: true,
+      username: "<<token>>",
+      password: "irrelevant",
+    }
+
+    const environmentVars: AggregateEnvironment[] = [
+      {
+        key: "token",
+        currentValue: "env-token",
+        initialValue: "env-token",
+        secret: false,
+        sourceEnv: "Test Env",
+      },
+    ]
+
+    const requestVariables: HoppRESTRequestVariable[] = []
+
+    // Act
+    const resolvedList = getEffectiveVariablesForRequest(
+      requestVariables,
+      [],
+      environmentVars
+    )
+
+    const computedHeaders = await getComputedAuthHeaders(
+      resolvedList,
+      undefined,
+      collectionAuth
+    )
+
+    // Assert
+    const authHeader = computedHeaders.find((h) => h.key === "Authorization")
+    const expectedEncoded = btoa("env-token:irrelevant")
+    expect(authHeader?.value).toBe(`Basic ${expectedEncoded}`)
+  })
+
+  it("falls back to collection variable when neither request nor matching env var exists", async () => {
+    // Arrange
+    const collectionAuth: HoppRESTAuth = {
+      authType: "basic",
+      authActive: true,
+      username: "<<token>>",
+      password: "irrelevant",
+    }
+
+    const environmentVars: AggregateEnvironment[] = []
+
+    const requestVariables: HoppRESTRequestVariable[] = []
+
+    const inheritedVariables: HoppInheritedProperty["variables"] = [
+      {
+        parentID: "parent-coll",
+        parentName: "Parent Coll",
+        inheritedVariables: [
+          {
+            key: "token",
+            currentValue: "coll-token",
+            initialValue: "coll-token",
+            secret: false,
+          },
+        ],
+      },
+    ]
+
+    // Act
+    const resolvedList = getEffectiveVariablesForRequest(
+      requestVariables,
+      inheritedVariables,
+      environmentVars
+    )
+
+    const computedHeaders = await getComputedAuthHeaders(
+      resolvedList,
+      undefined,
+      collectionAuth
+    )
+
+    // Assert
+    const authHeader = computedHeaders.find((h) => h.key === "Authorization")
+    const expectedEncoded = btoa("coll-token:irrelevant")
+    expect(authHeader?.value).toBe(`Basic ${expectedEncoded}`)
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/utils/__tests__/variablePrecedence.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/__tests__/variablePrecedence.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest"
 import { Environment, HoppRESTAuth } from "@hoppscotch/data"
-import { getEffectiveVariablesForRequest } from "../environments"
+import {
+  getEffectiveVariablesForRequest,
+  normalizeAggregateEnvs,
+} from "../environments"
 import { getComputedAuthHeaders } from "../EffectiveURL"
 import { filterNonEmptyEnvironmentVariables } from "~/helpers/RequestRunner"
 import { AggregateEnvironment } from "~/newstore/environments"
@@ -138,5 +141,40 @@ describe("inherited collection auth — variable precedence in the preview", () 
     )
 
     expect(await authHeaderFor(vars)).toBe(`Basic ${btoa("env-token:pw")}`)
+  })
+})
+
+describe("normalizeAggregateEnvs (legacy { key, value } rows)", () => {
+  test("fills currentValue/initialValue from a legacy `value`, leaving v2 rows intact", () => {
+    const [normalized] = normalizeAggregateEnvs([
+      {
+        key: "token",
+        value: "legacy",
+        secret: false,
+        sourceEnv: "RequestVariable",
+      },
+    ])
+    expect(normalized).toMatchObject({
+      key: "token",
+      currentValue: "legacy",
+      initialValue: "legacy",
+    })
+
+    const v2 = envVar("env", "v2-val")
+    expect(normalizeAggregateEnvs([v2])[0]).toMatchObject(v2)
+  })
+
+  test("a normalized legacy row resolves in computed auth instead of empty", async () => {
+    const legacy = [
+      {
+        key: "token",
+        value: "legacy-token",
+        secret: false,
+        sourceEnv: "RequestVariable",
+      },
+    ]
+    expect(await authHeaderFor(normalizeAggregateEnvs(legacy))).toBe(
+      `Basic ${btoa("legacy-token:pw")}`
+    )
   })
 })

--- a/packages/hoppscotch-common/src/helpers/utils/__tests__/variablePrecedence.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/__tests__/variablePrecedence.spec.ts
@@ -46,10 +46,8 @@ const collectionVar = (
   },
 ]
 
-// The Basic auth header the preview renders for `<<token>>` resolved against `vars`.
-// Pass the auth via a request-like object rather than the bare `auth` argument, so
-// the request context is a real `{ auth, headers }` value instead of an unsafe
-// `undefined` cast — this keeps working if an auth type starts reading the request.
+// Pass auth via a request-like object so the context stays a real `{ auth, headers }`
+// value — keeps working if an auth type starts reading the surrounding request.
 const authHeaderFor = async (vars: Environment["variables"]) => {
   const headers = await getComputedAuthHeaders(vars, {
     auth: collectionAuth,

--- a/packages/hoppscotch-common/src/helpers/utils/__tests__/variablePrecedence.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/__tests__/variablePrecedence.spec.ts
@@ -1,138 +1,136 @@
-import { describe, expect, it } from "vitest"
-import { HoppRESTAuth, HoppRESTRequestVariable } from "@hoppscotch/data"
+import { describe, expect, test } from "vitest"
+import { Environment, HoppRESTAuth } from "@hoppscotch/data"
 import { getEffectiveVariablesForRequest } from "../environments"
 import { getComputedAuthHeaders } from "../EffectiveURL"
+import { filterNonEmptyEnvironmentVariables } from "~/helpers/RequestRunner"
 import { AggregateEnvironment } from "~/newstore/environments"
 import { HoppInheritedProperty } from "../../types/HoppInheritedProperties"
 
-describe("inherited collection auth — variable precedence in preview", () => {
-  it("resolves request variable over environment variable with the same key", async () => {
-    // Arrange
-    const collectionAuth: HoppRESTAuth = {
-      authType: "basic",
-      authActive: true,
-      username: "<<token>>",
-      password: "irrelevant",
-    }
+// A request that inherits auth from a parent collection resolves `<<var>>` from
+// three sources, highest precedence first:
+//   request variable > collection variable > environment variable
+// `getEffectiveVariablesForRequest` builds that ordered list; the preview and the
+// request runner then pass it through `filterNonEmptyEnvironmentVariables`, so an
+// empty high-precedence value falls through to a non-empty lower one.
+// Tests use Basic auth with username "<<token>>", so the encoded header shows
+// which source won.
 
-    const environmentVars: AggregateEnvironment[] = [
-      {
-        key: "token",
-        currentValue: "env-token",
-        initialValue: "env-token",
-        secret: false,
-        sourceEnv: "Test Env",
-      },
-    ]
+const collectionAuth: HoppRESTAuth = {
+  authType: "basic",
+  authActive: true,
+  username: "<<token>>",
+  password: "pw",
+}
 
-    const requestVariables: HoppRESTRequestVariable[] = [
-      { key: "token", value: "request-token", active: true },
-    ]
+const envVar = (key: string, value: string): AggregateEnvironment => ({
+  key,
+  currentValue: value,
+  initialValue: value,
+  secret: false,
+  sourceEnv: "Test Env",
+})
 
-    // Act — build the same merged list the preview path now produces
-    const resolvedList = getEffectiveVariablesForRequest(
-      requestVariables,
-      [], // no collection vars in this case
-      environmentVars
+const collectionVar = (
+  key: string,
+  value: string
+): HoppInheritedProperty["variables"] => [
+  {
+    parentID: "parent-coll",
+    parentName: "Parent Coll",
+    inheritedVariables: [
+      { key, currentValue: value, initialValue: value, secret: false },
+    ],
+  },
+]
+
+// The Basic auth header the preview renders for `<<token>>` resolved against `vars`.
+const authHeaderFor = async (vars: Environment["variables"]) => {
+  const headers = await getComputedAuthHeaders(vars, undefined, collectionAuth)
+  return headers.find((h) => h.key === "Authorization")?.value
+}
+
+describe("getEffectiveVariablesForRequest", () => {
+  test("orders sources request → collection → environment and drops inactive request vars", () => {
+    const vars = getEffectiveVariablesForRequest(
+      [
+        { key: "a", value: "reqA", active: true },
+        { key: "b", value: "reqB", active: false },
+      ],
+      collectionVar("c", "collC"),
+      [envVar("d", "envD")]
     )
 
-    const computedHeaders = await getComputedAuthHeaders(
-      resolvedList,
-      undefined,
-      collectionAuth
-    )
-
-    // Assert
-    const authHeader = computedHeaders.find((h) => h.key === "Authorization")
-    const expectedEncoded = btoa("request-token:irrelevant")
-    expect(authHeader?.value).toBe(`Basic ${expectedEncoded}`)
-    // NOT btoa("env-token:irrelevant") — that would mean the bug regressed
+    expect(vars.map((v) => v.key)).toEqual(["a", "c", "d"])
+    expect(vars[0]).toMatchObject({
+      key: "a",
+      currentValue: "reqA",
+      initialValue: "reqA",
+      sourceEnv: "RequestVariable",
+      secret: false,
+    })
   })
 
-  it("falls back to environment variable when no request variable exists", async () => {
-    // Arrange
-    const collectionAuth: HoppRESTAuth = {
-      authType: "basic",
-      authActive: true,
-      username: "<<token>>",
-      password: "irrelevant",
-    }
+  test("treats undefined request and collection inputs as just the environment list", () => {
+    const vars = getEffectiveVariablesForRequest(undefined, undefined, [
+      envVar("d", "envD"),
+    ])
 
-    const environmentVars: AggregateEnvironment[] = [
-      {
-        key: "token",
-        currentValue: "env-token",
-        initialValue: "env-token",
-        secret: false,
-        sourceEnv: "Test Env",
-      },
-    ]
+    expect(vars).toEqual([
+      expect.objectContaining({ key: "d", currentValue: "envD" }),
+    ])
+  })
+})
 
-    const requestVariables: HoppRESTRequestVariable[] = []
+describe("inherited collection auth — variable precedence in the preview", () => {
+  test("request variable wins over collection and environment", async () => {
+    const vars = getEffectiveVariablesForRequest(
+      [{ key: "token", value: "request-token", active: true }],
+      collectionVar("token", "coll-token"),
+      [envVar("token", "env-token")]
+    )
 
-    // Act
-    const resolvedList = getEffectiveVariablesForRequest(
-      requestVariables,
+    expect(await authHeaderFor(vars)).toBe(`Basic ${btoa("request-token:pw")}`)
+  })
+
+  test("collection variable wins over environment", async () => {
+    const vars = getEffectiveVariablesForRequest(
       [],
-      environmentVars
+      collectionVar("token", "coll-token"),
+      [envVar("token", "env-token")]
     )
 
-    const computedHeaders = await getComputedAuthHeaders(
-      resolvedList,
-      undefined,
-      collectionAuth
-    )
-
-    // Assert
-    const authHeader = computedHeaders.find((h) => h.key === "Authorization")
-    const expectedEncoded = btoa("env-token:irrelevant")
-    expect(authHeader?.value).toBe(`Basic ${expectedEncoded}`)
+    expect(await authHeaderFor(vars)).toBe(`Basic ${btoa("coll-token:pw")}`)
   })
 
-  it("falls back to collection variable when neither request nor matching env var exists", async () => {
-    // Arrange
-    const collectionAuth: HoppRESTAuth = {
-      authType: "basic",
-      authActive: true,
-      username: "<<token>>",
-      password: "irrelevant",
-    }
-
-    const environmentVars: AggregateEnvironment[] = []
-
-    const requestVariables: HoppRESTRequestVariable[] = []
-
-    const inheritedVariables: HoppInheritedProperty["variables"] = [
-      {
-        parentID: "parent-coll",
-        parentName: "Parent Coll",
-        inheritedVariables: [
-          {
-            key: "token",
-            currentValue: "coll-token",
-            initialValue: "coll-token",
-            secret: false,
-          },
-        ],
-      },
-    ]
-
-    // Act
-    const resolvedList = getEffectiveVariablesForRequest(
-      requestVariables,
-      inheritedVariables,
-      environmentVars
+  test("falls back to the environment variable when nothing else defines the key", async () => {
+    const vars = getEffectiveVariablesForRequest(
+      [],
+      [],
+      [envVar("token", "env-token")]
     )
 
-    const computedHeaders = await getComputedAuthHeaders(
-      resolvedList,
-      undefined,
-      collectionAuth
+    expect(await authHeaderFor(vars)).toBe(`Basic ${btoa("env-token:pw")}`)
+  })
+
+  test("raw list: an empty request variable still shadows the env var (first match wins)", async () => {
+    const vars = getEffectiveVariablesForRequest(
+      [{ key: "token", value: "", active: true }],
+      [],
+      [envVar("token", "env-token")]
     )
 
-    // Assert
-    const authHeader = computedHeaders.find((h) => h.key === "Authorization")
-    const expectedEncoded = btoa("coll-token:irrelevant")
-    expect(authHeader?.value).toBe(`Basic ${expectedEncoded}`)
+    expect(await authHeaderFor(vars)).toBe(`Basic ${btoa(":pw")}`)
+  })
+
+  test("filtered list: the empty request variable falls through to the env var (matches runtime)", async () => {
+    const vars = filterNonEmptyEnvironmentVariables(
+      getEffectiveVariablesForRequest(
+        [{ key: "token", value: "", active: true }],
+        [],
+        [envVar("token", "env-token")]
+      )
+    )
+
+    expect(await authHeaderFor(vars)).toBe(`Basic ${btoa("env-token:pw")}`)
   })
 })

--- a/packages/hoppscotch-common/src/helpers/utils/__tests__/variablePrecedence.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/__tests__/variablePrecedence.spec.ts
@@ -44,8 +44,14 @@ const collectionVar = (
 ]
 
 // The Basic auth header the preview renders for `<<token>>` resolved against `vars`.
+// Pass the auth via a request-like object rather than the bare `auth` argument, so
+// the request context is a real `{ auth, headers }` value instead of an unsafe
+// `undefined` cast — this keeps working if an auth type starts reading the request.
 const authHeaderFor = async (vars: Environment["variables"]) => {
-  const headers = await getComputedAuthHeaders(vars, undefined, collectionAuth)
+  const headers = await getComputedAuthHeaders(vars, {
+    auth: collectionAuth,
+    headers: [],
+  })
   return headers.find((h) => h.key === "Authorization")?.value
 }
 

--- a/packages/hoppscotch-common/src/helpers/utils/environments.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/environments.ts
@@ -92,6 +92,25 @@ export const getCombinedEnvVariables = (temp?: Environment["variables"]) => {
 }
 
 /**
+ * Maps a request's `active` variables to the `AggregateEnvironment` (v2) shape,
+ * tagged `RequestVariable` — the stored `value` becomes both current and initial
+ * value. The request-scope counterpart of
+ * `transformInheritedCollectionVariablesToAggregateEnv`.
+ */
+export const transformRequestVariablesToAggregateEnv = (
+  requestVariables: HoppRESTRequestVariable[] | undefined
+): AggregateEnvironment[] =>
+  (requestVariables ?? [])
+    .filter((v) => v.active)
+    .map((v) => ({
+      key: v.key,
+      currentValue: v.value,
+      initialValue: v.value,
+      sourceEnv: "RequestVariable",
+      secret: false,
+    }))
+
+/**
  * Merges a request's variables into one precedence-ordered list:
  * request → collection → environment (highest precedence first). Template
  * resolution picks the first matching key, so this order — matching the
@@ -112,15 +131,7 @@ export const getEffectiveVariablesForRequest = (
   environmentVars: AggregateEnvironment[],
   showSecretCollectionValues = true
 ): AggregateEnvironment[] => {
-  const requestVars = (requestVariables ?? [])
-    .filter((v) => v.active)
-    .map((v) => ({
-      key: v.key,
-      currentValue: v.value,
-      initialValue: v.value,
-      sourceEnv: "RequestVariable",
-      secret: false,
-    }))
+  const requestVars = transformRequestVariablesToAggregateEnv(requestVariables)
 
   const collectionVars = transformInheritedCollectionVariablesToAggregateEnv(
     inheritedVariables ?? [],
@@ -129,3 +140,23 @@ export const getEffectiveVariablesForRequest = (
 
   return [...requestVars, ...collectionVars, ...environmentVars]
 }
+
+/**
+ * Defensively normalizes possibly-legacy env rows to the v2 `AggregateEnvironment`
+ * shape (preserving any extra fields), so consumers like
+ * `filterNonEmptyEnvironmentVariables` / `parseTemplateString` always see a
+ * `currentValue`/`initialValue`. Legacy rows shaped `{ key, value }` (e.g. older
+ * embed callers) lack those fields and would otherwise resolve to an empty string.
+ */
+export const normalizeAggregateEnvs = (
+  envs: ReadonlyArray<
+    Partial<AggregateEnvironment> & { key: string; value?: string }
+  >
+): AggregateEnvironment[] =>
+  envs.map((env) => ({
+    ...env,
+    currentValue: env.currentValue ?? env.value ?? "",
+    initialValue: env.initialValue ?? env.value ?? "",
+    sourceEnv: env.sourceEnv ?? "",
+    secret: env.secret ?? false,
+  }))

--- a/packages/hoppscotch-common/src/helpers/utils/environments.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/environments.ts
@@ -91,12 +91,8 @@ export const getCombinedEnvVariables = (temp?: Environment["variables"]) => {
   }
 }
 
-/**
- * Maps a request's `active` variables to the `AggregateEnvironment` (v2) shape,
- * tagged `RequestVariable` — the stored `value` becomes both current and initial
- * value. The request-scope counterpart of
- * `transformInheritedCollectionVariablesToAggregateEnv`.
- */
+// Active request variables → `AggregateEnvironment` rows; `value` populates both
+// `currentValue` and `initialValue`.
 export const transformRequestVariablesToAggregateEnv = (
   requestVariables: HoppRESTRequestVariable[] | undefined
 ): AggregateEnvironment[] =>
@@ -110,21 +106,12 @@ export const transformRequestVariablesToAggregateEnv = (
       secret: false,
     }))
 
-/**
- * Merges a request's variables into one precedence-ordered list:
- * request → collection → environment (highest precedence first). Template
- * resolution picks the first matching key, so this order — matching the
- * runtime's `combineEnvVariables` — lets request vars override collection vars,
- * which override environment vars. Not de-duplicated.
- *
- * @param requestVariables - Request's own variables; only `active` ones are kept.
- * @param inheritedVariables - Variables inherited from ancestor collections.
- * @param environmentVars - Active environment aggregate (selected + global + predefined).
- * @param showSecretCollectionValues - Resolve inherited collection secrets (`true`,
- *   default) or keep them masked (`false`).
- * @returns Precedence-ordered `AggregateEnvironment[]`. Wrap with
- *   `filterNonEmptyEnvironmentVariables` to match the runtime's empty-value handling.
- */
+// Builds the precedence-ordered variable list for resolving `<<var>>` templates:
+// request → collection → environment (highest first). Matches the runtime's
+// `combineEnvVariables` ordering, so previews stay in sync with execution. Not
+// de-duplicated — wrap with `filterNonEmptyEnvironmentVariables` for the runtime's
+// empty-value fall-through. `showSecretCollectionValues=false` keeps inherited
+// collection secrets masked (used by the inspector / autocomplete).
 export const getEffectiveVariablesForRequest = (
   requestVariables: HoppRESTRequestVariable[] | undefined,
   inheritedVariables: HoppInheritedProperty["variables"] | undefined,

--- a/packages/hoppscotch-common/src/helpers/utils/environments.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/environments.ts
@@ -1,13 +1,16 @@
-import { Environment } from "@hoppscotch/data"
+import { Environment, HoppRESTRequestVariable } from "@hoppscotch/data"
 import { cloneDeep } from "lodash-es"
 
 import { getService } from "~/modules/dioc"
 import {
   getCurrentEnvironment,
   getGlobalVariables,
+  AggregateEnvironment,
 } from "~/newstore/environments"
 import { CurrentValueService } from "~/services/current-environment-value.service"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
+import { HoppInheritedProperty } from "~/helpers/types/HoppInheritedProperties"
+import { transformInheritedCollectionVariablesToAggregateEnv } from "./inheritedCollectionVarTransformer"
 
 const secretEnvironmentService = getService(SecretEnvironmentService)
 const currentEnvironmentValueService = getService(CurrentValueService)
@@ -87,3 +90,26 @@ export const getCombinedEnvVariables = (temp?: Environment["variables"]) => {
     temp: temp ? cloneDeep(temp) : [],
   }
 }
+
+export const getEffectiveVariablesForRequest = (
+  requestVariables: HoppRESTRequestVariable[] | undefined,
+  inheritedVariables: HoppInheritedProperty["variables"] | undefined,
+  environmentVars: AggregateEnvironment[]
+): AggregateEnvironment[] => {
+  const requestVars = (requestVariables ?? [])
+    .filter((v) => v.active)
+    .map((v) => ({
+      key: v.key,
+      currentValue: v.value,
+      initialValue: v.value,
+      sourceEnv: "RequestVariable",
+      secret: false,
+    }))
+
+  const collectionVars = transformInheritedCollectionVariablesToAggregateEnv(
+    inheritedVariables ?? []
+  )
+
+  return [...requestVars, ...collectionVars, ...environmentVars]
+}
+

--- a/packages/hoppscotch-common/src/helpers/utils/environments.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/environments.ts
@@ -91,10 +91,26 @@ export const getCombinedEnvVariables = (temp?: Environment["variables"]) => {
   }
 }
 
+/**
+ * Merges a request's variables into one precedence-ordered list:
+ * request → collection → environment (highest precedence first). Template
+ * resolution picks the first matching key, so this order — matching the
+ * runtime's `combineEnvVariables` — lets request vars override collection vars,
+ * which override environment vars. Not de-duplicated.
+ *
+ * @param requestVariables - Request's own variables; only `active` ones are kept.
+ * @param inheritedVariables - Variables inherited from ancestor collections.
+ * @param environmentVars - Active environment aggregate (selected + global + predefined).
+ * @param showSecretCollectionValues - Resolve inherited collection secrets (`true`,
+ *   default) or keep them masked (`false`).
+ * @returns Precedence-ordered `AggregateEnvironment[]`. Wrap with
+ *   `filterNonEmptyEnvironmentVariables` to match the runtime's empty-value handling.
+ */
 export const getEffectiveVariablesForRequest = (
   requestVariables: HoppRESTRequestVariable[] | undefined,
   inheritedVariables: HoppInheritedProperty["variables"] | undefined,
-  environmentVars: AggregateEnvironment[]
+  environmentVars: AggregateEnvironment[],
+  showSecretCollectionValues = true
 ): AggregateEnvironment[] => {
   const requestVars = (requestVariables ?? [])
     .filter((v) => v.active)
@@ -107,9 +123,9 @@ export const getEffectiveVariablesForRequest = (
     }))
 
   const collectionVars = transformInheritedCollectionVariablesToAggregateEnv(
-    inheritedVariables ?? []
+    inheritedVariables ?? [],
+    showSecretCollectionValues
   )
 
   return [...requestVars, ...collectionVars, ...environmentVars]
 }
-

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -23,7 +23,7 @@ import { useStreamStatic } from "~/composables/stream"
 import { SecretEnvironmentService } from "~/services/secret-environment.service"
 import { RESTTabService } from "~/services/tab/rest"
 import { CurrentValueService } from "~/services/current-environment-value.service"
-import { transformInheritedCollectionVariablesToAggregateEnv } from "~/helpers/utils/inheritedCollectionVarTransformer"
+import { getEffectiveVariablesForRequest } from "~/helpers/utils/environments"
 import { HOPP_ENVIRONMENT_REGEX } from "~/helpers/environment-regex"
 
 const isENVInString = (str: string) => HOPP_ENVIRONMENT_REGEX.test(str)
@@ -81,33 +81,16 @@ export class EnvironmentInspectorService extends Service implements Inspector {
           ? currentTab.document.response.originalRequest
           : null
 
-    // inherited collection-level variables
-    const collectionVariables =
+    // request → collection → environment, in the same precedence order the
+    // request runner uses (single source of truth)
+    const environmentVariables = getEffectiveVariablesForRequest(
+      currentTabRequest?.requestVariables,
       currentTab.document.type === "request" ||
-      currentTab.document.type === "example-response"
-        ? transformInheritedCollectionVariablesToAggregateEnv(
-            currentTab.document.inheritedProperties?.variables ?? []
-          )
-        : []
-
-    // request variables (active only)
-    const requestVariables =
-      currentTabRequest?.requestVariables
-        .filter((v) => v.active)
-        .map(({ key, value }) => ({
-          key,
-          currentValue: value,
-          initialValue: value,
-          sourceEnv: "RequestVariable",
-          secret: false,
-        })) ?? []
-
-    // combine everything into one list
-    const environmentVariables = [
-      ...requestVariables,
-      ...collectionVariables,
-      ...this.aggregateEnvsWithValue.value,
-    ]
+        currentTab.document.type === "example-response"
+        ? currentTab.document.inheritedProperties?.variables
+        : [],
+      this.aggregateEnvsWithValue.value
+    )
     const envKeysSet = new Set(environmentVariables.map((e) => e.key))
 
     // Scan each string for <<VAR>> patterns
@@ -217,34 +200,19 @@ export class EnvironmentInspectorService extends Service implements Inspector {
               ? currentTab.document.response.originalRequest
               : null
 
-        // request variables (active only)
-        const requestVariables =
-          currentTabRequest?.requestVariables
-            .filter((v) => v.active)
-            .map(({ key, value }) => ({
-              key,
-              currentValue: value,
-              initialValue: value,
-              sourceEnv: "RequestVariable",
-              secret: false,
-            })) ?? []
-
-        // inherited collection variables
-        const collectionVariables =
-          currentTab.document.type === "request" ||
-          currentTab.document.type === "example-response"
-            ? transformInheritedCollectionVariablesToAggregateEnv(
-                currentTab.document.inheritedProperties?.variables ?? [],
-                false
-              )
-            : []
-
-        // Merge all variables
-        const environmentVariables = this.filterNonEmptyEnvironmentVariables([
-          ...requestVariables,
-          ...collectionVariables,
-          ...this.aggregateEnvsWithValue.value,
-        ])
+        // request → collection → environment, matching the request runner's
+        // precedence and non-empty resolution (single source of truth)
+        const environmentVariables = this.filterNonEmptyEnvironmentVariables(
+          getEffectiveVariablesForRequest(
+            currentTabRequest?.requestVariables,
+            currentTab.document.type === "request" ||
+              currentTab.document.type === "example-response"
+              ? currentTab.document.inheritedProperties?.variables
+              : [],
+            this.aggregateEnvsWithValue.value,
+            false
+          )
+        )
 
         // Check each variable for missing values
         environmentVariables.forEach((env) => {


### PR DESCRIPTION
Closes #6446

Had a look at the issue — when a request inherits Basic Auth from a 
collection and the username/password fields use `<<variable>>` syntax, 
the Authorization header comes out empty and the request 401s.

The problem is in `Headers.vue` — it was pulling from `aggregateEnvs$` 
which only has the saved initial values, not whatever the user has 
actually set in their active environment session. So the variables never 
resolve.

Fix threads `aggregateEnvsWithCurrentValue$` through instead, which 
includes current session values and secrets. Also wired the `envs` prop 
down through `RequestTab`, `ResponseTab`, and the collection 
`Properties` modal so the preview tooltips in the auth fields resolve 
correctly too.

## Files changed

- `http/Headers.vue` — switched to `aggregateEnvsWithCurrentValue$`, added `envs` prop with fallback, updated the watch on `inheritedProperties`
- `http/RequestTab.vue` — pass resolved envs down to `HttpRequestOptions`  
- `http/ResponseTab.vue` — same
- `collections/Properties.vue` — combine inherited collection vars + active env and pass to `HttpHeaders` and `HttpAuthorization`

## Testing

1. Create an environment, add `username` and `password` variables
2. Create a collection, set Basic Auth using `<<username>>` / `<<password>>`
3. Add a child request set to Inherit auth
4. Check the Headers tab — Authorization should show the resolved Base64 value
5. Switch environment and confirm it updates
6. Open collection Properties → Authorization tab, hover the variable tokens — tooltip should show the resolved value not the raw placeholder
7. Send the request — should get 200 not 401

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6446. Resolves env vars in inherited Basic Auth and headers, enforces request → collection → environment precedence in previews and execution, prevents stale previews/401s, and keeps collection secrets resolving in tooltips (incl. after OAuth redirects); also normalizes legacy env rows so embeds and previews resolve.

- **Bug Fixes**
  - Switch to `aggregateEnvsWithCurrentValue$`, add `:envs` prop, compute headers/auth with stale-update cancellation and non-empty filtering; normalize legacy `{ key, value }` rows via `normalizeAggregateEnvs`; clear inherited rows when the next request has no inherited properties.
  - Add `getEffectiveVariablesForRequest` (request > collection > environment) and use it in `RequestTab`, example `ResponseTab`, `Codegen`, `EnvInput`, the editor env tooltip extension, embeds, and the environment inspector; expand tests for precedence and empty-value fallthrough, and pass auth as a request-like object for correct header context.
  - In collection `Properties`/`Variables`, merge collection + inherited vars with the active env and pass to `HttpHeaders`/`HttpAuthorization`; introduce `collectionStoreKey`, set `sourceEnvID` on collection variables so tooltips resolve secret/current values, and preserve it across OAuth redirect rehydration; exclude request-level vars.

<sup>Written for commit 6625895a368af1297a2f28b5217b4a5bc2dca046. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

