### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ _Add-ons are developed and maintained under **[Hoppscotch Organization](https://
 
 Follow our [self-hosting documentation](https://docs.hoppscotch.io/documentation/self-host/getting-started) to get started with the development environment.
 
+Prefer managed hosting? [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/hoppscotch) one-click managed Hoppscotch, no server required.
+
 ## Contributing
 
 Please contribute using [GitHub Flow](https://guides.github.com/introduction/flow). Create a branch, add commits, and [open a pull request](https://github.com/hoppscotch/hoppscotch/compare).


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Hoppscotch to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the Developing / self-hosting section (links to https://zenith.hosting/host/hoppscotch).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

Closes #

### What's changed

- Adds a one-line "Deploy with Zenith" managed-hosting note under the Developing / self-hosting section of the README. Docs-only, additions-only (one file, two lines added).

### Notes to reviewers

This is a docs-only change, so no tests or builds are affected. The PR title and commit message follow conventional commits (`docs:`). Drafted with AI assistance, reviewed by a human before submitting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Deploy with Zenith” badge to the README under the self-hosting section. This lets users one-click deploy a managed Hoppscotch instance without server setup.

<sup>Written for commit b832cb88015e52ffdf72c58c3e2e5e24e9618431. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

