### PR TITLE
fix: preserve header values containing ': ' in cURL import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1159,6 +1159,30 @@ describe("Parse curl command to Hopp REST Request", () => {
     expect(customHeader.value).toBe(`-d {"fake":1}`)
   })
 
+  test("preserves header values containing ': ' (colon-space)", () => {
+    const command = `curl https://httpbin.org/get -H 'X-Note: hello: world' -H 'Accept: application/json'`
+
+    const actual = parseCurlToHoppRESTReq(command)
+
+    const xNote = actual.headers.find((h) => h.key === "X-Note")
+    expect(xNote).toBeDefined()
+    expect(xNote.value).toBe("hello: world")
+
+    const accept = actual.headers.find((h) => h.key === "Accept")
+    expect(accept).toBeDefined()
+    expect(accept.value).toBe("application/json")
+  })
+
+  test("preserves header values containing multiple ': ' delimiters", () => {
+    const command = `curl https://example.com -H 'X-Time: 12:30: 45'`
+
+    const actual = parseCurlToHoppRESTReq(command)
+
+    const xTime = actual.headers.find((h) => h.key === "X-Time")
+    expect(xTime).toBeDefined()
+    expect(xTime.value).toBe("12:30: 45")
+  })
+
   for (const [i, { command, response }] of samples.entries()) {
     test(`for sample #${i + 1}:\n\n${command}`, () => {
       const actual = parseCurlToHoppRESTReq(command)
@@ -1185,3 +1209,4 @@ describe("Parse curl command to Hopp REST Request", () => {
     })
   }
 })
+

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -10,13 +10,22 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
-const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
-)
+const getHeaderPair = (raw: string): O.Option<[string, string]> => {
+  const colonIndex = raw.indexOf(":")
+  if (colonIndex === -1) {
+    return O.none
+  }
+
+  const key = raw.slice(0, colonIndex).trim()
+  // RFC 9110: value is everything after the first colon (and optional leading space)
+  const value = raw.slice(colonIndex + 1).replace(/^ /, "").trim()
+
+  if (key.length === 0) {
+    return O.none
+  }
+
+  return O.some([key, value])
+}
 
 export function getHeaders(parsedArguments: parser.Arguments) {
   let headers: Record<string, string> = {}


### PR DESCRIPTION
## Description

When importing a cURL command, any header whose value contains `": "` (colon followed by a space) is **silently dropped**.

**Example:**
```
curl https://httpbin.org/get -H "X-Note: hello: world" -H "Accept: application/json"
```

**Result:** `Accept` is present, but `X-Note` is missing entirely.

## Root Cause

In `getHeaderPair` (`packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts`):

```ts
const getHeaderPair = flow(
  S.replace(":", ": "),
  S.split(": "),           // splits on ALL ": " → produces 3+ parts
  O.fromPredicate((arr) => arr.length === 2),  // fails → header dropped
  ...
)
```

When the value contains `": "`, the split produces 3+ parts, the `length === 2` predicate fails, and the header is silently discarded.

## Fix

Replace the `flow`-based implementation with a simple function that splits only on the **first** `:` per [RFC 9110](https://httpwg.org/specs/rfc9110.html#field.lines):

> A recipient SHOULD combine the field values from multiple field-values within a single field by appending each subsequent field-value to the merged field value in order, separated by a comma.

The header value is everything after the first colon (and optional leading space).

```ts
const getHeaderPair = (raw: string): O.Option<[string, string]> => {
  const colonIndex = raw.indexOf(":")
  if (colonIndex === -1) return O.none
  const key = raw.slice(0, colonIndex).trim()
  const value = raw.slice(colonIndex + 1).replace(/^ /, "").trim()
  if (key.length === 0) return O.none
  return O.some([key, value])
}
```

## Tests

Added two test cases in `curlparser.spec.js`:
- `X-Note: hello: world` → value preserved as `"hello: world"`
- `X-Time: 12:30: 45` → value preserved as `"12:30: 45"`

## Related issue

Fixes #6400

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cURL import so headers with values containing ": " are preserved by splitting on the first ":" per RFC 9110. Prevents headers like "X-Note: hello: world" from being dropped.

- **Bug Fixes**
  - Update `getHeaderPair` in `packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts` to split on the first `:`, trim, and ignore empty keys.
  - Add tests in `packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js` for "hello: world" and "12:30: 45" values.
  - Fixes #6400.

<sup>Written for commit 0598d4652c2edae30a3279cb71c9e1ee05f8db9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

