### PR TITLE
fix(common): preserve '=' in curl -F form field values on import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -751,6 +751,33 @@ const samples = [
     }),
   },
   {
+    command: "curl -F 'token=a=b=c' https://echo.hoppscotch.io/",
+    response: makeRESTRequest({
+      name: "Untitled",
+      endpoint: "https://echo.hoppscotch.io/",
+      method: "POST",
+      auth: { authType: "inherit", authActive: true },
+      headers: [],
+      body: {
+        contentType: "multipart/form-data",
+        body: [
+          {
+            active: true,
+            isFile: false,
+            key: "token",
+            value: "a=b=c",
+          },
+        ],
+      },
+      params: [],
+      preRequestScript: "",
+      testScript: "",
+      requestVariables: [],
+      responses: {},
+      description: null,
+    }),
+  },
+  {
     command: "curl 127.0.0.1 -X custommethod",
     response: makeRESTRequest({
       name: "Untitled",

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/body.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/body.ts
@@ -118,6 +118,22 @@ export const getBody = (
 }
 
 /**
+ * Splits a curl `-F`/`--form` argument into its key and value on the FIRST `=`
+ * only. curl treats everything after the first `=` as the value, so the value
+ * itself may legitimately contain `=` characters (e.g. base64 padding, query
+ * strings). Splitting on every `=` would silently truncate such values.
+ * @param fArg The raw `-F` argument (e.g. `key=a=b`)
+ * @returns `[key, value]`, or `[key]` when no `=` is present
+ */
+const splitFormArgumentOnFirstEquals = (fArg: string): string[] => {
+  const separatorIndex = fArg.indexOf("=")
+
+  return separatorIndex === -1
+    ? [fArg]
+    : [fArg.slice(0, separatorIndex), fArg.slice(separatorIndex + 1)]
+}
+
+/**
  * Parses and structures multipart/form-data from -F argument of curl command
  * @param parsedArguments Parsed Arguments object
  * @returns Option of Record<string, string> type containing key-value pairs of multipart/form-data
@@ -141,7 +157,7 @@ export function getFArgumentMultipartData(
     ),
     O.chain(
       flow(
-        A.map(S.split("=")),
+        A.map(splitFormArgumentOnFirstEquals),
         // can only have a key and no value
         O.fromPredicate((fArgs) => fArgs.length > 0),
         O.map(


### PR DESCRIPTION
## Problem

When importing a cURL command, multipart form fields (`-F`/`--form`) whose **value contains an `=`** are silently truncated at the second `=`. Everything after it is dropped.

Examples that get corrupted on import today:

| cURL argument | Imported value (before) | Expected |
|---|---|---|
| `-F 'token=a=b=c'` | `a` | `a=b=c` |
| `-F 'sig=YWJjZA=='` (base64) | `YWJjZA` | `YWJjZA==` |
| `-F 'q=name=John'` | `name` | `name=John` |

This is the same class of silent cURL-import corruption as the already-tracked header (`: `) and query-param (`*`) issues, but for form-field values.

## Root cause

`getFArgumentMultipartData` in `packages/hoppscotch-common/src/helpers/curl/sub_helpers/body.ts` split each `-F` argument with `S.split("=")`, then destructured only the first two elements:

```ts
A.map(S.split("=")),   // "token=a=b=c" -> ["token", "a", "b", "c"]
...
A.map(([k, v]) => ...) // v = "a"  ->  "b=c" is lost
```

`String.split("=")` splits on **every** `=`, so any value containing `=` loses everything past the second one. curl itself splits a form field on the **first** `=` only — the value may legitimately contain further `=` characters (base64 padding, query strings, JWTs, etc.).

## Fix

Split each `-F` argument on the first `=` only, keeping the remainder as the value:

```ts
const splitFormArgumentOnFirstEquals = (fArg: string): string[] => {
  const separatorIndex = fArg.indexOf("=")
  return separatorIndex === -1
    ? [fArg]
    : [fArg.slice(0, separatorIndex), fArg.slice(separatorIndex + 1)]
}
```

The downstream pipeline (file `@`/`<` handling, `--form-string`, record building) is unchanged, so simple `key=value` and file-upload cases behave exactly as before.

## How I verified

- Added a regression test to `curlparser.spec.js` (`curl -F 'token=a=b=c'` → value `a=b=c`).
- Exercised the actual parsing pipeline in isolation (real `fp-ts`, same `S.split` vs. the new splitter, same helper functions) across value-with-`=`, base64 padding, plain `key=value`, `@file`, and multiple-`-F` cases — the old code truncates, the new code preserves values, and the unchanged cases are byte-identical.

No behavior change for existing valid inputs; this only stops dropping data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cURL import for multipart form `-F` fields so values containing `=` are preserved. Prevents silent truncation after the first `=` in values like base64 tokens and query strings.

- **Bug Fixes**
  - Split `-F` arguments on the first `=` only to keep the full value.
  - Added a regression test (`curl -F 'token=a=b=c'`) to ensure the value is preserved.

<sup>Written for commit 1d8814c4fc9f94936cc3863bbeeb24f7db4f4aac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

