### PR TITLE
fix(common): lazy-load `jq-wasm` in the JSON lens renderer

### DIFF
--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -303,7 +303,15 @@ const t = useI18n()
 // JSON response render has to load and parse.
 let jqWasmPromise: Promise<typeof JqWasm> | null = null
 const getJqWasm = () => {
-  if (!jqWasmPromise) jqWasmPromise = import("jq-wasm")
+  if (!jqWasmPromise) {
+    // if the dynamic import fails (e.g. a transient network error), drop the
+    // cached promise so the next filter attempt can retry instead of being
+    // stuck failing until the page is reloaded
+    jqWasmPromise = import("jq-wasm").catch((err) => {
+      jqWasmPromise = null
+      throw err
+    })
+  }
   return jqWasmPromise
 }
 

--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -273,7 +273,6 @@ import * as E from "fp-ts/Either"
 import { pipe } from "fp-ts/function"
 import { computed, ref, reactive } from "vue"
 import { computedAsync, refDebounced } from "@vueuse/core"
-import type * as JqWasm from "jq-wasm"
 import { useCodemirror } from "@composables/codemirror"
 import { HoppRESTResponse } from "~/helpers/types/HoppRESTResponse"
 import jsonParse, { JSONObjectMember, JSONValue } from "~/helpers/jsonParse"
@@ -301,7 +300,7 @@ const t = useI18n()
 // ever needed when the user actively filters a JSON response with a jq
 // query. Importing it lazily keeps that payload out of the chunk every
 // JSON response render has to load and parse.
-let jqWasmPromise: Promise<typeof JqWasm> | null = null
+let jqWasmPromise: Promise<typeof import("jq-wasm")> | null = null
 const getJqWasm = () => {
   if (!jqWasmPromise) {
     // if the dynamic import fails (e.g. a transient network error), drop the

--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -273,7 +273,7 @@ import * as E from "fp-ts/Either"
 import { pipe } from "fp-ts/function"
 import { computed, ref, reactive } from "vue"
 import { computedAsync, refDebounced } from "@vueuse/core"
-import * as jq from "jq-wasm"
+import type * as JqWasm from "jq-wasm"
 import { useCodemirror } from "@composables/codemirror"
 import { HoppRESTResponse } from "~/helpers/types/HoppRESTResponse"
 import jsonParse, { JSONObjectMember, JSONValue } from "~/helpers/jsonParse"
@@ -296,6 +296,16 @@ import { HoppRESTRequestResponse } from "@hoppscotch/data"
 import { useScrollerRef } from "~/composables/useScrollerRef"
 
 const t = useI18n()
+
+// `jq-wasm` bundles a sizeable (1MB+) WASM/Emscripten payload that's only
+// ever needed when the user actively filters a JSON response with a jq
+// query. Importing it lazily keeps that payload out of the chunk every
+// JSON response render has to load and parse.
+let jqWasmPromise: Promise<typeof JqWasm> | null = null
+const getJqWasm = () => {
+  if (!jqWasmPromise) jqWasmPromise = import("jq-wasm")
+  return jqWasmPromise
+}
 
 const props = defineProps<{
   response: HoppRESTResponse | HoppRESTRequestResponse
@@ -382,6 +392,7 @@ const jsonResponseBodyText = computedAsync(
         const input = JSON.parse(
           LJSON.stringify(responseJsonObject.value.right as any) || "{}"
         )
+        const jq = await getJqWasm()
         const { exitCode, stdout, stderr } = await jq.raw(
           input,
           debouncedFilterQuery.value


### PR DESCRIPTION
Closes #6291

### What's changed

`JSONLensRenderer.vue` statically imported `jq-wasm` at the top of the file, even though it's only ever used inside the (debounced) jq filter computation, gated behind the user actually typing a filter query. `jq-wasm` bundles a sizeable Emscripten/WASM payload (~1.3MB on disk locally), and a static import pulls that into the same chunk that has to be fetched and parsed every time a JSON response is rendered — not just when the filter feature is used.

This matches the symptoms reported in the issue: a large `JSONLensRenderer-*.js` chunk (~1.3MB) being loaded on every JSON response render, with the main thread blocked while it's parsed — most noticeable on Linux/WebKitGTK desktop builds, but not specific to any one platform.

- [x] Replaced the static `import * as jq from "jq-wasm"` with a type-only import (`import type * as JqWasm from "jq-wasm"`) plus a memoized `getJqWasm()` helper that does a dynamic `import("jq-wasm")`, only called from inside the filter computation when a query is actually run.
- [x] No behavior change for the filter feature itself — same `jq.raw(...)` call, just resolved lazily and cached after first use.

### Notes to reviewers

- Verified via the dev server that `jq-wasm` no longer appears in the component's static imports and is only pulled in through the dynamic `import()` inside `getJqWasm()` (confirmed by inspecting Vite's transformed module output).
- A previous attempt at this exact fix (#6391) was closed unmerged — per review comments there, it bundled the one real fix together with ~36 unrelated/unwired files. This PR isolates just that one change.
- Ran the full `hoppscotch-common` test suite (no regressions) and `pnpm -r do-lint && pnpm -r do-typecheck` across all workspace packages via the repo's pre-commit hook — all passing.
- No interface/env var changes, so no README updates were needed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-loads `jq-wasm` in the JSON lens so its ~1.3MB WASM is fetched only when a jq filter runs, avoiding main-thread stalls during JSON renders. Replaces the static import in `JSONLensRenderer.vue` with a memoized dynamic import that retries on failure and uses `typeof import("jq-wasm")` for typing; behavior unchanged, resolving #6291.

<sup>Written for commit 96581d8137f4d60249b433c4314affb7fc8f0b1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

