### PR TITLE
fix: preserve header values containing colons in cURL import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -10,13 +10,14 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
-const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
-)
+const getHeaderPair = (raw: string): O.Option<[string, string]> => {
+  const colonIndex = raw.indexOf(":")
+  if (colonIndex === -1) return O.none
+  const key = raw.slice(0, colonIndex).trim()
+  const value = raw.slice(colonIndex + 1).trim()
+  if (!key) return O.none
+  return O.some([key, value] as [string, string])
+}
 
 export function getHeaders(parsedArguments: parser.Arguments) {
   let headers: Record<string, string> = {}


### PR DESCRIPTION
The previous implementation split on all ': ' occurrences, then rejected headers where the split produced more than 2 parts. This silently dropped any header whose value contained ': ' (e.g., 'X-Note: hello: world').

Split on the first colon only per RFC 9110: the header name is everything before the first colon, and the value is everything after.

Closes #6400

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix cURL import to preserve headers when values contain colons by splitting only on the first ":" per RFC 9110. This prevents dropping headers like "X-Note: hello: world".

<sup>Written for commit f03ad03e8b6659be75bb7ebcf20937d7eeab8fd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

