### PR TITLE
fix: correct active state check for team environment selector

### DIFF
--- a/packages/hoppscotch-common/src/components/environments/Selector.vue
+++ b/packages/hoppscotch-common/src/components/environments/Selector.vue
@@ -560,7 +560,7 @@ const isEnvActive = (id: string | number) => {
     }
     return (
       selectedEnvironmentIndex.value.type === "TEAM_ENV" &&
-      selectedEnv.value.teamEnvID === id
+      selectedEnvironmentIndex.value.teamEnvID === id
     )
   }
 }


### PR DESCRIPTION
Closes #6540

The environment selector does not mark a newly selected **workspace (team) environment** as active: the check mark stays on the previous entry and the selection does not register. Personal environments are unaffected.

### What's changed

- `isEnvActive` in `packages/hoppscotch-common/src/components/environments/Selector.vue` now compares against `selectedEnvironmentIndex.value.teamEnvID` instead of `selectedEnv.value.teamEnvID`.

`selectedEnv` is a computed that resolves the `TEAM_ENV` case through a `.find()` over `teamEnvironmentList`. When that lookup does not resolve — for instance while the team environment list is still being populated by its GraphQL query/subscription — it falls back to `NO_ENV_SELECTED`, which carries no `teamEnvID`, so no entry matches and the check mark does not move.

`handleEnvironmentChange` already writes the selection to the store, so `selectedEnvironmentIndex` holds the correct value at that point. The `MY_ENV` branch resolves its active state from `selectedEnvironmentIndex` directly, without an external lookup, which is why personal environments behave correctly; this change makes the `TEAM_ENV` branch consistent with it.

### Notes to reviewers

- One-line change, no behavioural change to environment selection itself — only to how the active state is resolved for display.
- The reported behaviour was observed on the Hoppscotch Cloud desktop app. The root cause was identified by reading the code rather than by stepping through a running build, so independent confirmation of the timing scenario would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)