### PR TITLE
fix(common): drop ctrl+backspace, ctrl+delete

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { resolvePressedKey } from "../keybindings"
+import { bindings, resolvePressedKey } from "../keybindings"
 
 // Fixture builder to keep individual cases readable. Layout name in the
 // describe block is the conceptual layout; `key` and `code` are what the
@@ -194,5 +194,28 @@ describe("resolvePressedKey: edge cases", () => {
         "hybrid"
       )
     ).toBeNull()
+  })
+})
+
+describe("bindings: native word-delete chords stay unmapped", () => {
+  // ctrl-backspace and ctrl-delete are the browser's word-delete chords in
+  // any editable input (URL bar, header value, body). Mapping either to
+  // response.erase wiped the response pane while the user was only deleting
+  // a word (hoppscotch/hoppscotch#5967). handleKeyDown lets the native chord
+  // through only while it stays unmapped, so a future shortcut addition that
+  // rebinds either one would silently bring the bug back. These assertions
+  // are the guard against that.
+  const chords = Object.keys(bindings)
+
+  test("ctrl-backspace has no action", () => {
+    expect(chords).not.toContain("ctrl-backspace")
+  })
+
+  test("ctrl-delete has no action", () => {
+    expect(chords).not.toContain("ctrl-delete")
+  })
+
+  test("no chord maps to response.erase", () => {
+    expect(Object.values(bindings)).not.toContain("response.erase")
   })
 })

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -91,8 +91,6 @@ const baseBindings: {
   "ctrl-shift-l": "editor.format",
   "ctrl-z": "editor.undo",
   "ctrl-y": "editor.redo",
-  "ctrl-delete": "response.erase",
-  "ctrl-backspace": "response.erase",
 }
 
 // Web-only bindings


### PR DESCRIPTION
`baseBindings` mapped `ctrl-backspace` and `ctrl-delete` to `response.erase`, so the browser word-delete combination fired the response-erase action and the native word-delete in any editable input was lost. Reported as hoppscotch/hoppscotch#5967, where users hitting `ctrl-backspace` in the URL bar, header value, or body field saw the response pane wipe instead.

Remove both entries from `baseBindings`. `handleKeyDown` returns early when the chord has no mapping and does not call `preventDefault`, so the native word-delete passes through.

The action layout work on `common-feat-keyboard-layout-strategy-schema` does not touch these two entries, so there is no collision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `ctrl+backspace` and `ctrl+delete` bindings that triggered `response.erase`. This restores native word-delete in inputs and prevents accidental response wipes.

- **Bug Fixes**
  - Dropped both chords from `baseBindings` in `hoppscotch-common`.
  - With no mapping, `handleKeyDown` returns early without `preventDefault`, so the browser handles the keys.
  - Added tests to ensure these chords stay unmapped and no chord maps to `response.erase`.

<sup>Written for commit 4b053f1e73fe87cf5ecc172ba35dc7b9a9de9881. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

