### PR TITLE
fix: Environment variables are not applied on collection level auth

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -282,7 +282,9 @@ import { isDragDropAllowed, DragDropEvent } from "~/helpers/dragDropValidation"
 import {
   AggregateEnvironment,
   aggregateEnvs$,
+  aggregateEnvsWithCurrentValue$,
   getAggregateEnvs,
+  getAggregateEnvsWithCurrentValue,
   getCurrentEnvironment,
 } from "~/newstore/environments"
 import { toggleNestedSetting } from "~/newstore/settings"
@@ -554,6 +556,10 @@ const clearContent = () => {
 }
 
 const aggregateEnvs = useReadonlyStream(aggregateEnvs$, getAggregateEnvs())
+const aggregateEnvsWithCurrentValue = useReadonlyStream(
+  aggregateEnvsWithCurrentValue$,
+  getAggregateEnvsWithCurrentValue()
+)
 
 const computedHeaders: Ref<
   {
@@ -598,7 +604,11 @@ watch([props.modelValue, aggregateEnvs], async () => {
 })
 
 watch(
-  () => [props.inheritedProperties, request.value],
+  () => [
+    props.inheritedProperties,
+    request.value,
+    aggregateEnvsWithCurrentValue.value,
+  ],
   async () => {
     if (!props.inheritedProperties) return
 
@@ -628,7 +638,7 @@ watch(
       )
     ) {
       const [computedAuthHeader] = await getComputedAuthHeaders(
-        aggregateEnvs.value,
+        aggregateEnvsWithCurrentValue.value,
         request.value,
         props.inheritedProperties.auth.inheritedAuth,
         false


### PR DESCRIPTION
- Fixed inherited Basic Auth header preview/execution in `packages/hoppscotch-common/src/components/http/Headers.vue`.
- The headers UI now resolves inherited auth using `aggregateEnvsWithCurrentValue$`, so environment variables in collection-level Basic Auth are evaluated with actual current/secret values instead of empty/masked values.
- Added the current-value env stream as a watcher dependency so inherited auth headers update when environment values change.

Verification:
- Installed required Node 22 + pnpm dependencies.
- Ran targeted ESLint for the changed file:
  - `cd packages/hoppscotch-common && pnpm exec eslint src/components/http/Headers.vue`
- Ran `git diff --check`.
- Commit hook also ran:
  - `pnpm -r do-lint`
  - `pnpm -r do-typecheck`
  - Both completed successfully, with existing lint warnings only.

Fixes #6446


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes collection-level Basic Auth not applying environment variables in inherited headers. Header preview and request execution now evaluate current and secret values. Fixes #6446.

- **Bug Fixes**
  - Resolve inherited auth using `aggregateEnvsWithCurrentValue$` in `packages/hoppscotch-common/src/components/http/Headers.vue`.
  - Add `aggregateEnvsWithCurrentValue` to watcher dependencies so headers update when environment values change.

<sup>Written for commit 25798a5163c9c75824fa995125f3eb238e4fb0a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

