### PR TITLE
fix(keybindings): replace boolean flag with lock counter to fix race condition

### DIFF
--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -16,11 +16,15 @@ import { getKernelMode } from "@hoppscotch/kernel"
 import { listen } from "@tauri-apps/api/event"
 
 /**
- * This variable keeps track whether keybindings are being accepted
- * true -> Keybindings are checked
- * false -> Key presses are ignored (Keybindings are not checked)
+ * Tracks the number of active modal locks on keybindings.
+ * Keybindings are disabled whenever this counter is greater than 0,
+ * which prevents the race condition where closing one modal re-enables
+ * keybindings while another modal is still open.
  */
-let keybindingsEnabled = true
+let keybindingLockCount = 0
+
+/** Derived helper — keybindings are active only when no locks are held */
+const keybindingsEnabled = () => keybindingLockCount === 0
 
 /**
  * Unlisten function for Tauri event
@@ -177,7 +181,7 @@ export function hookKeybindingsListener() {
 
 function handleKeyDown(ev: KeyboardEvent) {
   // Do not check keybinds if the mode is disabled
-  if (!keybindingsEnabled) return
+  if (!keybindingsEnabled()) return
 
   // Skip during IME composition (CJK input). Modern browsers report
   // `isComposing`. Older ones use the sentinel `keyCode === 229`.
@@ -448,16 +452,19 @@ function getActiveModifier(ev: KeyboardEvent): ModifierKeys | null {
 }
 
 /**
- * This composable allows for the UI component to be disabled if the component in question is mounted
+ * This composable allows a UI component to hold a keybinding lock.
+ * Each call to disableKeybindings() increments the lock counter;
+ * each call to enableKeybindings() decrements it. Keybindings are
+ * only re-enabled once every caller has released its lock, which
+ * prevents the race condition when multiple modals are open simultaneously.
  */
 export function useKeybindingDisabler() {
-  // TODO: Move to a lock based system that keeps the bindings disabled until all locks are lifted
   const disableKeybindings = () => {
-    keybindingsEnabled = false
+    keybindingLockCount++
   }
 
   const enableKeybindings = () => {
-    keybindingsEnabled = true
+    if (keybindingLockCount > 0) keybindingLockCount--
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes #6531.

`useKeybindingDisabler` used a single boolean `keybindingsEnabled`. When multiple modals are open simultaneously, closing the first modal called `enableKeybindings()` and set the flag to `true` — re-enabling keybindings while the second modal was still open.

The original code even had a `TODO` comment acknowledging this:
> `// TODO: Move to a lock based system that keeps the bindings disabled until all locks are lifted`

## Fix

Replaced the boolean with a **lock counter** (`keybindingLockCount`):
- `disableKeybindings()` increments the counter
- `enableKeybindings()` decrements it (with a floor of 0)
- Keybindings are only active when the counter is `0`

This ensures keybindings stay disabled until **every** open modal has closed.

## Changes

- `packages/hoppscotch-common/src/helpers/keybindings.ts`
  - Replaced `let keybindingsEnabled = true` with `let keybindingLockCount = 0`
  - `keybindingsEnabled` is now a derived function `() => keybindingLockCount === 0`
  - Updated both call sites from `!keybindingsEnabled` to `!keybindingsEnabled()`
  - Removed the TODO comment — the lock system is now implemented

## Pre-merge checklist
- [x] Starred the repo ⭐
- [x] Code follows project style guidelines
- [x] Changes tested locally
- [x] PR title follows Conventional Commits
- [x] Linked with Closes #6531


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the keybinding enable flag with a lock counter to fix the race condition when multiple modals are open. Keybindings now stay disabled until all modals close. Fixes #6531.

- **Bug Fixes**
  - Added `keybindingLockCount` and a derived `keybindingsEnabled()` helper.
  - Updated `useKeybindingDisabler()` to increment/decrement the lock (floored at 0).
  - Switched checks to `!keybindingsEnabled()` and removed the outdated TODO.

<sup>Written for commit 0ee6364d31a524d7a6455f040caa0ad8d3cba93d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

