### PR TITLE
fix: resolve web build failure from sitemap generation

### DIFF
--- a/packages/hoppscotch-selfhost-web/vite.config.ts
+++ b/packages/hoppscotch-selfhost-web/vite.config.ts
@@ -1,7 +1,5 @@
-import { defineConfig, loadEnv, normalizePath } from "vite"
+import { defineConfig, loadEnv } from "vite"
 import { APP_INFO, META_TAGS } from "./meta"
-import { viteStaticCopy as StaticCopy } from "vite-plugin-static-copy"
-import generateSitemap from "vite-plugin-pages-sitemap"
 import HtmlConfig from "vite-plugin-html-config"
 import Vue from "@vitejs/plugin-vue"
 import VueI18n from "@intlify/unplugin-vue-i18n/vite"
@@ -108,23 +106,6 @@ export default defineConfig({
       routeStyle: "nuxt",
       dirs: ["../hoppscotch-common/src/pages", "./src/pages"],
       importMode: "async",
-      onRoutesGenerated(routes) {
-        generateSitemap({
-          routes,
-          nuxtStyle: true,
-          allowRobots: true,
-          dest: ".sitemap-gen",
-          hostname: ENV.VITE_BASE_URL,
-        })
-      },
-    }),
-    StaticCopy({
-      targets: [
-        {
-          src: normalizePath(path.resolve(__dirname, "./.sitemap-gen/*")),
-          dest: normalizePath(path.resolve(__dirname, "./dist")),
-        },
-      ],
     }),
     Layouts({
       layoutsDirs: "../hoppscotch-common/src/layouts",


### PR DESCRIPTION
## Description

Fixes the web build failure caused by `vite-plugin-pages-sitemap` throwing an error during route generation.

## Changes made

- Removed `vite-plugin-pages-sitemap` integration from the Vite config
- Removed sitemap generation hook from `vite-plugin-pages`
- Removed unused static copy configuration for generated sitemap files

## Testing

- Verified `pnpm run build` succeeds for `packages/hoppscotch-selfhost-web`
- Verified Hoppscotch web app runs locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the web build failure caused by `vite-plugin-pages-sitemap` during route generation. Builds now succeed for `packages/hoppscotch-selfhost-web`, and the app runs locally.

- **Bug Fixes**
  - Removed `vite-plugin-pages-sitemap` and its `onRoutesGenerated` hook from `vite-plugin-pages`.
  - Removed unused `vite-plugin-static-copy` config for sitemap files.

<sup>Written for commit 483d656214375dc9e37e4846da288b89bb2cc5de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

