### PR TITLE
fix: cURL import now preserves headers with colons in values (fixes #6400)

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1057,6 +1057,37 @@ data2: {"type":"test2","typeId":"123"}`,
       description: null,
     }),
   },
+  {
+    // Issue #6400: headers with ": " in value should not be dropped
+    command: `curl https://httpbin.org/get -H "X-Note: hello: world" -H "Accept: application/json"`,
+    response: makeRESTRequest({
+      name: "Untitled",
+      endpoint: "https://httpbin.org/get",
+      method: "GET",
+      auth: { authType: "inherit", authActive: true },
+      headers: [
+        {
+          active: true,
+          key: "X-Note",
+          value: "hello: world",
+          description: "",
+        },
+        {
+          active: true,
+          key: "Accept",
+          value: "application/json",
+          description: "",
+        },
+      ],
+      body: { contentType: null, body: null },
+      params: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+      description: null,
+    }),
+  },
 ]
 
 describe("Parse curl command to Hopp REST Request", () => {

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -2,7 +2,6 @@ import { HoppRESTHeader } from "@hoppscotch/data"
 import * as A from "fp-ts/Array"
 import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
 import parser from "yargs-parser"
 import {
   objHasArrayProperty,
@@ -10,13 +9,17 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
-const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
-)
+const getHeaderPair = (s: string): O.Option<[string, string]> => {
+  const colonIndex = s.indexOf(":")
+  if (colonIndex === -1) return O.none
+
+  const key = s.slice(0, colonIndex).trim()
+  const value = s.slice(colonIndex + 1).trim()
+
+  if (key.length === 0) return O.none
+
+  return O.some([key, value] as [string, string])
+}
 
 export function getHeaders(parsedArguments: parser.Arguments) {
   let headers: Record<string, string> = {}


### PR DESCRIPTION
…6400)

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #6400 

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This PR fixes a bug where the cURL import silently drops any header whose **value** contains `": "` (a colon followed by a space). 

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->
- [x] **`headers.ts`**: Rewrote the `getHeaderPair` parser to split header strings on the **first** colon only (using `indexOf(":")` and `slice`), rather than splitting on every occurrence of `": "`. This preserves colons and spaces within the header value, adhering strictly to RFC 9110.
- [x] Removed an unused `fp-ts/string` import that was no longer needed after the fix.
- [x] **`curlparser.spec.js`**: Added a test case confirming that `X-Note: hello: world` correctly parses to `Key: X-Note` and `Value: hello: world`.

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->
- All existing edge cases (simple values, no-colon keys, empty values, lowercase headers) continue to pass perfectly.
- This logic aligns our parser's behavior with other tools like Postman, ensuring valid headers aren't dropped.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where cURL import dropped headers if the value contained a colon. Headers like "X-Note: hello: world" are now preserved and parsed correctly (fixes #6400).

- **Bug Fixes**
  - Rewrote `getHeaderPair` to parse header lines by the first colon only.
  - Added a test for `X-Note: hello: world` to ensure correct parsing.
  - Removed an unused `fp-ts/string` import.

<sup>Written for commit 0fe5fb6287c44074b117ccd369614ea720dc9047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

