### PR TITLE
fix(common): preserve header values containing colons during cURL import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1057,6 +1057,37 @@ data2: {"type":"test2","typeId":"123"}`,
       description: null,
     }),
   },
+  {
+    command:
+      'curl https://httpbin.org/get -H "X-Note: hello: world" -H "Accept: application/json"',
+    response: makeRESTRequest({
+      name: "Untitled",
+      endpoint: "https://httpbin.org/get",
+      method: "GET",
+      auth: { authType: "inherit", authActive: true },
+      body: { contentType: null, body: null },
+      params: [],
+      headers: [
+        {
+          active: true,
+          key: "X-Note",
+          value: "hello: world",
+          description: "",
+        },
+        {
+          active: true,
+          key: "Accept",
+          value: "application/json",
+          description: "",
+        },
+      ],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+      description: null,
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -2,7 +2,6 @@ import { HoppRESTHeader } from "@hoppscotch/data"
 import * as A from "fp-ts/Array"
 import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
 import parser from "yargs-parser"
 import {
   objHasArrayProperty,
@@ -10,13 +9,19 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
-const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
-)
+const getHeaderPair = (header: string): O.Option<[string, string]> => {
+  // a header is `name: value`, the name is everything before the first colon,
+  // the value (everything after) may itself contain colons (e.g. `X-Note: hello: world`)
+  const colonIndex = header.indexOf(":")
+  if (colonIndex === -1) return O.none
+
+  const key = header.slice(0, colonIndex).trim()
+  const value = header.slice(colonIndex + 1).trim()
+
+  if (!key) return O.none
+
+  return O.some([key, value])
+}
 
 export function getHeaders(parsedArguments: parser.Arguments) {
   let headers: Record<string, string> = {}


### PR DESCRIPTION
Closes #6400

### What's changed

When importing a cURL command, any header whose **value** contained `": "` (colon + space) was silently dropped. This happened because the header-pair parser naively inserted a space after the first colon in the raw header string and then split on `": "` — which produced more than 2 segments once the value itself contained a colon, failing the "must have exactly a key and a value" check and discarding the header entirely.

Per RFC 9110, a header is `name: value`, where the name is everything before the *first* colon, and the value (everything after) may itself contain colons. So `X-Note: hello: world` should import as `X-Note` -> `hello: world`.

- [x] Rewrote `getHeaderPair` in `packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts` to split on the first colon only, instead of naively re-inserting a space and splitting on `": "`.
- [x] Added a regression test in `curlparser.spec.js` covering `curl https://httpbin.org/get -H "X-Note: hello: world" -H "Accept: application/json"`.

### Notes to reviewers

- Verified this code path is only used by `hoppscotch-common`'s cURL importer (no other package references `headers.ts`).
- Ran the full `hoppscotch-common` test suite (59 files / 983 tests) — all passing, no regressions.
- Ran `pnpm -r do-lint && pnpm -r do-typecheck` (via the repo's pre-commit hook) across all workspace packages — all passing.
- No interface/env var/port changes, so no README updates were needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cURL import dropping headers when the value contains a colon by parsing the name before the first colon and keeping the rest as the value. Aligns with RFC 9110; headers like "X-Note: hello: world" now import correctly.

- **Bug Fixes**
  - Updated `packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts` to split on the first ":" and trim key/value.
  - Added a regression test in `packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js` for `X-Note: hello: world` and `Accept: application/json`.

<sup>Written for commit 7f0c79c3c0625f3b6cb3565de99a69a19f49901f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

