### PR TITLE
fix(common): use lock-based counter for keybinding disabler

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest"
-import { resolvePressedKey } from "../keybindings"
+import {
+  isKeybindingsEnabled,
+  resolvePressedKey,
+  useKeybindingDisabler,
+} from "../keybindings"
 
 // Fixture builder to keep individual cases readable. Layout name in the
 // describe block is the conceptual layout; `key` and `code` are what the
@@ -159,6 +163,42 @@ describe("resolvePressedKey: synthetic-event fallback", () => {
 
   test("'hybrid' strategy resolves Latin letter without needing code", () => {
     expect(resolvePressedKey(ev("a", ""), "hybrid")).toBe("a")
+  })
+})
+
+describe("useKeybindingDisabler: lock-based enable/disable", () => {
+  test("keybindings stay disabled while any lock is held", () => {
+    const { disableKeybindings, enableKeybindings } = useKeybindingDisabler()
+
+    expect(isKeybindingsEnabled()).toBe(true)
+
+    // Two modals both disable keybindings on open.
+    disableKeybindings()
+    disableKeybindings()
+    expect(isKeybindingsEnabled()).toBe(false)
+
+    // First modal closes: second modal's lock must keep bindings disabled.
+    enableKeybindings()
+    expect(isKeybindingsEnabled()).toBe(false)
+
+    // Second modal closes: all locks released, bindings re-enable.
+    enableKeybindings()
+    expect(isKeybindingsEnabled()).toBe(true)
+  })
+
+  test("extra enableKeybindings calls don't underflow the lock count", () => {
+    const { disableKeybindings, enableKeybindings } = useKeybindingDisabler()
+
+    disableKeybindings()
+    enableKeybindings()
+    enableKeybindings()
+    enableKeybindings()
+    expect(isKeybindingsEnabled()).toBe(true)
+
+    disableKeybindings()
+    expect(isKeybindingsEnabled()).toBe(false)
+    enableKeybindings()
+    expect(isKeybindingsEnabled()).toBe(true)
   })
 })
 

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -23,6 +23,14 @@ import { listen } from "@tauri-apps/api/event"
 let keybindingsEnabled = true
 
 /**
+ * Number of active locks requesting keybindings to be disabled.
+ * Keybindings only re-enable once every lock has been released, so
+ * multiple modals disabling keybindings at once don't race each other
+ * when only one of them closes.
+ */
+let keybindingsDisableLockCount = 0
+
+/**
  * Unlisten function for Tauri event
  */
 let unlistenTauriEvent: (() => void) | null = null
@@ -451,17 +459,29 @@ function getActiveModifier(ev: KeyboardEvent): ModifierKeys | null {
  * This composable allows for the UI component to be disabled if the component in question is mounted
  */
 export function useKeybindingDisabler() {
-  // TODO: Move to a lock based system that keeps the bindings disabled until all locks are lifted
   const disableKeybindings = () => {
+    keybindingsDisableLockCount += 1
     keybindingsEnabled = false
   }
 
   const enableKeybindings = () => {
-    keybindingsEnabled = true
+    keybindingsDisableLockCount = Math.max(0, keybindingsDisableLockCount - 1)
+
+    if (keybindingsDisableLockCount === 0) {
+      keybindingsEnabled = true
+    }
   }
 
   return {
     disableKeybindings,
     enableKeybindings,
   }
+}
+
+/**
+ * Exposes whether keybindings are currently enabled. Exported for testing
+ * the lock-based disable/enable behaviour in `useKeybindingDisabler`.
+ */
+export function isKeybindingsEnabled() {
+  return keybindingsEnabled
 }


### PR DESCRIPTION
Closes #6531

Fixes a race condition in the keybinding disabler where closing one modal re-enabled shortcuts while another modal was still open.

### What's changed
- `keybindings.ts`: replaced the boolean `keybindingsEnabled` flag's enable/disable logic in `useKeybindingDisabler()` with a lock counter (`keybindingsDisableLockCount`). `disableKeybindings()` increments the count; `enableKeybindings()` decrements it (floored at 0) and only re-enables keybindings once the count reaches 0.
- Added `isKeybindingsEnabled()` (exported) so the lock behavior is directly testable without needing a mounted Vue component.
- Added regression tests covering: two overlapping locks where releasing one keeps bindings disabled until the second is released, and extra `enableKeybindings()` calls not underflowing the counter.

### Root cause
`packages/hoppscotch-common/src/modules/ui.ts` wires a single global `disableKeybindings`/`enableKeybindings` pair to every modal's `onModalOpen`/`onModalClose` via the `@hoppscotch/ui` plugin. With a plain boolean, if two modals are open at once and the first one closes, its `enableKeybindings()` call sets the flag back to `true` even though the second modal is still open, letting keyboard shortcuts fire while a modal is active.

### Testing
- `pnpm exec vitest --run src/helpers/__tests__/keybindings.spec.ts` — 49 passed (includes 2 new tests for the lock behavior)
- `pnpm exec eslint src/helpers/keybindings.ts src/helpers/__tests__/keybindings.spec.ts src/modules/ui.ts` — no errors
- `npx tsc --noEmit` on the package — no errors for the changed file (`vue-tsc --noEmit` itself currently crashes in this sandboxed environment on an unrelated internal regex lookup against the installed TypeScript version, unrelated to this change)

### Notes to reviewers
Minimal, backward-compatible change: `keybindingsEnabled` and its two existing check sites (`handleKeyDown`, plus the other guard) are untouched — only the disable/enable composable now tracks a lock count instead of unconditionally flipping the flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where closing one modal re-enabled shortcuts while another modal was still open by switching the keybinding disabler to a lock-based counter. Shortcuts now re-enable only after all locks are released (fixes #6531).

- **Bug Fixes**
  - Replaced the boolean in `useKeybindingDisabler()` with a lock counter (`keybindingsDisableLockCount`); `disableKeybindings()` increments, `enableKeybindings()` decrements (floored at 0) and only re-enables at 0.
  - Exported `isKeybindingsEnabled()` for direct testing.
  - Added regression tests for overlapping locks and underflow prevention.

<sup>Written for commit b68d408eb23bc86a3642ba90b997cb7fa563621d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

