### PR TITLE
fix: desktop login loop caused by empty auth cookies

### DIFF
--- a/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
@@ -28,6 +28,9 @@ import {
  * the request with an unusable credential. A real JWT has no whitespace,
  * so the trim-and-length check drops both.
  *
+ * The value may not be a string: `cookie-parser` JSON-decodes `j:`-prefixed
+ * cookies into objects, where calling `.trim()` throws before auth fallback.
+ *
  * @param request - Express Request object
  * @returns Option<string> containing the token if found
  */
@@ -35,7 +38,10 @@ const extractFromCookie = (request: Request): O.Option<string> =>
   pipe(
     O.fromNullable(request.cookies),
     O.chain((cookies) => O.fromNullable(cookies['access_token'])),
-    O.filter((token) => token.trim().length > 0),
+    O.filter(
+      (token): token is string =>
+        typeof token === 'string' && token.trim().length > 0,
+    ),
   );
 
 /**

--- a/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
@@ -21,10 +21,12 @@ import {
 /**
  * Extracts an access token from a cookie in the request.
  *
- * An empty-string cookie is treated as absent so `extractToken` uses the
- * `Authorization` header. `O.fromNullable` alone keeps an empty string as
- * `Some('')`, which is read in preference to a valid bearer token and
- * rejects the request with an empty credential.
+ * A blank cookie is treated as absent so `extractToken` uses the
+ * `Authorization` header. `O.fromNullable` alone keeps `''` as `Some('')`,
+ * and a whitespace-only value (`access_token=   `) is non-empty by length,
+ * so both would be read in preference to a valid bearer token and reject
+ * the request with an unusable credential. A real JWT has no whitespace,
+ * so the trim-and-length check drops both.
  *
  * @param request - Express Request object
  * @returns Option<string> containing the token if found
@@ -33,7 +35,7 @@ const extractFromCookie = (request: Request): O.Option<string> =>
   pipe(
     O.fromNullable(request.cookies),
     O.chain((cookies) => O.fromNullable(cookies['access_token'])),
-    O.filter((token) => token.length > 0),
+    O.filter((token) => token.trim().length > 0),
   );
 
 /**

--- a/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
+++ b/packages/hoppscotch-backend/src/auth/strategies/jwt.strategy.ts
@@ -21,6 +21,11 @@ import {
 /**
  * Extracts an access token from a cookie in the request.
  *
+ * An empty-string cookie is treated as absent so `extractToken` uses the
+ * `Authorization` header. `O.fromNullable` alone keeps an empty string as
+ * `Some('')`, which is read in preference to a valid bearer token and
+ * rejects the request with an empty credential.
+ *
  * @param request - Express Request object
  * @returns Option<string> containing the token if found
  */
@@ -28,6 +33,7 @@ const extractFromCookie = (request: Request): O.Option<string> =>
   pipe(
     O.fromNullable(request.cookies),
     O.chain((cookies) => O.fromNullable(cookies['access_token'])),
+    O.filter((token) => token.length > 0),
   );
 
 /**

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/agent/index.ts
@@ -126,7 +126,20 @@ export class AgentKernelInterceptorService
       const effectiveRequest = this.store.completeRequest(
         preProcessRelayRequest(request)
       )
-      await this.cookieJar.applyCookiesToRequest(effectiveRequest)
+
+      // A caller opts a request out of the shared cookie jar by setting
+      // `meta.options.cookies` to false. The desktop auth module sets it
+      // on its own bearer-authenticated backend calls so the interceptor
+      // skips both attaching a captured auth cookie to them and capturing
+      // one from their responses. Without that, a stale or blank
+      // `access_token` cookie was read in preference to the bearer token
+      // and desktop login stalled. Read from the original request because
+      // `completeRequest` rebuilds `meta` from domain settings.
+      const useCookieJar = request.meta?.options?.cookies !== false
+
+      if (useCookieJar) {
+        await this.cookieJar.applyCookiesToRequest(effectiveRequest)
+      }
 
       const existingUserAgentHeader = Object.keys(
         effectiveRequest.headers || {}
@@ -204,10 +217,12 @@ export class AgentKernelInterceptorService
         multiHeaders: multiHeaders.length > 0 ? multiHeaders : undefined,
       }
 
-      await this.cookieJar.captureResponseCookies(
-        transformedResponse,
-        effectiveRequest.url
-      )
+      if (useCookieJar) {
+        await this.cookieJar.captureResponseCookies(
+          transformedResponse,
+          effectiveRequest.url
+        )
+      }
 
       return E.right(transformedResponse)
     } catch (e) {

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/native/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/native/index.ts
@@ -185,7 +185,19 @@ export class NativeKernelInterceptorService
         preProcessRelayRequest(request)
       )
 
-      await this.cookieJar.applyCookiesToRequest(effectiveRequest)
+      // A caller opts a request out of the shared cookie jar by setting
+      // `meta.options.cookies` to false. The desktop auth module sets it
+      // on its own bearer-authenticated backend calls so the interceptor
+      // skips both attaching a captured auth cookie to them and capturing
+      // one from their responses. Without that, a stale or blank
+      // `access_token` cookie was read in preference to the bearer token
+      // and desktop login stalled. Read from the original request because
+      // `completeRequest` rebuilds `meta` from domain settings.
+      const useCookieJar = request.meta?.options?.cookies !== false
+
+      if (useCookieJar) {
+        await this.cookieJar.applyCookiesToRequest(effectiveRequest)
+      }
 
       const existingUserAgentHeader = Object.keys(
         effectiveRequest.headers || {}
@@ -212,7 +224,7 @@ export class NativeKernelInterceptorService
       setRelayExecution(relayExecution)
 
       const relayResponse = await relayExecution.response
-      if (E.isRight(relayResponse)) {
+      if (E.isRight(relayResponse) && useCookieJar) {
         await this.cookieJar.captureResponseCookies(
           relayResponse.right,
           effectiveRequest.url

--- a/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
+++ b/packages/hoppscotch-common/src/platform/std/kernel-interceptors/proxy/index.ts
@@ -245,7 +245,12 @@ export class ProxyKernelInterceptorService
       // Same shared send path as native and agent. proxyscotch returns
       // Set-Cookie as a header string rather than structured cookies, so
       // receive-side capture for the proxy path is a separate follow-up.
-      await this.cookieJar.applyCookiesToRequest(processedRequest)
+      // A caller opts out of the jar by setting `meta.options.cookies` to
+      // false, so the interceptor skips attaching a captured auth cookie
+      // to the desktop auth module's bearer-authenticated backend calls.
+      if (request.meta?.options?.cookies !== false) {
+        await this.cookieJar.applyCookiesToRequest(processedRequest)
+      }
 
       let content: ContentType
       const multipartKey = `proxyRequestData-${v4()}`

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
@@ -47,7 +47,10 @@ const isGettingInitialUser: Ref<null | boolean> = ref(null)
 
 const persistenceService = getService(PersistenceService)
 const interceptorService = getService(KernelInterceptorService)
-const cookieJarService = getService(CookieJarService)
+// Deferred: this module is evaluated before `initKernel`, so a top-level
+// `getService(CookieJarService)` would permanently fail the jar's init and
+// the cleanup below would see an empty jar.
+const getCookieJarService = () => getService(CookieJarService)
 
 // Every backend call in this module authenticates with a bearer token
 // from local config, so none of them should touch the shared request
@@ -190,6 +193,7 @@ async function setUser(user: HoppUserWithAuthDetail | null) {
 // once on init. New installs never capture these, so this only heals state
 // an earlier build left behind.
 async function clearPersistedAuthCookiesFromJar() {
+  const cookieJarService = getCookieJarService()
   await cookieJarService.whenReady()
 
   const authCookieNames = new Set(["access_token", "refresh_token"])

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
@@ -12,6 +12,7 @@ import { parseBodyAsJSON } from "@hoppscotch/common/helpers/functional/json"
 import { AuthEvent, AuthPlatformDef } from "@hoppscotch/common/platform/auth"
 import { PersistenceService } from "@hoppscotch/common/services/persistence"
 import { KernelInterceptorService } from "@hoppscotch/common/services/kernel-interceptor.service"
+import { CookieJarService } from "@hoppscotch/common/services/cookie-jar.service"
 
 import Login from "@app/components/Login.vue"
 import { getAllowedAuthProviders, updateUserDisplayName } from "./api"
@@ -46,6 +47,7 @@ const isGettingInitialUser: Ref<null | boolean> = ref(null)
 
 const persistenceService = getService(PersistenceService)
 const interceptorService = getService(KernelInterceptorService)
+const cookieJarService = getService(CookieJarService)
 
 // Every backend call in this module authenticates with a bearer token
 // from local config, so none of them should touch the shared request
@@ -179,6 +181,49 @@ async function setUser(user: HoppUserWithAuthDetail | null) {
     "login_state",
     JSON.stringify(userWithToken)
   )
+}
+
+// Older installs captured the backend's auth `Set-Cookie` into the shared
+// jar before the opt-out above existed, so a blank or stale `access_token`
+// or `refresh_token` cookie can still be persisted from a prior version and
+// keep the login loop going. Remove any such entry for the backend host
+// once on init. New installs never capture these, so this only heals state
+// an earlier build left behind.
+async function clearPersistedAuthCookiesFromJar() {
+  await cookieJarService.whenReady()
+
+  const authCookieNames = new Set(["access_token", "refresh_token"])
+  const backendHosts = new Set<string>()
+  for (const rawUrl of [
+    import.meta.env.VITE_BACKEND_API_URL,
+    import.meta.env.VITE_BACKEND_GQL_URL,
+  ]) {
+    try {
+      backendHosts.add(
+        cookieJarService.canonStoreDomain(new URL(rawUrl).hostname)
+      )
+    } catch {
+      // A malformed env URL leaves no host to clear.
+    }
+  }
+
+  const targets: Array<{ domain: string; name: string; path: string }> = []
+  for (const host of backendHosts) {
+    const bucket = cookieJarService.cookieJar.value.get(host) ?? []
+    for (const cookie of bucket) {
+      if (authCookieNames.has(cookie.name)) {
+        targets.push({
+          domain: cookie.domain,
+          name: cookie.name,
+          path: cookie.path,
+        })
+      }
+    }
+  }
+
+  if (targets.length > 0) {
+    await cookieJarService.deleteCookies(targets)
+  }
 }
 
 export async function setInitialUser() {
@@ -397,6 +442,7 @@ export const def: AuthPlatformDef = {
     const loginState = await persistenceService.getLocalConfig("login_state")
     const probableUser = JSON.parse(loginState ?? "null")
     probableUser$.next(probableUser)
+    await clearPersistedAuthCookiesFromJar()
     await setInitialUser()
 
     await listen<string>(

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
@@ -47,12 +47,22 @@ const isGettingInitialUser: Ref<null | boolean> = ref(null)
 const persistenceService = getService(PersistenceService)
 const interceptorService = getService(KernelInterceptorService)
 
+// Every backend call in this module authenticates with a bearer token
+// from local config, so none of them should touch the shared request
+// cookie jar. Without this the interceptor captures the backend's auth
+// `Set-Cookie` into the jar and reattaches it to later calls, where a
+// stale or blank `access_token` cookie is read in preference to the
+// bearer token, the request is rejected, and desktop login stalls.
+// Spread into each request to opt it out of jar attach and capture.
+const NO_COOKIE_JAR = { meta: { options: { cookies: false } } }
+
 async function logout() {
   const { response } = interceptorService.execute({
     id: Date.now(),
     url: `${import.meta.env.VITE_BACKEND_API_URL}/auth/logout`,
     version: "HTTP/1.1",
     method: "GET",
+    ...NO_COOKIE_JAR,
   })
 
   await response
@@ -117,6 +127,7 @@ async function getInitialUserDetails(): Promise<
          }
        }`,
       }),
+      ...NO_COOKIE_JAR,
     })
 
     const responseBytes = await response
@@ -232,6 +243,7 @@ async function refreshToken() {
       headers: {
         Authorization: `Bearer ${refreshToken}`,
       },
+      ...NO_COOKIE_JAR,
     })
 
     const res = await response
@@ -269,6 +281,7 @@ async function sendMagicLink(email: string) {
       "Content-Type": "application/json",
     },
     content: content.json({ email }),
+    ...NO_COOKIE_JAR,
   })
 
   const res = await response
@@ -474,6 +487,7 @@ export const def: AuthPlatformDef = {
         token: verifyToken,
         deviceIdentifier,
       }),
+      ...NO_COOKIE_JAR,
     })
 
     const res = await response
@@ -542,6 +556,7 @@ export const def: AuthPlatformDef = {
         "Content-Type": "application/json",
         ...this.getBackendHeaders(),
       },
+      ...NO_COOKIE_JAR,
     })
 
     const res = await response

--- a/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/auth/desktop/index.ts
@@ -53,8 +53,11 @@ const interceptorService = getService(KernelInterceptorService)
 // `Set-Cookie` into the jar and reattaches it to later calls, where a
 // stale or blank `access_token` cookie is read in preference to the
 // bearer token, the request is rejected, and desktop login stalls.
-// Spread into each request to opt it out of jar attach and capture.
-const NO_COOKIE_JAR = { meta: { options: { cookies: false } } }
+// Used as each request's `meta` so it opts out of jar attach and
+// capture. A factory returns a fresh object per call, so a request that
+// later needs other `meta.options` can add them inline without a shared
+// top-level spread overwriting the whole `meta`.
+const noCookieJarMeta = () => ({ options: { cookies: false } })
 
 async function logout() {
   const { response } = interceptorService.execute({
@@ -62,7 +65,7 @@ async function logout() {
     url: `${import.meta.env.VITE_BACKEND_API_URL}/auth/logout`,
     version: "HTTP/1.1",
     method: "GET",
-    ...NO_COOKIE_JAR,
+    meta: noCookieJarMeta(),
   })
 
   await response
@@ -127,7 +130,7 @@ async function getInitialUserDetails(): Promise<
          }
        }`,
       }),
-      ...NO_COOKIE_JAR,
+      meta: noCookieJarMeta(),
     })
 
     const responseBytes = await response
@@ -243,7 +246,7 @@ async function refreshToken() {
       headers: {
         Authorization: `Bearer ${refreshToken}`,
       },
-      ...NO_COOKIE_JAR,
+      meta: noCookieJarMeta(),
     })
 
     const res = await response
@@ -281,7 +284,7 @@ async function sendMagicLink(email: string) {
       "Content-Type": "application/json",
     },
     content: content.json({ email }),
-    ...NO_COOKIE_JAR,
+    meta: noCookieJarMeta(),
   })
 
   const res = await response
@@ -487,7 +490,7 @@ export const def: AuthPlatformDef = {
         token: verifyToken,
         deviceIdentifier,
       }),
-      ...NO_COOKIE_JAR,
+      meta: noCookieJarMeta(),
     })
 
     const res = await response
@@ -556,7 +559,7 @@ export const def: AuthPlatformDef = {
         "Content-Type": "application/json",
         ...this.getBackendHeaders(),
       },
-      ...NO_COOKIE_JAR,
+      meta: noCookieJarMeta(),
     })
 
     const res = await response


### PR DESCRIPTION
Desktop login on a self-hosted 2026.6.0 build never completes after
a sign-in and the login window keeps spinning. The desktop auth
module authenticates every backend call with a bearer token from
local config, but since #6416 the request cookie jar captures the
backend's auth `Set-Cookie` and reattaches it to those calls, where
a blank or stale `access_token` cookie is read in preference to the
bearer token and the request 403s. This change excludes the auth
module's own requests from the shared jar and stops an empty cookie
from being read in preference to a valid bearer token on the backend.

Closes #6493
Part of FE-1306
Part of BE-788

## Keeping Desktop Auth Requests Off The Shared Cookie Jar

The native, agent, and proxy interceptors now honor
`meta.options.cookies === false` on the incoming request and skip
both `applyCookiesToRequest` and `captureResponseCookies` for it.
The flag is read from the original request because `completeRequest`
rebuilds `meta` from domain settings. The desktop auth module sets
it on all six of its backend calls through a shared `NO_COOKIE_JAR`
constant, so the backend's auth `Set-Cookie` is never captured from
them and no jar cookie is ever attached to them. A request that
leaves the flag unset, every ordinary user request, behaves exactly
as before.

## Ignoring An Empty Access Token Cookie On The Backend

`extractFromCookie` in `jwt.strategy.ts` used `O.fromNullable`,
which keeps an empty string as `Some('')`, so an `access_token=`
cookie was read as a present token and `extractToken` never read
the `Authorization` header. An `O.filter` on non-empty length makes
the empty cookie read as absent, so a valid bearer header
authenticates the request. This protects every client, web
included, from any future blank auth cookie.

## Backwards Compatibility

A fresh sign-in on desktop completes without the manual cookie
deletion the issue describes. An install that already persisted the
two blank cookies still needs them cleared once, since the fix
stops new blank cookies from being captured but does not remove
ones already on disk; clearing them from the cookie manager, or a
reinstall, is the one-time step. The request cookie jar keeps
applying and capturing user-authored cookies on ordinary requests,
so the API-testing cookie feature is unchanged. The backend change
accepts a superset of what it did before, an empty cookie now
authenticates on the bearer header where it used to 403, so no
previously working request breaks.

## Notes For Reviewers

The proxy interceptor only applies jar cookies and
does not yet capture responses, so its capture path stays a
separate follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a desktop login loop by preventing empty, whitespace, or stale auth cookies from overriding bearer tokens. Desktop auth calls skip the shared cookie jar, the backend ignores blank/whitespace or non‑string `access_token` cookies, and stale cookies are auto-cleared on launch; aligns with FE-1306 and BE-788 and closes #6493.

- **Bug Fixes**
  - `@hoppscotch-common`: Agent, Native, and Proxy interceptors honor `meta.options.cookies === false` to skip cookie jar attach/capture.
  - `hoppscotch-selfhost-web`: Desktop auth uses a `noCookieJarMeta()` factory to opt out of the jar, defers `CookieJarService` init, and clears persisted `access_token`/`refresh_token` for the backend host on launch.
  - `hoppscotch-backend`: JWT strategy treats blank, whitespace-only, or non-string `access_token` cookies as absent so a valid `Authorization` header authenticates.

- **Migration**
  - No manual action needed; older desktop installs auto-clear stale backend auth cookies on launch.

<sup>Written for commit 8bc8e26bf40bf07fbfb0710d7378a59c5d48a6be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

