### PR TITLE
fix(mock-server): prevent ValidationPipe from rejecting 'input' on up…

### DIFF
--- a/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
@@ -29,6 +29,7 @@ import { TeamAccessRole } from 'src/team/team.model';
 import { throwErr } from 'src/utils';
 import { AuthUser } from 'src/types/AuthUser';
 import { INVALID_PARAMS } from 'src/errors';
+import { IsString, IsNotEmpty } from "class-validator";
 
 @Resolver(() => MockServer)
 export class MockServerResolver {
@@ -173,6 +174,8 @@ export class MockServerResolver {
   async updateMockServer(
     @GqlUser() user: AuthUser,
     @Args({ name: "id", type: () => ID, description: "Id of the mockserver to update" })
+    @IsString()
+    @IsNotEmpty()
     id: string,
     @Args('input') input: UpdateMockServerInput,
   ): Promise<MockServer> {

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
@@ -29,7 +29,6 @@ import { TeamAccessRole } from 'src/team/team.model';
 import { throwErr } from 'src/utils';
 import { AuthUser } from 'src/types/AuthUser';
 import { INVALID_PARAMS } from 'src/errors';
-import { IsString, IsNotEmpty } from "class-validator";
 
 @Resolver(() => MockServer)
 export class MockServerResolver {
@@ -173,9 +172,11 @@ export class MockServerResolver {
   @UseGuards(GqlAuthGuard)
   async updateMockServer(
     @GqlUser() user: AuthUser,
-    @Args({ name: "id", type: () => ID, description: "Id of the mockserver to update" })
-    @IsString()
-    @IsNotEmpty()
+    @Args({
+      name: 'id',
+      type: () => ID,
+      description: 'Id of the mockserver to update',
+    })
     id: string,
     @Args('input') input: UpdateMockServerInput,
   ): Promise<MockServer> {

--- a/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
+++ b/packages/hoppscotch-backend/src/mock-server/mock-server.resolver.ts
@@ -172,11 +172,12 @@ export class MockServerResolver {
   @UseGuards(GqlAuthGuard)
   async updateMockServer(
     @GqlUser() user: AuthUser,
-    @Args() args: MockServerMutationArgs,
+    @Args({ name: "id", type: () => ID, description: "Id of the mockserver to update" })
+    id: string,
     @Args('input') input: UpdateMockServerInput,
   ): Promise<MockServer> {
     const result = await this.mockServerService.updateMockServer(
-      args.id,
+      id,
       user.uid,
       input,
     );


### PR DESCRIPTION
- Replaced @Args() args: MockServerMutationArgs with @Args('id') id: string in updateMockServer resolver.

- @Args() without a name captures all GraphQL args (including input) into MockServerMutationArgs, which only declares id. NestJS ValidationPipe then rejects input as unexpected. Binding id explicitly with @Args('id') eliminates the double-capture and the validation error.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed `updateMockServer` so `ValidationPipe` no longer rejects `input` ("property input should not exist"). We now explicitly bind `id` with `@Args({ name: 'id', type: () => ID })` and removed resolver-level validators, preventing double-captured args and allowing proper `input` validation.

<sup>Written for commit 46f989735b2814f51d7bac98f19c65d4bcd4b339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

