### PR TITLE
fix(common): preserve float .0 precision in request body

### DIFF
--- a/packages/hoppscotch-common/src/helpers/kernel/__tests__/kernel.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/__tests__/kernel.spec.ts
@@ -331,6 +331,32 @@ describe("REST Request Transformation", () => {
     })
   })
 
+  it("preserves JSON request body text without re-serializing numbers", async () => {
+    const jsonBody = '{"amount":70.0,"nested":{"value":1.0}}'
+    const request: EffectiveHoppRESTRequest = {
+      ...baseEffectiveRequest,
+      method: "POST",
+      body: { contentType: "application/json", body: jsonBody },
+      effectiveFinalBody: jsonBody,
+      effectiveFinalHeaders: [
+        {
+          active: true,
+          key: "content-type",
+          value: "application/json",
+          description: "",
+        },
+      ],
+    }
+
+    const result = await RESTRequest.toRequest(request)
+
+    expect(result.content).toEqual({
+      kind: "text",
+      content: jsonBody,
+      mediaType: "application/json",
+    })
+  })
+
   it("includes auth parameters when basic auth is active", async () => {
     const request: EffectiveHoppRESTRequest = {
       ...baseEffectiveRequest,

--- a/packages/hoppscotch-common/src/helpers/kernel/common/content.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/common/content.ts
@@ -5,6 +5,12 @@ import { pipe } from "fp-ts/function"
 
 import { ContentType, MediaType, content } from "@hoppscotch/kernel"
 import { EffectiveHoppRESTRequest } from "~/helpers/utils/EffectiveURL"
+import { isJSONContentType } from "~/helpers/utils/contenttypes"
+
+const isJSONContentTypeWithPreservedText = (
+  contentType: string | null
+): contentType is string =>
+  typeof contentType === "string" && isJSONContentType(contentType)
 
 /**
  * Content processors for converting raw body strings to standardized ContentType objects.
@@ -13,17 +19,6 @@ import { EffectiveHoppRESTRequest } from "~/helpers/utils/EffectiveURL"
  * NOTE: Validation belongs in upper layers, not the processor layer.
  */
 const Processors = {
-  /**
-   * Processes JSON content as pre-stringified JSON text.
-   *
-   * NOTE: Assumes input is valid JSON in string format since user selected "JSON".
-   * Uses `content.text()` with JSON media type to avoid double-encoding.
-   */
-  json: {
-    process: (body: string): E.Either<Error, ContentType> =>
-      E.right(content.text(body, MediaType.APPLICATION_JSON)),
-  },
-
   /**
    * Processes binary content from Blob/File objects.
    *
@@ -92,11 +87,6 @@ const Processors = {
  */
 const getProcessor = (contentType: string) => {
   switch (contentType) {
-    case "application/json":
-    case "application/ld+json":
-    case "application/hal+json":
-    case "application/vnd.api+json":
-      return Processors.json.process
     case "application/xml":
     case "text/xml":
       return Processors.xml.process
@@ -144,6 +134,15 @@ export const transformContent = (
       if (typeof effectiveFinalBody !== "string") {
         return TE.right(O.none)
       }
+
+      // JSON request bodies originate from the editor as text. Preserve that
+      // exact representation instead of passing it through any JSON parser or
+      // serializer, because JavaScript number serialization normalizes values
+      // like `70.0` to `70`.
+      if (isJSONContentTypeWithPreservedText(body.contentType)) {
+        return TE.right(O.some(content.text(effectiveFinalBody, body.contentType)))
+      }
+
       return pipe(
         TE.fromEither(getProcessor(body.contentType)(effectiveFinalBody)),
         TE.map(O.some)

--- a/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/EffectiveURL.ts
@@ -30,6 +30,20 @@ import { toFormData } from "../functional/formData"
 import { tupleWithSameKeysToRecord } from "../functional/record"
 import { isJSONContentType } from "./contenttypes"
 
+const getJSONBodyContent = (body: string | null): string => {
+  const bodyContent = body ?? ""
+
+  // If the body is already valid JSON, preserve the exact text the user wrote.
+  // Rebuilding JSON through a parser/serializer normalizes number tokens, e.g.
+  // `70.0` becomes `70`, which changes the outbound request body.
+  try {
+    JSON.parse(bodyContent)
+    return bodyContent
+  } catch (_) {
+    return stripComments(bodyContent)
+  }
+}
+
 export interface EffectiveHoppRESTRequest extends HoppRESTRequest {
   /**
    * The effective final URL.
@@ -241,7 +255,7 @@ export const resolvesEnvsInBody = (
   // underlying stripComments_("") from jsonc-parser returns null. This pattern is used
   // consistently throughout this file (see also getFinalBodyFromRequest).
   if (isJSONContentType(body.contentType))
-    bodyContent = stripComments(body.body ?? "")
+    bodyContent = getJSONBodyContent(body.body)
 
   if (body.contentType === "application/x-www-form-urlencoded") {
     bodyContent = body.body
@@ -343,7 +357,7 @@ export function getFinalBodyFromRequest(
   let bodyContent = request.body.body ?? ""
 
   if (isJSONContentType(request.body.contentType))
-    bodyContent = stripComments(request.body.body ?? "")
+    bodyContent = getJSONBodyContent(request.body.body)
 
   // body can be null if the content-type is not set
   return parseBodyEnvVariables(bodyContent, envVariables)


### PR DESCRIPTION
## Summary
Fix request body float values like 70.0 being sent as 70 (integer).

Closes #6317

## Root Cause
JSON.parse/JSON.stringify round-trip drops .0 from float values. The body should be sent as-is when it is already valid JSON text.

## Changes
Avoid re-serializing JSON body through parse/stringify when the raw text is already valid JSON, preserving the original numeric representation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the exact JSON request body text so numbers like 70.0 aren’t normalized to 70 when sending requests. Prevents precision loss for JSON bodies.

- **Bug Fixes**
  - For JSON content types, send the body exactly as written if it’s already valid JSON; skip parse/stringify.
  - Only strip comments when the body isn’t valid JSON, keeping JSONC support.
  - Added a unit test to ensure numeric tokens (e.g., 70.0) are preserved.

<sup>Written for commit 6019a862d5adccf4881762fa64db7e61705d0ae2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

