### PR TITLE
fix(curl): preserve header values containing ": " on import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/headers.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/headers.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import { parseCurlCommand } from "../curlparser"
+
+// Regression tests for https://github.com/hoppscotch/hoppscotch/issues/6400
+// A header value that itself contains ": " was silently dropped because the old
+// parser split on every occurrence of ": " and then rejected arrays with > 2 elements.
+describe("cURL header parsing", () => {
+  it("imports a header whose value contains ': ' (colon + space)", () => {
+    const result = parseCurlCommand(
+      `curl https://example.com -H "X-Note: hello: world" -H "Accept: application/json"`
+    )
+
+    const xNote = result.headers.find((h) => h.key === "X-Note")
+    const accept = result.headers.find((h) => h.key === "Accept")
+
+    expect(xNote).toBeDefined()
+    expect(xNote?.value).toBe("hello: world")
+    expect(accept).toBeDefined()
+    expect(accept?.value).toBe("application/json")
+  })
+
+  it("imports a header whose value has a colon without trailing space", () => {
+    const result = parseCurlCommand(
+      `curl https://example.com -H "X-Time: 12:30"`
+    )
+
+    const xTime = result.headers.find((h) => h.key === "X-Time")
+
+    expect(xTime).toBeDefined()
+    expect(xTime?.value).toBe("12:30")
+  })
+
+  it("imports a header with no space after the colon (compact form)", () => {
+    const result = parseCurlCommand(
+      `curl https://example.com -H "Authorization:Bearer token123"`
+    )
+
+    const auth = result.headers.find((h) => h.key === "Authorization")
+
+    expect(auth).toBeDefined()
+    expect(auth?.value).toBe("Bearer token123")
+  })
+
+  it("imports multiple headers with colon-containing values", () => {
+    const result = parseCurlCommand(
+      `curl https://example.com -H "X-A: foo: bar" -H "X-B: baz: qux: quux"`
+    )
+
+    const a = result.headers.find((h) => h.key === "X-A")
+    const b = result.headers.find((h) => h.key === "X-B")
+
+    expect(a?.value).toBe("foo: bar")
+    expect(b?.value).toBe("baz: qux: quux")
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -2,7 +2,6 @@ import { HoppRESTHeader } from "@hoppscotch/data"
 import * as A from "fp-ts/Array"
 import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
 import parser from "yargs-parser"
 import {
   objHasArrayProperty,
@@ -10,13 +9,17 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
-const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
-)
+// RFC 9110: a header is "name: value". The name ends at the first colon;
+// everything after the colon (trimmed) is the value, which may itself contain
+// ": " sequences. Splitting on all ": " would silently drop such headers.
+const getHeaderPair = (raw: string): O.Option<[string, string]> => {
+  const idx = raw.indexOf(":")
+  if (idx === -1) return O.none
+  const key = raw.slice(0, idx).trim()
+  const value = raw.slice(idx + 1).trim()
+  if (!key) return O.none
+  return O.some([key, value])
+}
 
 export function getHeaders(parsedArguments: parser.Arguments) {
   let headers: Record<string, string> = {}


### PR DESCRIPTION
## Summary

Fixes a bug where importing a cURL command silently drops any header whose **value** contains `": "` (colon + space).

**Steps to reproduce:**
```bash
curl https://httpbin.org/get -H "X-Note: hello: world" -H "Accept: application/json"
```
Import this in Hoppscotch → only `Accept` appears; `X-Note` is gone.

## Root cause

`getHeaderPair` in `headers.ts` had a three-step pipeline:

```ts
const getHeaderPair = flow(
  S.replace(":", ": "),   // normalize "Header:value"
  S.split(": "),           // ← splits on ALL ": " occurrences
  O.fromPredicate((arr) => arr.length === 2),  // ← drops if > 2 segments
  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
)
```

A header like `"X-Note: hello: world"` produces `["X-Note", "hello", "world"]` (three segments) and is discarded by the `length === 2` predicate.

## Fix

Per RFC 9110, the header name is everything before the **first** colon; the value (which may itself contain `": "`) is everything after it. Replace the multi-step flow with `indexOf(":")` + `slice`:

```ts
const getHeaderPair = (raw: string): O.Option<[string, string]> => {
  const idx = raw.indexOf(":")
  if (idx === -1) return O.none
  const key = raw.slice(0, idx).trim()
  const value = raw.slice(idx + 1).trim()
  if (!key) return O.none
  return O.some([key, value])
}
```

This also correctly handles compact form (`Authorization:Bearer token`) by trimming the value.

## Tests

Added `packages/hoppscotch-common/src/helpers/curl/__tests__/headers.spec.ts` with 4 cases:
- Value with `": "` → preserved in full (`hello: world`)
- Value with `:` but no space → preserved (`12:30`)
- Compact form without space after colon → key/value both trimmed
- Multiple headers with `": "` values → all preserved

Closes #6400

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cURL import dropping headers when the value contains ": ". We now split on the first colon only (RFC 9110) so values like "hello: world" are preserved.

- **Bug Fixes**
  - Parse header lines using first-colon `indexOf` + `slice`, trimming key/value and supporting compact form (e.g., `Authorization:Bearer token`).
  - Add regression tests covering colon-space values, colon without space, compact form, and multiple headers with colons.

<sup>Written for commit 5397ee78b30c51f38ffd82c5e4282d5f1a328ecc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

