### PR TITLE
fix: bump `relay` for agent response-cookie capture and pin fork revisions

### DIFF
--- a/packages/hoppscotch-agent/package.json
+++ b/packages/hoppscotch-agent/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hoppscotch-agent",
   "private": true,
-  "version": "0.1.17",
+  "version": "0.1.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/packages/hoppscotch-agent/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.lock
@@ -4203,9 +4203,10 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 [[package]]
 name = "relay"
 version = "0.1.1"
-source = "git+https://github.com/CuriousCorrelation/relay.git#ed2329e4ebb71bb984c4705aa950cb9c3f9ff931"
+source = "git+https://github.com/CuriousCorrelation/relay.git?rev=1c4f1e16106ed48983926ea6ddb114c1dbb2f688#1c4f1e16106ed48983926ea6ddb114c1dbb2f688"
 dependencies = [
  "bytes",
+ "cookie",
  "curl",
  "dashmap",
  "env_logger",

--- a/packages/hoppscotch-agent/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.lock
@@ -2070,7 +2070,7 @@ dependencies = [
 
 [[package]]
 name = "hoppscotch-agent"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/packages/hoppscotch-agent/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ rand = "0.8.5"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "json", "fmt", "std", "time"] }
 tracing-appender = "0.2.3"
-relay = { git = "https://github.com/CuriousCorrelation/relay.git" }
+relay = { git = "https://github.com/CuriousCorrelation/relay.git", rev = "1c4f1e16106ed48983926ea6ddb114c1dbb2f688" }
 thiserror = "1.0.69"
 tauri-plugin-store = "2.4.1"
 x25519-dalek = { version = "2.0.1", features = ["getrandom"] }

--- a/packages/hoppscotch-agent/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-agent/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoppscotch-agent"
-version = "0.1.17"
+version = "0.1.18"
 description = "A cross-platform HTTP request agent for Hoppscotch for advanced request handling including custom headers, certificates, proxies, and local system integration."
 authors = ["AndrewBastin", "CuriousCorrelation"]
 edition = "2021"

--- a/packages/hoppscotch-agent/src-tauri/tauri.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/packages/hoppscotch-desktop/plugin-workspace/relay/Cargo.lock
+++ b/packages/hoppscotch-desktop/plugin-workspace/relay/Cargo.lock
@@ -168,7 +168,7 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 [[package]]
 name = "curl"
 version = "0.4.47"
-source = "git+https://github.com/CuriousCorrelation/curl-rust.git#1ec8079cf527b9cf47cc7a48c68b458affdae273"
+source = "git+https://github.com/CuriousCorrelation/curl-rust.git?rev=1ec8079cf527b9cf47cc7a48c68b458affdae273#1ec8079cf527b9cf47cc7a48c68b458affdae273"
 dependencies = [
  "curl-sys",
  "libc",
@@ -180,7 +180,7 @@ dependencies = [
 [[package]]
 name = "curl-sys"
 version = "0.4.77+curl-8.10.1"
-source = "git+https://github.com/CuriousCorrelation/curl-rust.git#1ec8079cf527b9cf47cc7a48c68b458affdae273"
+source = "git+https://github.com/CuriousCorrelation/curl-rust.git?rev=1ec8079cf527b9cf47cc7a48c68b458affdae273#1ec8079cf527b9cf47cc7a48c68b458affdae273"
 dependencies = [
  "cc",
  "libc",

--- a/packages/hoppscotch-desktop/plugin-workspace/relay/Cargo.toml
+++ b/packages/hoppscotch-desktop/plugin-workspace/relay/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["CuriousCorrelation"]
 edition = "2021"
 
 [dependencies]
-curl = { git = "https://github.com/CuriousCorrelation/curl-rust.git", features = ["ntlm"] }
+curl = { git = "https://github.com/CuriousCorrelation/curl-rust.git", rev = "1ec8079cf527b9cf47cc7a48c68b458affdae273", features = ["ntlm"] }
 cookie = "0.18"
 tokio-util = "0.7.12"
 lazy_static = "1.5.0"

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/Cargo.lock
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/Cargo.lock
@@ -2931,9 +2931,10 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "relay"
 version = "0.1.1"
-source = "git+https://github.com/CuriousCorrelation/relay.git#ed2329e4ebb71bb984c4705aa950cb9c3f9ff931"
+source = "git+https://github.com/CuriousCorrelation/relay.git?rev=1c4f1e16106ed48983926ea6ddb114c1dbb2f688#1c4f1e16106ed48983926ea6ddb114c1dbb2f688"
 dependencies = [
  "bytes",
+ "cookie",
  "curl",
  "dashmap",
  "env_logger",

--- a/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/Cargo.toml
+++ b/packages/hoppscotch-desktop/plugin-workspace/tauri-plugin-relay/Cargo.toml
@@ -13,7 +13,7 @@ tauri = { version = "2.1.0" }
 serde = "1.0"
 thiserror = "2"
 tracing = "0.1.41"
-relay = { git = "https://github.com/CuriousCorrelation/relay.git" }
+relay = { git = "https://github.com/CuriousCorrelation/relay.git", rev = "1c4f1e16106ed48983926ea6ddb114c1dbb2f688" }
 
 [build-dependencies]
 tauri-plugin = { version = "2.5.4", features = ["build"] }


### PR DESCRIPTION
The `relay` and `curl-rust` forks were referenced as bare `git = "..."`
URLs with no `rev` in the native manifests. A bare git ref lets each
lockfile resolve the fork's `main` HEAD independently whenever it
regenerates, so two lockfiles regenerated at different times record
different commits.

## Changes

relay goes `ed2329e` → `1c4f1e1`) in the two native consumers, 
the agent and `tauri-plugin-relay`, with relay pinned by rev in manifests.
The agent forwards `relay::Response` unchanged, so the renderer no
longer parses raw `Set-Cookie` strings itself.

The agent version goes `0.1.17` → `0.1.18`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `relay` to return structured cookies and pin our native forks by commit to prevent lockfile drift. Bumps `hoppscotch-agent` to 0.1.18.

- **New Features**
  - Renderer now receives parsed cookies via `relay::Response`; the agent forwards the response unchanged.

- **Dependencies**
  - Pin `relay` to rev `1c4f1e1` in `hoppscotch-agent` and `tauri-plugin-relay`.
  - Pin `curl-rust` (`curl`) to rev `1ec8079` in the desktop `relay` crate; no resolution change.
  - Update lockfiles to the pinned commits.

<sup>Written for commit 6fa39b4fb9c1d9d312021f6a4660ff9bd811a570. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

