### PR TITLE
feat(mock-server): append /backend to domain-based URL when subpath access is enabled

### DIFF
--- a/packages/hoppscotch-backend/src/mock-server/mock-server.service.spec.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.service.spec.ts
@@ -151,6 +151,102 @@ describe('MockServerService', () => {
     });
   });
 
+  describe('cast - server URL generation', () => {
+    test('should not append /backend to serverUrlDomainBased when ENABLE_SUBPATH_BASED_ACCESS is not set', async () => {
+      mockPrisma.mockServer.findMany.mockResolvedValue([dbMockServer]);
+
+      const result = await mockServerService.getUserMockServers(user.uid, {
+        take: 10,
+        skip: 0,
+      });
+
+      expect(result[0].serverUrlDomainBased).toBe(
+        'http://test-subdomain.mock.hopp.io',
+      );
+    });
+
+    test('should not append /backend to serverUrlDomainBased when ENABLE_SUBPATH_BASED_ACCESS is "false"', async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'VITE_BACKEND_API_URL') return 'http://localhost:3170/v1';
+        if (key === 'INFRA.MOCK_SERVER_WILDCARD_DOMAIN')
+          return '*.mock.hopp.io';
+        if (key === 'INFRA.ALLOW_SECURE_COOKIES') return 'false';
+        if (key === 'ENABLE_SUBPATH_BASED_ACCESS') return 'false';
+        return undefined;
+      });
+      mockPrisma.mockServer.findMany.mockResolvedValue([dbMockServer]);
+
+      const result = await mockServerService.getUserMockServers(user.uid, {
+        take: 10,
+        skip: 0,
+      });
+
+      expect(result[0].serverUrlDomainBased).toBe(
+        'http://test-subdomain.mock.hopp.io',
+      );
+    });
+
+    test('should append /backend to serverUrlDomainBased when ENABLE_SUBPATH_BASED_ACCESS is "true"', async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'VITE_BACKEND_API_URL') return 'http://localhost:3170/v1';
+        if (key === 'INFRA.MOCK_SERVER_WILDCARD_DOMAIN')
+          return '*.mock.hopp.io';
+        if (key === 'INFRA.ALLOW_SECURE_COOKIES') return 'false';
+        if (key === 'ENABLE_SUBPATH_BASED_ACCESS') return 'true';
+        return undefined;
+      });
+      mockPrisma.mockServer.findMany.mockResolvedValue([dbMockServer]);
+
+      const result = await mockServerService.getUserMockServers(user.uid, {
+        take: 10,
+        skip: 0,
+      });
+
+      expect(result[0].serverUrlDomainBased).toBe(
+        'http://test-subdomain.mock.hopp.io/backend',
+      );
+    });
+
+    test('should use https protocol and append /backend when secure cookies and subpath access are enabled', async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'VITE_BACKEND_API_URL') return 'https://localhost:3170/v1';
+        if (key === 'INFRA.MOCK_SERVER_WILDCARD_DOMAIN')
+          return '*.mock.hopp.io';
+        if (key === 'INFRA.ALLOW_SECURE_COOKIES') return 'true';
+        if (key === 'ENABLE_SUBPATH_BASED_ACCESS') return 'true';
+        return undefined;
+      });
+      mockPrisma.mockServer.findMany.mockResolvedValue([dbMockServer]);
+
+      const result = await mockServerService.getUserMockServers(user.uid, {
+        take: 10,
+        skip: 0,
+      });
+
+      expect(result[0].serverUrlDomainBased).toBe(
+        'https://test-subdomain.mock.hopp.io/backend',
+      );
+    });
+
+    test('should leave serverUrlDomainBased null and not append /backend when wildcard domain is not configured', async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'VITE_BACKEND_API_URL') return 'http://localhost:3170/v1';
+        if (key === 'INFRA.MOCK_SERVER_WILDCARD_DOMAIN') return undefined;
+        if (key === 'INFRA.ALLOW_SECURE_COOKIES') return 'false';
+        if (key === 'ENABLE_SUBPATH_BASED_ACCESS') return 'true';
+        return undefined;
+      });
+      mockPrisma.mockServer.findMany.mockResolvedValue([dbMockServer]);
+
+      const result = await mockServerService.getUserMockServers(user.uid, {
+        take: 10,
+        skip: 0,
+      });
+
+      expect(result[0].serverUrlDomainBased).toBeNull();
+    });
+  });
+
   describe('getTeamMockServers', () => {
     test('should return team mock servers with pagination', async () => {
       const teamMockServer = {

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.service.spec.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.service.spec.ts
@@ -245,6 +245,27 @@ describe('MockServerService', () => {
 
       expect(result[0].serverUrlDomainBased).toBeNull();
     });
+
+    test('should strip trailing slashes from wildcard domain before appending subpath suffix', async () => {
+      mockConfigService.get.mockImplementation((key: string) => {
+        if (key === 'VITE_BACKEND_API_URL') return 'http://localhost:3170/v1';
+        if (key === 'INFRA.MOCK_SERVER_WILDCARD_DOMAIN')
+          return '*.mock.hopp.io/'; // Domain with trailing slash
+        if (key === 'INFRA.ALLOW_SECURE_COOKIES') return 'false';
+        if (key === 'ENABLE_SUBPATH_BASED_ACCESS') return 'true';
+        return undefined;
+      });
+      mockPrisma.mockServer.findMany.mockResolvedValue([dbMockServer]);
+
+      const result = await mockServerService.getUserMockServers(user.uid, {
+        take: 10,
+        skip: 0,
+      });
+
+      expect(result[0].serverUrlDomainBased).toBe(
+        'http://test-subdomain.mock.hopp.io/backend',
+      );
+    });
   });
 
   describe('getTeamMockServers', () => {

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.service.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.service.ts
@@ -64,15 +64,20 @@ export class MockServerService {
     const isSecure =
       this.configService.get<string>('INFRA.ALLOW_SECURE_COOKIES') === 'true';
     const protocol = isSecure ? 'https://' : 'http://';
+
+    // ENABLE_SUBPATH_BASED_ACCESS is a flat config key (no INFRA. prefix) to support flexible deployment strategies
+    const SUBPATH_BACKEND_SUFFIX = '/backend';
     const subpathSuffix =
       this.configService.get<string>('ENABLE_SUBPATH_BASED_ACCESS') === 'true'
-        ? '/backend'
+        ? SUBPATH_BACKEND_SUFFIX
         : '';
-    const serverUrlDomainBased = wildcardDomain
-      ? protocol +
-        dbMockServer.subdomain +
-        wildcardDomain.substring(1) +
-        subpathSuffix
+
+    const domainPart = wildcardDomain
+      ? dbMockServer.subdomain + wildcardDomain.substring(1)
+      : null;
+
+    const serverUrlDomainBased = domainPart
+      ? `${protocol}${domainPart.replace(/\/+$/, '')}${subpathSuffix}`
       : null;
 
     return {

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.service.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.service.ts
@@ -64,8 +64,15 @@ export class MockServerService {
     const isSecure =
       this.configService.get<string>('INFRA.ALLOW_SECURE_COOKIES') === 'true';
     const protocol = isSecure ? 'https://' : 'http://';
+    const subpathSuffix =
+      this.configService.get<string>('ENABLE_SUBPATH_BASED_ACCESS') === 'true'
+        ? '/backend'
+        : '';
     const serverUrlDomainBased = wildcardDomain
-      ? protocol + dbMockServer.subdomain + wildcardDomain.substring(1)
+      ? protocol +
+        dbMockServer.subdomain +
+        wildcardDomain.substring(1) +
+        subpathSuffix
       : null;
 
     return {


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes BE-782

When a deployment uses subpath-based access (`ENABLE_SUBPATH_BASED_ACCESS=true`), the backend is served under the `/backend` subpath. The generated domain-based mock server URL (`serverUrlDomainBased`) previously omitted this suffix, so the URL did not route correctly in those deployments. This PR appends `/backend` to that URL when subpath-based access is enabled.

### What's changed

- `mock-server.service.ts`: in the `cast` helper, read `ENABLE_SUBPATH_BASED_ACCESS` via `ConfigService` and conditionally append `/backend` to `serverUrlDomainBased`.
  - Only the domain-based URL is affected. `serverUrlPathBased` is unchanged since it derives from `VITE_BACKEND_API_URL`, which already reflects the subpath.
  - The existing `null` guard (when no wildcard domain is configured) is preserved — no suffix is added in that case.
  - Example: `https://myapp.mock.hopp.io` → `https://myapp.mock.hopp.io/backend`
- `mock-server.service.spec.ts`: add a `cast - server URL generation` test block covering the unset, `"false"`, `"true"`, secure-cookies (`https`), and null-wildcard cases.

### Notes to reviewers

- `ENABLE_SUBPATH_BASED_ACCESS` is a plain process env var (not under the `INFRA.` namespace), read the same way as `WHITELISTED_ORIGINS`.
- The new field is only consumed by the frontend display layer; there are no other side effects.
