### PR TITLE
fix(common): narrow env-highlight watcher to stop UI freeze on Content-Type toggle

### DIFF
--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -374,10 +374,15 @@ export class HoppEnvironmentPlugin {
     subscribeToStream: StreamSubscriberFunc,
     private editorView: Ref<EditorView | undefined>
   ) {
-    // Watch the current active tab to update the variables accordingly
+    // Watch only the request/collection variables that affect environment
+    // highlighting, instead of deep-watching the entire active tab (which
+    // includes headers, params, body, auth, tests, scripts, response, etc).
+    // Deep-watching the whole tab meant that any unrelated mutation - such as
+    // toggling the request body's Content-Type - re-triggered a full CodeMirror
+    // decoration rebuild in every mounted editor for the tab (see #6339).
     watch(
-      () => restTabs.currentActiveTab.value,
-      (currentTab) => {
+      () => {
+        const currentTab = restTabs.currentActiveTab.value
         const request =
           currentTab.document.type === "example-response"
             ? currentTab.document.response.originalRequest
@@ -397,6 +402,9 @@ export class HoppEnvironmentPlugin {
             ? request.requestVariables
             : []
 
+        return { requestVariables, collectionVariables }
+      },
+      ({ requestVariables, collectionVariables }) => {
         this.envs = getEffectiveVariablesForRequest(
           requestVariables,
           collectionVariables,


### PR DESCRIPTION
Resolves #6339

## Problem
Toggling a request body's Content-Type (e.g. None -> application/json) freezes the UI for several seconds, especially when a large JSON response is being displayed.

## Root cause
`HoppEnvironmentPlugin` (in `packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts`) had a `watch(..., { deep: true })` on the **entire active tab** (`restTabs.currentActiveTab.value`) just to recompute the request/collection variables used for `<<variable>>` highlighting.

Since this plugin is mounted by **~16 different editor instances** simultaneously per tab (RawBody, Headers, Parameters, BodyParameters, RequestVariables, JSON/XML/HTML response viewers, JWT, ASAP, etc.), any mutation **unrelated** to environment variables - such as toggling the Content-Type - fired every one of those deep watchers at once, forcing a full CodeMirror decoration/tooltip rebuild (`compartment.reconfigure`) in each of them.

## Fix
Narrowed the `watch()` source to only the two slices that actually matter for computing the highlight (`requestVariables` and `collectionVariables`), instead of the whole tab. Editing the body, toggling Content-Type, editing headers, etc. no longer trigger any unnecessary CodeMirror reconfiguration - only mutations that actually change the available variables do.

## Evidence
I measured this precisely by temporarily instrumenting a counter around `compartment.reconfigure` and firing ONE Content-Type toggle:

| | reconfigure() calls triggered by 1 Content-Type toggle |
|---|---|
| Before fix | **3** (one per mounted editor with highlighting enabled) |
| After fix | **0** |

I also confirmed the highlighting feature still works correctly: created a request variable (`myVar = hello`), referenced `<<myVar>>` in a JSON body, and the token is still highlighted correctly (`request-variable-highlight` class applied).

- `pnpm run do-typecheck` (package `hoppscotch-common`): passed with no errors.

## How to test
1. `pnpm install && pnpm --filter @hoppscotch/selfhost-web run do-dev`
2. Open a request, go to the "Body" tab
3. Paste a large JSON payload and toggle Content-Type between "None" and "application/json" repeatedly
4. Before the fix: UI stalls noticeably. After: the toggle is instant.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6339: Stops UI freeze when toggling Body Content-Type by narrowing the environment-highlighting watcher to only relevant variables. This removes unnecessary CodeMirror reconfigures across editors and makes the toggle instant.

- **Bug Fixes**
  - Watch only request/collection variables instead of deep-watching the entire active tab.
  - Prevents ~16 editors from rebuilding on unrelated changes; reconfigures per toggle drop from 3 to 0.

<sup>Written for commit 4ce9d4199131b91fe7dd3e866c8a5ae9c77d73a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

