### PR TITLE
fix(common): personal workspace possible data loss issue

### DIFF
--- a/packages/hoppscotch-common/src/helpers/backend/gql/queries/GetRestUserHistory.graphql
+++ b/packages/hoppscotch-common/src/helpers/backend/gql/queries/GetRestUserHistory.graphql
@@ -1,6 +1,6 @@
-query GetRESTUserHistory {
+query GetRESTUserHistory($take: Int) {
   me {
-    RESTHistory {
+    RESTHistory(take: $take) {
       id
       userUid
       reqType
@@ -10,7 +10,7 @@ query GetRESTUserHistory {
       executedOn
     }
 
-    GQLHistory {
+    GQLHistory(take: $take) {
       id
       userUid
       reqType
@@ -21,3 +21,4 @@ query GetRESTUserHistory {
     }
   }
 }
+

--- a/packages/hoppscotch-common/src/lib/sync/collections/gqlCollections.sync.ts
+++ b/packages/hoppscotch-common/src/lib/sync/collections/gqlCollections.sync.ts
@@ -25,7 +25,7 @@ import {
 import { getSettingSubject, settingsStore } from "~/newstore/settings"
 import { getSyncInitFunction, StoreSyncDefinitionOf } from ".."
 import { createMapper } from "../mapper"
-import { applyDuplicatedCollectionResult, moveOrReorderRequests } from "./sync"
+import { applyDuplicatedCollectionResult, moveOrReorderRequests, ensurePathSynced } from "./sync"
 import { ReqType } from "~/helpers/backend/graphql"
 import { stripClientLocalValuesForWire } from "~/helpers/clientLocalVariables"
 
@@ -108,6 +108,7 @@ const recursivelySyncCollections = async (
       )
     } else {
       parentCollectionID = undefined
+      return
     }
   } else {
     // if parentUserCollectionID exists, create the collection as a child collection
@@ -154,6 +155,9 @@ const recursivelySyncCollections = async (
         childCollectionId,
         `${collectionPath}`
       )
+    } else {
+      parentCollectionID = undefined
+      return
     }
   }
 
@@ -207,42 +211,8 @@ type OperationCollectionRemoved = {
 
 export const gqlCollectionsOperations: Array<OperationCollectionRemoved> = []
 
-async function ensurePathSynced(path: string | number | null): Promise<boolean> {
-  if (path === null || path === undefined || path === "") return true
-
-  const collections = graphqlCollectionStore.value.state
-  const pathIndexes = typeof path === "number" ? [path] : path.split("/").map((index) => parseInt(index))
-
-  let highestUnsyncedPath: number[] | null = null
-  let parentID: string | undefined = undefined
-
-  for (let i = 0; i < pathIndexes.length; i++) {
-    const subPath = pathIndexes.slice(0, i + 1)
-    const collection = navigateToFolderWithIndexPath(collections, subPath)
-    if (!collection) break
-
-    if (!collection.id) {
-      highestUnsyncedPath = subPath
-      break
-    } else {
-      parentID = collection.id
-    }
-  }
-
-  if (highestUnsyncedPath) {
-    const collectionToSync = navigateToFolderWithIndexPath(collections, highestUnsyncedPath)
-    if (collectionToSync) {
-      await recursivelySyncCollections(
-        collectionToSync,
-        highestUnsyncedPath.join("/"),
-        parentID
-      )
-      return false
-    }
-  }
-
-  return true
-}
+const ensureGQLPathSynced = (path: string | number | null) =>
+  ensurePathSynced(path, graphqlCollectionStore, recursivelySyncCollections)
 
 export const storeSyncDefinition: StoreSyncDefinitionOf<
   typeof graphqlCollectionStore
@@ -292,7 +262,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async editCollection({ collection, collectionIndex }) {
-    const isSynced = await ensurePathSynced(collectionIndex)
+    const isSynced = await ensureGQLPathSynced(collectionIndex)
     if (!isSynced) return
 
     const collectionID = navigateToFolderWithIndexPath(
@@ -312,7 +282,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async addFolder({ name, path }) {
-    const isSynced = await ensurePathSynced(path)
+    const isSynced = await ensureGQLPathSynced(path)
     if (!isSynced) return
 
     const parentCollection = navigateToFolderWithIndexPath(
@@ -346,7 +316,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async editFolder({ folder, path }) {
-    const isSynced = await ensurePathSynced(path)
+    const isSynced = await ensureGQLPathSynced(path)
     if (!isSynced) return
 
     const folderBackendId = navigateToFolderWithIndexPath(
@@ -384,7 +354,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async editRequest({ path, requestIndex, requestNew }) {
-    const isSynced = await ensurePathSynced(path)
+    const isSynced = await ensureGQLPathSynced(path)
 
     const folder = navigateToFolderWithIndexPath(
       graphqlCollectionStore.value.state,
@@ -422,7 +392,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
 
     if (!folder) return
 
-    const isSynced = await ensurePathSynced(path)
+    const isSynced = await ensureGQLPathSynced(path)
     if (!isSynced) return
 
     const parentCollectionBackendID = folder.id
@@ -453,8 +423,10 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async moveRequest({ destinationPath, path, requestIndex }) {
-    await ensurePathSynced(path)
-    await ensurePathSynced(destinationPath)
+    const isSourceSynced = await ensureGQLPathSynced(path)
+    const isDestSynced = await ensureGQLPathSynced(destinationPath)
+    if (!isSourceSynced || !isDestSynced) return
+
     moveOrReorderRequests(requestIndex, path, destinationPath, undefined, "GQL")
   },
 }

--- a/packages/hoppscotch-common/src/lib/sync/collections/gqlCollections.sync.ts
+++ b/packages/hoppscotch-common/src/lib/sync/collections/gqlCollections.sync.ts
@@ -207,6 +207,43 @@ type OperationCollectionRemoved = {
 
 export const gqlCollectionsOperations: Array<OperationCollectionRemoved> = []
 
+async function ensurePathSynced(path: string | number | null): Promise<boolean> {
+  if (path === null || path === undefined || path === "") return true
+
+  const collections = graphqlCollectionStore.value.state
+  const pathIndexes = typeof path === "number" ? [path] : path.split("/").map((index) => parseInt(index))
+
+  let highestUnsyncedPath: number[] | null = null
+  let parentID: string | undefined = undefined
+
+  for (let i = 0; i < pathIndexes.length; i++) {
+    const subPath = pathIndexes.slice(0, i + 1)
+    const collection = navigateToFolderWithIndexPath(collections, subPath)
+    if (!collection) break
+
+    if (!collection.id) {
+      highestUnsyncedPath = subPath
+      break
+    } else {
+      parentID = collection.id
+    }
+  }
+
+  if (highestUnsyncedPath) {
+    const collectionToSync = navigateToFolderWithIndexPath(collections, highestUnsyncedPath)
+    if (collectionToSync) {
+      await recursivelySyncCollections(
+        collectionToSync,
+        highestUnsyncedPath.join("/"),
+        parentID
+      )
+      return false
+    }
+  }
+
+  return true
+}
+
 export const storeSyncDefinition: StoreSyncDefinitionOf<
   typeof graphqlCollectionStore
 > = {
@@ -254,13 +291,14 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       await deleteUserCollection(collectionID)
     }
   },
-  editCollection({ collection, collectionIndex }) {
-    // Send the backend id when present, otherwise the index path — GraphQL
-    // collections on some platforms (e.g. hoppscotch-web) carry no backend id.
-    const collectionID =
-      navigateToFolderWithIndexPath(graphqlCollectionStore.value.state, [
-        collectionIndex,
-      ])?.id ?? `${collectionIndex}`
+  async editCollection({ collection, collectionIndex }) {
+    const isSynced = await ensurePathSynced(collectionIndex)
+    if (!isSynced) return
+
+    const collectionID = navigateToFolderWithIndexPath(
+      graphqlCollectionStore.value.state,
+      [collectionIndex]
+    )?.id
 
     const data = {
       auth: collection.auth,
@@ -269,9 +307,14 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       _ref_id: collection._ref_id,
     }
 
-    updateUserCollection(collectionID, collection.name, JSON.stringify(data))
+    if (collectionID) {
+      updateUserCollection(collectionID, collection.name, JSON.stringify(data))
+    }
   },
   async addFolder({ name, path }) {
+    const isSynced = await ensurePathSynced(path)
+    if (!isSynced) return
+
     const parentCollection = navigateToFolderWithIndexPath(
       graphqlCollectionStore.value.state,
       path.split("/").map((index) => parseInt(index))
@@ -279,35 +322,37 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
 
     if (!parentCollection) return
 
-    // Send the parent backend id when present, otherwise its index path.
-    const parentCollectionBackendID = parentCollection.id ?? path
+    const parentCollectionBackendID = parentCollection.id
 
     const foldersLength = parentCollection.folders.length
 
-    const res = await createGQLChildUserCollection(
-      name,
-      parentCollectionBackendID
-    )
+    if (parentCollectionBackendID) {
+      const res = await createGQLChildUserCollection(
+        name,
+        parentCollectionBackendID
+      )
 
-    if (E.isRight(res)) {
-      const { id } = res.right.createGQLChildUserCollection
+      if (E.isRight(res)) {
+        const { id } = res.right.createGQLChildUserCollection
 
-      if (foldersLength) {
-        parentCollection.folders[foldersLength - 1].id = id
-        removeDuplicateGraphqlCollectionOrFolder(
-          id,
-          `${path}/${foldersLength - 1}`
-        )
+        if (foldersLength) {
+          parentCollection.folders[foldersLength - 1].id = id
+          removeDuplicateGraphqlCollectionOrFolder(
+            id,
+            `${path}/${foldersLength - 1}`
+          )
+        }
       }
     }
   },
-  editFolder({ folder, path }) {
-    // Send the backend id when present, otherwise the index path.
-    const folderBackendId =
-      navigateToFolderWithIndexPath(
-        graphqlCollectionStore.value.state,
-        path.split("/").map((index) => parseInt(index))
-      )?.id ?? path
+  async editFolder({ folder, path }) {
+    const isSynced = await ensurePathSynced(path)
+    if (!isSynced) return
+
+    const folderBackendId = navigateToFolderWithIndexPath(
+      graphqlCollectionStore.value.state,
+      path.split("/").map((index) => parseInt(index))
+    )?.id
 
     const data = {
       auth: folder.auth,
@@ -316,7 +361,9 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       _ref_id: folder._ref_id,
     }
 
-    updateUserCollection(folderBackendId, folder.name, JSON.stringify(data))
+    if (folderBackendId) {
+      updateUserCollection(folderBackendId, folder.name, JSON.stringify(data))
+    }
   },
   async removeFolder({ folderID }) {
     if (folderID) {
@@ -336,20 +383,36 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       }
     }
   },
-  editRequest({ path, requestIndex, requestNew }) {
-    const request = navigateToFolderWithIndexPath(
+  async editRequest({ path, requestIndex, requestNew }) {
+    const isSynced = await ensurePathSynced(path)
+
+    const folder = navigateToFolderWithIndexPath(
       graphqlCollectionStore.value.state,
       path.split("/").map((index) => parseInt(index))
-    )?.requests[requestIndex]
-
-    // Send the backend id when present, otherwise the index path.
-    const requestBackendID = request?.id ?? `${path}/${requestIndex}`
-
-    editGQLUserRequest(
-      requestBackendID,
-      (requestNew as HoppRESTRequest).name,
-      JSON.stringify(requestNew)
     )
+    if (!folder) return
+
+    const request = folder.requests[requestIndex]
+    if (!request) return
+
+    if (request.id) {
+      editGQLUserRequest(
+        request.id,
+        (requestNew as HoppRESTRequest).name,
+        JSON.stringify(requestNew)
+      )
+    } else {
+      if (isSynced && folder.id) {
+        const res = await createGQLUserRequest(
+          (requestNew as HoppRESTRequest).name,
+          JSON.stringify(requestNew),
+          folder.id
+        )
+        if (res && E.isRight(res)) {
+          request.id = res.right.createGQLUserRequest.id
+        }
+      }
+    }
   },
   async saveRequestAs({ path, request }) {
     const folder = navigateToFolderWithIndexPath(
@@ -359,8 +422,11 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
 
     if (!folder) return
 
-    // Send the parent backend id when present, otherwise its index path.
-    const parentCollectionBackendID = folder.id ?? path
+    const isSynced = await ensurePathSynced(path)
+    if (!isSynced) return
+
+    const parentCollectionBackendID = folder.id
+    if (!parentCollectionBackendID) return
 
     const newRequest = folder.requests[folder.requests.length - 1]
 
@@ -386,7 +452,9 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       await deleteUserRequest(requestID)
     }
   },
-  moveRequest({ destinationPath, path, requestIndex }) {
+  async moveRequest({ destinationPath, path, requestIndex }) {
+    await ensurePathSynced(path)
+    await ensurePathSynced(destinationPath)
     moveOrReorderRequests(requestIndex, path, destinationPath, undefined, "GQL")
   },
 }

--- a/packages/hoppscotch-common/src/lib/sync/collections/gqlCollections.sync.ts
+++ b/packages/hoppscotch-common/src/lib/sync/collections/gqlCollections.sync.ts
@@ -292,9 +292,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
 
     if (!parentCollection) return
 
-    const parentCollectionBackendID = parentCollection.id
-
     const foldersLength = parentCollection.folders.length
+    if (foldersLength > 0 && parentCollection.folders[foldersLength - 1].id) {
+      return
+    }
+
+    const parentCollectionBackendID = parentCollection.id
 
     if (parentCollectionBackendID) {
       const res = await createGQLChildUserCollection(
@@ -395,6 +398,11 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     const isSynced = await ensureGQLPathSynced(path)
     if (!isSynced) return
 
+    const requestsLength = folder.requests.length
+    if (requestsLength > 0 && folder.requests[requestsLength - 1].id) {
+      return
+    }
+
     const parentCollectionBackendID = folder.id
     if (!parentCollectionBackendID) return
 
@@ -423,9 +431,24 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async moveRequest({ destinationPath, path, requestIndex }) {
+    const collections = graphqlCollectionStore.value.state
+    const sourceCollection = navigateToFolderWithIndexPath(
+      collections,
+      path.split("/").map((index) => parseInt(index))
+    )
+    const destCollection = navigateToFolderWithIndexPath(
+      collections,
+      destinationPath.split("/").map((index) => parseInt(index))
+    )
+
+    const wasSourceSynced = !!sourceCollection?.id
+    const wasDestSynced = !!destCollection?.id
+
     const isSourceSynced = await ensureGQLPathSynced(path)
     const isDestSynced = await ensureGQLPathSynced(destinationPath)
     if (!isSourceSynced || !isDestSynced) return
+
+    if (!wasSourceSynced || !wasDestSynced) return
 
     moveOrReorderRequests(requestIndex, path, destinationPath, undefined, "GQL")
   },

--- a/packages/hoppscotch-common/src/lib/sync/collections/index.ts
+++ b/packages/hoppscotch-common/src/lib/sync/collections/index.ts
@@ -256,6 +256,108 @@ export function exportedCollectionToHoppCollection(
   })
 }
 
+function mergeTwoCollections(
+  local: HoppCollection,
+  fetched: HoppCollection
+): HoppCollection {
+  const mergedFolders: HoppCollection[] = []
+  const fetchedFoldersMap = new Map<string, HoppCollection>()
+  for (const f of fetched.folders) {
+    if (f.id) fetchedFoldersMap.set(f.id, f)
+  }
+
+  const processedFetchedFolderIds = new Set<string>()
+  for (const localFolder of local.folders) {
+    if (localFolder.id) {
+      const fetchedFolder = fetchedFoldersMap.get(localFolder.id)
+      if (fetchedFolder) {
+        mergedFolders.push(mergeTwoCollections(localFolder, fetchedFolder))
+        processedFetchedFolderIds.add(localFolder.id)
+      } else {
+        mergedFolders.push(localFolder)
+      }
+    } else {
+      mergedFolders.push(localFolder)
+    }
+  }
+
+  for (const fetchedFolder of fetched.folders) {
+    if (fetchedFolder.id && !processedFetchedFolderIds.has(fetchedFolder.id)) {
+      mergedFolders.push(fetchedFolder)
+    }
+  }
+
+  const mergedRequests: typeof fetched.requests = []
+  const fetchedRequestsMap = new Map<string, any>()
+  for (const r of fetched.requests) {
+    if (r.id) fetchedRequestsMap.set(r.id, r)
+  }
+
+  const processedFetchedRequestIds = new Set<string>()
+  for (const localReq of local.requests) {
+    if (localReq.id) {
+      const fetchedReq = fetchedRequestsMap.get(localReq.id)
+      if (fetchedReq) {
+        mergedRequests.push(fetchedReq)
+        processedFetchedRequestIds.add(localReq.id)
+      } else {
+        mergedRequests.push(localReq)
+      }
+    } else {
+      mergedRequests.push(localReq)
+    }
+  }
+
+  for (const fetchedReq of fetched.requests) {
+    if (fetchedReq.id && !processedFetchedRequestIds.has(fetchedReq.id)) {
+      mergedRequests.push(fetchedReq)
+    }
+  }
+
+  return {
+    ...fetched,
+    folders: mergedFolders,
+    requests: mergedRequests,
+  }
+}
+
+function mergeCollections(
+  localCollections: HoppCollection[],
+  fetchedCollections: HoppCollection[]
+): HoppCollection[] {
+  const fetchedMap = new Map<string, HoppCollection>()
+  for (const col of fetchedCollections) {
+    if (col.id) {
+      fetchedMap.set(col.id, col)
+    }
+  }
+
+  const merged: HoppCollection[] = []
+  const processedFetchedIds = new Set<string>()
+
+  for (const localCol of localCollections) {
+    if (localCol.id) {
+      const fetchedCol = fetchedMap.get(localCol.id)
+      if (fetchedCol) {
+        merged.push(mergeTwoCollections(localCol, fetchedCol))
+        processedFetchedIds.add(localCol.id)
+      } else {
+        merged.push(localCol)
+      }
+    } else {
+      merged.push(localCol)
+    }
+  }
+
+  for (const fetchedCol of fetchedCollections) {
+    if (fetchedCol.id && !processedFetchedIds.has(fetchedCol.id)) {
+      merged.push(fetchedCol)
+    }
+  }
+
+  return merged
+}
+
 async function loadUserCollections(collectionType: "REST" | "GQL") {
   const res = await exportUserCollectionsToJSON(
     undefined,
@@ -269,26 +371,26 @@ async function loadUserCollections(collectionType: "REST" | "GQL") {
         ExportedUserCollectionGQL | ExportedUserCollectionREST
       >
     ).map((collection) => ({ v: 1, ...collection }))
+
+    const fetchedCollections = exportedCollections.map(
+      (collection) =>
+        exportedCollectionToHoppCollection(
+          collection,
+          collectionType
+        ) as HoppCollection
+    )
+
+    const localCollections =
+      collectionType == "REST"
+        ? restCollectionStore.value.state
+        : graphqlCollectionStore.value.state
+
+    const mergedCollections = mergeCollections(localCollections, fetchedCollections)
+
     runDispatchWithOutSyncing(() => {
       collectionType == "REST"
-        ? setRESTCollections(
-            exportedCollections.map(
-              (collection) =>
-                exportedCollectionToHoppCollection(
-                  collection,
-                  "REST"
-                ) as HoppCollection
-            )
-          )
-        : setGraphqlCollections(
-            exportedCollections.map(
-              (collection) =>
-                exportedCollectionToHoppCollection(
-                  collection,
-                  "GQL"
-                ) as HoppCollection
-            )
-          )
+        ? setRESTCollections(mergedCollections)
+        : setGraphqlCollections(mergedCollections)
     })
   }
 }

--- a/packages/hoppscotch-common/src/lib/sync/collections/sync.ts
+++ b/packages/hoppscotch-common/src/lib/sync/collections/sync.ts
@@ -461,7 +461,8 @@ export async function ensurePathSynced(
         highestUnsyncedPath.join("/"),
         parentID
       )
-      return false
+      const targetCollection = navigateToFolderWithIndexPath(collections, pathIndexes)
+      return !!targetCollection?.id
     }
   }
 
@@ -577,6 +578,13 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       path.split("/").map((index) => parseInt(index))
     )
 
+    if (parentCollection) {
+      const foldersLength = parentCollection.folders.length
+      if (foldersLength > 0 && parentCollection.folders[foldersLength - 1].id) {
+        return
+      }
+    }
+
     const parentCollectionBackendID = parentCollection?.id
 
     if (parentCollectionBackendID) {
@@ -639,12 +647,29 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     )
 
     if (newSourcePath) {
+      const collections = restCollectionStore.value.state
+      const sourceCollection = navigateToFolderWithIndexPath(
+        collections,
+        newSourcePath.split("/").map((index) => parseInt(index))
+      )
+      const destCollection = destinationPath && newDestinationPath
+        ? navigateToFolderWithIndexPath(
+            collections,
+            newDestinationPath.split("/").map((index) => parseInt(index))
+          )
+        : null
+
+      const wasSourceSynced = !!sourceCollection?.id
+      const wasDestSynced = destinationPath ? !!destCollection?.id : true
+
       const isSourceSynced = await ensureRESTPathSynced(newSourcePath)
       const isDestSynced = newDestinationPath
         ? await ensureRESTPathSynced(newDestinationPath)
         : true
 
       if (!isSourceSynced || !isDestSynced) return
+
+      if (!wasSourceSynced || !wasDestSynced) return
 
       const sourceCollectionID = navigateToFolderWithIndexPath(
         restCollectionStore.value.state,
@@ -717,6 +742,13 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       path.split("/").map((index) => parseInt(index))
     )
 
+    if (folder) {
+      const requestsLength = folder.requests.length
+      if (requestsLength > 0 && folder.requests[requestsLength - 1].id) {
+        return
+      }
+    }
+
     const parentCollectionBackendID = folder?.id
 
     if (parentCollectionBackendID) {
@@ -754,9 +786,24 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async moveRequest({ destinationPath, path, requestIndex }) {
+    const collections = restCollectionStore.value.state
+    const sourceCollection = navigateToFolderWithIndexPath(
+      collections,
+      path.split("/").map((index) => parseInt(index))
+    )
+    const destCollection = navigateToFolderWithIndexPath(
+      collections,
+      destinationPath.split("/").map((index) => parseInt(index))
+    )
+
+    const wasSourceSynced = !!sourceCollection?.id
+    const wasDestSynced = !!destCollection?.id
+
     const isSourceSynced = await ensureRESTPathSynced(path)
     const isDestSynced = await ensureRESTPathSynced(destinationPath)
     if (!isSourceSynced || !isDestSynced) return
+
+    if (!wasSourceSynced || !wasDestSynced) return
 
     moveOrReorderRequests(requestIndex, path, destinationPath)
   },
@@ -769,8 +816,17 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
      * currently the FE implementation only supports reordering requests between the same collection,
      * so destinationCollectionPath and sourceCollectionPath will be same
      */
+    const collections = restCollectionStore.value.state
+    const collection = navigateToFolderWithIndexPath(
+      collections,
+      destinationCollectionPath.split("/").map((index) => parseInt(index))
+    )
+    const wasSynced = !!collection?.id
+
     const isSynced = await ensureRESTPathSynced(destinationCollectionPath)
     if (!isSynced) return
+
+    if (!wasSynced) return
 
     moveOrReorderRequests(
       requestIndex,

--- a/packages/hoppscotch-common/src/lib/sync/collections/sync.ts
+++ b/packages/hoppscotch-common/src/lib/sync/collections/sync.ts
@@ -318,6 +318,7 @@ const recursivelySyncCollections = async (
       )
     } else {
       parentCollectionID = undefined
+      return
     }
   } else {
     // if parentUserCollectionID exists, create the collection as a child collection
@@ -366,6 +367,9 @@ const recursivelySyncCollections = async (
         childCollectionId,
         `${collectionPath}`
       )
+    } else {
+      parentCollectionID = undefined
+      return
     }
   }
 
@@ -419,10 +423,18 @@ type OperationCollectionRemoved = {
 
 export const restCollectionsOperations: Array<OperationCollectionRemoved> = []
 
-async function ensurePathSynced(path: string | number | null): Promise<boolean> {
+export async function ensurePathSynced(
+  path: string | number | null,
+  collectionStore: typeof restCollectionStore | typeof graphqlCollectionStore,
+  recursivelySyncFn: (
+    collection: HoppCollection,
+    collectionPath: string,
+    parentUserCollectionID?: string
+  ) => Promise<void>
+): Promise<boolean> {
   if (path === null || path === undefined || path === "") return true
 
-  const collections = restCollectionStore.value.state
+  const collections = collectionStore.value.state
   const pathIndexes = typeof path === "number" ? [path] : path.split("/").map((index) => parseInt(index))
 
   let highestUnsyncedPath: number[] | null = null
@@ -444,7 +456,7 @@ async function ensurePathSynced(path: string | number | null): Promise<boolean> 
   if (highestUnsyncedPath) {
     const collectionToSync = navigateToFolderWithIndexPath(collections, highestUnsyncedPath)
     if (collectionToSync) {
-      await recursivelySyncCollections(
+      await recursivelySyncFn(
         collectionToSync,
         highestUnsyncedPath.join("/"),
         parentID
@@ -455,6 +467,9 @@ async function ensurePathSynced(path: string | number | null): Promise<boolean> 
 
   return true
 }
+
+const ensureRESTPathSynced = (path: string | number | null) =>
+  ensurePathSynced(path, restCollectionStore, recursivelySyncCollections)
 
 export const storeSyncDefinition: StoreSyncDefinitionOf<
   typeof restCollectionStore
@@ -503,7 +518,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async editCollection({ partialCollection: collection, collectionIndex }) {
-    const isSynced = await ensurePathSynced(collectionIndex)
+    const isSynced = await ensureRESTPathSynced(collectionIndex)
     if (!isSynced) return
 
     const collectionID = navigateToFolderWithIndexPath(
@@ -554,7 +569,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   },
 
   async addFolder({ name, path }) {
-    const isSynced = await ensurePathSynced(path)
+    const isSynced = await ensureRESTPathSynced(path)
     if (!isSynced) return
 
     const parentCollection = navigateToFolderWithIndexPath(
@@ -592,7 +607,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async editFolder({ folder, path }) {
-    const isSynced = await ensurePathSynced(path)
+    const isSynced = await ensureRESTPathSynced(path)
     if (!isSynced) return
 
     const folderID = navigateToFolderWithIndexPath(
@@ -624,10 +639,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     )
 
     if (newSourcePath) {
-      await ensurePathSynced(newSourcePath)
-      if (newDestinationPath) {
-        await ensurePathSynced(newDestinationPath)
-      }
+      const isSourceSynced = await ensureRESTPathSynced(newSourcePath)
+      const isDestSynced = newDestinationPath
+        ? await ensureRESTPathSynced(newDestinationPath)
+        : true
+
+      if (!isSourceSynced || !isDestSynced) return
 
       const sourceCollectionID = navigateToFolderWithIndexPath(
         restCollectionStore.value.state,
@@ -661,7 +678,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async editRequest({ path, requestIndex, requestNew }) {
-    const isSynced = await ensurePathSynced(path)
+    const isSynced = await ensureRESTPathSynced(path)
 
     const folder = navigateToFolderWithIndexPath(
       restCollectionStore.value.state,
@@ -692,7 +709,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async saveRequestAs({ path, request }) {
-    const isSynced = await ensurePathSynced(path)
+    const isSynced = await ensureRESTPathSynced(path)
     if (!isSynced) return
 
     const folder = navigateToFolderWithIndexPath(
@@ -737,8 +754,10 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     }
   },
   async moveRequest({ destinationPath, path, requestIndex }) {
-    await ensurePathSynced(path)
-    await ensurePathSynced(destinationPath)
+    const isSourceSynced = await ensureRESTPathSynced(path)
+    const isDestSynced = await ensureRESTPathSynced(destinationPath)
+    if (!isSourceSynced || !isDestSynced) return
+
     moveOrReorderRequests(requestIndex, path, destinationPath)
   },
   async updateRequestOrder({
@@ -750,7 +769,9 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
      * currently the FE implementation only supports reordering requests between the same collection,
      * so destinationCollectionPath and sourceCollectionPath will be same
      */
-    await ensurePathSynced(destinationCollectionPath)
+    const isSynced = await ensureRESTPathSynced(destinationCollectionPath)
+    if (!isSynced) return
+
     moveOrReorderRequests(
       requestIndex,
       destinationCollectionPath,

--- a/packages/hoppscotch-common/src/lib/sync/collections/sync.ts
+++ b/packages/hoppscotch-common/src/lib/sync/collections/sync.ts
@@ -419,6 +419,43 @@ type OperationCollectionRemoved = {
 
 export const restCollectionsOperations: Array<OperationCollectionRemoved> = []
 
+async function ensurePathSynced(path: string | number | null): Promise<boolean> {
+  if (path === null || path === undefined || path === "") return true
+
+  const collections = restCollectionStore.value.state
+  const pathIndexes = typeof path === "number" ? [path] : path.split("/").map((index) => parseInt(index))
+
+  let highestUnsyncedPath: number[] | null = null
+  let parentID: string | undefined = undefined
+
+  for (let i = 0; i < pathIndexes.length; i++) {
+    const subPath = pathIndexes.slice(0, i + 1)
+    const collection = navigateToFolderWithIndexPath(collections, subPath)
+    if (!collection) break
+
+    if (!collection.id) {
+      highestUnsyncedPath = subPath
+      break
+    } else {
+      parentID = collection.id
+    }
+  }
+
+  if (highestUnsyncedPath) {
+    const collectionToSync = navigateToFolderWithIndexPath(collections, highestUnsyncedPath)
+    if (collectionToSync) {
+      await recursivelySyncCollections(
+        collectionToSync,
+        highestUnsyncedPath.join("/"),
+        parentID
+      )
+      return false
+    }
+  }
+
+  return true
+}
+
 export const storeSyncDefinition: StoreSyncDefinitionOf<
   typeof restCollectionStore
 > = {
@@ -465,7 +502,10 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       await deleteUserCollection(collectionID)
     }
   },
-  editCollection({ partialCollection: collection, collectionIndex }) {
+  async editCollection({ partialCollection: collection, collectionIndex }) {
+    const isSynced = await ensurePathSynced(collectionIndex)
+    if (!isSynced) return
+
     const collectionID = navigateToFolderWithIndexPath(
       restCollectionStore.value.state,
       [collectionIndex]
@@ -514,6 +554,9 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
   },
 
   async addFolder({ name, path }) {
+    const isSynced = await ensurePathSynced(path)
+    if (!isSynced) return
+
     const parentCollection = navigateToFolderWithIndexPath(
       restCollectionStore.value.state,
       path.split("/").map((index) => parseInt(index))
@@ -548,7 +591,10 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       }
     }
   },
-  editFolder({ folder, path }) {
+  async editFolder({ folder, path }) {
+    const isSynced = await ensurePathSynced(path)
+    if (!isSynced) return
+
     const folderID = navigateToFolderWithIndexPath(
       restCollectionStore.value.state,
       path.split("/").map((index) => parseInt(index))
@@ -578,6 +624,11 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
     )
 
     if (newSourcePath) {
+      await ensurePathSynced(newSourcePath)
+      if (newDestinationPath) {
+        await ensurePathSynced(newDestinationPath)
+      }
+
       const sourceCollectionID = navigateToFolderWithIndexPath(
         restCollectionStore.value.state,
         newSourcePath.split("/").map((index) => parseInt(index))
@@ -609,23 +660,41 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       }
     }
   },
-  editRequest({ path, requestIndex, requestNew }) {
-    const request = navigateToFolderWithIndexPath(
+  async editRequest({ path, requestIndex, requestNew }) {
+    const isSynced = await ensurePathSynced(path)
+
+    const folder = navigateToFolderWithIndexPath(
       restCollectionStore.value.state,
       path.split("/").map((index) => parseInt(index))
-    )?.requests[requestIndex]
+    )
+    if (!folder) return
 
-    const requestBackendID = request?.id
+    const request = folder.requests[requestIndex]
+    if (!request) return
 
-    if (requestBackendID) {
+    if (request.id) {
       editUserRequest(
-        requestBackendID,
+        request.id,
         (requestNew as HoppRESTRequest).name,
         JSON.stringify(requestNew)
       )
+    } else {
+      if (isSynced && folder.id) {
+        const res = await createRESTUserRequest(
+          (requestNew as HoppRESTRequest).name,
+          JSON.stringify(requestNew),
+          folder.id
+        )
+        if (res && E.isRight(res)) {
+          request.id = res.right.createRESTUserRequest.id
+        }
+      }
     }
   },
   async saveRequestAs({ path, request }) {
+    const isSynced = await ensurePathSynced(path)
+    if (!isSynced) return
+
     const folder = navigateToFolderWithIndexPath(
       restCollectionStore.value.state,
       path.split("/").map((index) => parseInt(index))
@@ -667,10 +736,12 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
       await deleteUserRequest(requestID)
     }
   },
-  moveRequest({ destinationPath, path, requestIndex }) {
+  async moveRequest({ destinationPath, path, requestIndex }) {
+    await ensurePathSynced(path)
+    await ensurePathSynced(destinationPath)
     moveOrReorderRequests(requestIndex, path, destinationPath)
   },
-  updateRequestOrder({
+  async updateRequestOrder({
     destinationCollectionPath,
     destinationRequestIndex,
     requestIndex,
@@ -679,6 +750,7 @@ export const storeSyncDefinition: StoreSyncDefinitionOf<
      * currently the FE implementation only supports reordering requests between the same collection,
      * so destinationCollectionPath and sourceCollectionPath will be same
      */
+    await ensurePathSynced(destinationCollectionPath)
     moveOrReorderRequests(
       requestIndex,
       destinationCollectionPath,

--- a/packages/hoppscotch-common/src/lib/sync/history/api.ts
+++ b/packages/hoppscotch-common/src/lib/sync/history/api.ts
@@ -4,6 +4,8 @@ import {
   runGQLSubscription,
 } from "~/helpers/backend/GQLClient"
 
+import { HISTORY_LIMIT } from "~/newstore/history"
+
 import {
   CreateUserHistoryDocument,
   CreateUserHistoryMutation,
@@ -28,10 +30,12 @@ import {
   UserHistoryAllDeletedDocument,
 } from "~/helpers/backend/graphql"
 
-export const getUserHistoryEntries = () =>
+export const getUserHistoryEntries = (take: number = HISTORY_LIMIT) =>
   runGQLQuery<GetRestUserHistoryQuery, GetRestUserHistoryQueryVariables, "">({
     query: GetRestUserHistoryDocument,
-    variables: {},
+    variables: {
+      take,
+    },
   })
 
 export const createUserHistory = (

--- a/packages/hoppscotch-common/src/lib/sync/history/index.ts
+++ b/packages/hoppscotch-common/src/lib/sync/history/index.ts
@@ -86,12 +86,52 @@ function setupSubscriptions() {
   }
 }
 
+function mergeHistoryEntries<T extends { id?: string; updatedOn?: Date }>(
+  local: T[],
+  fetched: T[]
+): T[] {
+  const fetchedMap = new Map<string, T>()
+  for (const entry of fetched) {
+    if (entry.id) {
+      fetchedMap.set(entry.id, entry)
+    }
+  }
+
+  const merged: T[] = []
+
+  for (const localEntry of local) {
+    if (!localEntry.id) {
+      merged.push(localEntry)
+    } else {
+      const fetchedEntry = fetchedMap.get(localEntry.id)
+      if (fetchedEntry) {
+        merged.push(fetchedEntry)
+        fetchedMap.delete(localEntry.id)
+      } else {
+        merged.push(localEntry)
+      }
+    }
+  }
+
+  for (const fetchedEntry of fetchedMap.values()) {
+    merged.push(fetchedEntry)
+  }
+
+  merged.sort((a, b) => {
+    const timeA = a.updatedOn ? a.updatedOn.getTime() : 0
+    const timeB = b.updatedOn ? b.updatedOn.getTime() : 0
+    return timeB - timeA
+  })
+
+  return merged
+}
+
 async function loadHistoryEntries() {
   const res = await getUserHistoryEntries()
 
   if (E.isRight(res)) {
-    const restEntries = res.right.me.RESTHistory
-    const gqlEntries = res.right.me.GQLHistory
+    const restEntries = res.right.me.RESTHistory ?? []
+    const gqlEntries = res.right.me.GQLHistory ?? []
 
     const restHistoryEntries: RESTHistoryEntry[] = restEntries.map((entry) => ({
       v: 1,
@@ -111,9 +151,15 @@ async function loadHistoryEntries() {
       id: entry.id,
     }))
 
+    const localRESTHistory = restHistoryStore.value.state
+    const localGQLHistory = graphqlHistoryStore.value.state
+
+    const mergedREST = mergeHistoryEntries(localRESTHistory, restHistoryEntries)
+    const mergedGQL = mergeHistoryEntries(localGQLHistory, gqlHistoryEntries)
+
     runDispatchWithOutSyncing(() => {
-      setRESTHistoryEntries(restHistoryEntries)
-      setGraphqlHistoryEntries(gqlHistoryEntries)
+      setRESTHistoryEntries(mergedREST)
+      setGraphqlHistoryEntries(mergedGQL)
     })
   }
 }

--- a/packages/hoppscotch-common/src/lib/sync/history/index.ts
+++ b/packages/hoppscotch-common/src/lib/sync/history/index.ts
@@ -86,10 +86,9 @@ function setupSubscriptions() {
   }
 }
 
-function mergeHistoryEntries<T extends { id?: string; updatedOn?: Date }>(
-  local: T[],
-  fetched: T[]
-): T[] {
+function mergeHistoryEntries<
+  T extends { id?: string; updatedOn?: Date | string | null }
+>(local: T[], fetched: T[]): T[] {
   const fetchedMap = new Map<string, T>()
   for (const entry of fetched) {
     if (entry.id) {
@@ -117,9 +116,15 @@ function mergeHistoryEntries<T extends { id?: string; updatedOn?: Date }>(
     merged.push(fetchedEntry)
   }
 
+  const getSafeTimestamp = (date: Date | string | null | undefined): number => {
+    if (!date) return 0
+    const time = new Date(date).getTime()
+    return isNaN(time) ? 0 : time
+  }
+
   merged.sort((a, b) => {
-    const timeA = a.updatedOn ? a.updatedOn.getTime() : 0
-    const timeB = b.updatedOn ? b.updatedOn.getTime() : 0
+    const timeA = getSafeTimestamp(a.updatedOn)
+    const timeB = getSafeTimestamp(b.updatedOn)
     return timeB - timeA
   })
 

--- a/packages/hoppscotch-common/src/newstore/history.ts
+++ b/packages/hoppscotch-common/src/newstore/history.ts
@@ -60,7 +60,24 @@ export function makeGQLHistoryEntry(
 }
 
 export function translateToNewRESTHistory(x: any): RESTHistoryEntry {
-  if (x.v === 1) return x
+  let responseMeta = x.responseMeta
+  if (typeof responseMeta === "string") {
+    try {
+      responseMeta = JSON.parse(responseMeta)
+    } catch {
+      responseMeta = { duration: null, statusCode: null }
+    }
+  }
+
+  if (x.v === 1) {
+    return {
+      ...x,
+      responseMeta: {
+        duration: responseMeta?.duration ?? null,
+        statusCode: responseMeta?.statusCode ?? null,
+      },
+    }
+  }
 
   // Legacy
   const request = translateToNewRequest(x)

--- a/packages/hoppscotch-common/src/services/persistence/__tests__/index.spec.ts
+++ b/packages/hoppscotch-common/src/services/persistence/__tests__/index.spec.ts
@@ -963,11 +963,17 @@ describe("PersistenceService", () => {
             setGraphqlCollections: vi.fn(),
             setRESTCollections: vi.fn(),
             graphqlCollectionStore: {
+              value: {
+                state: [],
+              },
               subject$: {
                 subscribe: vi.fn(),
               },
             },
             restCollectionStore: {
+              value: {
+                state: [],
+              },
               subject$: {
                 subscribe: vi.fn(),
               },

--- a/packages/hoppscotch-common/src/services/persistence/__tests__/index.spec.ts
+++ b/packages/hoppscotch-common/src/services/persistence/__tests__/index.spec.ts
@@ -56,6 +56,7 @@ import {
   STORE_KEYS,
   STORE_NAMESPACE,
 } from "../../persistence"
+import { REST_HISTORY_ENTRY_SCHEMA } from "../validation-schemas"
 import {
   ENVIRONMENTS_MOCK,
   GLOBAL_ENV_MOCK,
@@ -855,6 +856,51 @@ describe("PersistenceService", () => {
         expect(graphqlHistoryStore.subject$.subscribe).toHaveBeenCalledWith(
           expect.any(Function)
         )
+      })
+
+      it("validates REST_HISTORY_ENTRY_SCHEMA responseMeta correctly", () => {
+        // 1. Valid object responseMeta
+        const entryWithValidObj = {
+          ...REST_HISTORY_MOCK[0],
+          responseMeta: { duration: 807, statusCode: 200 },
+        }
+        expect(
+          REST_HISTORY_ENTRY_SCHEMA.safeParse(entryWithValidObj).success
+        ).toBe(true)
+
+        // 2. Valid stringified responseMeta
+        const entryWithValidStr = {
+          ...REST_HISTORY_MOCK[0],
+          responseMeta: JSON.stringify({ duration: 807, statusCode: 200 }),
+        }
+        expect(
+          REST_HISTORY_ENTRY_SCHEMA.safeParse(entryWithValidStr).success
+        ).toBe(true)
+
+        // 3. Malformed stringified responseMeta (non-numeric duration/statusCode) should fail and fall back to catch values
+        const entryWithMalformedStr = {
+          ...REST_HISTORY_MOCK[0],
+          responseMeta: JSON.stringify({ duration: "invalid", statusCode: 200 }),
+        }
+        const parseResult = REST_HISTORY_ENTRY_SCHEMA.safeParse(entryWithMalformedStr)
+        expect(parseResult.success).toBe(true)
+        expect(parseResult.data?.responseMeta).toEqual({
+          duration: null,
+          statusCode: null,
+        })
+
+        // 4. Non-JSON string should fail and fall back to catch values
+        const entryWithNonJSONStr = {
+          ...REST_HISTORY_MOCK[0],
+          responseMeta: "not-json",
+        }
+        const parseResultNonJSON =
+          REST_HISTORY_ENTRY_SCHEMA.safeParse(entryWithNonJSONStr)
+        expect(parseResultNonJSON.success).toBe(true)
+        expect(parseResultNonJSON.data?.responseMeta).toEqual({
+          duration: null,
+          statusCode: null,
+        })
       })
     })
 

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -621,7 +621,7 @@ export class PersistenceService extends Service {
           )
           setRESTCollections(translatedData)
         } else {
-          console.error(`Failed with `, result.error, data)
+          console.error(`Failed with `, result.error.message)
           this.showErrorToast(STORE_KEYS.REST_COLLECTIONS)
           await Store.set(
             STORE_NAMESPACE,

--- a/packages/hoppscotch-common/src/services/persistence/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/index.ts
@@ -541,6 +541,7 @@ export class PersistenceService extends Service {
           const translatedData = result.data.map(translateToNewRESTHistory)
           setRESTHistoryEntries(translatedData)
         } else {
+          console.error(`Failed parsing persisted REST_HISTORY:`, result.error.message)
           this.showErrorToast(STORE_KEYS.REST_HISTORY)
           await Store.set(
             STORE_NAMESPACE,

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -138,8 +138,8 @@ export const REST_HISTORY_ENTRY_SCHEMA = z
       })
       .strict(),
     star: z.boolean(),
-    id: z.optional(z.string()),
-    updatedOn: z.optional(z.union([z.date(), z.string()])),
+    id: z.string().nullish(),
+    updatedOn: z.union([z.date(), z.string()]).nullish(),
   })
   .strict()
 
@@ -150,8 +150,8 @@ export const GQL_HISTORY_ENTRY_SCHEMA = z
     request: HoppGQLRequestSchema,
     response: z.string(),
     star: z.boolean(),
-    id: z.optional(z.string()),
-    updatedOn: z.optional(z.union([z.date(), z.string()])),
+    id: z.string().nullish(),
+    updatedOn: z.union([z.date(), z.string()]).nullish(),
   })
   .strict()
 

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -132,11 +132,16 @@ export const REST_HISTORY_ENTRY_SCHEMA = z
     //! Versioned entity
     request: HoppRESTRequestSchema,
     responseMeta: z
-      .object({
-        duration: z.nullable(z.number()),
-        statusCode: z.nullable(z.number()),
-      })
-      .strict(),
+      .union([
+        z.string(),
+        z
+          .object({
+            duration: z.nullable(z.number()),
+            statusCode: z.nullable(z.number()),
+          })
+          .strict(),
+      ])
+      .catch({ duration: null, statusCode: null }),
     star: z.boolean(),
     id: z.string().nullish(),
     updatedOn: z.union([z.date(), z.string()]).nullish(),

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -133,7 +133,23 @@ export const REST_HISTORY_ENTRY_SCHEMA = z
     request: HoppRESTRequestSchema,
     responseMeta: z
       .union([
-        z.string(),
+        z.string().refine((val) => {
+          try {
+            const parsed = JSON.parse(val)
+            return (
+              typeof parsed === "object" &&
+              parsed !== null &&
+              (parsed.duration === undefined ||
+                parsed.duration === null ||
+                typeof parsed.duration === "number") &&
+              (parsed.statusCode === undefined ||
+                parsed.statusCode === null ||
+                typeof parsed.statusCode === "number")
+            )
+          } catch {
+            return false
+          }
+        }),
         z
           .object({
             duration: z.nullable(z.number()),

--- a/packages/hoppscotch-selfhost-web/src/api/queries/GetRestUserHistory.graphql
+++ b/packages/hoppscotch-selfhost-web/src/api/queries/GetRestUserHistory.graphql
@@ -1,6 +1,6 @@
-query GetRESTUserHistory {
+query GetRESTUserHistory($take: Int) {
   me {
-    RESTHistory {
+    RESTHistory(take: $take) {
       id
       userUid
       reqType
@@ -10,7 +10,7 @@ query GetRESTUserHistory {
       executedOn
     }
 
-    GQLHistory {
+    GQLHistory(take: $take) {
       id
       userUid
       reqType
@@ -21,3 +21,4 @@ query GetRESTUserHistory {
     }
   }
 }
+


### PR DESCRIPTION
Closes FE-1308 #6483

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data loss and duplicate folders/requests in personal workspace sync for REST and GQL collections and history in `hoppscotch-common`. Addresses FE-1308 by merging server data into local state, gating all mutations on path sync to avoid ID‑less writes, adding history pagination, and hardening history response metadata parsing/validation.

- **Bug Fixes**
  - Collections merge (REST/GQL): merge by backend id; keep local-only; add server-only.
  - Path sync and mutations (REST/GQL): sync folders before edit/add/move/reorder; stop on failed/unsynced parents; require both source and destination previously synced for move/reorder; remove index‑path fallbacks.
  - Safer creates and logging: create missing requests during edits; skip duplicate creates when the last item already has an id; improve error logs using error.message for REST collections and malformed persisted REST history.
  - History merge and schema: merge local/fetched history by id; keep local-only; add server-only; sort by updatedOn; allow nullish id/updatedOn; accept string or object `responseMeta` with safe defaults for malformed inputs; add a `take` parameter to history queries to limit fetched entries.

<sup>Written for commit 6f7e45c5c3416f350a8d771b4867dff9df41e93e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



