### PR TITLE
chore(agent): bump portable config to `v0.1.18`

### DIFF
--- a/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
+++ b/packages/hoppscotch-agent/src-tauri/tauri.portable.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0-rc",
   "productName": "Hoppscotch Agent Portable",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "identifier": "io.hoppscotch.agent",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Bumps Hoppscotch Agent's portable version to match installer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps Hoppscotch Agent Portable version to 0.1.18 to match the installer. Ensures consistent versioning across builds.

<sup>Written for commit 28a8595f7cb258803fc997104b7f4fc334133670. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

