### PR TITLE
fix(backend): deprecate old members field

### DIFF
--- a/packages/hoppscotch-backend/src/team/team.resolver.ts
+++ b/packages/hoppscotch-backend/src/team/team.resolver.ts
@@ -36,11 +36,10 @@ export class TeamResolver {
     private readonly userService: UserService,
   ) {}
 
-  // Field Resolvers
-  // TODO: Deprecate this
   @ResolveField(() => [TeamMember], {
     description: 'Returns the list of members of a team',
     complexity: 10,
+    deprecationReason: 'Use teamMembers instead',
   })
   members(
     @Parent() team: Team,


### PR DESCRIPTION
## Summary
## Overview
Modernized the Team GraphQL API by formally deprecating the legacy `members` field in favor of the standardized `teamMembers` resolver.

## Technical Details
- **The Problem**: The backend API was exposing an outdated `members` resolver that engineers were actively trying to phase out, leaving an open `// TODO: Deprecate this` in `team.resolver.ts`.
- **The Solution**: Injected a formal `@ResolveField` directive with a strict `deprecationReason` ("Use teamMembers instead"), cleanly warning clients of the phase-out without breaking existing integrations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates the old `members` field in the Team GraphQL API and directs clients to use `teamMembers`. Adds a `deprecationReason` to the resolver so existing integrations keep working while receiving a clear warning.

<sup>Written for commit ec6ba4e21081b7ec9562cd80c5faac0c5bf575f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

