### PR TITLE
fix(http): refresh inherited collection auth when env vars change

### DIFF
--- a/packages/hoppscotch-common/src/components/http/Headers.vue
+++ b/packages/hoppscotch-common/src/components/http/Headers.vue
@@ -598,7 +598,7 @@ watch([props.modelValue, aggregateEnvs], async () => {
 })
 
 watch(
-  () => [props.inheritedProperties, request.value],
+  () => [props.inheritedProperties, request.value, aggregateEnvs.value],
   async () => {
     if (!props.inheritedProperties) return
 


### PR DESCRIPTION
### Summary
`Headers.vue` builds the inherited Authorization header from collection-level auth via a Vue watcher. The watcher only depended on `props.inheritedProperties` and `request.value`, not on `aggregateEnvs`. During tab hydration the inherited-properties prop often arrives before the `aggregateEnvs` stream has emitted, so the watch fires with an empty env list and the inherited Authorization header never resolves `<<varName>>` references. Adding `aggregateEnvs.value` to the watch dependencies makes the header recompute whenever env vars change.

### Test plan
Manual reproduction matches issue #6446 — open a request tab for a request that inherits auth from a collection whose basic-auth fields use `<<varName>>` references; the Authorization header stays unresolved until something else triggers a watch. With the fix, the header resolves as soon as the env stream emits.

Refs #6446

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unresolved inherited Authorization headers when collection-level auth uses env var references by making `Headers.vue` recompute when `aggregateEnvs` changes. The header now resolves as soon as envs load or update (refs #6446).

- **Bug Fixes**
  - Added `aggregateEnvs.value` to the watcher dependencies in `packages/hoppscotch-common/src/components/http/Headers.vue` so inherited auth headers refresh when env vars emit or change.

<sup>Written for commit b4367ad42287304919a1e947e0009102168752d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

