### PR TITLE
fix(backend): team workspace search not matching endpoint URLs

### DIFF
--- a/packages/hoppscotch-backend/prisma/migrations/20260621163429_team_request_endpoint_search_index/migration.sql
+++ b/packages/hoppscotch-backend/prisma/migrations/20260621163429_team_request_endpoint_search_index/migration.sql
@@ -1,0 +1,7 @@
+-- Create GIN Trigram Index for TeamRequest endpoint (extracted from request JSON)
+CREATE INDEX
+  "TeamRequest_endpoint_trgm_idx"
+ON
+  "TeamRequest"
+USING
+  GIN ((request->>'endpoint') gin_trgm_ops);

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.spec.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.spec.ts
@@ -2133,3 +2133,59 @@ describe('getCollectionForCLI', () => {
   //   });
   // });
 });
+
+describe('searchByTitle', () => {
+  beforeEach(() => {
+    mockReset(mockPrisma);
+  });
+
+  test('should return a request when only the endpoint URL matches (not the title)', async () => {
+    const teamID = team.id;
+    const searchQuery = 'api/v1/users';
+
+    mockPrisma.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          id: 'req_1',
+          title: 'Get Users',
+          method: 'GET',
+          type: 'request',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const result = await teamCollectionService.searchByTitle(
+      searchQuery,
+      teamID,
+    );
+
+    expect(result).toEqualRight({
+      data: [
+        {
+          id: 'req_1',
+          title: 'Get Users',
+          method: 'GET',
+          type: 'request',
+          path: [],
+        },
+      ],
+    });
+  });
+
+  test('should return empty results when neither title nor endpoint matches', async () => {
+    const teamID = team.id;
+    const searchQuery = 'nonexistent';
+
+    mockPrisma.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const result = await teamCollectionService.searchByTitle(
+      searchQuery,
+      teamID,
+    );
+
+    expect(result).toEqualRight({ data: [] });
+  });
+});

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1253,7 +1253,10 @@ export class TeamCollectionService {
         (title ILIKE ${`%${escapeSqlLikeString(searchQuery)}%`}
         OR request->>'endpoint' ILIKE ${`%${escapeSqlLikeString(searchQuery)}%`})
     ORDER BY
-      similarity(title, ${searchQuery})
+      GREATEST(
+        similarity(title, ${searchQuery}),
+        COALESCE(similarity(request->>'endpoint', ${searchQuery}), 0)
+      ) DESC
     LIMIT ${take}
     OFFSET ${skip === 0 ? 0 : (skip - 1) * take};
   `;

--- a/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
+++ b/packages/hoppscotch-backend/src/team-collection/team-collection.service.ts
@@ -1250,7 +1250,8 @@ export class TeamCollectionService {
     WHERE
       "TeamRequest"."teamID"=${teamID}
       AND
-        title ILIKE ${`%${escapeSqlLikeString(searchQuery)}%`}
+        (title ILIKE ${`%${escapeSqlLikeString(searchQuery)}%`}
+        OR request->>'endpoint' ILIKE ${`%${escapeSqlLikeString(searchQuery)}%`})
     ORDER BY
       similarity(title, ${searchQuery})
     LIMIT ${take}


### PR DESCRIPTION
## Problem

Searching for endpoints in a Team Workspace returns no results when searching by URL, even though the same search works fine in Personal Workspace.

## Root cause

Personal workspace filtering runs client-side and matches both the request name and endpoint URL. Team workspace search is server-side (SQL query in `searchRequests()`), but the query only matched against the `title` column , it never looked at the endpoint URL stored in the `request` JSON column.

## Fix

Added `OR request->>'endpoint' ILIKE ...` to the WHERE clause in `searchRequests()` so that searching by URL/endpoint works the same way it does in personal workspaces.

Fixes #6437


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Team Workspace search to match endpoint URLs and ranks results by the best similarity across title and endpoint. Adds a GIN trigram index on the `TeamRequest` endpoint for faster search and unit tests for `searchByTitle`.

<sup>Written for commit f112b6c4ff408c20093f85fbf7b282c2105b55e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



