### PR TITLE
docs: adiciona documentação de arquitetura e contribuições

### DIFF
--- a/documentacao/arquitetura.md
+++ b/documentacao/arquitetura.md
@@ -1,0 +1,132 @@
+# Arquitetura do Hoppscotch
+
+> Documento do Caminho de Arquitetura e Modelagem — CSI410 (UFOP).
+> Projeto analisado: [Hoppscotch](https://github.com/hoppscotch/hoppscotch) — ecossistema open source de desenvolvimento de APIs (alternativa ao Postman).
+
+## 1. Visão geral
+
+O Hoppscotch é organizado como um **monorepo** gerenciado por `pnpm workspaces`
+(ver `pnpm-workspace.yaml` e `package.json` na raiz). Cada capacidade do
+produto vive em um pacote isolado dentro de `packages/`, o que favorece
+**separação de responsabilidades** e **reuso** entre as diferentes formas de
+distribuição (web self-host, desktop, CLI, admin).
+
+| Pacote | Responsabilidade | Stack principal |
+|---|---|---|
+| `hoppscotch-common` | Núcleo da aplicação (UI, estado, lógica de requisições) | Vue 3 (Composition API), Vite, TailwindCSS |
+| `hoppscotch-selfhost-web` | Empacota a `common` como app web self-hosted | Vite |
+| `hoppscotch-desktop` | App desktop | Tauri (Rust) + `common` |
+| `hoppscotch-sh-admin` | Painel administrativo do self-host | Vue 3 |
+| `hoppscotch-backend` | API/servidor | NestJS + GraphQL + Prisma |
+| `hoppscotch-data` | Esquemas de dados versionados e migrações | TypeScript, Zod |
+| `hoppscotch-js-sandbox` | Execução isolada de scripts de pré-request/testes | JS sandbox |
+| `hoppscotch-kernel` / `hoppscotch-relay` | Camada de execução de requisições (kernel) e proxy nativo | TypeScript / Rust |
+| `hoppscotch-cli` | Execução de coleções via linha de comando | TypeScript |
+| `codemirror-lang-graphql` | Suporte de linguagem GraphQL para o editor | CodeMirror 6 |
+
+## 2. Estilo arquitetural
+
+O sistema combina **três estilos** complementares:
+
+1. **Arquitetura em camadas / componentes (frontend `hoppscotch-common`)**
+   Dentro de `packages/hoppscotch-common/src/` as responsabilidades estão
+   separadas por diretório:
+
+   - `components/` — componentes de apresentação Vue (camada de View).
+   - `composables/` — lógica reutilizável de UI (hooks da Composition API).
+   - `services/` — serviços de domínio/estado, resolvidos por **injeção de
+     dependência** com a biblioteca `dioc`.
+   - `newstore/` — estado global reativo baseado em **streams RxJS**
+     (padrão Observer).
+   - `helpers/` — utilidades puras (parsing, editor, linting, etc.).
+   - `platform/` — abstração das diferenças entre plataformas (web/desktop).
+   - `pages/` + `layouts/` — roteamento e composição de telas.
+
+2. **Injeção de dependência via container (`dioc`)**
+   Serviços como `RESTTabService`, `InspectionService`,
+   `SecretEnvironmentService` são registrados e resolvidos por um container,
+   promovendo baixo acoplamento e testabilidade (aproxima-se do princípio de
+   **Inversão de Dependência** do SOLID).
+
+3. **Cliente/servidor com API GraphQL (backend `hoppscotch-backend`)**
+   O backend segue a arquitetura modular do **NestJS** (módulos, controllers,
+   resolvers, guards, interceptors), com persistência via **Prisma** e
+   comunicação em tempo real via **PubSub/GraphQL subscriptions**.
+
+## 3. Fluxo de dados (frontend)
+
+A View (componentes Vue) lê e escreve estado através de:
+- **composables** (ex.: `useCodemirror`, `useVModel`) para lógica de UI, e
+- **services/newstore** para estado compartilhado e reativo.
+
+As mudanças de estado propagam-se de volta à View por **reatividade do Vue** e
+por **streams RxJS** (Observer), fechando o ciclo unidirecional
+View → composable/service → estado → View.
+
+## 4. Diagrama de componentes (Mermaid)
+
+```mermaid
+graph TD
+    subgraph Distribuição
+        WEB[hoppscotch-selfhost-web]
+        DESK[hoppscotch-desktop / Tauri]
+        ADMIN[hoppscotch-sh-admin]
+        CLI[hoppscotch-cli]
+    end
+
+    subgraph Núcleo Frontend
+        COMMON[hoppscotch-common]
+        subgraph common/src
+            VIEW[components / pages / layouts]
+            COMPOSABLES[composables]
+            SERVICES[services + dioc DI]
+            STORE[newstore - RxJS]
+            HELPERS[helpers - editor/linting]
+        end
+    end
+
+    subgraph Compartilhado
+        DATA[hoppscotch-data]
+        SANDBOX[hoppscotch-js-sandbox]
+        KERNEL[hoppscotch-kernel / relay]
+    end
+
+    subgraph Servidor
+        BACKEND[hoppscotch-backend<br/>NestJS + GraphQL + Prisma]
+        DB[(PostgreSQL)]
+    end
+
+    WEB --> COMMON
+    DESK --> COMMON
+    ADMIN --> BACKEND
+    CLI --> KERNEL
+
+    VIEW --> COMPOSABLES
+    COMPOSABLES --> SERVICES
+    COMPOSABLES --> HELPERS
+    SERVICES --> STORE
+    VIEW --> STORE
+
+    COMMON --> DATA
+    COMMON --> SANDBOX
+    COMMON --> KERNEL
+
+    COMMON -->|GraphQL| BACKEND
+    BACKEND --> DB
+```
+
+## 5. Justificativa
+
+- O **monorepo** permite compartilhar `hoppscotch-common` entre web, desktop e
+  admin sem duplicação, reduzindo custo de manutenção.
+- A separação **components / composables / services / newstore** aplica o
+  princípio de **Responsabilidade Única (SRP)** em nível de camada: a UI não
+  conhece detalhes de estado global nem de execução de requisições.
+- O uso de **DI (`dioc`)** e de **streams (RxJS)** desacopla produtores e
+  consumidores de estado, o que é essencial num app com muitos painéis
+  reagindo às mesmas fontes (ambientes, abas, respostas).
+
+> **Relação com o trabalho:** a issue tratada no Caminho A (#6339) e as
+> refatorações do Caminho B concentram-se na camada
+> `helpers/editor` + `composables` do `hoppscotch-common`, exatamente onde o
+> editor de código (CodeMirror) integra-se ao estado reativo.

--- a/documentacao/contribuicoes.md
+++ b/documentacao/contribuicoes.md
@@ -1,0 +1,53 @@
+# Contribuições da Dupla
+
+> CSI410 — Engenharia de Software II — Trabalho Prático (Open Source Engineering Challenge)
+> Projeto: [Hoppscotch](https://github.com/hoppscotch/hoppscotch)
+
+## Integrantes e papéis
+
+| Integrante | Papel principal |
+|---|---|
+| Tharsoso (Pessoa A) | Caminho A (correção da issue #6339) + testes de aceitação Cypress |
+| João Vitor Cota (Pessoa B) | Caminho B (refatoração + code smells + padrões), arquitetura, DevOps/CI-CD, documentação |
+
+> Ambos revisam os PRs um do outro (revisão entre membros — requisito do TP).
+
+## Caminho A — Manutenção Corretiva
+
+- **Issue escolhida:** [#6339 — UI freeze while changing Content type](https://github.com/hoppscotch/hoppscotch/issues/6339)
+- **Causa raiz:** watcher com `deep: true` sobre o documento inteiro da aba
+  ativa em `helpers/editor/extensions/HoppEnvironment.ts`, que percorre a
+  árvore reativa completa (incluindo corpo e resposta JSON) a cada mudança.
+- **Descrição da solução:** substituir o `deep watch` por um watcher enxuto
+  (identidade da aba + `requestVariables` + variáveis de coleção) e aplicar
+  *debounce* na reconfiguração do editor. Detalhes em
+  [`padroes_e_smells.md`](./padroes_e_smells.md) (Smell #1).
+- **Validação:** _(preencher)_ evidências de reprodução antes/depois
+  (profiler do DevTools) + testes de aceitação (`testes_devops.md`).
+
+## Caminho B — Engenharia de Qualidade e Refatoração
+
+- **Code smells tratados:** ver [`padroes_e_smells.md`](./padroes_e_smells.md)
+  (mínimo 3): deep watch, long method / cadeia if-else de linguagem, custo
+  ignorado em arquivos grandes.
+- **Padrões aplicados/sugeridos:** Strategy (seleção de linguagem),
+  Dependency Injection (`dioc`), Observer (RxJS).
+- **Descrição da refatoração:** _(preencher com o diff final e justificativas)_.
+
+## Lista de Pull Requests
+
+> Preencher com os links reais conforme os PRs forem abertos no fork.
+
+| PR | Conteúdo | Autor | Branch | Link |
+|---|---|---|---|---|
+| PR1 | Arquitetura (`documentacao/arquitetura.md`) | João (B) | `docs/arquitetura` | _(preencher)_ |
+| PR2 | Padrões e smells (`documentacao/padroes_e_smells.md`) | João (B) | `docs/padroes-smells` | _(preencher)_ |
+| PR3 | Refatoração (Caminho B) | João (B) | `refactor/codemirror-quality` | _(preencher)_ |
+| PR4 | Testes de aceitação (Cypress) | Tharsoso (A) | `test/cypress-acceptance-tests` | _(preencher)_ |
+| PR5 | DevOps / CI (`tests.yml` job de qualidade) | João (B) | `ci/quality-job` | _(preencher)_ |
+| PR6 | Correção da issue #6339 (Caminho A) | Tharsoso (A) | `fix/content-type-freeze` | _(preencher)_ |
+
+## Links de entrega (Moodle)
+
+- **Fork:** _(preencher com o link do fork do colega)_
+- **Repositório público:** sim / não — _(confirmar)_


### PR DESCRIPTION
## O que este PR faz

Adiciona a documentação de arquitetura do projeto, exigida pelo trabalho
prático de CSI410 (Engenharia de Software II - UFOP).

## Conteúdo

- `documentacao/arquitetura.md`: descreve o estilo arquitetural do
  Hoppscotch — monorepo pnpm com separação em camadas no
  `hoppscotch-common` (components / composables / services / newstore),
  injeção de dependência via `dioc`, e arquitetura cliente/servidor via
  GraphQL no `hoppscotch-backend`. Inclui diagrama de componentes em
  Mermaid e justificativa das decisões arquiteturais.
- `documentacao/contribuicoes.md`: registra os papéis da dupla e a
  lista de Pull Requests do trabalho.

## Contexto

Parte da entrega do Caminho B (Engenharia de Qualidade) do trabalho
prático. Análise feita a partir da estrutura real do monorepo
(`packages/`, `pnpm-workspace.yaml`) e do código-fonte de
`hoppscotch-common`.

## Como revisar

Não há mudança de código/comportamento — apenas documentação. Conferir
se a descrição da arquitetura e o diagrama Mermaid refletem
corretamente a estrutura do repositório.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adiciona a documentação de arquitetura do monorepo e o registro de contribuições do trabalho CSI410, sem mudanças de código (documentacao/arquitetura.md e documentacao/contribuicoes.md).
A arquitetura cobre as camadas do `hoppscotch-common`, DI com `dioc`, cliente/servidor via GraphQL no `hoppscotch-backend`, e inclui diagrama Mermaid e tabela de PRs/papéis.

<sup>Written for commit aa12156d9b77cf4ba93c5cc44dd238b92fc68195. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

