### PR TITLE
fix(desktop): hide native Edit menu bar on Linux

### DIFF
--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/commands.rs
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/commands.rs
@@ -241,7 +241,9 @@ pub async fn load<R: Runtime>(app: AppHandle<R>, options: LoadOptions) -> Result
 
     #[cfg(target_os = "linux")]
     {
-        let _ = window.hide_menu();
+        if let Err(e) = window.hide_menu() {
+            tracing::warn!(?e, window_label = %label, "Failed to hide menu bar");
+        }
     }
 
     let is_visible = window.is_visible().unwrap_or(false);

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/commands.rs
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-appload/src/commands.rs
@@ -239,6 +239,11 @@ pub async fn load<R: Runtime>(app: AppHandle<R>, options: LoadOptions) -> Result
         })?;
     }
 
+    #[cfg(target_os = "linux")]
+    {
+        let _ = window.hide_menu();
+    }
+
     let is_visible = window.is_visible().unwrap_or(false);
     let response = LoadResponse {
         success: is_visible,

--- a/packages/hoppscotch-desktop/src-tauri/src/lib.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/lib.rs
@@ -169,6 +169,7 @@ pub fn run() {
             #[cfg(target_os = "linux")]
             {
                 use tauri::menu::{Menu, PredefinedMenuItem, Submenu};
+                use tauri::Manager;
 
                 let result = (|| -> Result<(), Box<dyn std::error::Error>> {
                     let handle = app.handle();
@@ -187,12 +188,16 @@ pub fn run() {
                             &PredefinedMenuItem::select_all(handle, None)?,
                         ],
                     )?;
-                    // NOTE: This menu bar will be visible on Linux. Removing it or hiding it
-                    // also removes the accelerator registrations and breaks clipboard shortcuts
-                    // (webkit2gtk requires native menu items to recognise Ctrl+C/V/X etc.).
+                    // The menu must be registered so webkit2gtk picks up the accelerators
+                    // (Ctrl+C/V/X etc.), but the menu bar itself should be hidden so it
+                    // does not appear as a visible "Edit" strip the user cannot dismiss.
                     // See https://github.com/tauri-apps/tauri/issues/2397
                     let menu = Menu::with_items(handle, &[&edit_menu])?;
                     app.set_menu(menu)?;
+
+                    for (_label, window) in app.webview_windows() {
+                        let _ = window.hide_menu();
+                    }
                     Ok(())
                 })();
 

--- a/packages/hoppscotch-desktop/src-tauri/src/lib.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/lib.rs
@@ -195,9 +195,9 @@ pub fn run() {
                     let menu = Menu::with_items(handle, &[&edit_menu])?;
                     app.set_menu(menu)?;
 
-                    for (_label, window) in app.webview_windows() {
+                    for (label, window) in app.webview_windows() {
                         if let Err(e) = window.hide_menu() {
-                            tracing::warn!("failed to hide menu for window {}: {e}", _label);
+                            tracing::warn!(?e, window_label = %label, "Failed to hide menu bar");
                         }
                     }
                     Ok(())

--- a/packages/hoppscotch-desktop/src-tauri/src/lib.rs
+++ b/packages/hoppscotch-desktop/src-tauri/src/lib.rs
@@ -196,7 +196,9 @@ pub fn run() {
                     app.set_menu(menu)?;
 
                     for (_label, window) in app.webview_windows() {
-                        let _ = window.hide_menu();
+                        if let Err(e) = window.hide_menu() {
+                            tracing::warn!("failed to hide menu for window {}: {e}", _label);
+                        }
                     }
                     Ok(())
                 })();


### PR DESCRIPTION
## The Problem
On Linux, there's a native "Edit" menu bar showing up at the top of every window in the desktop app. It just sits there and can't be dismissed . pretty annoying since it serves no visible purpose from the user's perspective.

## Root cause

webkit2gtk (the webview engine on Linux) won't recognize clipboard shortcuts like Ctrl+C, Ctrl+V, Ctrl+X unless native menu items with those accelerators are registered. A previous fix added an Edit submenu specifically for this, which solved the clipboard issue but left the menu bar visible.

## What I changed

After the menu is registered, I added a `hide_menu()` call in two places:

- On the initial window in `lib.rs`
- On windows created dynamically by the appload plugin in `commands.rs`

On GTK, hiding the menu bar doesn't remove the accelerator bindings , they live in GTK's accel map independently of whether the bar is visible. So Ctrl+C/V/X keep working, the menu just stops showing up.

The change is wrapped in `#[cfg(target_os = "linux")]` so it doesn't touch macOS or Windows at all.

## Testing

- Linux: Edit menu bar is gone
- Linux: Ctrl+C / Ctrl+V / Ctrl+X still work
- macOS / Windows: no change in behavior

Fixes ##6088




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the native Edit menu bar on Linux while keeping clipboard shortcuts (Ctrl+C/V/X) working across all desktop windows.

- **Bug Fixes**
  - Register the `Edit` submenu to satisfy `webkit2gtk` accelerators, then hide the menu bar:
    - On startup, set the app menu and hide it for all existing windows in `src-tauri/src/lib.rs`.
    - For new windows created by `tauri-plugin-appload`, hide after creation in `src/commands.rs`.
    - Log a structured warning with `window_label` if hiding the menu fails.
  - Linux-only via `#[cfg(target_os = "linux")]`; no changes for macOS or Windows.

<sup>Written for commit 1f1430be62553920bde34daf290395cc41fdd27e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





