### PR TITLE
chore(native): pin plugin git deps by rev

### DIFF
--- a/packages/hoppscotch-common/package.json
+++ b/packages/hoppscotch-common/package.json
@@ -40,7 +40,7 @@
     "@hoppscotch/httpsnippet": "3.0.9",
     "@hoppscotch/js-sandbox": "workspace:^",
     "@hoppscotch/kernel": "workspace:^",
-    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#95eb43e6036b34a1ddcf4c4deb941b198aa02e4b",
+    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33",
     "@hoppscotch/ui": "0.2.6",
     "@hoppscotch/vue-toasted": "0.1.0",
     "@lezer/highlight": "1.2.1",

--- a/packages/hoppscotch-desktop/package.json
+++ b/packages/hoppscotch-desktop/package.json
@@ -27,7 +27,7 @@
     "@fontsource-variable/roboto-mono": "5.2.9",
     "@hoppscotch/common": "workspace:^",
     "@hoppscotch/kernel": "workspace:^",
-    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#95eb43e6036b34a1ddcf4c4deb941b198aa02e4b",
+    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33",
     "@hoppscotch/ui": "0.2.6",
     "@tauri-apps/api": "2.1.1",
     "@tauri-apps/plugin-fs": "2.0.2",

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.lock
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.lock
@@ -5567,7 +5567,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-appload"
 version = "0.1.0"
-source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload?rev=95eb43e6036b34a1ddcf4c4deb941b198aa02e4b#95eb43e6036b34a1ddcf4c4deb941b198aa02e4b"
+source = "git+https://github.com/CuriousCorrelation/tauri-plugin-appload?rev=7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33#7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33"
 dependencies = [
  "base64 0.22.1",
  "blake3",

--- a/packages/hoppscotch-desktop/src-tauri/Cargo.toml
+++ b/packages/hoppscotch-desktop/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ tauri-plugin-store = "2.2.0"
 tauri-plugin-dialog = "2.2.0"
 tauri-plugin-fs = "2.2.0"
 tauri-plugin-deep-link = "2.2.0"
-tauri-plugin-appload = { git = "https://github.com/CuriousCorrelation/tauri-plugin-appload", rev = "95eb43e6036b34a1ddcf4c4deb941b198aa02e4b" }
+tauri-plugin-appload = { git = "https://github.com/CuriousCorrelation/tauri-plugin-appload", rev = "7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33" }
 tauri-plugin-relay = { git = "https://github.com/CuriousCorrelation/tauri-plugin-relay", rev = "273488c8f50a22ee707af6b50ccd5570851f8bc9" }
 axum = "0.8.1"
 tower-http = { version = "0.6.2", features = ["cors"] }

--- a/packages/hoppscotch-selfhost-web/package.json
+++ b/packages/hoppscotch-selfhost-web/package.json
@@ -29,7 +29,7 @@
     "@hoppscotch/common": "workspace:^",
     "@hoppscotch/data": "workspace:^",
     "@hoppscotch/kernel": "workspace:^",
-    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#95eb43e6036b34a1ddcf4c4deb941b198aa02e4b",
+    "@hoppscotch/plugin-appload": "github:CuriousCorrelation/tauri-plugin-appload#7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33",
     "@hoppscotch/ui": "0.2.6",
     "@import-meta-env/unplugin": "0.6.3",
     "@tauri-apps/api": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -563,8 +563,8 @@ importers:
         specifier: workspace:^
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
-        specifier: github:CuriousCorrelation/tauri-plugin-appload#95eb43e6036b34a1ddcf4c4deb941b198aa02e4b
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/95eb43e6036b34a1ddcf4c4deb941b198aa02e4b'
+        specifier: github:CuriousCorrelation/tauri-plugin-appload#7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33'
       '@hoppscotch/ui':
         specifier: 0.2.6
         version: 0.2.6(eslint@9.39.2(jiti@2.6.1))(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(sass@1.101.0)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
@@ -1060,8 +1060,8 @@ importers:
         specifier: workspace:^
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
-        specifier: github:CuriousCorrelation/tauri-plugin-appload#95eb43e6036b34a1ddcf4c4deb941b198aa02e4b
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/95eb43e6036b34a1ddcf4c4deb941b198aa02e4b'
+        specifier: github:CuriousCorrelation/tauri-plugin-appload#7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33'
       '@hoppscotch/ui':
         specifier: 0.2.6
         version: 0.2.6(eslint@9.39.2(jiti@2.6.1))(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.3)(jiti@2.6.1)(sass@1.101.0)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
@@ -1402,8 +1402,8 @@ importers:
         specifier: workspace:^
         version: link:../hoppscotch-kernel
       '@hoppscotch/plugin-appload':
-        specifier: github:CuriousCorrelation/tauri-plugin-appload#95eb43e6036b34a1ddcf4c4deb941b198aa02e4b
-        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/95eb43e6036b34a1ddcf4c4deb941b198aa02e4b'
+        specifier: github:CuriousCorrelation/tauri-plugin-appload#7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33
+        version: '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33'
       '@hoppscotch/ui':
         specifier: 0.2.6
         version: 0.2.6(eslint@9.39.2(jiti@2.6.1))(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@25.9.3)(jiti@2.6.1)(sass@1.101.0)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
@@ -1777,8 +1777,8 @@ packages:
       graphql:
         optional: true
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/95eb43e6036b34a1ddcf4c4deb941b198aa02e4b':
-    resolution: {gitHosted: true, integrity: sha512-+sJ6tTM8TqpckwwSorde2X5xGvcJdFuzWex/nFRPvNB8CFPdhWXboLmNA9B6gUY69PkLZCmRKO596+A1kDBdkQ==, tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/95eb43e6036b34a1ddcf4c4deb941b198aa02e4b}
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33':
+    resolution: {gitHosted: true, integrity: sha512-F5iGxxm5OgX47c6BzFazPIFJgWuv10M2/CbpFc/SjfOIHyBXa3o+dLj3tupGPiPMCQPtVCzZ1wIMjH4Xc61pMw==, tarball: https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33}
     version: 0.1.0
 
   '@CuriousCorrelation/plugin-relay@https://codeload.github.com/CuriousCorrelation/tauri-plugin-relay/tar.gz/273488c8f50a22ee707af6b50ccd5570851f8bc9':
@@ -14010,7 +14010,7 @@ snapshots:
     optionalDependencies:
       graphql: 16.14.0
 
-  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/95eb43e6036b34a1ddcf4c4deb941b198aa02e4b':
+  '@CuriousCorrelation/plugin-appload@https://codeload.github.com/CuriousCorrelation/tauri-plugin-appload/tar.gz/7c5d9c23b73f2d22bed4c3198f36e2cfd5799a33':
     dependencies:
       '@tauri-apps/api': 2.9.1
 


### PR DESCRIPTION
Pin the tauri-plugin-appload, relay, and curl-rust git dependencies to explicit revisions across the Cargo and pnpm manifests and their lockfiles, so every reference resolves to one revision rather than drifting when a lockfile regenerates. Relay moves to the structured-cookies revision, appload to current main. Bumps the agent to 0.1.18.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins git-based native/plugin dependencies to fixed revisions for reproducible builds across desktop, agent, and self-hosted, and updates `tauri-plugin-appload` to keep the Linux Edit menu hidden on windows opened after startup. Bumps the agent to 0.1.18.

- **Dependencies**
  - Pin `relay` to the structured-cookies revision (adds `cookie`).
  - Pin `curl-rust` (used by relay workspace) to a specific revision.
  - Pin `tauri-plugin-appload` in Rust and `@hoppscotch/plugin-appload` in pnpm to the fork main tip.
  - Update Cargo and pnpm lockfiles to match these pins.

- **Bug Fixes**
  - Fix pnpm lockfile integrity for `@hoppscotch/plugin-appload` to prevent tarball integrity errors.
  - Align portable Tauri config version to 0.1.18.

<sup>Written for commit c0fef1bf5c7574561e650a42005fc096b70cf451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

