### PR TITLE
fix(curl-importer): preserve colons in basic auth passwords

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -366,6 +366,65 @@ const samples = [
     }),
   },
   {
+    command: "curl -X GET localhost --user admin:p:a:s:s",
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "http://localhost/",
+      auth: {
+        authType: "basic",
+        authActive: true,
+        username: "admin",
+        password: "p:a:s:s",
+      },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      params: [],
+      headers: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+      description: null,
+    }),
+  },
+  {
+    // Base64 of "admin:p:a:s:s"
+    command:
+      "curl -X GET localhost --header 'Authorization: Basic YWRtaW46cDphOnM6cw=='",
+    response: makeRESTRequest({
+      method: "GET",
+      name: "Untitled",
+      endpoint: "http://localhost/",
+      auth: {
+        authType: "basic",
+        authActive: true,
+        username: "admin",
+        password: "p:a:s:s",
+      },
+      body: {
+        contentType: null,
+        body: null,
+      },
+      params: [],
+      headers: [
+        {
+          active: true,
+          key: "Authorization",
+          value: "Basic YWRtaW46cDphOnM6cw==",
+          description: "",
+        },
+      ],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+      description: null,
+    }),
+  },
+  {
     command:
       "curl -X GET localhost --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'",
     response: makeRESTRequest({

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/auth.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/auth.ts
@@ -1,12 +1,18 @@
 import { HoppRESTAuth } from "@hoppscotch/data"
 import parser from "yargs-parser"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
 import { pipe } from "fp-ts/function"
 import { getDefaultRESTRequest } from "~/helpers/rest/default"
 import { objHasProperty } from "~/helpers/functional/object"
 
 const defaultRESTReq = getDefaultRESTRequest()
+
+// Passwords may contain colons; only the first colon separates username from password
+const splitUserInfo = (userInfo: string): [string, string] => {
+  const colonIdx = userInfo.indexOf(":")
+  if (colonIdx === -1) return [userInfo, ""]
+  return [userInfo.slice(0, colonIdx), userInfo.slice(colonIdx + 1)]
+}
 
 const getAuthFromAuthHeader = (headers: Record<string, string>) =>
   pipe(
@@ -27,14 +33,8 @@ const getAuthFromAuthHeader = (headers: Record<string, string>) =>
             case "basic": {
               const [username, password] = pipe(
                 O.tryCatch(() => atob(kv[1])),
-                O.map(S.split(":")),
-                // can have a username with no password
-                O.filter((arr) => arr.length > 0),
-                O.map(
-                  ([username, password]) =>
-                    <[string, string]>[username, password]
-                ),
-                O.getOrElse(() => ["", ""])
+                O.map(splitUserInfo),
+                O.getOrElse(() => <[string, string]>["", ""])
               )
 
               if (!username) return undefined
@@ -61,12 +61,10 @@ const getAuthFromParsedArgs = (parsedArguments: parser.Arguments) =>
     O.chain((args) =>
       pipe(
         args.u,
-        S.split(":"),
+        splitUserInfo,
         // can have a username with no password
-        O.fromPredicate((arr) => arr.length > 0 && arr[0].length > 0),
-        O.map(
-          ([username, password]) => <[string, string]>[username, password ?? ""]
-        )
+        O.fromPredicate(([username]) => username.length > 0),
+        O.map(([username, password]) => <[string, string]>[username, password])
       )
     ),
     O.map(


### PR DESCRIPTION
Passwords may legitimately contain colons, but the cURL importer was splitting on every colon instead of only the first one, truncating anything after the first colon in the password.

Fixes #6403


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cURL importer so Basic Auth passwords with colons are preserved, instead of being truncated after the first colon. Fixes #6403.

- **Bug Fixes**
  - Correct Basic credential parsing for both `--user` and `Authorization: Basic` header inputs.
  - Add tests for colon-containing passwords and base64-encoded credentials.

<sup>Written for commit f7b0b82d7b681b9837a2526cab5a0c4bea1f178a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

