### PR TITLE
fix: [bug]: Environment variables are not applied on collection level auth

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -263,7 +263,7 @@ import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
 import * as RA from "fp-ts/ReadonlyArray"
 import { cloneDeep, isEqual } from "lodash-es"
-import { reactive, Ref, ref, toRef, watch } from "vue"
+import { computed, reactive, Ref, ref, toRef, watch } from "vue"
 import draggable from "vuedraggable-es"
 
 import { useVModel } from "@vueuse/core"
@@ -281,8 +281,8 @@ import {
 import { isDragDropAllowed, DragDropEvent } from "~/helpers/dragDropValidation"
 import {
   AggregateEnvironment,
-  aggregateEnvs$,
-  getAggregateEnvs,
+  aggregateEnvsWithCurrentValue$,
+  getAggregateEnvsWithCurrentValue,
   getCurrentEnvironment,
 } from "~/newstore/environments"
 import { toggleNestedSetting } from "~/newstore/settings"
@@ -553,7 +553,10 @@ const clearContent = () => {
   bulkHeaders.value = ""
 }
 
-const aggregateEnvs = useReadonlyStream(aggregateEnvs$, getAggregateEnvs())
+const aggregateEnvs = useReadonlyStream(
+  aggregateEnvsWithCurrentValue$,
+  getAggregateEnvsWithCurrentValue()
+)
 
 const computedHeaders: Ref<
   {
@@ -574,23 +577,24 @@ const inheritedProperty = ref<
 
 const currentSelectedEnvironment = getCurrentEnvironment()
 
-watch([props.modelValue, aggregateEnvs], async () => {
-  const resolvedEnvs = aggregateEnvs.value.map((env) => {
-    return {
-      ...env,
-      currentValue:
-        env.currentValue !== ""
-          ? env.currentValue
-          : (currentEnvironmentValueService.getEnvironmentByKey(
-              env?.sourceEnv !== "Global"
-                ? currentSelectedEnvironment.id
-                : "Global",
-              env?.key ?? ""
-            )?.currentValue ?? ""),
-    }
-  })
+const resolvedEnvs = computed(() =>
+  aggregateEnvs.value.map((env) => ({
+    ...env,
+    currentValue:
+      env.currentValue !== ""
+        ? env.currentValue
+        : (currentEnvironmentValueService.getEnvironmentByKey(
+            env?.sourceEnv !== "Global"
+              ? currentSelectedEnvironment.id
+              : "Global",
+            env?.key ?? ""
+          )?.currentValue ?? ""),
+  }))
+)
+
+watch([props.modelValue, resolvedEnvs], async () => {
   computedHeaders.value = (
-    await getComputedHeaders(props.modelValue, resolvedEnvs)
+    await getComputedHeaders(props.modelValue, resolvedEnvs.value)
   ).map((header, index) => ({
     id: `header-${index}`,
     ...header,
@@ -598,7 +602,7 @@ watch([props.modelValue, aggregateEnvs], async () => {
 })
 
 watch(
-  () => [props.inheritedProperties, request.value],
+  () => [props.inheritedProperties, request.value, resolvedEnvs.value],
   async () => {
     if (!props.inheritedProperties) return
 
@@ -628,7 +632,7 @@ watch(
       )
     ) {
       const [computedAuthHeader] = await getComputedAuthHeaders(
-        aggregateEnvs.value,
+        resolvedEnvs.value,
         request.value,
         props.inheritedProperties.auth.inheritedAuth,
         false


### PR DESCRIPTION
## Summary
# Agent Report

## Summary

Implemented the fix and committed it.

What changed:
- Updated `packages/hoppscotch-common/src/components/http/Headers.vue`
- The HTTP headers panel now uses environment variables hydrated with current/secret values via `aggregateEnvsWithCurrentValue$`.
- Inherited authorization header preview now uses the same resolved environment values as regular computed headers.
- The inherited auth preview watcher now also reacts when resolved environment values change.

Verification:
- Ran `pnpm --filter @hoppscotch/common exec eslint src/components/http/Headers.vue` successfully.
- Ran `git diff --check` successfully.
- Attempted `pnpm --filter @hoppscotch/common exec vue-tsc --noEmit --pretty false`, but it failed due to the repository’s `vue-tsc`/TypeScript compatibility issue:
  - `Search string not found: "/supportedTSExtensions = .*(?=;)/"`
  - Environment has Node 18 from Debian, while some workspace packages require Node >=22.

Commit:
- `15d2c3810 fix(common): resolve inherited auth header env values`

## Execution Stats

- Turns: 64
- Input tokens: 2474429
- Output tokens: 5080
- Cache read tokens: 2027008
- Cache write tokens: 0
- Tool calls: 63

## Tool Call Breakdown

- bash: 17
- edit: 7
- glob: 1
- grep: 10
- read: 28

Closes #6446

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes environment variables not being applied to collection-level auth and headers preview by resolving envs with current/secret values and reacting to env changes.

- **Bug Fixes**
  - Use `aggregateEnvsWithCurrentValue$` and `getAggregateEnvsWithCurrentValue()` to hydrate environment values.
  - Introduce `resolvedEnvs` and pass it to `getComputedHeaders` and `getComputedAuthHeaders`.
  - Update watchers to react to `resolvedEnvs` changes so inherited auth header preview stays in sync.

<sup>Written for commit 15d2c3810c52522a9ad7f80062df41795d7fc9b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

