### PR TITLE
fix: resolve desktop app auth CORS issue for self-hosted instances (f…

### DIFF
--- a/packages/hoppscotch-backend/src/auth/helper.ts
+++ b/packages/hoppscotch-backend/src/auth/helper.ts
@@ -8,7 +8,7 @@ import {
   COOKIES_NOT_FOUND,
   INVALID_AUTH_HEADER,
 } from 'src/errors';
-import { throwErr } from 'src/utils';
+import { throwErr, getWhitelistedOrigins } from 'src/utils';
 import { ConfigService } from '@nestjs/config';
 import { IncomingHttpHeaders } from 'http';
 
@@ -72,8 +72,9 @@ export const authCookieHandler = (
   }
 
   // check to see if redirectUrl is a whitelisted url
-  const whitelistedOrigins =
-    configService.get('WHITELISTED_ORIGINS')?.split(',') ?? [];
+  const whitelistedOrigins = getWhitelistedOrigins(
+    configService.get('WHITELISTED_ORIGINS'),
+  );
   if (!whitelistedOrigins.includes(redirectUrl))
     // if it is not redirect by default to App
     redirectUrl = configService.get('VITE_BASE_URL');

--- a/packages/hoppscotch-backend/src/main.ts
+++ b/packages/hoppscotch-backend/src/main.ts
@@ -9,6 +9,7 @@ import { ConfigService } from '@nestjs/config';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { InfraTokenModule } from './infra-token/infra-token.module';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import { getWhitelistedOrigins } from './utils';
 
 function setupSwagger(
   app: NestExpressApplication,
@@ -58,7 +59,7 @@ async function bootstrap() {
   if (isProduction) {
     console.log('Enabling CORS with production settings');
     app.enableCors({
-      origin: configService.get('WHITELISTED_ORIGINS').split(','),
+      origin: getWhitelistedOrigins(configService.get('WHITELISTED_ORIGINS')),
       credentials: true,
     });
   } else {

--- a/packages/hoppscotch-backend/src/utils.spec.ts
+++ b/packages/hoppscotch-backend/src/utils.spec.ts
@@ -1,0 +1,103 @@
+import { getWhitelistedOrigins } from './utils';
+
+describe('getWhitelistedOrigins', () => {
+  describe('Tauri origin generation from https origins', () => {
+    test('Should generate a Tauri origin for a simple https domain', () => {
+      const result = getWhitelistedOrigins('https://hoppscotch.example.com');
+      expect(result).toContain('https://hoppscotch.example.com');
+      expect(result).toContain('https://app.hoppscotch_hoppscotch_example_com');
+    });
+
+    test('Should generate a Tauri origin for each https domain in a comma-separated list', () => {
+      const result = getWhitelistedOrigins(
+        'https://hoppscotch.company.com,hopp_auth://token',
+      );
+      expect(result).toContain('https://hoppscotch.company.com');
+      expect(result).toContain('hopp_auth://token');
+      expect(result).toContain('https://app.hoppscotch_hoppscotch_company_com');
+      // hopp_auth:// is not http/https, should not generate a Tauri origin
+      expect(result).not.toContain(expect.stringContaining('hopp_auth_'));
+    });
+
+    test('Should generate Tauri origins for both http and https', () => {
+      const result = getWhitelistedOrigins(
+        'http://localhost:3000,https://hoppscotch.yourdomain.com',
+      );
+      expect(result).toContain('http://localhost:3000');
+      expect(result).toContain('https://hoppscotch.yourdomain.com');
+      // http localhost => Tauri origin
+      expect(result).toContain('https://app.hoppscotch_localhost');
+      // https domain => Tauri origin
+      expect(result).toContain(
+        'https://app.hoppscotch_hoppscotch_yourdomain_com',
+      );
+    });
+
+    test('Should correctly replace dots with underscores in Tauri origin', () => {
+      const result = getWhitelistedOrigins('https://my.deeply.nested.domain.io');
+      expect(result).toContain(
+        'https://app.hoppscotch_my_deeply_nested_domain_io',
+      );
+    });
+
+    test('Should NOT generate Tauri origin for non-http/https schemes', () => {
+      const result = getWhitelistedOrigins(
+        'hopp_auth://token,app://localhost_3200',
+      );
+      // These are not http/https, so no Tauri origins should be generated
+      expect(result.length).toBe(2);
+      expect(result).toContain('hopp_auth://token');
+      expect(result).toContain('app://localhost_3200');
+    });
+  });
+
+  describe('Edge cases and null handling', () => {
+    test('Should return empty array for null input', () => {
+      const result = getWhitelistedOrigins(null);
+      expect(result).toEqual([]);
+    });
+
+    test('Should return empty array for undefined input', () => {
+      const result = getWhitelistedOrigins(undefined);
+      expect(result).toEqual([]);
+    });
+
+    test('Should return empty array for empty string', () => {
+      const result = getWhitelistedOrigins('');
+      expect(result).toEqual([]);
+    });
+
+    test('Should not produce duplicate Tauri origins', () => {
+      const result = getWhitelistedOrigins('https://hoppscotch.io');
+      const tauriOrigin = 'https://app.hoppscotch_hoppscotch_io';
+      const count = result.filter((o) => o === tauriOrigin).length;
+      expect(count).toBe(1);
+    });
+
+    test('Should silently skip malformed/unparseable origin strings', () => {
+      const result = getWhitelistedOrigins(
+        'not-a-valid-url,https://hoppscotch.io',
+      );
+      // malformed entry is preserved in origins, but no Tauri origin generated for it
+      expect(result).toContain('not-a-valid-url');
+      expect(result).toContain('https://hoppscotch.io');
+      expect(result).toContain('https://app.hoppscotch_hoppscotch_io');
+    });
+  });
+
+  describe('Real-world Helm chart scenario (issue #6389)', () => {
+    test('Should resolve desktop app auth with self-hosted Helm instance', () => {
+      // Simulates the exact scenario from the bug report:
+      // WHITELISTED_ORIGINS only has the web URL and hopp_auth,
+      // but the Desktop App (Tauri v2) needs its auto-generated origin.
+      const result = getWhitelistedOrigins(
+        'https://hoppscotch.yourdomain.com,hopp_auth://token',
+      );
+
+      // The computed Tauri origin should be in the list
+      expect(result).toContain(
+        'https://app.hoppscotch_hoppscotch_yourdomain_com',
+      );
+    });
+  });
+});

--- a/packages/hoppscotch-backend/src/utils.ts
+++ b/packages/hoppscotch-backend/src/utils.ts
@@ -368,3 +368,28 @@ export function decrypt(
   decrypted = Buffer.concat([decrypted, decipher.final()]);
   return decrypted.toString();
 }
+
+/**
+ * Returns a list of all whitelisted origins, including dynamically generated Tauri v2 origins.
+ *
+ * @param whitelistedOrigins A comma-separated string of whitelisted origins
+ * @returns An array of all whitelisted origins
+ */
+export function getWhitelistedOrigins(whitelistedOrigins: string | undefined | null): string[] {
+  const origins = whitelistedOrigins ? whitelistedOrigins.split(',') : [];
+  const tauriOrigins = origins
+    .map((origin) => {
+      try {
+        const url = new URL(origin);
+        if (url.protocol === 'http:' || url.protocol === 'https:') {
+          return `https://app.hoppscotch_${url.hostname.replace(/\./g, '_')}`;
+        }
+      } catch (e) {
+        return undefined;
+      }
+    })
+    .filter((origin) => origin !== undefined);
+
+  return [...origins, ...tauriOrigins] as string[];
+}
+

--- a/packages/hoppscotch-desktop/README.md
+++ b/packages/hoppscotch-desktop/README.md
@@ -48,7 +48,15 @@ brew install --cask hoppscotch
 > [!Note]
 > To enable desktop app support for your self-hosted Hoppscotch instance, make sure to update the `WHITELISTED_ORIGINS` environment variable in your `.env` file with your deployment URL.
 >
-> e.g. to allow connection to `https://hoppscotch.mydomain.com` you need to add `app://hoppscotch_mydomain_com` (MacOS, Linux) and `http://app.hoppscotch_mydomain_com` (Windows) to the `WHITELISTED_ORIGINS` environment variable.
+> **As of this version, the Tauri v2 desktop app origin (`https://app.hoppscotch_<domain>`) is automatically derived from each `https://` or `http://` entry in `WHITELISTED_ORIGINS` — you no longer need to add it manually.**
+>
+> For example, if you set:
+> ```bash
+> WHITELISTED_ORIGINS=https://hoppscotch.mydomain.com,hopp_auth://token
+> ```
+> The backend will automatically also whitelist `https://app.hoppscotch_hoppscotch_mydomain_com`, which is the origin the Desktop App (Tauri v2) sends when making API requests.
+>
+> If you are on an older version or self-hosting without this fix, you can still add it manually:
 > ```bash
 > WHITELISTED_ORIGINS=...existing_origins,app://hoppscotch_mydomain_com,http://app.hoppscotch_mydomain_com
 > ```


### PR DESCRIPTION
…ixes #6389)

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6389

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This PR resolves the issue where the Hoppscotch Desktop App (Tauri v2) spins indefinitely when authenticating against a self-hosted backend. The failure occurred because the desktop app sends API requests using an auto-generated protocol origin (`https://app.hoppscotch_<domain_with_underscores>`), which was previously missing from the backend's CORS and SSO redirect whitelists.

### What's changed
- [x] **`utils.ts`**: Added the `getWhitelistedOrigins` helper function. This parses the `WHITELISTED_ORIGINS` env variable and automatically computes and appends the corresponding Tauri v2 desktop app origin for any valid `http/https` domain.
- [x] **`main.ts`**: Updated the NestJS CORS configuration to use the newly derived whitelist, allowing preflight `OPTIONS` and subsequent `POST` requests from the desktop app to succeed.
- [x] **`auth/helper.ts`**: Updated the redirect validation logic in `authCookieHandler` so that SSO providers (like GitHub/Google) can successfully redirect back to the desktop app.
- [x] **`utils.spec.ts`**: Added 11 comprehensive unit tests to ensure edge cases, malformed URLs, and non-http schemes (`app://`, `hopp_auth://`) are parsed and ignored safely.
- [x] **`packages/hoppscotch-desktop/README.md`**: Updated documentation to inform users that they no longer need to manually add the desktop origin to their `.env` file!

### Notes to reviewers
- This fix is completely backward-compatible. Users do not need to update their `.env` files; the backend seamlessly computes the expected Tauri origins dynamically based on their existing web URLs.
- For users already relying on the manual workaround, this will not break anything as duplicate whitelists are natively ignored.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes desktop app authentication for self-hosted deployments by auto-whitelisting the Tauri v2 desktop origin derived from `WHITELISTED_ORIGINS`. Removes the need to manually add the desktop origin and resolves the CORS/SSO redirect loop (issue #6389).

- **Bug Fixes**
  - Added `getWhitelistedOrigins` to compute `https://app.hoppscotch_<hostname>` for each `http/https` origin in `WHITELISTED_ORIGINS`.
  - Updated CORS config and redirect validation to accept the computed desktop origin.
  - Added unit tests covering malformed URLs, non-http schemes, and duplicates.
  - Updated desktop README to note the origin is now derived automatically.

<sup>Written for commit 2694bff516561d83a82e5364c60c1f9a37e5a77c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

