### PR TITLE
fix: accept single environment object on import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/hoppEnv.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/hoppEnv.spec.ts
@@ -1,0 +1,52 @@
+import * as E from "fp-ts/Either"
+import { describe, expect, it } from "vitest"
+
+import { hoppEnvImporter } from "../hoppEnv"
+
+const runImport = async (content: unknown) => {
+  const result = await hoppEnvImporter([JSON.stringify(content)])()
+  if (E.isLeft(result)) throw new Error(`importer failed: ${result.left}`)
+  return result.right
+}
+
+const validEnvironment = {
+  id: "test-env-id",
+  v: 1,
+  name: "Test Environment",
+  variables: [
+    { key: "API_URL", value: "https://api.example.com" },
+    { key: "TOKEN", value: "abc123" },
+  ],
+}
+
+describe("hoppEnvImporter", () => {
+  it("imports an array of environments", async () => {
+    const result = await runImport([validEnvironment])
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe("Test Environment")
+  })
+
+  it("imports a single environment object (not wrapped in array)", async () => {
+    const result = await runImport(validEnvironment)
+    expect(result).toHaveLength(1)
+    expect(result[0].name).toBe("Test Environment")
+    expect(result[0].variables).toHaveLength(2)
+  })
+
+  it("imports multiple environments from an array", async () => {
+    const second = { ...validEnvironment, id: "second-id", name: "Staging" }
+    const result = await runImport([validEnvironment, second])
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe("Test Environment")
+    expect(result[1].name).toBe("Staging")
+  })
+
+  it("converts variable values to strings", async () => {
+    const envWithNumericValue = {
+      ...validEnvironment,
+      variables: [{ key: "PORT", value: 3000 }],
+    }
+    const result = await runImport(envWithNumericValue)
+    expect(result[0].variables[0].value).toBe("3000")
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
@@ -16,7 +16,10 @@ export const hoppEnvImporter = (contents: string[]) => {
   }
 
   const parsedValues = parsedContents.flatMap((content) => {
-    const unwrappedContent = O.toNullable(content) as Environment[] | null
+    const rawContent = O.toNullable(content)
+    const unwrappedContent = (
+      Array.isArray(rawContent) ? rawContent : rawContent ? [rawContent] : null
+    ) as Environment[] | null
 
     if (unwrappedContent) {
       return unwrappedContent.map((contentEntry) => {

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
@@ -9,7 +9,7 @@ import { Environment } from "@hoppscotch/data"
 import { z } from "zod"
 
 export const hoppEnvImporter = (contents: string[]) => {
-  const parsedContents = contents.map((str) => safeParseJSON(str, true))
+  const parsedContents = contents.map((str) => safeParseJSON(str))
 
   if (parsedContents.some((parsed) => O.isNone(parsed))) {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppEnv.ts
@@ -9,17 +9,14 @@ import { Environment } from "@hoppscotch/data"
 import { z } from "zod"
 
 export const hoppEnvImporter = (contents: string[]) => {
-  const parsedContents = contents.map((str) => safeParseJSON(str))
+  const parsedContents = contents.map((str) => safeParseJSON(str, true))
 
   if (parsedContents.some((parsed) => O.isNone(parsed))) {
     return TE.left(IMPORTER_INVALID_FILE_FORMAT)
   }
 
   const parsedValues = parsedContents.flatMap((content) => {
-    const rawContent = O.toNullable(content)
-    const unwrappedContent = (
-      Array.isArray(rawContent) ? rawContent : rawContent ? [rawContent] : null
-    ) as Environment[] | null
+    const unwrappedContent = O.toNullable(content) as Environment[] | null
 
     if (unwrappedContent) {
       return unwrappedContent.map((contentEntry) => {


### PR DESCRIPTION
Closes #3554

### What's changed

After investigation, \`safeParseJSON(str, true)\` already wraps single-object JSON into an array via the \`convertToArray\` parameter — so the importer already handles both formats correctly.

**This PR adds regression tests** to guard that behavior. If the \`convertToArray: true\` flag is removed in a future refactor, these tests will catch the regression.

### Test file added

\`packages/hoppscotch-common/src/helpers/import-export/import/__tests__/hoppEnv.spec.ts\`

Covers:
- Array of environments (existing behavior)
- Single environment object without array wrapper (the #3554 scenario)
- Multiple environments in array
- Variable value coercion to string

### Notes to reviewers

- No production code changes — test-only PR
- If a test-only PR isn't desired, happy to close