### PR TITLE
feat(response): allow adding new headers when editing a saved example

### DIFF
--- a/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
@@ -55,7 +55,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  (e: "update:modelValue"): void
+  (e: "update:modelValue", value: HoppRESTResponseHeader[]): void
 }>()
 
 const headers = useVModel(props, "modelValue", emit)

--- a/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
@@ -72,10 +72,10 @@ const copyHeaders = () => {
 }
 
 const addHeader = () => {
-  headers.value.push({ key: "", value: "" })
+  headers.value = [...headers.value, { key: "", value: "" }]
 }
 
 const deleteHeader = (index: number) => {
-  headers.value.splice(index, 1)
+  headers.value = headers.value.filter((_, i) => i !== index)
 }
 </script>

--- a/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
@@ -8,6 +8,13 @@
       </label>
       <div class="flex">
         <HoppButtonSecondary
+          v-if="isEditable"
+          v-tippy="{ theme: 'tooltip' }"
+          :title="t('add.new')"
+          :icon="IconPlus"
+          @click="addHeader"
+        />
+        <HoppButtonSecondary
           v-if="headers"
           v-tippy="{ theme: 'tooltip' }"
           :title="t('action.copy')"
@@ -30,6 +37,7 @@
 <script setup lang="ts">
 import IconCopy from "~icons/lucide/copy"
 import IconCheck from "~icons/lucide/check"
+import IconPlus from "~icons/lucide/plus"
 import { refAutoReset } from "@vueuse/core"
 import { copyToClipboard } from "~/helpers/utils/clipboard"
 import { useI18n } from "@composables/i18n"
@@ -61,6 +69,10 @@ const copyHeaders = () => {
   copyToClipboard(JSON.stringify(props.modelValue))
   copyIcon.value = IconCheck
   toast.success(`${t("state.copied_to_clipboard")}`)
+}
+
+const addHeader = () => {
+  headers.value.push({ key: "", value: "" })
 }
 
 const deleteHeader = (index: number) => {

--- a/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue
@@ -8,7 +8,7 @@
       </label>
       <div class="flex">
         <HoppButtonSecondary
-          v-if="isEditable"
+          v-if="isEditable && headers"
           v-tippy="{ theme: 'tooltip' }"
           :title="t('add.new')"
           :icon="IconPlus"


### PR DESCRIPTION
### What

Adds an **Add** button to the response Headers editor so users can add brand-new header rows while editing a saved Example, not just edit or delete the ones captured from the original response.

Refs #6491

### Why

#6491 asks for editable response headers/body in saved Examples so developers can design mock responses. Most of that already works on `main` — status code, body (via the Raw/JSON CodeMirror lenses), and header **edit/delete** are all editable, and `saveExample()` already persists changes back to user and team collections.

The one missing primitive is **adding a header that wasn't in the original response** — the exact thing you need when authoring a mock from scratch. `LensesHeadersRenderer` only iterated over existing headers, so there was no way to introduce, say, an `X-RateLimit-Remaining` header on a saved Example.

### Changes

`packages/hoppscotch-common/src/components/lenses/HeadersRenderer.vue`:
- Add an **Add** button (`lucide/plus`, `add.new` i18n key), gated on `isEditable` so it only shows in the editable saved-Example context and stays hidden on live responses.
- `addHeader()` pushes an empty `{ key: "", value: "" }` row, mirroring the existing `deleteHeader()`/`splice()` pattern. The new row uses the same editable `SmartEnvInput` entries already rendered by `HeadersRendererEntry`.

No schema, store, or new-component changes. Persistence rides the existing dirty-tracking (`ResponseTab.vue`) → `saveExample()` flow.

### Scope / call sites

`LensesHeadersRenderer` is used in three places; behavior verified for each:
- `http/example/LenseBodyRenderer.vue` — `is-editable="true"` → **Add button shows** (target flow).
- `lenses/ResponseBodyRenderer.vue` (live response headers + request headers) — `is-editable="false"` → **Add button hidden** (unchanged).

### Testing

- [ ] Save a response as an Example, open it, go to the Headers tab → click **Add** → new editable row appears.
- [ ] Fill key/value, click **Save** → reopen the Example → the added header persists.
- [ ] Open a live response's Headers tab → **no** Add button (unchanged behavior).

### Notes for reviewers

Content-type headers remain non-editable by design (`HeadersRendererEntry` guards this, since changing content-type can switch the active lens). Adding *other* headers is unaffected. Happy to revisit if you'd like new rows to allow a content-type override.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow adding response headers when editing a saved Example (refs #6491) to support mock response design. Previously you could only edit/delete existing headers; now you can add new rows. Live response views remain unchanged.

- Show an Add button only when `isEditable` and `headers` are present; hidden on live responses.
- Reassign the `headers` array on add/delete so `v-model` emits and persists; `update:modelValue` now emits `HoppRESTResponseHeader[]`.
- Content-Type rows remain non-editable.

<sup>Written for commit 729663b3c3f9dc49312ef03275a276551e5fae9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

