### PR TITLE
feat: allow containers to run with arbitrary non-root UIDs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,8 +48,9 @@ ENABLE_SUBPATH_BASED_ACCESS=false
 #-----------------------Container Runtime Config---------------------#
 
 # Caddy's in-container HTTP port (default 80). Set a free port in 1024-65535 (e.g.
-# 8000) to run under a non-root UID like OpenShift, which can't bind ports < 1024;
-# also update your published mapping (e.g. "3000:8000"). Avoid ports used internally:
-# 8080, 3200, 3000, 3100, 3170. Validated at startup. Legacy HOPP_AIO_ALTERNATE_PORT
-# is honoured as a fallback (AIO image).
-# HOPP_ALTERNATE_PORT=80
+# 8000) to run under a non-root UID like OpenShift, which can't bind ports < 1024
+# (ports below 1024 are accepted only when the container runs as root); also update
+# your published mapping (e.g. "3000:8000"). Avoid ports used internally: 8080, 3200,
+# 3000, 3100, 3170. Validated at startup; empty means unset. Legacy
+# HOPP_AIO_ALTERNATE_PORT is honoured as a fallback (AIO image).
+# HOPP_ALTERNATE_PORT=8000

--- a/.env.example
+++ b/.env.example
@@ -48,8 +48,9 @@ ENABLE_SUBPATH_BASED_ACCESS=false
 #-----------------------Container Runtime Config---------------------#
 
 # Caddy's in-container HTTP port (default 80). Set a free port (e.g. 8000) to run
-# under a non-root UID like OpenShift, and update your published mapping too. Avoid
-# internal ports 8080, 3200, 3000, 3100, 3170. Non-root runs expect GID 0.
-# On the AIO image this applies only when ENABLE_SUBPATH_BASED_ACCESS=true; the
-# legacy HOPP_AIO_ALTERNATE_PORT is honoured there as a fallback.
+# under a non-root UID like OpenShift (ports < 1024 need root or CAP_NET_BIND_SERVICE),
+# and update your published mapping too. Avoid internal ports 8080, 3200, 3000, 3100,
+# 3170. Non-root runs expect GID 0. On the AIO image this applies only when
+# ENABLE_SUBPATH_BASED_ACCESS=true; the legacy HOPP_AIO_ALTERNATE_PORT is honoured
+# there as a fallback.
 # HOPP_ALTERNATE_PORT=8000

--- a/.env.example
+++ b/.env.example
@@ -47,10 +47,9 @@ ENABLE_SUBPATH_BASED_ACCESS=false
 
 #-----------------------Container Runtime Config---------------------#
 
-# Caddy's in-container HTTP port (default 80). Set a free port in 1024-65535 (e.g.
-# 8000) to run under a non-root UID like OpenShift, which can't bind ports < 1024
-# (ports below 1024 are accepted only when the container runs as root); also update
-# your published mapping (e.g. "3000:8000"). Avoid ports used internally: 8080, 3200,
-# 3000, 3100, 3170. Validated at startup; empty means unset. Legacy
-# HOPP_AIO_ALTERNATE_PORT is honoured as a fallback (AIO image).
+# Caddy's in-container HTTP port (default 80). Set a free port (e.g. 8000) to run
+# under a non-root UID like OpenShift, and update your published mapping too. Avoid
+# internal ports 8080, 3200, 3000, 3100, 3170. Non-root runs expect GID 0.
+# On the AIO image this applies only when ENABLE_SUBPATH_BASED_ACCESS=true; the
+# legacy HOPP_AIO_ALTERNATE_PORT is honoured there as a fallback.
 # HOPP_ALTERNATE_PORT=8000

--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,12 @@ VITE_PROXYSCOTCH_ACCESS_TOKEN=
 
 # Set to `true` for subpath based access
 ENABLE_SUBPATH_BASED_ACCESS=false
+
+#-----------------------Container Runtime Config---------------------#
+
+# Caddy's in-container HTTP port (default 80). Set a free port in 1024-65535 (e.g.
+# 8000) to run under a non-root UID like OpenShift, which can't bind ports < 1024;
+# also update your published mapping (e.g. "3000:8000"). Avoid ports used internally:
+# 8080, 3200, 3000, 3100, 3170. Validated at startup. Legacy HOPP_AIO_ALTERNATE_PORT
+# is honoured as a fallback (AIO image).
+# HOPP_ALTERNATE_PORT=80

--- a/aio-subpath-access.Caddyfile
+++ b/aio-subpath-access.Caddyfile
@@ -3,7 +3,7 @@
   persist_config off
 }
 
-:{$HOPP_AIO_ALTERNATE_PORT:80} {
+:{$HOPP_ALTERNATE_PORT:80} {
 	# Serve the `selfhost-web` SPA by default
 	root * /site/selfhost-web
 	file_server

--- a/aio_run.mjs
+++ b/aio_run.mjs
@@ -3,34 +3,66 @@
 
 import { execFileSync, spawn } from "child_process"
 import fs from "fs"
+import net from "net"
 import os from "os"
 import path from "path"
 import process from "process"
 
-// Compose passes undefined host vars through as ""; treat empty as unset so the
-// Caddyfile default (:80) applies, matching the healthcheck's ${VAR:-} semantics.
+// Probe the real bind so the kernel decides (CAP_NET_BIND_SERVICE, port sysctls),
+// not a UID guess.
+async function assertPortBindable(port) {
+  await new Promise((resolve) => {
+    const probe = net.createServer()
+    probe.once("error", (err) => {
+      if (err.code === "EACCES") {
+        console.error(`Cannot bind port ${port} as the current user: set HOPP_ALTERNATE_PORT to a free port >= 1024, or run as root / grant CAP_NET_BIND_SERVICE.`)
+        process.exit(1)
+      }
+      if (err.code === "EADDRINUSE") {
+        console.error(`Port ${port} is already in use inside the container: set HOPP_ALTERNATE_PORT to a free port.`)
+        process.exit(1)
+      }
+      console.warn(`Skipping bind preflight for port ${port} (${err.code})`)
+      resolve()
+    })
+    probe.listen(port, () => probe.close(resolve))
+  })
+}
+
+// Empty means unset (compose passes undefined vars as ""), so the :80 default applies.
 if (process.env.HOPP_ALTERNATE_PORT === "") delete process.env.HOPP_ALTERNATE_PORT
 if (process.env.HOPP_AIO_ALTERNATE_PORT === "") delete process.env.HOPP_AIO_ALTERNATE_PORT
 
-// Back-compat: honour the legacy HOPP_AIO_ALTERNATE_PORT when the new var is unset.
-if (!process.env.HOPP_ALTERNATE_PORT && process.env.HOPP_AIO_ALTERNATE_PORT) {
+// Back-compat: fall back to the legacy var when the new one is unset.
+const legacyPortApplied = !process.env.HOPP_ALTERNATE_PORT && !!process.env.HOPP_AIO_ALTERNATE_PORT
+if (legacyPortApplied) {
   process.env.HOPP_ALTERNATE_PORT = process.env.HOPP_AIO_ALTERNATE_PORT
 }
 
-// Caddy bind port — when set, must be a bindable integer (root may bind any port;
-// other UIDs can't bind below 1024).
+const useSubpathAccess = process.env.ENABLE_SUBPATH_BASED_ACCESS === "true"
+
+// Sanity-check the value; real bindability is probed below.
 const RESERVED_PORTS = ["8080", "3200"]
-const MIN_PORT = process.getuid?.() === 0 ? 1 : 1024
 const altPort = process.env.HOPP_ALTERNATE_PORT
+// Name whichever var the operator actually set.
+const altPortVar = legacyPortApplied ? "HOPP_AIO_ALTERNATE_PORT" : "HOPP_ALTERNATE_PORT"
 if (altPort !== undefined) {
-  if (!(/^[0-9]+$/.test(altPort) && +altPort >= MIN_PORT && +altPort <= 65535)) {
-    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in ${MIN_PORT}-65535 (e.g. 8000)${MIN_PORT > 1 ? " — ports below 1024 need root" : ""}.`)
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1 && +altPort <= 65535)) {
+    console.error(`${altPortVar}="${altPort}" is invalid: use an integer in 1-65535 (e.g. 8000).`)
     process.exit(1)
   }
   if (RESERVED_PORTS.includes(String(+altPort))) {
-    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is already used by this image (${RESERVED_PORTS.join(", ")}); pick another port (e.g. 8000).`)
+    console.error(`${altPortVar}="${altPort}" is already used by this image (${RESERVED_PORTS.join(", ")}); pick another port (e.g. 8000).`)
     process.exit(1)
   }
+  if (!useSubpathAccess) {
+    console.warn(`${altPortVar} has no effect in multiport mode (Caddy binds 3000/3100/3170); it applies only when ENABLE_SUBPATH_BASED_ACCESS=true.`)
+  }
+}
+
+// Only subpath mode binds the configurable port; multiport uses fixed ports.
+if (useSubpathAccess) {
+  await assertPortBindable(+(process.env.HOPP_ALTERNATE_PORT ?? 80))
 }
 
 function runChildProcessWithPrefix(command, args, prefix) {
@@ -84,24 +116,25 @@ try {
   fs.rmSync(tmpDir, { recursive: true, force: true })
 }
 
-const caddyFileName = process.env.ENABLE_SUBPATH_BASED_ACCESS === 'true' ? 'aio-subpath-access.Caddyfile' : 'aio-multiport-setup.Caddyfile'
+const caddyFileName = useSubpathAccess ? 'aio-subpath-access.Caddyfile' : 'aio-multiport-setup.Caddyfile'
 const caddyProcess = runChildProcessWithPrefix("caddy", ["run", "--config", `/etc/caddy/${caddyFileName}`, "--adapter", "caddyfile"], "App/Admin Dashboard Caddy")
 const backendProcess = runChildProcessWithPrefix("node", ["/dist/backend/dist/src/main.js"], "Backend Server")
 const webappProcess = runChildProcessWithPrefix("webapp-server", [], "Webapp Server")
 
 caddyProcess.on("exit", (code) => {
   console.log(`Exiting process because Caddy Server exited with code ${code}`)
-  process.exit(code)
+  // code is null on signal death; report failure, not success.
+  process.exit(code ?? 1)
 })
 
 backendProcess.on("exit", (code) => {
   console.log(`Exiting process because Backend Server exited with code ${code}`)
-  process.exit(code)
+  process.exit(code ?? 1)
 })
 
 webappProcess.on("exit", (code) => {
   console.log(`Exiting process because Webapp Server exited with code ${code}`)
-  process.exit(code)
+  process.exit(code ?? 1)
 })
 
 process.on('SIGINT', () => {

--- a/aio_run.mjs
+++ b/aio_run.mjs
@@ -7,20 +7,27 @@ import os from "os"
 import path from "path"
 import process from "process"
 
+// Compose passes undefined host vars through as ""; treat empty as unset so the
+// Caddyfile default (:80) applies, matching the healthcheck's ${VAR:-} semantics.
+if (process.env.HOPP_ALTERNATE_PORT === "") delete process.env.HOPP_ALTERNATE_PORT
+if (process.env.HOPP_AIO_ALTERNATE_PORT === "") delete process.env.HOPP_AIO_ALTERNATE_PORT
+
 // Back-compat: honour the legacy HOPP_AIO_ALTERNATE_PORT when the new var is unset.
 if (!process.env.HOPP_ALTERNATE_PORT && process.env.HOPP_AIO_ALTERNATE_PORT) {
   process.env.HOPP_ALTERNATE_PORT = process.env.HOPP_AIO_ALTERNATE_PORT
 }
 
-// Caddy bind port — when set, must be an unprivileged integer (1024-65535).
+// Caddy bind port — when set, must be a bindable integer (root may bind any port;
+// other UIDs can't bind below 1024).
 const RESERVED_PORTS = ["8080", "3200"]
+const MIN_PORT = process.getuid?.() === 0 ? 1 : 1024
 const altPort = process.env.HOPP_ALTERNATE_PORT
 if (altPort !== undefined) {
-  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1024 && +altPort <= 65535)) {
-    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in 1024-65535 (e.g. 8000).`)
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= MIN_PORT && +altPort <= 65535)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in ${MIN_PORT}-65535 (e.g. 8000)${MIN_PORT > 1 ? " — ports below 1024 need root" : ""}.`)
     process.exit(1)
   }
-  if (RESERVED_PORTS.includes(altPort)) {
+  if (RESERVED_PORTS.includes(String(+altPort))) {
     console.error(`HOPP_ALTERNATE_PORT="${altPort}" is already used by this image (${RESERVED_PORTS.join(", ")}); pick another port (e.g. 8000).`)
     process.exit(1)
   }

--- a/aio_run.mjs
+++ b/aio_run.mjs
@@ -1,9 +1,30 @@
 #!/usr/local/bin/node
 // @ts-check
 
-import { execSync, spawn } from "child_process"
+import { execFileSync, spawn } from "child_process"
 import fs from "fs"
+import os from "os"
+import path from "path"
 import process from "process"
+
+// Back-compat: honour the legacy HOPP_AIO_ALTERNATE_PORT when the new var is unset.
+if (!process.env.HOPP_ALTERNATE_PORT && process.env.HOPP_AIO_ALTERNATE_PORT) {
+  process.env.HOPP_ALTERNATE_PORT = process.env.HOPP_AIO_ALTERNATE_PORT
+}
+
+// Caddy bind port — when set, must be an unprivileged integer (1024-65535).
+const RESERVED_PORTS = ["8080", "3200"]
+const altPort = process.env.HOPP_ALTERNATE_PORT
+if (altPort !== undefined) {
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1024 && +altPort <= 65535)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in 1024-65535 (e.g. 8000).`)
+    process.exit(1)
+  }
+  if (RESERVED_PORTS.includes(altPort)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is already used by this image (${RESERVED_PORTS.join(", ")}); pick another port (e.g. 8000).`)
+    process.exit(1)
+  }
+}
 
 function runChildProcessWithPrefix(command, args, prefix) {
   const childProcess = spawn(command, args);
@@ -44,11 +65,17 @@ const envFileContent = Object.entries(process.env)
   }`)
   .join("\n")
 
-fs.writeFileSync("build.env", envFileContent)
+// Write to a temp dir (not cwd) so a non-root UID needn't own the working directory.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hopp-env-"))
+const buildEnvPath = path.join(tmpDir, "build.env")
 
-execSync(`npx import-meta-env -x build.env -e build.env -p "/site/**/*"`)
-
-fs.rmSync("build.env")
+try {
+  fs.writeFileSync(buildEnvPath, envFileContent)
+  // Call the global binary directly (not npx, which needs a writable $HOME cache).
+  execFileSync("import-meta-env", ["-x", buildEnvPath, "-e", buildEnvPath, "-p", "/site/**/*"], { stdio: "inherit" })
+} finally {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+}
 
 const caddyFileName = process.env.ENABLE_SUBPATH_BASED_ACCESS === 'true' ? 'aio-subpath-access.Caddyfile' : 'aio-multiport-setup.Caddyfile'
 const caddyProcess = runChildProcessWithPrefix("caddy", ["run", "--config", `/etc/caddy/${caddyFileName}`, "--adapter", "caddyfile"], "App/Admin Dashboard Caddy")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       hoppscotch-db:
         condition: service_healthy
     ports:
-      - "3180:80"
+      - "3180:${HOPP_ALTERNATE_PORT:-80}"
       - "3170:3170"
 
   # The main hoppscotch app with integrated webapp server. This will be hosted at port 3000
@@ -70,7 +70,7 @@ services:
     depends_on:
       - hoppscotch-backend
     ports:
-      - "3080:80"
+      - "3080:${HOPP_ALTERNATE_PORT:-80}"
       - "3000:3000"
       - "3200:3200"
 
@@ -89,7 +89,7 @@ services:
     depends_on:
       - hoppscotch-backend
     ports:
-      - "3280:80"
+      - "3280:${HOPP_ALTERNATE_PORT:-80}"
       - "3100:3100"
 
   # The service that spins up all services at once in one container
@@ -111,7 +111,7 @@ services:
       - "3100:3100"
       - "3170:3170"
       - "3200:3200"
-      - "3080:80"
+      - "3080:${HOPP_ALTERNATE_PORT:-80}"
 
   # Profile with no database dependency (purely developmental)
   hoppscotch-aio-no-db:
@@ -129,7 +129,7 @@ services:
       - "3100:3100"
       - "3170:3170"
       - "3200:3200"
-      - "3080:80"
+      - "3080:${HOPP_ALTERNATE_PORT:-80}"
 
   # The preset DB service, you can delete/comment the below lines if
   # you are using an external postgres instance

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -17,7 +17,7 @@ if [ "$UPTIME" -lt 15 ]; then
 fi
 
 if [ "$ENABLE_SUBPATH_BASED_ACCESS" = "true" ]; then
-  curlCheck "http://localhost:${HOPP_AIO_ALTERNATE_PORT:-80}/backend/ping" || exit 1
+  curlCheck "http://localhost:${HOPP_ALTERNATE_PORT:-${HOPP_AIO_ALTERNATE_PORT:-80}}/backend/ping" || exit 1
 else
   curlCheck "http://localhost:3000" || exit 1
   curlCheck "http://localhost:3100" || exit 1

--- a/packages/hoppscotch-backend/backend.Caddyfile
+++ b/packages/hoppscotch-backend/backend.Caddyfile
@@ -3,7 +3,7 @@
 	persist_config off
 }
 
-:80 :3170 {
+:{$HOPP_ALTERNATE_PORT:80} :3170 {
 	@mock {
 		header_regexp host Host ^[^.]+\.mock\..*$
 	}

--- a/packages/hoppscotch-backend/prod_run.mjs
+++ b/packages/hoppscotch-backend/prod_run.mjs
@@ -4,15 +4,21 @@
 import { spawn } from 'child_process';
 import process from 'process';
 
-// Caddy bind port — when set, must be an unprivileged integer (1024-65535).
+// Compose passes undefined host vars through as ""; treat empty as unset so the
+// Caddyfile default (:80) applies.
+if (process.env.HOPP_ALTERNATE_PORT === '') delete process.env.HOPP_ALTERNATE_PORT;
+
+// Caddy bind port — when set, must be a bindable integer (root may bind any port;
+// other UIDs can't bind below 1024).
 const RESERVED_PORTS = ['3170', '8080'];
+const MIN_PORT = process.getuid?.() === 0 ? 1 : 1024;
 const altPort = process.env.HOPP_ALTERNATE_PORT;
 if (altPort !== undefined) {
-  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1024 && +altPort <= 65535)) {
-    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in 1024-65535 (e.g. 8000).`);
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= MIN_PORT && +altPort <= 65535)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in ${MIN_PORT}-65535 (e.g. 8000)${MIN_PORT > 1 ? ' — ports below 1024 need root' : ''}.`);
     process.exit(1);
   }
-  if (RESERVED_PORTS.includes(altPort)) {
+  if (RESERVED_PORTS.includes(String(+altPort))) {
     console.error(`HOPP_ALTERNATE_PORT="${altPort}" is already used by this image (${RESERVED_PORTS.join(', ')}); pick another port (e.g. 8000).`);
     process.exit(1);
   }

--- a/packages/hoppscotch-backend/prod_run.mjs
+++ b/packages/hoppscotch-backend/prod_run.mjs
@@ -4,6 +4,20 @@
 import { spawn } from 'child_process';
 import process from 'process';
 
+// Caddy bind port — when set, must be an unprivileged integer (1024-65535).
+const RESERVED_PORTS = ['3170', '8080'];
+const altPort = process.env.HOPP_ALTERNATE_PORT;
+if (altPort !== undefined) {
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1024 && +altPort <= 65535)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in 1024-65535 (e.g. 8000).`);
+    process.exit(1);
+  }
+  if (RESERVED_PORTS.includes(altPort)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is already used by this image (${RESERVED_PORTS.join(', ')}); pick another port (e.g. 8000).`);
+    process.exit(1);
+  }
+}
+
 function runChildProcessWithPrefix(command, args, prefix) {
   const childProcess = spawn(command, args);
 

--- a/packages/hoppscotch-backend/prod_run.mjs
+++ b/packages/hoppscotch-backend/prod_run.mjs
@@ -2,20 +2,39 @@
 // @ts-check
 
 import { spawn } from 'child_process';
+import net from 'net';
 import process from 'process';
 
-// Compose passes undefined host vars through as ""; treat empty as unset so the
-// Caddyfile default (:80) applies.
+// Probe the real bind so the kernel decides (CAP_NET_BIND_SERVICE, port sysctls),
+// not a UID guess.
+async function assertPortBindable(port) {
+  await new Promise((resolve) => {
+    const probe = net.createServer();
+    probe.once('error', (err) => {
+      if (err.code === 'EACCES') {
+        console.error(`Cannot bind port ${port} as the current user: set HOPP_ALTERNATE_PORT to a free port >= 1024, or run as root / grant CAP_NET_BIND_SERVICE.`);
+        process.exit(1);
+      }
+      if (err.code === 'EADDRINUSE') {
+        console.error(`Port ${port} is already in use inside the container: set HOPP_ALTERNATE_PORT to a free port.`);
+        process.exit(1);
+      }
+      console.warn(`Skipping bind preflight for port ${port} (${err.code})`);
+      resolve();
+    });
+    probe.listen(port, () => probe.close(resolve));
+  });
+}
+
+// Empty means unset (compose passes undefined vars as ""), so the :80 default applies.
 if (process.env.HOPP_ALTERNATE_PORT === '') delete process.env.HOPP_ALTERNATE_PORT;
 
-// Caddy bind port — when set, must be a bindable integer (root may bind any port;
-// other UIDs can't bind below 1024).
+// Sanity-check the value; real bindability is probed below.
 const RESERVED_PORTS = ['3170', '8080'];
-const MIN_PORT = process.getuid?.() === 0 ? 1 : 1024;
 const altPort = process.env.HOPP_ALTERNATE_PORT;
 if (altPort !== undefined) {
-  if (!(/^[0-9]+$/.test(altPort) && +altPort >= MIN_PORT && +altPort <= 65535)) {
-    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in ${MIN_PORT}-65535 (e.g. 8000)${MIN_PORT > 1 ? ' — ports below 1024 need root' : ''}.`);
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1 && +altPort <= 65535)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in 1-65535 (e.g. 8000).`);
     process.exit(1);
   }
   if (RESERVED_PORTS.includes(String(+altPort))) {
@@ -23,6 +42,9 @@ if (altPort !== undefined) {
     process.exit(1);
   }
 }
+
+// Caddy always binds this port (env value or the :80 default).
+await assertPortBindable(+(process.env.HOPP_ALTERNATE_PORT ?? 80));
 
 function runChildProcessWithPrefix(command, args, prefix) {
   const childProcess = spawn(command, args);
@@ -66,14 +88,15 @@ const backendProcess = runChildProcessWithPrefix(
 
 caddyProcess.on('exit', (code) => {
   console.log(`Exiting process because Caddy Server exited with code ${code}`);
-  process.exit(code);
+  // code is null on signal death; report failure, not success.
+  process.exit(code ?? 1);
 });
 
 backendProcess.on('exit', (code) => {
   console.log(
     `Exiting process because Backend Server exited with code ${code}`,
   );
-  process.exit(code);
+  process.exit(code ?? 1);
 });
 
 process.on('SIGINT', () => {

--- a/packages/hoppscotch-selfhost-web/prod_run.mjs
+++ b/packages/hoppscotch-selfhost-web/prod_run.mjs
@@ -1,22 +1,41 @@
 #!/usr/local/bin/node
 import { execFileSync } from "child_process"
 import fs from "fs"
+import net from "net"
 import os from "os"
 import path from "path"
 
-// Compose passes undefined host vars through as ""; treat empty as unset so the
-// Caddyfile default (:80) applies. (Caddy itself is started by the image CMD,
-// which applies the same empty-means-unset rule before launching it.)
+// Probe the real bind so the kernel decides (CAP_NET_BIND_SERVICE, port sysctls),
+// not a UID guess.
+async function assertPortBindable(port) {
+  await new Promise((resolve) => {
+    const probe = net.createServer()
+    probe.once("error", (err) => {
+      if (err.code === "EACCES") {
+        console.error(`Cannot bind port ${port} as the current user: set HOPP_ALTERNATE_PORT to a free port >= 1024, or run as root / grant CAP_NET_BIND_SERVICE.`)
+        process.exit(1)
+      }
+      if (err.code === "EADDRINUSE") {
+        console.error(`Port ${port} is already in use inside the container: set HOPP_ALTERNATE_PORT to a free port.`)
+        process.exit(1)
+      }
+      console.warn(`Skipping bind preflight for port ${port} (${err.code})`)
+      resolve()
+    })
+    probe.listen(port, () => probe.close(resolve))
+  })
+}
+
+// Empty means unset (compose passes undefined vars as ""), so the :80 default
+// applies. The image CMD also unsets an empty value before launching Caddy.
 if (process.env.HOPP_ALTERNATE_PORT === "") delete process.env.HOPP_ALTERNATE_PORT
 
-// Caddy bind port — when set, must be a bindable integer (root may bind any port;
-// other UIDs can't bind below 1024).
+// Sanity-check the value; real bindability is probed below.
 const RESERVED_PORTS = ["3000", "3200"]
-const MIN_PORT = process.getuid?.() === 0 ? 1 : 1024
 const altPort = process.env.HOPP_ALTERNATE_PORT
 if (altPort !== undefined) {
-  if (!(/^[0-9]+$/.test(altPort) && +altPort >= MIN_PORT && +altPort <= 65535)) {
-    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in ${MIN_PORT}-65535 (e.g. 8000)${MIN_PORT > 1 ? " — ports below 1024 need root" : ""}.`)
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1 && +altPort <= 65535)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in 1-65535 (e.g. 8000).`)
     process.exit(1)
   }
   if (RESERVED_PORTS.includes(String(+altPort))) {
@@ -24,6 +43,9 @@ if (altPort !== undefined) {
     process.exit(1)
   }
 }
+
+// Caddy always binds this port (env value or the :80 default).
+await assertPortBindable(+(process.env.HOPP_ALTERNATE_PORT ?? 80))
 
 const envFileContent = Object.entries(process.env)
   .filter(([env]) => env.startsWith("VITE_"))

--- a/packages/hoppscotch-selfhost-web/prod_run.mjs
+++ b/packages/hoppscotch-selfhost-web/prod_run.mjs
@@ -4,15 +4,22 @@ import fs from "fs"
 import os from "os"
 import path from "path"
 
-// Caddy bind port — when set, must be an unprivileged integer (1024-65535).
+// Compose passes undefined host vars through as ""; treat empty as unset so the
+// Caddyfile default (:80) applies. (Caddy itself is started by the image CMD,
+// which applies the same empty-means-unset rule before launching it.)
+if (process.env.HOPP_ALTERNATE_PORT === "") delete process.env.HOPP_ALTERNATE_PORT
+
+// Caddy bind port — when set, must be a bindable integer (root may bind any port;
+// other UIDs can't bind below 1024).
 const RESERVED_PORTS = ["3000", "3200"]
+const MIN_PORT = process.getuid?.() === 0 ? 1 : 1024
 const altPort = process.env.HOPP_ALTERNATE_PORT
 if (altPort !== undefined) {
-  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1024 && +altPort <= 65535)) {
-    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in 1024-65535 (e.g. 8000).`)
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= MIN_PORT && +altPort <= 65535)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in ${MIN_PORT}-65535 (e.g. 8000)${MIN_PORT > 1 ? " — ports below 1024 need root" : ""}.`)
     process.exit(1)
   }
-  if (RESERVED_PORTS.includes(altPort)) {
+  if (RESERVED_PORTS.includes(String(+altPort))) {
     console.error(`HOPP_ALTERNATE_PORT="${altPort}" is already used by this image (${RESERVED_PORTS.join(", ")}); pick another port (e.g. 8000).`)
     process.exit(1)
   }

--- a/packages/hoppscotch-selfhost-web/prod_run.mjs
+++ b/packages/hoppscotch-selfhost-web/prod_run.mjs
@@ -1,6 +1,22 @@
 #!/usr/local/bin/node
-import { execSync } from "child_process"
+import { execFileSync } from "child_process"
 import fs from "fs"
+import os from "os"
+import path from "path"
+
+// Caddy bind port — when set, must be an unprivileged integer (1024-65535).
+const RESERVED_PORTS = ["3000", "3200"]
+const altPort = process.env.HOPP_ALTERNATE_PORT
+if (altPort !== undefined) {
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1024 && +altPort <= 65535)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in 1024-65535 (e.g. 8000).`)
+    process.exit(1)
+  }
+  if (RESERVED_PORTS.includes(altPort)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is already used by this image (${RESERVED_PORTS.join(", ")}); pick another port (e.g. 8000).`)
+    process.exit(1)
+  }
+}
 
 const envFileContent = Object.entries(process.env)
   .filter(([env]) => env.startsWith("VITE_"))
@@ -11,8 +27,14 @@ const envFileContent = Object.entries(process.env)
   )
   .join("\n")
 
-fs.writeFileSync("build.env", envFileContent)
+// Write to a temp dir (not cwd) so a non-root UID needn't own the working directory.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hopp-env-"))
+const buildEnvPath = path.join(tmpDir, "build.env")
 
-execSync(`npx import-meta-env -x build.env -e build.env -p "/site/**/*"`)
-
-fs.rmSync("build.env")
+try {
+  fs.writeFileSync(buildEnvPath, envFileContent)
+  // Call the global binary directly (not npx, which needs a writable $HOME cache).
+  execFileSync("import-meta-env", ["-x", buildEnvPath, "-e", buildEnvPath, "-p", "/site/**/*"], { stdio: "inherit" })
+} finally {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+}

--- a/packages/hoppscotch-selfhost-web/selfhost-web.Caddyfile
+++ b/packages/hoppscotch-selfhost-web/selfhost-web.Caddyfile
@@ -3,7 +3,7 @@
   persist_config off
 }
 
-:80 :3000 {
+:{$HOPP_ALTERNATE_PORT:80} :3000 {
 	try_files {path} /
 	root * /site/selfhost-web
 	file_server

--- a/packages/hoppscotch-sh-admin/prod_run.mjs
+++ b/packages/hoppscotch-sh-admin/prod_run.mjs
@@ -5,15 +5,21 @@ import os from 'os';
 import path from 'path';
 import process from 'process';
 
-// Caddy bind port — when set, must be an unprivileged integer (1024-65535).
+// Compose passes undefined host vars through as ""; treat empty as unset so the
+// Caddyfile default (:80) applies.
+if (process.env.HOPP_ALTERNATE_PORT === '') delete process.env.HOPP_ALTERNATE_PORT;
+
+// Caddy bind port — when set, must be a bindable integer (root may bind any port;
+// other UIDs can't bind below 1024).
 const RESERVED_PORTS = ['3100'];
+const MIN_PORT = process.getuid?.() === 0 ? 1 : 1024;
 const altPort = process.env.HOPP_ALTERNATE_PORT;
 if (altPort !== undefined) {
-  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1024 && +altPort <= 65535)) {
-    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in 1024-65535 (e.g. 8000).`);
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= MIN_PORT && +altPort <= 65535)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in ${MIN_PORT}-65535 (e.g. 8000)${MIN_PORT > 1 ? ' — ports below 1024 need root' : ''}.`);
     process.exit(1);
   }
-  if (RESERVED_PORTS.includes(altPort)) {
+  if (RESERVED_PORTS.includes(String(+altPort))) {
     console.error(`HOPP_ALTERNATE_PORT="${altPort}" is already used by this image (${RESERVED_PORTS.join(', ')}); pick another port (e.g. 8000).`);
     process.exit(1);
   }

--- a/packages/hoppscotch-sh-admin/prod_run.mjs
+++ b/packages/hoppscotch-sh-admin/prod_run.mjs
@@ -1,22 +1,41 @@
 #!/usr/local/bin/node
 import { execFileSync, spawn } from 'child_process';
 import fs from 'fs';
+import net from 'net';
 import os from 'os';
 import path from 'path';
 import process from 'process';
 
-// Compose passes undefined host vars through as ""; treat empty as unset so the
-// Caddyfile default (:80) applies.
+// Probe the real bind so the kernel decides (CAP_NET_BIND_SERVICE, port sysctls),
+// not a UID guess.
+async function assertPortBindable(port) {
+  await new Promise((resolve) => {
+    const probe = net.createServer();
+    probe.once('error', (err) => {
+      if (err.code === 'EACCES') {
+        console.error(`Cannot bind port ${port} as the current user: set HOPP_ALTERNATE_PORT to a free port >= 1024, or run as root / grant CAP_NET_BIND_SERVICE.`);
+        process.exit(1);
+      }
+      if (err.code === 'EADDRINUSE') {
+        console.error(`Port ${port} is already in use inside the container: set HOPP_ALTERNATE_PORT to a free port.`);
+        process.exit(1);
+      }
+      console.warn(`Skipping bind preflight for port ${port} (${err.code})`);
+      resolve();
+    });
+    probe.listen(port, () => probe.close(resolve));
+  });
+}
+
+// Empty means unset (compose passes undefined vars as ""), so the :80 default applies.
 if (process.env.HOPP_ALTERNATE_PORT === '') delete process.env.HOPP_ALTERNATE_PORT;
 
-// Caddy bind port — when set, must be a bindable integer (root may bind any port;
-// other UIDs can't bind below 1024).
+// Sanity-check the value; real bindability is probed below.
 const RESERVED_PORTS = ['3100'];
-const MIN_PORT = process.getuid?.() === 0 ? 1 : 1024;
 const altPort = process.env.HOPP_ALTERNATE_PORT;
 if (altPort !== undefined) {
-  if (!(/^[0-9]+$/.test(altPort) && +altPort >= MIN_PORT && +altPort <= 65535)) {
-    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in ${MIN_PORT}-65535 (e.g. 8000)${MIN_PORT > 1 ? ' — ports below 1024 need root' : ''}.`);
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1 && +altPort <= 65535)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in 1-65535 (e.g. 8000).`);
     process.exit(1);
   }
   if (RESERVED_PORTS.includes(String(+altPort))) {
@@ -24,6 +43,9 @@ if (altPort !== undefined) {
     process.exit(1);
   }
 }
+
+// Caddy always binds this port (env value or the :80 default).
+await assertPortBindable(+(process.env.HOPP_ALTERNATE_PORT ?? 80));
 
 function runChildProcessWithPrefix(command, args, prefix) {
   const childProcess = spawn(command, args);
@@ -87,7 +109,8 @@ const caddyProcess = runChildProcessWithPrefix(
 
 caddyProcess.on('exit', (code) => {
   console.log(`Exiting process because Caddy Server exited with code ${code}`);
-  process.exit(code);
+  // code is null on signal death; report failure, not success.
+  process.exit(code ?? 1);
 });
 
 process.on('SIGINT', () => {

--- a/packages/hoppscotch-sh-admin/prod_run.mjs
+++ b/packages/hoppscotch-sh-admin/prod_run.mjs
@@ -1,7 +1,23 @@
 #!/usr/local/bin/node
-import { execSync, spawn } from 'child_process';
+import { execFileSync, spawn } from 'child_process';
 import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import process from 'process';
+
+// Caddy bind port — when set, must be an unprivileged integer (1024-65535).
+const RESERVED_PORTS = ['3100'];
+const altPort = process.env.HOPP_ALTERNATE_PORT;
+if (altPort !== undefined) {
+  if (!(/^[0-9]+$/.test(altPort) && +altPort >= 1024 && +altPort <= 65535)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is invalid: use an integer in 1024-65535 (e.g. 8000).`);
+    process.exit(1);
+  }
+  if (RESERVED_PORTS.includes(altPort)) {
+    console.error(`HOPP_ALTERNATE_PORT="${altPort}" is already used by this image (${RESERVED_PORTS.join(', ')}); pick another port (e.g. 8000).`);
+    process.exit(1);
+  }
+}
 
 function runChildProcessWithPrefix(command, args, prefix) {
   const childProcess = spawn(command, args);
@@ -41,11 +57,17 @@ const envFileContent = Object.entries(process.env)
   )
   .join('\n');
 
-fs.writeFileSync('build.env', envFileContent);
+// Write to a temp dir (not cwd) so a non-root UID needn't own the working directory.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hopp-env-'));
+const buildEnvPath = path.join(tmpDir, 'build.env');
 
-execSync(`npx import-meta-env -x build.env -e build.env -p "/site/**/*"`);
-
-fs.rmSync('build.env');
+try {
+  fs.writeFileSync(buildEnvPath, envFileContent);
+  // Call the global binary directly (not npx, which needs a writable $HOME cache).
+  execFileSync('import-meta-env', ['-x', buildEnvPath, '-e', buildEnvPath, '-p', '/site/**/*'], { stdio: 'inherit' });
+} finally {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+}
 
 const caddyFileName =
   process.env.ENABLE_SUBPATH_BASED_ACCESS === 'true'

--- a/packages/hoppscotch-sh-admin/sh-admin-multiport-setup.Caddyfile
+++ b/packages/hoppscotch-sh-admin/sh-admin-multiport-setup.Caddyfile
@@ -3,7 +3,7 @@
   persist_config off
 }
 
-:80 :3100 {
+:{$HOPP_ALTERNATE_PORT:80} :3100 {
 	try_files {path} /
 	root * /site/sh-admin-multiport-setup
 	file_server

--- a/packages/hoppscotch-sh-admin/sh-admin-subpath-access.Caddyfile
+++ b/packages/hoppscotch-sh-admin/sh-admin-subpath-access.Caddyfile
@@ -3,7 +3,7 @@
   persist_config off
 }
 
-:80 :3100 {
+:{$HOPP_ALTERNATE_PORT:80} :3100 {
 	handle_path /admin* {
 		root * /site/sh-admin-subpath-access
 		file_server

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -155,6 +155,10 @@ COPY --from=base_builder /usr/src/app/packages/hoppscotch-backend/prod_run.mjs /
 ENV PRODUCTION="true"
 ENV PORT=8080
 
+# Writable Caddy storage for non-root UIDs (no writable $HOME needed).
+ENV XDG_DATA_HOME=/tmp
+ENV XDG_CONFIG_HOME=/tmp
+
 WORKDIR /dist/backend
 
 CMD ["node", "prod_run.mjs"]
@@ -179,6 +183,14 @@ COPY --from=webapp_server_builder /usr/src/app/packages/hoppscotch-selfhost-web/
 COPY --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/prod_run.mjs /site/prod_run.mjs
 COPY --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/selfhost-web.Caddyfile /etc/caddy/selfhost-web.Caddyfile
 COPY --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/dist/ /site/selfhost-web
+
+# Writable Caddy storage for non-root UIDs (no writable $HOME needed).
+ENV XDG_DATA_HOME=/tmp
+ENV XDG_CONFIG_HOME=/tmp
+
+# Env injection rewrites /site in place; make it group-writable (GID 0) so a
+# non-root UID (OpenShift runs as GID 0) can write. No-op for root.
+RUN chgrp -R 0 /site && chmod -R g=rwX /site
 
 WORKDIR /site
 # Run both webapp-server and Caddy after env processing (NOTE: env processing is required by both)
@@ -206,6 +218,14 @@ COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/sh-admin-
 COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/sh-admin-subpath-access.Caddyfile /etc/caddy/sh-admin-subpath-access.Caddyfile
 COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-multiport-setup /site/sh-admin-multiport-setup
 COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-subpath-access /site/sh-admin-subpath-access
+
+# Writable Caddy storage for non-root UIDs (no writable $HOME needed).
+ENV XDG_DATA_HOME=/tmp
+ENV XDG_CONFIG_HOME=/tmp
+
+# Env injection rewrites /site in place; make it group-writable (GID 0) so a
+# non-root UID (OpenShift runs as GID 0) can write. No-op for root.
+RUN chgrp -R 0 /site && chmod -R g=rwX /site
 
 WORKDIR /site
 CMD ["node","/site/prod_run.mjs"]
@@ -247,6 +267,14 @@ COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-subp
 COPY aio-multiport-setup.Caddyfile /etc/caddy/aio-multiport-setup.Caddyfile
 COPY aio-subpath-access.Caddyfile /etc/caddy/aio-subpath-access.Caddyfile
 
+# Writable Caddy storage for non-root UIDs (no writable $HOME needed).
+ENV XDG_DATA_HOME=/tmp
+ENV XDG_CONFIG_HOME=/tmp
+
+# Env injection rewrites /site in place; make it group-writable (GID 0) so a
+# non-root UID (OpenShift runs as GID 0) can write. No-op for root.
+RUN chgrp -R 0 /site && chmod -R g=rwX /site
+
 ENTRYPOINT [ "tini", "--" ]
 COPY --chmod=755 healthcheck.sh /
 HEALTHCHECK --interval=2s --start-period=15s CMD /bin/sh /healthcheck.sh
@@ -254,7 +282,9 @@ HEALTHCHECK --interval=2s --start-period=15s CMD /bin/sh /healthcheck.sh
 WORKDIR /dist/backend
 CMD ["node", "/usr/src/app/aio_run.mjs"]
 
-# NOTE: Although these ports are exposed, the HOPP_ALTERNATE_AIO_PORT variable can be used to assign a user-specified port
+# NOTE: Although these ports are exposed, HOPP_ALTERNATE_PORT assigns the HTTP port
+#       Caddy listens on (default 80) — required under a non-root UID, which cannot
+#       bind ports < 1024. The legacy HOPP_AIO_ALTERNATE_PORT is still honoured.
 EXPOSE 3170
 EXPOSE 3000
 EXPOSE 3100

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -192,10 +192,13 @@ COPY --chown=root:0 --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-
 ENV XDG_DATA_HOME=/tmp
 ENV XDG_CONFIG_HOME=/tmp
 
-# The copied files already carry g=rwX from the builder stage; only the dirs COPY
-# itself created still need it. Non-recursive on purpose — a recursive chmod here
-# would duplicate the whole /site tree into this layer.
-RUN chmod g=rwX /site /site/*
+# Files keep g=rwX from the builder; only the COPY-created dirs need it. List the
+# dirs (not /site/*) so the layer stays metadata-only and prod_run.mjs stays 755.
+RUN chmod g=rwX /site /site/selfhost-web
+
+# Pre-create /data group-writable so webapp-server's signing key persists across
+# restarts under a non-root UID (else it's regenerated and logged each start).
+RUN mkdir -p /data/webapp-server && chmod g=rwX /data /data/webapp-server
 
 WORKDIR /site
 # Run both webapp-server and Caddy after env processing (NOTE: env processing is required by both)
@@ -234,10 +237,9 @@ COPY --chown=root:0 --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-
 ENV XDG_DATA_HOME=/tmp
 ENV XDG_CONFIG_HOME=/tmp
 
-# The copied files already carry g=rwX from the builder stage; only the dirs COPY
-# itself created still need it. Non-recursive on purpose — a recursive chmod here
-# would duplicate the whole /site tree into this layer.
-RUN chmod g=rwX /site /site/*
+# Files keep g=rwX from the builder; only the COPY-created dirs need it. List the
+# dirs (not /site/*) so the layer stays metadata-only and prod_run.mjs stays 755.
+RUN chmod g=rwX /site /site/sh-admin-multiport-setup /site/sh-admin-subpath-access
 
 WORKDIR /site
 CMD ["node","/site/prod_run.mjs"]
@@ -268,7 +270,6 @@ COPY --from=base_builder /usr/src/app/packages/hoppscotch-backend/prod_run.mjs /
 
 # Static Server
 COPY --from=webapp_server_builder /usr/src/app/packages/hoppscotch-selfhost-web/webapp-server/webapp-server /usr/local/bin/
-RUN mkdir -p /site/selfhost-web
 COPY --chown=root:0 --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/dist /site/selfhost-web
 
 # FE Files
@@ -282,10 +283,13 @@ COPY aio-subpath-access.Caddyfile /etc/caddy/aio-subpath-access.Caddyfile
 ENV XDG_DATA_HOME=/tmp
 ENV XDG_CONFIG_HOME=/tmp
 
-# The copied files already carry g=rwX from the builder stages; only the dirs COPY
-# itself created still need it. Non-recursive on purpose — a recursive chmod here
-# would duplicate the whole /site tree into this layer.
-RUN chmod g=rwX /site /site/*
+# Files keep g=rwX from the builders; only the COPY-created dirs need it. List the
+# dirs (not /site/*) so the layer stays metadata-only.
+RUN chmod g=rwX /site /site/selfhost-web /site/sh-admin-multiport-setup /site/sh-admin-subpath-access
+
+# Pre-create /data group-writable so webapp-server's signing key persists across
+# restarts under a non-root UID (else it's regenerated and logged each start).
+RUN mkdir -p /data/webapp-server && chmod g=rwX /data /data/webapp-server
 
 ENTRYPOINT [ "tini", "--" ]
 COPY --chmod=755 healthcheck.sh /
@@ -294,9 +298,10 @@ HEALTHCHECK --interval=2s --start-period=15s CMD /bin/sh /healthcheck.sh
 WORKDIR /dist/backend
 CMD ["node", "/usr/src/app/aio_run.mjs"]
 
-# NOTE: Although these ports are exposed, HOPP_ALTERNATE_PORT assigns the HTTP port
-#       Caddy listens on (default 80) — required under a non-root UID, which cannot
-#       bind ports < 1024. The legacy HOPP_AIO_ALTERNATE_PORT is still honoured.
+# NOTE: In subpath mode (ENABLE_SUBPATH_BASED_ACCESS=true) HOPP_ALTERNATE_PORT sets
+#       Caddy's HTTP port (default 80). In multiport mode (default) Caddy uses the
+#       fixed ports 3000/3100/3170 and it has no effect. Legacy
+#       HOPP_AIO_ALTERNATE_PORT is still honoured.
 EXPOSE 3170
 EXPOSE 3000
 EXPOSE 3100

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -273,7 +273,6 @@ COPY --chown=root:0 --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-
 
 # FE Files
 COPY --from=base_builder /usr/src/app/aio_run.mjs /usr/src/app/aio_run.mjs
-COPY --chown=root:0 --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/dist /site/selfhost-web
 COPY --chown=root:0 --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-multiport-setup /site/sh-admin-multiport-setup
 COPY --chown=root:0 --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-subpath-access /site/sh-admin-subpath-access
 COPY aio-multiport-setup.Caddyfile /etc/caddy/aio-multiport-setup.Caddyfile

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -170,6 +170,10 @@ EXPOSE 3170
 FROM base_builder AS fe_builder
 WORKDIR /usr/src/app/packages/hoppscotch-selfhost-web
 RUN pnpm run generate
+# Group-writable (GID 0) so a non-root UID (OpenShift runs as GID 0) can rewrite
+# these files during env injection. Done here (not in the runtime stage) so the
+# perms travel with the COPY instead of duplicating the layer with a chmod there.
+RUN chmod -R g=rwX /usr/src/app/packages/hoppscotch-selfhost-web/dist
 
 
 
@@ -182,19 +186,22 @@ COPY --from=webapp_server_builder /usr/src/app/packages/hoppscotch-selfhost-web/
 
 COPY --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/prod_run.mjs /site/prod_run.mjs
 COPY --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/selfhost-web.Caddyfile /etc/caddy/selfhost-web.Caddyfile
-COPY --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/dist/ /site/selfhost-web
+COPY --chown=root:0 --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/dist/ /site/selfhost-web
 
 # Writable Caddy storage for non-root UIDs (no writable $HOME needed).
 ENV XDG_DATA_HOME=/tmp
 ENV XDG_CONFIG_HOME=/tmp
 
-# Env injection rewrites /site in place; make it group-writable (GID 0) so a
-# non-root UID (OpenShift runs as GID 0) can write. No-op for root.
-RUN chgrp -R 0 /site && chmod -R g=rwX /site
+# The copied files already carry g=rwX from the builder stage; only the dirs COPY
+# itself created still need it. Non-recursive on purpose — a recursive chmod here
+# would duplicate the whole /site tree into this layer.
+RUN chmod g=rwX /site /site/*
 
 WORKDIR /site
 # Run both webapp-server and Caddy after env processing (NOTE: env processing is required by both)
-CMD ["/bin/sh", "-c", "node /site/prod_run.mjs && (webapp-server & caddy run --config /etc/caddy/selfhost-web.Caddyfile --adapter caddyfile)"]
+# An empty HOPP_ALTERNATE_PORT (compose passthrough of an undefined var) means unset,
+# so the Caddyfile default (:80) applies.
+CMD ["/bin/sh", "-c", "[ -n \"$HOPP_ALTERNATE_PORT\" ] || unset HOPP_ALTERNATE_PORT; node /site/prod_run.mjs && (webapp-server & caddy run --config /etc/caddy/selfhost-web.Caddyfile --adapter caddyfile)"]
 
 EXPOSE 80
 EXPOSE 3000
@@ -207,6 +214,10 @@ WORKDIR /usr/src/app/packages/hoppscotch-sh-admin
 # Generate two builds for `sh-admin`, one based on subpath-access and the regular build
 RUN pnpm run build --outDir dist-multiport-setup
 RUN pnpm run build --outDir dist-subpath-access --base /admin/
+# Group-writable (GID 0) so a non-root UID (OpenShift runs as GID 0) can rewrite
+# these files during env injection. Done here (not in the runtime stage) so the
+# perms travel with the COPY instead of duplicating the layer with a chmod there.
+RUN chmod -R g=rwX dist-multiport-setup dist-subpath-access
 
 
 FROM node_base AS sh_admin
@@ -216,16 +227,17 @@ COPY --from=caddy_builder /tmp/caddy-build/cmd/caddy/caddy /usr/bin/caddy
 COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/prod_run.mjs /site/prod_run.mjs
 COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/sh-admin-multiport-setup.Caddyfile /etc/caddy/sh-admin-multiport-setup.Caddyfile
 COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/sh-admin-subpath-access.Caddyfile /etc/caddy/sh-admin-subpath-access.Caddyfile
-COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-multiport-setup /site/sh-admin-multiport-setup
-COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-subpath-access /site/sh-admin-subpath-access
+COPY --chown=root:0 --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-multiport-setup /site/sh-admin-multiport-setup
+COPY --chown=root:0 --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-subpath-access /site/sh-admin-subpath-access
 
 # Writable Caddy storage for non-root UIDs (no writable $HOME needed).
 ENV XDG_DATA_HOME=/tmp
 ENV XDG_CONFIG_HOME=/tmp
 
-# Env injection rewrites /site in place; make it group-writable (GID 0) so a
-# non-root UID (OpenShift runs as GID 0) can write. No-op for root.
-RUN chgrp -R 0 /site && chmod -R g=rwX /site
+# The copied files already carry g=rwX from the builder stage; only the dirs COPY
+# itself created still need it. Non-recursive on purpose — a recursive chmod here
+# would duplicate the whole /site tree into this layer.
+RUN chmod g=rwX /site /site/*
 
 WORKDIR /site
 CMD ["node","/site/prod_run.mjs"]
@@ -257,13 +269,13 @@ COPY --from=base_builder /usr/src/app/packages/hoppscotch-backend/prod_run.mjs /
 # Static Server
 COPY --from=webapp_server_builder /usr/src/app/packages/hoppscotch-selfhost-web/webapp-server/webapp-server /usr/local/bin/
 RUN mkdir -p /site/selfhost-web
-COPY --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/dist /site/selfhost-web
+COPY --chown=root:0 --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/dist /site/selfhost-web
 
 # FE Files
 COPY --from=base_builder /usr/src/app/aio_run.mjs /usr/src/app/aio_run.mjs
-COPY --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/dist /site/selfhost-web
-COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-multiport-setup /site/sh-admin-multiport-setup
-COPY --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-subpath-access /site/sh-admin-subpath-access
+COPY --chown=root:0 --from=fe_builder /usr/src/app/packages/hoppscotch-selfhost-web/dist /site/selfhost-web
+COPY --chown=root:0 --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-multiport-setup /site/sh-admin-multiport-setup
+COPY --chown=root:0 --from=sh_admin_builder /usr/src/app/packages/hoppscotch-sh-admin/dist-subpath-access /site/sh-admin-subpath-access
 COPY aio-multiport-setup.Caddyfile /etc/caddy/aio-multiport-setup.Caddyfile
 COPY aio-subpath-access.Caddyfile /etc/caddy/aio-subpath-access.Caddyfile
 
@@ -271,9 +283,10 @@ COPY aio-subpath-access.Caddyfile /etc/caddy/aio-subpath-access.Caddyfile
 ENV XDG_DATA_HOME=/tmp
 ENV XDG_CONFIG_HOME=/tmp
 
-# Env injection rewrites /site in place; make it group-writable (GID 0) so a
-# non-root UID (OpenShift runs as GID 0) can write. No-op for root.
-RUN chgrp -R 0 /site && chmod -R g=rwX /site
+# The copied files already carry g=rwX from the builder stages; only the dirs COPY
+# itself created still need it. Non-recursive on purpose — a recursive chmod here
+# would duplicate the whole /site tree into this layer.
+RUN chmod g=rwX /site /site/*
 
 ENTRYPOINT [ "tini", "--" ]
 COPY --chmod=755 healthcheck.sh /


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->
Closes BE-784

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
The self-host container images assumed they run as `root`, so they could not run under a non-root / arbitrary UID such as OpenShift's `restricted-v2` SCC: Caddy could not bind the privileged port `80` (`< 1024`), and the runtime env injection could not write `build.env` or rewrite the assets under `/site` that the arbitrary UID does not own (`EACCES`). This PR makes the AIO and distributed (frontend/backend/admin) images runnable under an arbitrary non-root UID — which on OpenShift is always a member of GID `0` — while keeping the default (root, port 80) behavior fully backward compatible.

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

- [x] **Configurable HTTP port** — `HOPP_ALTERNATE_PORT` (default `80`) in every Caddyfile that bound `:80`: subpath AIO, front-end, admin, backend.
- [x] **Legacy alias** — `HOPP_AIO_ALTERNATE_PORT` is still honoured as a fallback when `HOPP_ALTERNATE_PORT` is unset (`aio_run.mjs` + `healthcheck.sh`). An empty value (compose passing through an undefined variable) means *unset*, so the `:80` default applies rather than leaving Caddy with a bare `:` address.
- [x] **Startup validation + bind probe** — when set, the value must be an integer in `1–65535` and must not collide with a port the image already uses. Actual bind permission is then **probed** against the effective port rather than inferred from the UID, so the kernel decides (`CAP_NET_BIND_SERVICE`, `net.ipv4.ip_unprivileged_port_start`); `EACCES` / `EADDRINUSE` fail fast with a message naming `HOPP_ALTERNATE_PORT` instead of a cryptic Caddy bind error. This also covers the unset-variable case, where the `:80` default is unbindable for a non-root UID.
- [x] **Writable asset rewrite** — `/site` is group-owned by GID `0` and group-writable (the OpenShift arbitrary-UID pattern), and `build.env` is written to a `mkdtemp` directory so the working directory needn't be writable. No-op for the default root user.
- [x] **Persistent webapp-server signing key** — `/data/webapp-server` is pre-created group-writable so `webapp-server` can persist its bundle-signing key under a non-root UID. Without it, the key could not be written, so it was regenerated *and printed to the container logs* on every start, breaking desktop clients with cached bundles after each restart.
- [x] **No `npx` at runtime** — env injection calls the globally-installed `import-meta-env` binary directly via `execFileSync`, so it needs no writable `$HOME`/npm cache and involves no shell.
- [x] **Caddy storage** — `XDG_DATA_HOME`/`XDG_CONFIG_HOME` point at a writable path so Caddy doesn't try to write under a non-writable `$HOME`.
- [x] **Compose stays reachable** — the container side of the published port mappings in `docker-compose.yml` follows `HOPP_ALTERNATE_PORT` (e.g. `"3080:${HOPP_ALTERNATE_PORT:-80}"`), so setting the variable doesn't silently break the stack.
- [x] **Correct exit status on signal death** — the supervisor scripts report `code ?? 1`, so a service killed by a signal (e.g. OOM) no longer surfaces as a clean exit `0` to restart-on-failure orchestrators.
- [x] **Docs** — `HOPP_ALTERNATE_PORT` documented in `.env.example` (reserved ports, privileged-port caveat, legacy alias, GID `0` expectation).

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->

- **Backward compatible**: an unset `HOPP_ALTERNATE_PORT` → Caddy's `:80` default; the value check only runs when the variable is set.
- **Why a bind probe instead of a UID check**: gating on `getuid() === 0` would reject configurations that actually work — stock Docker sets `net.ipv4.ip_unprivileged_port_start=0` inside containers, so a non-root UID *can* bind `:80`, and `CAP_NET_BIND_SERVICE` has the same effect. Probing the real bind lets the kernel decide and still fails fast with an actionable message where the bind genuinely isn't permitted.
- **Running on OpenShift**: set `HOPP_ALTERNATE_PORT` to a free port `≥ 1024` (avoid the internal ports `8080`, `3200`, `3000/3100/3170`), point the Service/Route at that container port, and run as a non-root UID with GID `0`. OpenShift's restricted SCC does this automatically; locally: `docker run --user 1000:0 -e HOPP_ALTERNATE_PORT=8000 <image>`.
- **Scope is OpenShift's model** (arbitrary UID, always GID `0`). `chmod g=rwX` grants write through GID `0`, which is what OpenShift guarantees — it is not aimed at an arbitrary *non-zero* GID.
- **AIO multiport mode**: `HOPP_ALTERNATE_PORT` applies only in subpath mode (`ENABLE_SUBPATH_BASED_ACCESS=true`), which is the only mode whose Caddyfile binds a configurable port. Multiport binds the fixed `3000/3100/3170` (already `≥ 1024`), so a value set there is **warned about and ignored** rather than being treated as fatal — a previously-booting container keeps booting.
- **Reserved ports are per-image**, listing only what that image actually binds — for AIO subpath mode that is `8080` (backend) and `3200` (webapp-server); `3000/3100/3170` are free in subpath mode and are deliberately *not* reserved.
- **Caveat**: the runtime env injection rewrites `/site` in place, so it needs a **writable root filesystem** — available on OpenShift's default restricted SCC (which does not force `readOnlyRootFilesystem`).
