### PR TITLE
fix(keybindings): replace boolean flag with reference counter to fix concurrent-disable race condition

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts
@@ -1,198 +1,94 @@
-import { describe, expect, test } from "vitest"
-import { resolvePressedKey } from "../keybindings"
+import { describe, it, expect, vi } from "vitest"
 
-// Fixture builder to keep individual cases readable. Layout name in the
-// describe block is the conceptual layout; `key` and `code` are what the
-// browser actually emits when the user presses a given physical key on
-// that layout.
-const ev = (key: string, code: string) => ({ key, code })
+// Mock all external imports so the module can be loaded in a plain Node/JSDOM
+// environment without a full Hoppscotch runtime.
+vi.mock("vue", () => ({
+  onMounted: vi.fn(),
+  onBeforeUnmount: vi.fn(),
+}))
 
-describe("resolvePressedKey: letter dispatch", () => {
-  describe("strategy: 'key' (typed letter)", () => {
-    test("US-QWERTY Q resolves to q", () => {
-      expect(resolvePressedKey(ev("q", "KeyQ"), "key")).toBe("q")
-    })
+vi.mock("../actions", () => ({
+  invokeAction: vi.fn(),
+}))
 
-    test("AZERTY 'A' keycap (physical Q position) resolves to a", () => {
-      // On AZERTY the physical KeyQ position types "a"; the user pressing
-      // the keycap labelled A expects Ctrl+A behaviour.
-      expect(resolvePressedKey(ev("a", "KeyQ"), "key")).toBe("a")
-    })
+vi.mock("../keyboard-strategy", () => ({
+  getKeyboardLayoutStrategy: vi.fn(() => "key"),
+}))
 
-    test("QWERTZ 'Z' keycap (physical Y position) resolves to z", () => {
-      expect(resolvePressedKey(ev("z", "KeyY"), "key")).toBe("z")
-    })
+vi.mock("../platformutils", () => ({
+  isAppleDevice: vi.fn(() => false),
+}))
 
-    test("Cyrillic Q (typed 'й') falls through to non-letter handling", () => {
-      // 'й' is not a-z so the letter branch returns null and the rest
-      // of the resolver doesn't recognise it either.
-      expect(resolvePressedKey(ev("й", "KeyQ"), "key")).toBeNull()
-    })
+vi.mock("../utils/dom", () => ({
+  isCodeMirrorEditor: vi.fn(() => false),
+  isDOMElement: vi.fn(() => false),
+  isInShortcutsFlyout: vi.fn(() => false),
+  isMonacoEditor: vi.fn(() => false),
+  isTypableElement: vi.fn(() => false),
+}))
 
-    test("Mac Option+Q (typed 'œ') falls through", () => {
-      expect(resolvePressedKey(ev("œ", "KeyQ"), "key")).toBeNull()
-    })
+vi.mock("@hoppscotch/kernel", () => ({
+  getKernelMode: vi.fn(() => "web"),
+}))
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(),
+}))
+
+import { areKeybindingsEnabled, useKeybindingDisabler } from "../keybindings"
+
+describe("useKeybindingDisabler – reference counter", () => {
+  /**
+   * Each test must leave keybindingDisabledCount at 0 on exit so
+   * subsequent tests start from a clean state (module state is shared
+   * across tests in the same file).
+   */
+
+  it("keybindings are enabled by default", () => {
+    expect(areKeybindingsEnabled()).toBe(true)
   })
 
-  describe("strategy: 'code' (physical position)", () => {
-    test("US-QWERTY Q resolves to q", () => {
-      expect(resolvePressedKey(ev("q", "KeyQ"), "code")).toBe("q")
-    })
+  it("disabling once suppresses keybindings", () => {
+    const { disableKeybindings, enableKeybindings } = useKeybindingDisabler()
 
-    test("AZERTY 'A' keycap (physical Q position) resolves to q", () => {
-      // Pure physical strategy; whatever the user typed is ignored.
-      expect(resolvePressedKey(ev("a", "KeyQ"), "code")).toBe("q")
-    })
+    disableKeybindings()
+    expect(areKeybindingsEnabled()).toBe(false)
 
-    test("Cyrillic physical Q (typed 'й') resolves to q", () => {
-      expect(resolvePressedKey(ev("й", "KeyQ"), "code")).toBe("q")
-    })
-
-    test("Mac Option+Q (typed 'œ') resolves to q", () => {
-      expect(resolvePressedKey(ev("œ", "KeyQ"), "code")).toBe("q")
-    })
+    enableKeybindings() // cleanup
   })
 
-  describe("strategy: 'hybrid' (key first, code fallback)", () => {
-    test("US-QWERTY Q resolves to q", () => {
-      expect(resolvePressedKey(ev("q", "KeyQ"), "hybrid")).toBe("q")
-    })
+  it("enabling after the sole disable restores keybindings", () => {
+    const { disableKeybindings, enableKeybindings } = useKeybindingDisabler()
 
-    test("AZERTY 'A' keycap (physical Q position) resolves to a", () => {
-      // Latin glyph available, so use it.
-      expect(resolvePressedKey(ev("a", "KeyQ"), "hybrid")).toBe("a")
-    })
+    disableKeybindings()
+    enableKeybindings()
 
-    test("Cyrillic physical Q (typed 'й') falls back to code → q", () => {
-      // Non-Latin glyph, fall back to physical position.
-      expect(resolvePressedKey(ev("й", "KeyQ"), "hybrid")).toBe("q")
-    })
-
-    test("Mac Option+Q (typed 'œ') falls back to code → q", () => {
-      // 'œ' is not in [a-z] so hybrid falls through to code.
-      expect(resolvePressedKey(ev("œ", "KeyQ"), "hybrid")).toBe("q")
-    })
-
-    test("Dvorak 'Q' keycap typing 'q' resolves to q", () => {
-      // Dvorak users with Dvorak software remapping see the typed
-      // letter match the keycap; hybrid uses event.key directly.
-      expect(resolvePressedKey(ev("q", "KeyX"), "hybrid")).toBe("q")
-    })
-  })
-})
-
-describe("resolvePressedKey: digit dispatch", () => {
-  test("'key' uses event.key for digits", () => {
-    expect(resolvePressedKey(ev("1", "Digit1"), "key")).toBe("1")
+    expect(areKeybindingsEnabled()).toBe(true)
   })
 
-  test("'code' uses event.code for digits", () => {
-    expect(resolvePressedKey(ev("1", "Digit1"), "code")).toBe("1")
+  it("two callers: closing one modal does not re-enable keybindings while the other is still open", () => {
+    const modal1 = useKeybindingDisabler()
+    const modal2 = useKeybindingDisabler()
+
+    modal1.disableKeybindings()
+    modal2.disableKeybindings()
+
+    // Modal 1 closes — Modal 2 is still open
+    modal1.enableKeybindings()
+    expect(areKeybindingsEnabled()).toBe(false) // must still be suppressed
+
+    // Modal 2 closes — both are gone now
+    modal2.enableKeybindings()
+    expect(areKeybindingsEnabled()).toBe(true)
   })
 
-  test("AZERTY digit row (typed '&', code Digit1) resolves to 1 under hybrid", () => {
-    expect(resolvePressedKey(ev("&", "Digit1"), "hybrid")).toBe("1")
-  })
+  it("spurious enableKeybindings does not underflow the counter", () => {
+    const { disableKeybindings, enableKeybindings } = useKeybindingDisabler()
 
-  test("AZERTY digit row resolves to 1 under code", () => {
-    expect(resolvePressedKey(ev("&", "Digit1"), "code")).toBe("1")
-  })
+    disableKeybindings()
+    enableKeybindings()
+    enableKeybindings() // extra call — counter must not go below zero
 
-  test("AZERTY digit row falls through under key (no Latin digit typed)", () => {
-    expect(resolvePressedKey(ev("&", "Digit1"), "key")).toBeNull()
-  })
-})
-
-describe("resolvePressedKey: layout-stable keys", () => {
-  // These keys produce the same event.key regardless of layout, so
-  // every strategy resolves them identically.
-  const strategies = ["key", "code", "hybrid"] as const
-
-  for (const strategy of strategies) {
-    describe(`strategy: '${strategy}'`, () => {
-      test("ArrowUp resolves to up", () => {
-        expect(resolvePressedKey(ev("ArrowUp", "ArrowUp"), strategy)).toBe("up")
-      })
-
-      test("Tab resolves to tab", () => {
-        expect(resolvePressedKey(ev("Tab", "Tab"), strategy)).toBe("tab")
-      })
-
-      test("Enter resolves to enter", () => {
-        expect(resolvePressedKey(ev("Enter", "Enter"), strategy)).toBe("enter")
-      })
-
-      test("Shift+/ (typed '?') maps to /", () => {
-        expect(resolvePressedKey(ev("?", "Slash"), strategy)).toBe("/")
-      })
-
-      test("[ resolves to [", () => {
-        expect(resolvePressedKey(ev("[", "BracketLeft"), strategy)).toBe("[")
-      })
-
-      test("Cyrillic physical [ key (typed 'х') falls back to [", () => {
-        // On Russian Cyrillic the physical KeyBracketLeft position
-        // types "х"; the resolver falls back to the bracket code so
-        // the shortcut still fires.
-        expect(resolvePressedKey(ev("х", "BracketLeft"), strategy)).toBe("[")
-      })
-
-      test("Cyrillic physical ] key (typed 'ъ') falls back to ]", () => {
-        expect(resolvePressedKey(ev("ъ", "BracketRight"), strategy)).toBe("]")
-      })
-    })
-  }
-})
-
-describe("resolvePressedKey: synthetic-event fallback", () => {
-  // Synthetic events (programmatic dispatch, certain older environments)
-  // can arrive without `event.code` set. The resolver falls back to
-  // `event.key` for ASCII letters under every strategy so the shortcut
-  // still resolves rather than being silently dropped.
-  test("'code' strategy falls back to event.key when code is empty", () => {
-    expect(resolvePressedKey(ev("a", ""), "code")).toBe("a")
-  })
-
-  test("'key' strategy resolves Latin letter without needing code", () => {
-    expect(resolvePressedKey(ev("a", ""), "key")).toBe("a")
-  })
-
-  test("'hybrid' strategy resolves Latin letter without needing code", () => {
-    expect(resolvePressedKey(ev("a", ""), "hybrid")).toBe("a")
-  })
-})
-
-describe("resolvePressedKey: edge cases", () => {
-  test("empty event returns null", () => {
-    expect(resolvePressedKey(ev("", ""), "hybrid")).toBeNull()
-  })
-
-  test("uppercase letter is normalised to lowercase under 'key'", () => {
-    expect(resolvePressedKey(ev("Q", "KeyQ"), "key")).toBe("q")
-  })
-
-  test("numpad branch resolves under 'code' strategy when NumLock is on", () => {
-    // The digit branch normally picks up key="1" before the numpad
-    // branch sees the event. Strategy "code" suppresses that path
-    // (event.code "Numpad1" isn't "Digit1"), so resolution falls to
-    // the numpad branch, which gates on NumLock.
-    expect(
-      resolvePressedKey(
-        { key: "1", code: "Numpad1", getModifierState: () => true },
-        "code"
-      )
-    ).toBe("1")
-  })
-
-  test("numpad digit returns null without NumLock when key is navigational", () => {
-    // Without NumLock, browsers send the navigation function ("End"
-    // for Numpad1) in event.key, so neither the digit nor the numpad
-    // branch can resolve.
-    expect(
-      resolvePressedKey(
-        { key: "End", code: "Numpad1", getModifierState: () => false },
-        "hybrid"
-      )
-    ).toBeNull()
+    expect(areKeybindingsEnabled()).toBe(true)
   })
 })

--- a/packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts
@@ -1,24 +1,10 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, test } from "vitest"
 
-// Mock all external imports so the module can be loaded in a plain Node/JSDOM
-// environment without a full Hoppscotch runtime.
-vi.mock("vue", () => ({
-  onMounted: vi.fn(),
-  onBeforeUnmount: vi.fn(),
-}))
-
-vi.mock("../actions", () => ({
-  invokeAction: vi.fn(),
-}))
-
-vi.mock("../keyboard-strategy", () => ({
-  getKeyboardLayoutStrategy: vi.fn(() => "key"),
-}))
-
-vi.mock("../platformutils", () => ({
-  isAppleDevice: vi.fn(() => false),
-}))
-
+// Mock external imports to load keybindings in Node/JSDOM without full runtime
+vi.mock("vue", () => ({ onMounted: vi.fn(), onBeforeUnmount: vi.fn() }))
+vi.mock("../actions", () => ({ invokeAction: vi.fn() }))
+vi.mock("../keyboard-strategy", () => ({ getKeyboardLayoutStrategy: vi.fn(() => "key") }))
+vi.mock("../platformutils", () => ({ isAppleDevice: vi.fn(() => false) }))
 vi.mock("../utils/dom", () => ({
   isCodeMirrorEditor: vi.fn(() => false),
   isDOMElement: vi.fn(() => false),
@@ -26,16 +12,237 @@ vi.mock("../utils/dom", () => ({
   isMonacoEditor: vi.fn(() => false),
   isTypableElement: vi.fn(() => false),
 }))
+vi.mock("@hoppscotch/kernel", () => ({ getKernelMode: vi.fn(() => "web") }))
+vi.mock("@tauri-apps/api/event", () => ({ listen: vi.fn() }))
 
-vi.mock("@hoppscotch/kernel", () => ({
-  getKernelMode: vi.fn(() => "web"),
-}))
+import { bindings, resolvePressedKey, areKeybindingsEnabled, useKeybindingDisabler } from "../keybindings"
 
-vi.mock("@tauri-apps/api/event", () => ({
-  listen: vi.fn(),
-}))
+// ---------------------------------------------------------------------------
+// Restored suite: resolvePressedKey and bindings guards (from upstream main)
+// ---------------------------------------------------------------------------
 
-import { areKeybindingsEnabled, useKeybindingDisabler } from "../keybindings"
+// Fixture builder to keep individual cases readable. Layout name in the
+// describe block is the conceptual layout; `key` and `code` are what the
+// browser actually emits when the user presses a given physical key on
+// that layout.
+const ev = (key: string, code: string) => ({ key, code })
+
+describe("resolvePressedKey: letter dispatch", () => {
+  describe("strategy: 'key' (typed letter)", () => {
+    test("US-QWERTY Q resolves to q", () => {
+      expect(resolvePressedKey(ev("q", "KeyQ"), "key")).toBe("q")
+    })
+
+    test("AZERTY 'A' keycap (physical Q position) resolves to a", () => {
+      // On AZERTY the physical KeyQ position types "a"; the user pressing
+      // the keycap labelled A expects Ctrl+A behaviour.
+      expect(resolvePressedKey(ev("a", "KeyQ"), "key")).toBe("a")
+    })
+
+    test("QWERTZ 'Z' keycap (physical Y position) resolves to z", () => {
+      expect(resolvePressedKey(ev("z", "KeyY"), "key")).toBe("z")
+    })
+
+    test("Cyrillic Q (typed 'й') falls through to non-letter handling", () => {
+      // 'й' is not a-z so the letter branch returns null and the rest
+      // of the resolver doesn't recognise it either.
+      expect(resolvePressedKey(ev("й", "KeyQ"), "key")).toBeNull()
+    })
+
+    test("Mac Option+Q (typed 'œ') falls through", () => {
+      expect(resolvePressedKey(ev("œ", "KeyQ"), "key")).toBeNull()
+    })
+  })
+
+  describe("strategy: 'code' (physical position)", () => {
+    test("US-QWERTY Q resolves to q", () => {
+      expect(resolvePressedKey(ev("q", "KeyQ"), "code")).toBe("q")
+    })
+
+    test("AZERTY 'A' keycap (physical Q position) resolves to q", () => {
+      // Pure physical strategy; whatever the user typed is ignored.
+      expect(resolvePressedKey(ev("a", "KeyQ"), "code")).toBe("q")
+    })
+
+    test("Cyrillic physical Q (typed 'й') resolves to q", () => {
+      expect(resolvePressedKey(ev("й", "KeyQ"), "code")).toBe("q")
+    })
+
+    test("Mac Option+Q (typed 'œ') resolves to q", () => {
+      expect(resolvePressedKey(ev("œ", "KeyQ"), "code")).toBe("q")
+    })
+  })
+
+  describe("strategy: 'hybrid' (key first, code fallback)", () => {
+    test("US-QWERTY Q resolves to q", () => {
+      expect(resolvePressedKey(ev("q", "KeyQ"), "hybrid")).toBe("q")
+    })
+
+    test("AZERTY 'A' keycap (physical Q position) resolves to a", () => {
+      // Latin glyph available, so use it.
+      expect(resolvePressedKey(ev("a", "KeyQ"), "hybrid")).toBe("a")
+    })
+
+    test("Cyrillic physical Q (typed 'й') falls back to code → q", () => {
+      // Non-Latin glyph, fall back to physical position.
+      expect(resolvePressedKey(ev("й", "KeyQ"), "hybrid")).toBe("q")
+    })
+
+    test("Mac Option+Q (typed 'œ') falls back to code → q", () => {
+      // 'œ' is not in [a-z] so hybrid falls through to code.
+      expect(resolvePressedKey(ev("œ", "KeyQ"), "hybrid")).toBe("q")
+    })
+
+    test("Dvorak 'Q' keycap typing 'q' resolves to q", () => {
+      // Dvorak users with Dvorak software remapping see the typed
+      // letter match the keycap; hybrid uses event.key directly.
+      expect(resolvePressedKey(ev("q", "KeyX"), "hybrid")).toBe("q")
+    })
+  })
+})
+
+describe("resolvePressedKey: digit dispatch", () => {
+  test("'key' uses event.key for digits", () => {
+    expect(resolvePressedKey(ev("1", "Digit1"), "key")).toBe("1")
+  })
+
+  test("'code' uses event.code for digits", () => {
+    expect(resolvePressedKey(ev("1", "Digit1"), "code")).toBe("1")
+  })
+
+  test("AZERTY digit row (typed '&', code Digit1) resolves to 1 under hybrid", () => {
+    expect(resolvePressedKey(ev("&", "Digit1"), "hybrid")).toBe("1")
+  })
+
+  test("AZERTY digit row resolves to 1 under code", () => {
+    expect(resolvePressedKey(ev("&", "Digit1"), "code")).toBe("1")
+  })
+
+  test("AZERTY digit row falls through under key (no Latin digit typed)", () => {
+    expect(resolvePressedKey(ev("&", "Digit1"), "key")).toBeNull()
+  })
+})
+
+describe("resolvePressedKey: layout-stable keys", () => {
+  // These keys produce the same event.key regardless of layout, so
+  // every strategy resolves them identically.
+  const strategies = ["key", "code", "hybrid"] as const
+
+  for (const strategy of strategies) {
+    describe(`strategy: '${strategy}'`, () => {
+      test("ArrowUp resolves to up", () => {
+        expect(resolvePressedKey(ev("ArrowUp", "ArrowUp"), strategy)).toBe("up")
+      })
+
+      test("Tab resolves to tab", () => {
+        expect(resolvePressedKey(ev("Tab", "Tab"), strategy)).toBe("tab")
+      })
+
+      test("Enter resolves to enter", () => {
+        expect(resolvePressedKey(ev("Enter", "Enter"), strategy)).toBe("enter")
+      })
+
+      test("Shift+/ (typed '?') maps to /", () => {
+        expect(resolvePressedKey(ev("?", "Slash"), strategy)).toBe("/")
+      })
+
+      test("[ resolves to [", () => {
+        expect(resolvePressedKey(ev("[", "BracketLeft"), strategy)).toBe("[")
+      })
+
+      test("Cyrillic physical [ key (typed 'х') falls back to [", () => {
+        // On Russian Cyrillic the physical KeyBracketLeft position
+        // types "х"; the resolver falls back to the bracket code so
+        // the shortcut still fires.
+        expect(resolvePressedKey(ev("х", "BracketLeft"), strategy)).toBe("[")
+      })
+
+      test("Cyrillic physical ] key (typed 'ъ') falls back to ]", () => {
+        expect(resolvePressedKey(ev("ъ", "BracketRight"), strategy)).toBe("]")
+      })
+    })
+  }
+})
+
+describe("resolvePressedKey: synthetic-event fallback", () => {
+  // Synthetic events (programmatic dispatch, certain older environments)
+  // can arrive without `event.code` set. The resolver falls back to
+  // `event.key` for ASCII letters under every strategy so the shortcut
+  // still resolves rather than being silently dropped.
+  test("'code' strategy falls back to event.key when code is empty", () => {
+    expect(resolvePressedKey(ev("a", ""), "code")).toBe("a")
+  })
+
+  test("'key' strategy resolves Latin letter without needing code", () => {
+    expect(resolvePressedKey(ev("a", ""), "key")).toBe("a")
+  })
+
+  test("'hybrid' strategy resolves Latin letter without needing code", () => {
+    expect(resolvePressedKey(ev("a", ""), "hybrid")).toBe("a")
+  })
+})
+
+describe("resolvePressedKey: edge cases", () => {
+  test("empty event returns null", () => {
+    expect(resolvePressedKey(ev("", ""), "hybrid")).toBeNull()
+  })
+
+  test("uppercase letter is normalised to lowercase under 'key'", () => {
+    expect(resolvePressedKey(ev("Q", "KeyQ"), "key")).toBe("q")
+  })
+
+  test("numpad branch resolves under 'code' strategy when NumLock is on", () => {
+    // The digit branch normally picks up key="1" before the numpad
+    // branch sees the event. Strategy "code" suppresses that path
+    // (event.code "Numpad1" isn't "Digit1"), so resolution falls to
+    // the numpad branch, which gates on NumLock.
+    expect(
+      resolvePressedKey(
+        { key: "1", code: "Numpad1", getModifierState: () => true } as any,
+        "code"
+      )
+    ).toBe("1")
+  })
+
+  test("numpad digit returns null without NumLock when key is navigational", () => {
+    // Without NumLock, browsers send the navigation function ("End"
+    // for Numpad1) in event.key, so neither the digit nor the numpad
+    // branch can resolve.
+    expect(
+      resolvePressedKey(
+        { key: "End", code: "Numpad1", getModifierState: () => false } as any,
+        "hybrid"
+      )
+    ).toBeNull()
+  })
+})
+
+describe("bindings: native word-delete chords stay unmapped", () => {
+  // ctrl-backspace and ctrl-delete are the browser's word-delete chords in
+  // any editable input (URL bar, header value, body). Mapping either to
+  // response.erase wiped the response pane while the user was only deleting
+  // a word (hoppscotch/hoppscotch#5967). handleKeyDown lets the native chord
+  // through only while it stays unmapped, so a future shortcut addition that
+  // rebinds either one would silently bring the bug back. These assertions
+  // are the guard against that.
+  const chords = Object.keys(bindings)
+
+  test("ctrl-backspace has no action", () => {
+    expect(chords).not.toContain("ctrl-backspace")
+  })
+
+  test("ctrl-delete has no action", () => {
+    expect(chords).not.toContain("ctrl-delete")
+  })
+
+  test("no chord maps to response.erase", () => {
+    expect(Object.values(bindings)).not.toContain("response.erase")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// New suite: reference counter semantics for keybinding disabler
+// ---------------------------------------------------------------------------
 
 describe("useKeybindingDisabler – reference counter", () => {
   /**

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -16,11 +16,14 @@ import { getKernelMode } from "@hoppscotch/kernel"
 import { listen } from "@tauri-apps/api/event"
 
 /**
- * This variable keeps track whether keybindings are being accepted
- * true -> Keybindings are checked
- * false -> Key presses are ignored (Keybindings are not checked)
+ * Tracks how many callers have requested that keybindings be suppressed.
+ * Keybindings are active only when this counter is zero.
+ *
+ * A reference counter (rather than a single boolean) ensures that when
+ * multiple components disable keybindings concurrently, the bindings
+ * stay suppressed until every caller has released its lock.
  */
-let keybindingsEnabled = true
+let keybindingDisabledCount = 0
 
 /**
  * Unlisten function for Tauri event
@@ -176,8 +179,8 @@ export function hookKeybindingsListener() {
 }
 
 function handleKeyDown(ev: KeyboardEvent) {
-  // Do not check keybinds if the mode is disabled
-  if (!keybindingsEnabled) return
+  // Do not check keybinds if any component currently holds a disable lock
+  if (keybindingDisabledCount > 0) return
 
   // Skip during IME composition (CJK input). Modern browsers report
   // `isComposing`. Older ones use the sentinel `keyCode === 229`.
@@ -272,8 +275,8 @@ function handleKeyDown(ev: KeyboardEvent) {
 function handleTauriShortcut(shortcut: string) {
   console.info("Tauri shortcut:", shortcut)
 
-  // Do not check keybinds if the mode is disabled
-  if (!keybindingsEnabled) return
+  // Do not check keybinds if any component currently holds a disable lock
+  if (keybindingDisabledCount > 0) return
 
   const activeBindings = getActiveBindings()
   const boundAction = activeBindings[shortcut as ShortcutKey]
@@ -447,17 +450,28 @@ function getActiveModifier(ev: KeyboardEvent): ModifierKeys | null {
   return activeModifier === "" ? null : (activeModifier as ModifierKeys)
 }
 
+/** Returns true when keybindings are currently active (no component holds a disable lock). */
+export function areKeybindingsEnabled(): boolean {
+  return keybindingDisabledCount === 0
+}
+
 /**
- * This composable allows for the UI component to be disabled if the component in question is mounted
+ * Composable that lets a UI component suppress global keybindings for
+ * as long as it is mounted (e.g. a modal or flyout that handles its own
+ * keyboard interactions).
+ *
+ * Multiple components may call `disableKeybindings()` concurrently.
+ * Keybindings are only re-enabled once every caller has called
+ * `enableKeybindings()`, preventing the race condition where closing one
+ * modal would re-activate shortcuts while a second modal was still open.
  */
 export function useKeybindingDisabler() {
-  // TODO: Move to a lock based system that keeps the bindings disabled until all locks are lifted
   const disableKeybindings = () => {
-    keybindingsEnabled = false
+    keybindingDisabledCount++
   }
 
   const enableKeybindings = () => {
-    keybindingsEnabled = true
+    keybindingDisabledCount = Math.max(0, keybindingDisabledCount - 1)
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes #6531

### Bug

`useKeybindingDisabler` used a single `boolean` (`keybindingsEnabled`) to suppress global keyboard shortcuts. When two components called `disableKeybindings()` concurrently (e.g. two modals open at the same time), closing the first one called `enableKeybindings()` which set the boolean back to `true` — even though the second modal was still open. This caused keyboard shortcuts to fire through an open modal.

The module itself contained a `TODO` pointing at the exact fix needed:
```ts
// TODO: Move to a lock based system that keeps the bindings disabled until all locks are lifted
```

### Root cause

```
Modal A opens  → keybindingsEnabled = false
Modal B opens  → keybindingsEnabled = false  (no-op, already false)
Modal A closes → keybindingsEnabled = true   ← BUG: Modal B is still open!
```

### Fix

Replace the `boolean` with a **reference counter** (`keybindingDisabledCount`):

| Call | Counter | Keybindings active? |
|------|---------|---------------------|
| Modal A: `disableKeybindings()` | 1 | ❌ No |
| Modal B: `disableKeybindings()` | 2 | ❌ No |
| Modal A: `enableKeybindings()` | 1 | ❌ No (correctly suppressed) |
| Modal B: `enableKeybindings()` | 0 | ✅ Yes |

`enableKeybindings()` uses `Math.max(0, count - 1)` to prevent underflow from mismatched calls.

The new `areKeybindingsEnabled()` export makes the counter observable for unit tests without exposing raw mutable state.

### Changes

| File | Change |
|------|--------|
| `packages/hoppscotch-common/src/helpers/keybindings.ts` | Replace `boolean` with ref counter; resolve the TODO; export `areKeybindingsEnabled()` |
| `packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts` | New: 5 unit tests covering default state, single disable/enable, concurrent callers, and counter underflow guard |

### Tests (vitest)

```
✓ keybindings are enabled by default
✓ disabling once suppresses keybindings
✓ enabling after the sole disable restores keybindings
✓ two callers: closing one modal does not re-enable keybindings while the other is still open
✓ spurious enableKeybindings does not underflow the counter
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the boolean keybinding switch with a reference counter so global shortcuts stay disabled until all callers release, fixing the concurrent-disable race with multiple open modals. Restores keybinding parsing tests and adds guards to prevent shortcut regressions.

- **Bug Fixes**
  - Replaced boolean with counter (`keybindingDisabledCount`); shortcuts are suppressed when count > 0. `disableKeybindings()` increments; `enableKeybindings()` decrements (floored at 0). Exported `areKeybindingsEnabled()` and resolved the TODO.
  - Tests: restored `resolvePressedKey` suite; added guards so `ctrl-backspace` and `ctrl-delete` remain unmapped and nothing targets `response.erase`. Covered default state, concurrent disables, and underflow protection in `packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts`.

<sup>Written for commit bd7a1988c610abb567f2f30311bd946833fb85ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

