### PR TITLE
fix(common): preserve headers containing colon-space in cURL import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -870,6 +870,36 @@ const samples = [
     }),
   },
   {
+    command: `curl google.com -H "X-Signature: sha256: abc:def"`,
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "https://google.com/",
+      auth: {
+        authType: "inherit",
+        authActive: true,
+      },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      params: [],
+      headers: [
+        {
+          active: true,
+          key: "X-Signature",
+          value: "sha256: abc:def",
+          description: "",
+        },
+      ],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+      description: null,
+    }),
+  },
+  {
     command: `curl google.com -H "Authorization"`,
     response: makeRESTRequest({
       method: "GET",

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -2,7 +2,6 @@ import { HoppRESTHeader } from "@hoppscotch/data"
 import * as A from "fp-ts/Array"
 import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
 import parser from "yargs-parser"
 import {
   objHasArrayProperty,
@@ -10,13 +9,21 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
-const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
-)
+const getHeaderPair = (header: string) => {
+  const separatorIndex = header.indexOf(":")
+
+  return pipe(
+    separatorIndex,
+    O.fromPredicate((index) => index >= 0),
+    O.map(
+      (index) =>
+        [header.slice(0, index).trim(), header.slice(index + 1).trim()] as [
+          string,
+          string,
+        ]
+    )
+  )
+}
 
 export function getHeaders(parsedArguments: parser.Arguments) {
   let headers: Record<string, string> = {}


### PR DESCRIPTION
## Summary
Fix cURL import silently dropping headers whose value contains ": " (colon+space).

Closes #6400

## Root Cause
The header parser splits on all occurrences of ": " instead of only the first one. Per RFC 9110, a header is name: value where only the first colon separates name from value.

## Changes
Updated the cURL header parser to split only on the first colon, preserving colon-space sequences in header values.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cURL import dropping headers when the value contains ": ". We now split on only the first colon to keep the full header value.

- **Bug Fixes**
  - Updated `hoppscotch-common` cURL header parser to split on the first `:` only (per RFC 9110).
  - Added a test for `X-Signature: sha256: abc:def` to ensure values with colons are preserved.

<sup>Written for commit 1fbc0eb8aae3f310989f398d50b949acf4430e35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

