### PR TITLE
fix(common): defer CookieJarService binding

### DIFF
--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -74,7 +74,7 @@ const currentEnvironmentValueService = getService(CurrentValueService)
 // the service during ESM evaluation. `onServiceInit` then reads
 // `window.__KERNEL__.store` and throws because `createHoppApp` has
 // not yet called `initKernel(...)` at that point.
-const cookieJarService = () => getService(CookieJarService)
+const getCookieJarService = () => getService(CookieJarService)
 const kernelInterceptorService = getService(KernelInterceptorService)
 
 const EXPERIMENTAL_SCRIPTING_SANDBOX = useSetting(
@@ -807,7 +807,7 @@ const getCookieJarEntries = () => {
   // and returns the same array would produce a pre-vs-post delta
   // of "identical" and the mutation would silently drop.
   const cookieJarEntries = cloneDeep(
-    Array.from(cookieJarService().cookieJar.value.values()).flatMap(
+    Array.from(getCookieJarService().cookieJar.value.values()).flatMap(
       (cookies) => cookies
     )
   )
@@ -816,7 +816,7 @@ const getCookieJarEntries = () => {
 }
 
 const cookieKey = (c: { domain: string; name: string; path?: string }) =>
-  `${cookieJarService().canonStoreDomain(c.domain)}\u0000${c.name}\u0000${c.path && c.path.length > 0 ? c.path : "/"}`
+  `${getCookieJarService().canonStoreDomain(c.domain)}\u0000${c.name}\u0000${c.path && c.path.length > 0 ? c.path : "/"}`
 
 const applyScriptCookieDelta = async (
   preScript: Cookie[],
@@ -847,10 +847,10 @@ const applyScriptCookieDelta = async (
   }
 
   if (mutated.length > 0) {
-    await cookieJarService().upsertCookies(mutated)
+    await getCookieJarService().upsertCookies(mutated)
   }
   if (removed.length > 0) {
-    await cookieJarService().deleteCookies(removed)
+    await getCookieJarService().deleteCookies(removed)
   }
 }
 

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -70,7 +70,11 @@ import { applyScriptRequestUpdates } from "./experimental-sandbox-integration"
 
 const secretEnvironmentService = getService(SecretEnvironmentService)
 const currentEnvironmentValueService = getService(CurrentValueService)
-const cookieJarService = getService(CookieJarService)
+// `getService(CookieJarService)` at module top level would construct
+// the service during ESM evaluation. `onServiceInit` then reads
+// `window.__KERNEL__.store` and throws because `createHoppApp` has
+// not yet called `initKernel(...)` at that point.
+const cookieJarService = () => getService(CookieJarService)
 const kernelInterceptorService = getService(KernelInterceptorService)
 
 const EXPERIMENTAL_SCRIPTING_SANDBOX = useSetting(
@@ -803,7 +807,7 @@ const getCookieJarEntries = () => {
   // and returns the same array would produce a pre-vs-post delta
   // of "identical" and the mutation would silently drop.
   const cookieJarEntries = cloneDeep(
-    Array.from(cookieJarService.cookieJar.value.values()).flatMap(
+    Array.from(cookieJarService().cookieJar.value.values()).flatMap(
       (cookies) => cookies
     )
   )
@@ -812,7 +816,7 @@ const getCookieJarEntries = () => {
 }
 
 const cookieKey = (c: { domain: string; name: string; path?: string }) =>
-  `${cookieJarService.canonStoreDomain(c.domain)}\u0000${c.name}\u0000${c.path && c.path.length > 0 ? c.path : "/"}`
+  `${cookieJarService().canonStoreDomain(c.domain)}\u0000${c.name}\u0000${c.path && c.path.length > 0 ? c.path : "/"}`
 
 const applyScriptCookieDelta = async (
   preScript: Cookie[],
@@ -843,10 +847,10 @@ const applyScriptCookieDelta = async (
   }
 
   if (mutated.length > 0) {
-    await cookieJarService.upsertCookies(mutated)
+    await cookieJarService().upsertCookies(mutated)
   }
   if (removed.length > 0) {
-    await cookieJarService.deleteCookies(removed)
+    await cookieJarService().deleteCookies(removed)
   }
 }
 

--- a/packages/hoppscotch-common/src/helpers/__tests__/RequestRunner-cookie-jar-laziness.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/RequestRunner-cookie-jar-laziness.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest"
 import { readFileSync } from "node:fs"
-import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { dirname, resolve } from "node:path"
 
 // `getService(CookieJarService)` at module top level would construct
 // the service during ESM evaluation. `onServiceInit` then calls
@@ -15,14 +16,26 @@ import { resolve } from "node:path"
 // This spec pins the source form. A re-import test would re-trigger
 // RequestRunner's circular `i18n → newstore/history → RequestRunner`
 // cycle and fail under vitest's module evaluation.
+//
+// `fileURLToPath(import.meta.url)` keeps the path resolution
+// ESM-portable. A bare `__dirname` works under vitest today but
+// depends on a CJS global the package's `module: "ESNext"` config
+// does not guarantee. `new URL("../X", import.meta.url)` would hit
+// Vite's asset-URL transform and resolve against the dev server
+// origin (`http://localhost:3000/...`).
+const here = dirname(fileURLToPath(import.meta.url))
+
 describe("RequestRunner cookie-jar binding", () => {
   test("binds CookieJarService lazily on first call", () => {
     const source = readFileSync(
-      resolve(__dirname, "../RequestRunner.ts"),
+      resolve(here, "../RequestRunner.ts"),
       "utf8"
     )
+    // The optional `\s*:\s*\S+` group catches a typed eager binding
+    // like `const cookieJarService: CookieJarService = getService(...)`
+    // which a plain `^const\s+\w+\s*=` would skip.
     expect(source).not.toMatch(
-      /^const\s+\w+\s*=\s*getService\s*\(\s*CookieJarService\s*\)/m
+      /^const\s+\w+(?:\s*:\s*\S+)?\s*=\s*getService\s*\(\s*CookieJarService\s*\)/m
     )
     expect(source).toMatch(/=>\s*getService\s*\(\s*CookieJarService\s*\)/)
   })

--- a/packages/hoppscotch-common/src/helpers/__tests__/RequestRunner-cookie-jar-laziness.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/RequestRunner-cookie-jar-laziness.spec.ts
@@ -27,10 +27,7 @@ const here = dirname(fileURLToPath(import.meta.url))
 
 describe("RequestRunner cookie-jar binding", () => {
   test("binds CookieJarService lazily on first call", () => {
-    const source = readFileSync(
-      resolve(here, "../RequestRunner.ts"),
-      "utf8"
-    )
+    const source = readFileSync(resolve(here, "../RequestRunner.ts"), "utf8")
     // The optional `\s*:\s*\S+` group catches a typed eager binding
     // like `const cookieJarService: CookieJarService = getService(...)`
     // which a plain `^const\s+\w+\s*=` would skip.

--- a/packages/hoppscotch-common/src/helpers/__tests__/RequestRunner-cookie-jar-laziness.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/RequestRunner-cookie-jar-laziness.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+
+// `getService(CookieJarService)` at module top level would construct
+// the service during ESM evaluation. `onServiceInit` then calls
+// `Store.init()`, which reads `window.__KERNEL__.store` and throws
+// because `createHoppApp` has not yet called `initKernel(...)`. The
+// catch in `onServiceInit` degrades the service to in-memory mode
+// but logs `[CookieJar] Kernel store unavailable` on every browser
+// load. The lazy form `() => getService(...)` defers construction to
+// first call, by which point `initKernel(...)` has run and
+// `Store.init()` succeeds.
+//
+// This spec pins the source form. A re-import test would re-trigger
+// RequestRunner's circular `i18n → newstore/history → RequestRunner`
+// cycle and fail under vitest's module evaluation.
+describe("RequestRunner cookie-jar binding", () => {
+  test("binds CookieJarService lazily on first call", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../RequestRunner.ts"),
+      "utf8"
+    )
+    expect(source).not.toMatch(
+      /^const\s+\w+\s*=\s*getService\s*\(\s*CookieJarService\s*\)/m
+    )
+    expect(source).toMatch(/=>\s*getService\s*\(\s*CookieJarService\s*\)/)
+  })
+})


### PR DESCRIPTION
RequestRunner had a module-level
`const cookieJarService = getService(CookieJarService)` which constructed the service during ESM evaluation. The constructor's `onServiceInit` calls `Store.init()`, which reads
`window.__KERNEL__.store` and throws because `createHoppApp` has not yet called `initKernel(...)` at that point. The catch in `onServiceInit` degrades the service to in-memory mode but logs `[CookieJar] Kernel store unavailable` on every browser load.

The lazy form `() => getService(CookieJarService)` defers construction. The Proxy/Agent kernel-interceptor bind chain triggers it after `createHoppApp` has run `initKernel(...)`, so `Store.init()` succeeds.

The regression spec `RequestRunner-cookie-jar-laziness.spec.ts` pins the source form. A re-import test would re-trigger RequestRunner's circular `i18n → newstore/history → RequestRunner` cycle and fail under vitest's module evaluation.

FE-1305 tracks the architectural pattern that allowed the bug, where `InitializationService` sequences `init()` method calls but does not coordinate dioc construction, so any kernel-reading `onServiceInit` called at ESM module-eval time races `initKernel(...)`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defer `CookieJarService` binding in `RequestRunner` to avoid eager ESM construction that raced `initKernel(...)`, which caused in-memory fallback and “[CookieJar] Kernel store unavailable” on load. Addresses FE-1305 by ensuring the service is constructed only after the app is initialized.

- **Bug Fixes**
  - Replace top-level `getService(CookieJarService)` with lazy `() => getService(CookieJarService)`.
  - Ensure `Store.init()` runs after `initKernel(...)`, removing the startup log and using the kernel-backed store.
  - Tighten the regression spec for ESM portability (`fileURLToPath(import.meta.url)`) and to catch typed eager bindings.

- **Refactors**
  - Rename lazy accessor to `getCookieJarService` and update its call sites.
  - Minor formatting updates.

<sup>Written for commit aaf435aebb705c864bf7f2b45cb8edee7f91980b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

