### PR TITLE
fix(common): correct share message grammar

### DIFF
--- a/packages/hoppscotch-common/src/components/app/Share.vue
+++ b/packages/hoppscotch-common/src/components/app/Share.vue
@@ -67,7 +67,7 @@ const text = "Hoppscotch - Open source API development ecosystem."
 const description =
   "Helps you create requests faster, saving precious time on development."
 const subject = "Checkout Hoppscotch - an open source API development ecosystem"
-const summary = `Hi there!%0D%0A%0D%0AI thought you'll like this new platform that I joined called Hoppscotch - https://hoppscotch.io.%0D%0AIt is a simple and intuitive interface for creating and managing your APIs. You can build, test, document, and share your APIs.%0D%0A%0D%0AThe best part about Hoppscotch is that it is open source and free to get started.%0D%0A%0D%0A`
+const summary = `Hi there!%0D%0A%0D%0AI thought you'd like this new platform that I joined called Hoppscotch - https://hoppscotch.io.%0D%0AIt is a simple and intuitive interface for creating and managing your APIs. You can build, test, document, and share your APIs.%0D%0A%0D%0AThe best part about Hoppscotch is that it is open source and free to get started.%0D%0A%0D%0A`
 const twitter = "hoppscotch_io"
 
 const copyIcon = refAutoReset<typeof IconCopy | typeof IconCheck>(


### PR DESCRIPTION
## Summary
Fix "your" vs "you are" grammar mistake in app description.

Closes #6332

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the share message grammar in the Share dialog by changing 'I thought you'll like' to 'I thought you'd like' so the prefilled text reads naturally.

<sup>Written for commit 31e5d6f3b2f1c8e13bc7a6bdfe1af8bcfa09f3c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

