### PR TITLE
fix(common): preserve literal }} in Postman collection import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/postman.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/postman.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import { replacePMVarTemplating } from "../postman"
+
+describe("replacePMVarTemplating", () => {
+  it("converts matched Postman variable templates to Hoppscotch templates", () => {
+    expect(replacePMVarTemplating("{{baseUrl}}/users/{{ userId }}")).toBe(
+      "<<baseUrl>>/users/<<userId>>"
+    )
+  })
+
+  it("preserves unmatched closing Postman template delimiters", () => {
+    expect(replacePMVarTemplating('{ "literal": "}}" }')).toBe(
+      '{ "literal": "}}" }'
+    )
+  })
+
+  it("does not let unmatched closing delimiters affect later valid variables", () => {
+    expect(replacePMVarTemplating('body }} then {{variable}}')).toBe(
+      'body }} then <<variable>>'
+    )
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/postman.ts
@@ -65,7 +65,8 @@ const getCollectionSchema = (jsonStr: string): string | null => {
 
 export const replacePMVarTemplating = (value: unknown): string => {
   const str = typeof value === "string" ? value : String(value ?? "")
-  return pipe(str, S.replace(/{{\s*/g, "<<"), S.replace(/\s*}}/g, ">>"))
+
+  return str.replace(/{{\s*([^{}]*?)\s*}}/g, "<<$1>>")
 }
 
 const PMRawLanguageOptionsToContentTypeMap: Record<


### PR DESCRIPTION
## Summary
Fix Postman collection import converting literal `}}` to `>>`, corrupting JSON bodies.

Closes #6324

## Root Cause
The Postman variable substitution replaces `}}` unconditionally without checking that `{{` opened a variable reference.

## Changes
Updated the variable replacement logic to only substitute matched `{{var}}` pairs, leaving unmatched `}}` as-is.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves literal "}}" during Postman collection import to prevent JSON body corruption and only converts valid `{{var}}` templates.

- **Bug Fixes**
  - Updated `replacePMVarTemplating` to convert only matched `{{ ... }}` to `<<...>>`.
  - Added tests covering matched variables, unmatched closing delimiters, and unaffected later variables.

<sup>Written for commit 4b7fa1d7c707ecc55aa22046d83c35295a1acf90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

