### PR TITLE
feat: add option to disable cookies globally and per-request

### DIFF
--- a/packages/codemirror-lang-graphql/package.json
+++ b/packages/codemirror-lang-graphql/package.json
@@ -11,8 +11,10 @@
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
   },
   "types": "dist/index.d.ts",
   "sideEffects": false,

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1241,7 +1241,7 @@
     "generate_name_error": "Failed to generate request name.",
     "disable_cookies": "Disable cookie jar",
     "disable_cookies_default": "(Default: Settings)",
-    "disable_cookies_description": "Prevent cookies used in this request from being stored in the cookie jar. Existing cookies in the cookie jar will not be added as headers for this request."
+    "disable_cookies_description": "Prevent cookies used in this request from being stored in the cookie jar. Existing cookies in the cookie jar will not be added as headers for this request. Note: Due to browser limitations, same-origin requests will still include cookies."
   },
   "response": {
     "audio": "Audio",
@@ -1430,7 +1430,7 @@
     "proxy_auth": "You can also include username and password in the URL.",
     "network": "Network",
     "disable_cookies": "Disable cookies",
-    "disable_cookies_description": "Disable cookie jar for all requests."
+    "disable_cookies_description": "Disable cookie jar for all requests. Note: Due to browser limitations, same-origin requests will still include cookies."
   },
   "shared_requests": {
     "button": "Button",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1238,7 +1238,10 @@
     "url_placeholder": "Enter a URL or paste a cURL command",
     "variables": "Variables",
     "view_my_links": "View my links",
-    "generate_name_error": "Failed to generate request name."
+    "generate_name_error": "Failed to generate request name.",
+    "disable_cookies": "Disable cookie jar",
+    "disable_cookies_default": "(Default: Settings)",
+    "disable_cookies_description": "Prevent cookies used in this request from being stored in the cookie jar. Existing cookies in the cookie jar will not be added as headers for this request."
   },
   "response": {
     "audio": "Audio",
@@ -1387,11 +1390,11 @@
     "theme_description": "Customize your application theme.",
     "update_check_description": "Manually check for a new version and install it. Works regardless of the toggle below.",
     "update_check_now": "Check for updates",
-    "update_checking": "Checking\u2026",
+    "update_checking": "Checking…",
     "update_download_version": "Download v{version}",
-    "update_downloading": "Downloading\u2026",
+    "update_downloading": "Downloading…",
     "update_downloading_percent": "Downloading {percent}%",
-    "update_installing": "Installing\u2026",
+    "update_installing": "Installing…",
     "update_restart_now": "Restart to apply update",
     "update_up_to_date": "Up to date",
     "use_experimental_url_bar": "Use experimental URL bar with environment highlighting",
@@ -1424,7 +1427,10 @@
     "ca_certificates": "CA Certificates",
     "ca_certificates_support": "Hoppscotch supports .crt, .cer or .pem files containing one or more certificates.",
     "proxy_capabilities": "Hoppscotch Agent and Desktop App supports HTTP/HTTPS/SOCKS proxies with NTLM and Basic Auth support.",
-    "proxy_auth": "You can also include username and password in the URL."
+    "proxy_auth": "You can also include username and password in the URL.",
+    "network": "Network",
+    "disable_cookies": "Disable cookies",
+    "disable_cookies_description": "Disable cookie jar for all requests."
   },
   "shared_requests": {
     "button": "Button",
@@ -1852,7 +1858,8 @@
     "websocket": "WebSocket",
     "all_tests": "All Tests",
     "passed": "Passed",
-    "failed": "Failed"
+    "failed": "Failed",
+    "settings": "Settings"
   },
   "team": {
     "activity_logs": "Activity Logs",

--- a/packages/hoppscotch-common/src/components.d.ts
+++ b/packages/hoppscotch-common/src/components.d.ts
@@ -212,6 +212,7 @@ declare module 'vue' {
     HttpReqChangeConfirmModal: typeof import('./components/http/ReqChangeConfirmModal.vue')['default']
     HttpRequest: typeof import('./components/http/Request.vue')['default']
     HttpRequestOptions: typeof import('./components/http/RequestOptions.vue')['default']
+    HttpRequestSettings: typeof import('./components/http/RequestSettings.vue')['default']
     HttpRequestTab: typeof import('./components/http/RequestTab.vue')['default']
     HttpRequestVariables: typeof import('./components/http/RequestVariables.vue')['default']
     HttpResponse: typeof import('./components/http/Response.vue')['default']

--- a/packages/hoppscotch-common/src/components/http/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestOptions.vue
@@ -91,6 +91,14 @@
     >
       <HttpRequestVariables v-model="request.requestVariables" />
     </HoppSmartTab>
+    <HoppSmartTab
+      v-if="properties?.includes('settings') ?? true"
+      :id="'settings'"
+      :label="'Settings'"
+      :align-last="true"
+    >
+      <HttpRequestSettings v-model="request.requestOptions" />
+    </HoppSmartTab>
   </HoppSmartTabs>
 </template>
 
@@ -116,6 +124,7 @@ const _VALID_OPTION_TABS = [
   "preRequestScript",
   "tests",
   "requestVariables",
+  "settings",
 ] as const
 
 export type RESTOptionTabs = (typeof _VALID_OPTION_TABS)[number]

--- a/packages/hoppscotch-common/src/components/http/RequestOptions.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestOptions.vue
@@ -92,12 +92,15 @@
       <HttpRequestVariables v-model="request.requestVariables" />
     </HoppSmartTab>
     <HoppSmartTab
-      v-if="properties?.includes('settings') ?? true"
+      v-if="(properties?.includes('settings') ?? true) && 'requestOptions' in request"
       :id="'settings'"
-      :label="'Settings'"
+      :label="`${t('tab.settings')}`"
       :align-last="true"
     >
-      <HttpRequestSettings v-model="request.requestOptions" />
+      <HttpRequestSettings
+        v-if="'requestOptions' in request"
+        v-model="request.requestOptions"
+      />
     </HoppSmartTab>
   </HoppSmartTabs>
 </template>

--- a/packages/hoppscotch-common/src/components/http/RequestSettings.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestSettings.vue
@@ -1,0 +1,59 @@
+<template>
+  <div class="flex flex-col">
+    <div
+      class="sticky top-upperMobileSecondaryStickyFold z-10 flex flex-shrink-0 items-center justify-between overflow-x-auto border-b border-dividerLight bg-primary px-4 py-2 sm:top-upperSecondaryStickyFold"
+    >
+      <label class="truncate font-semibold text-secondaryLight">
+        {{ t('tab.settings') || 'Settings' }}
+      </label>
+    </div>
+    <div class="flex flex-col p-4 space-y-4">
+      <div class="flex flex-col">
+        <div class="flex items-center justify-between">
+          <span class="font-semibold text-secondaryDark">
+            Disable cookie jar
+            <span class="text-secondaryLight font-normal text-xs ml-2">(Default: Settings)</span>
+          </span>
+          <HoppSmartToggle
+            :on="disableCookies"
+            @change="disableCookies = !disableCookies"
+          >
+            {{ disableCookies ? 'ON' : 'OFF' }}
+          </HoppSmartToggle>
+        </div>
+        <p class="mt-2 text-secondaryLight">
+          Prevent cookies used in this request from being stored in the cookie jar. Existing cookies in the cookie jar will not be added as headers for this request.
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { useVModel } from "@vueuse/core"
+import { HoppRESTRequestOptions } from "@hoppscotch/data"
+import { useI18n } from "@composables/i18n"
+
+const t = useI18n()
+
+const props = defineProps<{
+  modelValue?: HoppRESTRequestOptions
+}>()
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: HoppRESTRequestOptions): void
+}>()
+
+const requestOptions = useVModel(props, "modelValue", emit)
+
+const disableCookies = computed({
+  get: () => requestOptions.value?.disableCookies ?? false,
+  set: (val: boolean) => {
+    requestOptions.value = {
+      ...(requestOptions.value || {}),
+      disableCookies: val,
+    }
+  },
+})
+</script>

--- a/packages/hoppscotch-common/src/components/http/RequestSettings.vue
+++ b/packages/hoppscotch-common/src/components/http/RequestSettings.vue
@@ -11,8 +11,8 @@
       <div class="flex flex-col">
         <div class="flex items-center justify-between">
           <span class="font-semibold text-secondaryDark">
-            Disable cookie jar
-            <span class="text-secondaryLight font-normal text-xs ml-2">(Default: Settings)</span>
+            {{ t('request.disable_cookies') }}
+            <span class="text-secondaryLight font-normal text-xs ml-2">{{ t('request.disable_cookies_default') }}</span>
           </span>
           <HoppSmartToggle
             :on="disableCookies"
@@ -21,8 +21,8 @@
             {{ disableCookies ? 'ON' : 'OFF' }}
           </HoppSmartToggle>
         </div>
-        <p class="mt-2 text-secondaryLight">
-          Prevent cookies used in this request from being stored in the cookie jar. Existing cookies in the cookie jar will not be added as headers for this request.
+        <p class="mt-2 text-secondaryLight text-tiny">
+          {{ t('request.disable_cookies_description') }}
         </p>
       </div>
     </div>

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -653,8 +653,14 @@ export function runRESTRequest$(
             }
 
             const updatedCookies = postRequestScriptResult.right.updatedCookies
+            const finalCookieJarDisabled =
+              getEffectiveCookieJarDisabled(finalRequest)
 
-            if (updatedCookies && cookieJarEntries !== null) {
+            if (
+              updatedCookies &&
+              cookieJarEntries !== null &&
+              !finalCookieJarDisabled
+            ) {
               // The script's `updatedCookies` is the post-script state of
               // its pre-script view, so a set difference against the
               // pre-script snapshot gives the actual mutations. Cookies

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -389,7 +389,11 @@ const delegatePreRequestScriptRunner = (
     })
   }
 
-  const hoppFetchHook = createHoppFetchHook(kernelInterceptorService)
+  const hoppFetchHook = createHoppFetchHook(
+    kernelInterceptorService,
+    undefined,
+    getEffectiveCookieJarDisabled(request)
+  )
 
   return runPreRequestScript(combinedScript, {
     envs,
@@ -437,7 +441,11 @@ const runPostRequestScript = (
     })
   }
 
-  const hoppFetchHook = createHoppFetchHook(kernelInterceptorService)
+  const hoppFetchHook = createHoppFetchHook(
+    kernelInterceptorService,
+    undefined,
+    getEffectiveCookieJarDisabled(request)
+  )
 
   return runTestScript(combinedScript, {
     envs,
@@ -885,7 +893,8 @@ export async function runTestRunnerRequest(
     }>
   | undefined
 > {
-  const cookieJarEntries = getCookieJarEntries()
+  const disableCookies = getEffectiveCookieJarDisabled(request)
+  const cookieJarEntries = disableCookies ? null : getCookieJarEntries()
 
   const {
     initialGlobalEnvs,

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -76,6 +76,7 @@ import {
 import { transformInheritedCollectionVariablesToAggregateEnv } from "./utils/inheritedCollectionVarTransformer"
 import { isJSONContentType } from "./utils/contenttypes"
 import { applyScriptRequestUpdates } from "./experimental-sandbox-integration"
+import { getEffectiveCookieJarDisabled } from "~/helpers/utils/cookiePolicy"
 
 const secretEnvironmentService = getService(SecretEnvironmentService)
 const currentEnvironmentValueService = getService(CurrentValueService)
@@ -352,12 +353,7 @@ const getEnvironmentVariableValue = (
   )
 }
 
-export function getEffectiveCookieJarDisabled(request: HoppRESTRequest): boolean {
-  return (
-    (request.requestOptions?.disableCookies ?? false) ||
-    settingsStore.value.DISABLE_COOKIES
-  )
-}
+
 
 const delegatePreRequestScriptRunner = (
   request: HoppRESTRequest,

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -26,6 +26,7 @@ import { map } from "fp-ts/Either"
 
 import { runPreRequestScript, runTestScript } from "@hoppscotch/js-sandbox/web"
 import { useSetting } from "~/composables/settings"
+import { settingsStore } from "~/newstore/settings"
 import { getService } from "~/modules/dioc"
 import {
   combineScriptsWithIIFE,
@@ -465,7 +466,11 @@ export function runRESTRequest$(
     cancelFunc?.()
   }
 
-  const cookieJarEntries = getCookieJarEntries()
+  const cookieJarDisabled =
+    (tab.value.document.request.requestOptions?.disableCookies ?? false) ||
+    settingsStore.value.DISABLE_COOKIES
+
+  const cookieJarEntries = cookieJarDisabled ? null : getCookieJarEntries()
 
   const { request, inheritedProperties } = tab.value.document
 

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -481,9 +481,9 @@ export function runRESTRequest$(
     cancelFunc?.()
   }
 
-  const cookieJarDisabled =
-    (tab.value.document.request.requestOptions?.disableCookies ?? false) ||
-    settingsStore.value.DISABLE_COOKIES
+  const cookieJarDisabled = getEffectiveCookieJarDisabled(
+    tab.value.document.request
+  )
 
   const cookieJarEntries = cookieJarDisabled ? null : getCookieJarEntries()
 

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -352,6 +352,13 @@ const getEnvironmentVariableValue = (
   )
 }
 
+export function getEffectiveCookieJarDisabled(request: HoppRESTRequest): boolean {
+  return (
+    (request.requestOptions?.disableCookies ?? false) ||
+    settingsStore.value.DISABLE_COOKIES
+  )
+}
+
 const delegatePreRequestScriptRunner = (
   request: HoppRESTRequest,
   envs: {

--- a/packages/hoppscotch-common/src/helpers/RequestRunner.ts
+++ b/packages/hoppscotch-common/src/helpers/RequestRunner.ts
@@ -76,7 +76,10 @@ import {
 import { transformInheritedCollectionVariablesToAggregateEnv } from "./utils/inheritedCollectionVarTransformer"
 import { isJSONContentType } from "./utils/contenttypes"
 import { applyScriptRequestUpdates } from "./experimental-sandbox-integration"
-import { getEffectiveCookieJarDisabled } from "~/helpers/utils/cookiePolicy"
+import {
+  getEffectiveCookieJarDisabled,
+  getCookiePolicy,
+} from "~/helpers/utils/cookiePolicy"
 
 const secretEnvironmentService = getService(SecretEnvironmentService)
 const currentEnvironmentValueService = getService(CurrentValueService)
@@ -395,7 +398,7 @@ const delegatePreRequestScriptRunner = (
   const hoppFetchHook = createHoppFetchHook(
     kernelInterceptorService,
     undefined,
-    getEffectiveCookieJarDisabled(request)
+    getCookiePolicy(request)
   )
 
   return runPreRequestScript(combinedScript, {
@@ -447,7 +450,7 @@ const runPostRequestScript = (
   const hoppFetchHook = createHoppFetchHook(
     kernelInterceptorService,
     undefined,
-    getEffectiveCookieJarDisabled(request)
+    getCookiePolicy(request)
   )
 
   return runTestScript(combinedScript, {

--- a/packages/hoppscotch-common/src/helpers/__tests__/hopp-fetch.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/hopp-fetch.spec.ts
@@ -359,6 +359,51 @@ describe("Common hopp-fetch", () => {
       )
     })
 
+    it("should not allow script to relax initial request isolation policy", async () => {
+      const hoppFetch = createHoppFetchHook(mockKernelInterceptor, undefined, {
+        globalDisabled: false,
+        requestDisabled: true, // Initial request had cookies disabled
+      })
+
+      // The pre-request script attempts to mutate the request and enable cookies.
+      // This sends an explicit false marker, but the initial restrictive policy should be preserved.
+      await hoppFetch("https://api.example.com/data", {
+        __hoppDisableCookies: false,
+      } as any)
+
+      expect(mockKernelInterceptor.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            options: expect.objectContaining({
+              cookies: false, // Cookies MUST remain disabled
+            }),
+          }),
+        })
+      )
+    })
+
+    it("should allow script to dynamically enable isolation when request starts enabled", async () => {
+      const hoppFetch = createHoppFetchHook(mockKernelInterceptor, undefined, {
+        globalDisabled: false,
+        requestDisabled: false, // Initial request has cookies enabled
+      })
+
+      // Script disables cookies
+      await hoppFetch("https://api.example.com/data", {
+        __hoppDisableCookies: true,
+      } as any)
+
+      expect(mockKernelInterceptor.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            options: expect.objectContaining({
+              cookies: false, // Cookies became disabled
+            }),
+          }),
+        })
+      )
+    })
+
     it("should handle FormData body", async () => {
       const hoppFetch = createHoppFetchHook(mockKernelInterceptor)
 

--- a/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
+++ b/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
@@ -33,15 +33,14 @@ export const createHoppFetchHook = (
       timestamp: Date.now(),
     })
 
-    // Convert Fetch API request to RelayRequest.
     // `__hoppDisableCookies` is a hidden non-enumerable property stamped by the
     // pre-request sandbox fetch wrapper at call time, so it reflects any
-    // requestOptions.disableCookies mutation made by the script — overriding
-    // the static snapshot captured when the hook was constructed.
+    // requestOptions.disableCookies mutation made by the script.
+    // We OR with the static snapshot so the global "Disable cookies" setting
+    // can never be overridden by a request-level false value from the script.
     const effectiveCookieJarDisabled =
-      typeof (init as any)?.__hoppDisableCookies === "boolean"
-        ? (init as any).__hoppDisableCookies
-        : cookieJarDisabled
+      cookieJarDisabled === true ||
+      (init as any)?.__hoppDisableCookies === true
 
     const relayRequest = await convertFetchToRelayRequest(
       input,

--- a/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
+++ b/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
@@ -14,7 +14,8 @@ import type { RelayRequest } from "@hoppscotch/kernel"
  */
 export const createHoppFetchHook = (
   kernelInterceptor: KernelInterceptorService,
-  onFetchCall?: (meta: FetchCallMeta) => void
+  onFetchCall?: (meta: FetchCallMeta) => void,
+  cookieJarDisabled?: boolean
 ): HoppFetchHook => {
   return async (input, init) => {
     const urlStr =
@@ -33,7 +34,11 @@ export const createHoppFetchHook = (
     })
 
     // Convert Fetch API request to RelayRequest
-    const relayRequest = await convertFetchToRelayRequest(input, init)
+    const relayRequest = await convertFetchToRelayRequest(
+      input,
+      init,
+      cookieJarDisabled
+    )
 
     // Execute via interceptor
     const execution = kernelInterceptor.execute(relayRequest)
@@ -66,7 +71,8 @@ export const createHoppFetchHook = (
  */
 async function convertFetchToRelayRequest(
   input: RequestInfo | URL,
-  init?: RequestInit
+  init?: RequestInit,
+  cookieJarDisabled?: boolean
 ): Promise<RelayRequest> {
   const urlStr =
     typeof input === "string"
@@ -199,6 +205,11 @@ async function convertFetchToRelayRequest(
     params: undefined, // Undefined so preProcessRelayRequest doesn't try to process it
     auth: { kind: "none" }, // Required field - no auth for fetch()
     content,
+    meta: {
+      options: {
+        cookies: !cookieJarDisabled,
+      },
+    },
     // Note: auth, proxy, security are inherited from interceptor configuration
   }
 

--- a/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
+++ b/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
@@ -34,14 +34,17 @@ export const createHoppFetchHook = (
       timestamp: Date.now(),
     })
 
-    // Extract the marker transmitted across the sandbox bridge.
-    // This enumerable property is stamped by the sandbox wrapper to reflect
-    // the live script-mutated requestOptions.disableCookies value.
+    // Extract the markers transmitted across the sandbox bridge.
     const scriptRequestDisabled = (init as any)?.__hoppDisableCookies
+    const initWasUndefined = (init as any)?.__hoppInitWasUndefined
 
-    // Clean up the marker so it doesn't leak into the relay request or native fetch
-    if (init && "__hoppDisableCookies" in init) {
+    // Clean up the markers so they don't leak into the relay request or native fetch
+    if (init && ("__hoppDisableCookies" in init || "__hoppInitWasUndefined" in init)) {
       delete (init as any).__hoppDisableCookies
+      delete (init as any).__hoppInitWasUndefined
+      if (initWasUndefined) {
+        init = undefined
+      }
     }
 
     // Use the live request-level value if provided by the sandbox, otherwise

--- a/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
+++ b/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
@@ -10,12 +10,13 @@ import type { RelayRequest } from "@hoppscotch/kernel"
  *
  * @param kernelInterceptor - The kernel interceptor service instance
  * @param onFetchCall - Optional callback to track fetch calls for inspector warnings
+ * @param cookiePolicy - Snapshots of the global and request-level cookie isolation settings
  * @returns HoppFetchHook implementation
  */
 export const createHoppFetchHook = (
   kernelInterceptor: KernelInterceptorService,
   onFetchCall?: (meta: FetchCallMeta) => void,
-  cookieJarDisabled?: boolean
+  cookiePolicy?: { globalDisabled: boolean; requestDisabled: boolean }
 ): HoppFetchHook => {
   return async (input, init) => {
     const urlStr =
@@ -33,14 +34,27 @@ export const createHoppFetchHook = (
       timestamp: Date.now(),
     })
 
-    // `__hoppDisableCookies` is a hidden non-enumerable property stamped by the
-    // pre-request sandbox fetch wrapper at call time, so it reflects any
-    // requestOptions.disableCookies mutation made by the script.
-    // We OR with the static snapshot so the global "Disable cookies" setting
-    // can never be overridden by a request-level false value from the script.
+    // Extract the marker transmitted across the sandbox bridge.
+    // This enumerable property is stamped by the sandbox wrapper to reflect
+    // the live script-mutated requestOptions.disableCookies value.
+    const scriptRequestDisabled = (init as any)?.__hoppDisableCookies
+
+    // Clean up the marker so it doesn't leak into the relay request or native fetch
+    if (init && "__hoppDisableCookies" in init) {
+      delete (init as any).__hoppDisableCookies
+    }
+
+    // Use the live request-level value if provided by the sandbox, otherwise
+    // fall back to the static snapshot captured when the hook was created.
+    const requestDisabled =
+      typeof scriptRequestDisabled === "boolean"
+        ? scriptRequestDisabled
+        : cookiePolicy?.requestDisabled ?? false
+
+    // Combine with the global policy: if globally disabled, cookies are disabled
+    // regardless of the request-level setting.
     const effectiveCookieJarDisabled =
-      cookieJarDisabled === true ||
-      (init as any)?.__hoppDisableCookies === true
+      (cookiePolicy?.globalDisabled ?? false) || requestDisabled
 
     const relayRequest = await convertFetchToRelayRequest(
       input,

--- a/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
+++ b/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
@@ -47,12 +47,14 @@ export const createHoppFetchHook = (
       }
     }
 
-    // Use the live request-level value if provided by the sandbox, otherwise
-    // fall back to the static snapshot captured when the hook was created.
+    // If the request started with cookies disabled, a script cannot relax that isolation.
+    // If it started enabled, a script can disable them dynamically.
+    const initialRequestDisabled = cookiePolicy?.requestDisabled ?? false
     const requestDisabled =
-      typeof scriptRequestDisabled === "boolean"
+      initialRequestDisabled ||
+      (typeof scriptRequestDisabled === "boolean"
         ? scriptRequestDisabled
-        : cookiePolicy?.requestDisabled ?? false
+        : false)
 
     // Combine with the global policy: if globally disabled, cookies are disabled
     // regardless of the request-level setting.

--- a/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
+++ b/packages/hoppscotch-common/src/helpers/hopp-fetch.ts
@@ -33,11 +33,20 @@ export const createHoppFetchHook = (
       timestamp: Date.now(),
     })
 
-    // Convert Fetch API request to RelayRequest
+    // Convert Fetch API request to RelayRequest.
+    // `__hoppDisableCookies` is a hidden non-enumerable property stamped by the
+    // pre-request sandbox fetch wrapper at call time, so it reflects any
+    // requestOptions.disableCookies mutation made by the script — overriding
+    // the static snapshot captured when the hook was constructed.
+    const effectiveCookieJarDisabled =
+      typeof (init as any)?.__hoppDisableCookies === "boolean"
+        ? (init as any).__hoppDisableCookies
+        : cookieJarDisabled
+
     const relayRequest = await convertFetchToRelayRequest(
       input,
       init,
-      cookieJarDisabled
+      effectiveCookieJarDisabled
     )
 
     // Execute via interceptor

--- a/packages/hoppscotch-common/src/helpers/kernel/rest/request.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/rest/request.ts
@@ -13,6 +13,7 @@ import {
   filterActiveParams,
 } from "~/helpers/functional/filter-active"
 import { settingsStore } from "~/newstore/settings"
+import { getEffectiveCookieJarDisabled } from "~/helpers/RequestRunner"
 
 export const RESTRequest = {
   async toRequest(request: EffectiveHoppRESTRequest): Promise<RelayRequest> {
@@ -41,10 +42,7 @@ export const RESTRequest = {
       content,
       meta: {
         options: {
-          cookies: !(
-            (request.requestOptions?.disableCookies ?? false) ||
-            settingsStore.value.DISABLE_COOKIES
-          )
+          cookies: !getEffectiveCookieJarDisabled(request as any)
         }
       }
     }

--- a/packages/hoppscotch-common/src/helpers/kernel/rest/request.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/rest/request.ts
@@ -12,8 +12,7 @@ import {
   filterActiveToRecord,
   filterActiveParams,
 } from "~/helpers/functional/filter-active"
-import { settingsStore } from "~/newstore/settings"
-import { getEffectiveCookieJarDisabled } from "~/helpers/RequestRunner"
+import { getEffectiveCookieJarDisabled } from "~/helpers/utils/cookiePolicy"
 
 export const RESTRequest = {
   async toRequest(request: EffectiveHoppRESTRequest): Promise<RelayRequest> {

--- a/packages/hoppscotch-common/src/helpers/kernel/rest/request.ts
+++ b/packages/hoppscotch-common/src/helpers/kernel/rest/request.ts
@@ -12,6 +12,7 @@ import {
   filterActiveToRecord,
   filterActiveParams,
 } from "~/helpers/functional/filter-active"
+import { settingsStore } from "~/newstore/settings"
 
 export const RESTRequest = {
   async toRequest(request: EffectiveHoppRESTRequest): Promise<RelayRequest> {
@@ -38,6 +39,14 @@ export const RESTRequest = {
       params,
       auth,
       content,
+      meta: {
+        options: {
+          cookies: !(
+            (request.requestOptions?.disableCookies ?? false) ||
+            settingsStore.value.DISABLE_COOKIES
+          )
+        }
+      }
     }
   },
 }

--- a/packages/hoppscotch-common/src/helpers/utils/cookiePolicy.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/cookiePolicy.ts
@@ -1,0 +1,15 @@
+import { HoppRESTRequest } from "@hoppscotch/data"
+import { settingsStore } from "~/newstore/settings"
+
+/**
+ * Evaluates the effective cookie isolation policy for a request.
+ * Cookies are disabled if the per-request control or the global setting is enabled.
+ */
+export function getEffectiveCookieJarDisabled(
+  request: HoppRESTRequest
+): boolean {
+  return (
+    (request.requestOptions?.disableCookies ?? false) ||
+    settingsStore.value.DISABLE_COOKIES
+  )
+}

--- a/packages/hoppscotch-common/src/helpers/utils/cookiePolicy.ts
+++ b/packages/hoppscotch-common/src/helpers/utils/cookiePolicy.ts
@@ -13,3 +13,14 @@ export function getEffectiveCookieJarDisabled(
     settingsStore.value.DISABLE_COOKIES
   )
 }
+
+/**
+ * Evaluates the cookie isolation policy for a request and returns the parts,
+ * preserving provenance so that scripts can override the request-level setting.
+ */
+export function getCookiePolicy(request: HoppRESTRequest) {
+  return {
+    globalDisabled: settingsStore.value.DISABLE_COOKIES,
+    requestDisabled: request.requestOptions?.disableCookies ?? false,
+  }
+}

--- a/packages/hoppscotch-common/src/newstore/settings.ts
+++ b/packages/hoppscotch-common/src/newstore/settings.ts
@@ -85,6 +85,7 @@ export type SettingsDef = {
   EXPERIMENTAL_SCRIPTING_SANDBOX: boolean
   ENABLE_EXPERIMENTAL_MOCK_SERVERS: boolean
   ENABLE_EXPERIMENTAL_DOCUMENTATION: boolean
+  DISABLE_COOKIES: boolean
 }
 
 export const getDefaultSettings = (): SettingsDef => {
@@ -144,6 +145,7 @@ export const getDefaultSettings = (): SettingsDef => {
     EXPERIMENTAL_SCRIPTING_SANDBOX: true,
     ENABLE_EXPERIMENTAL_MOCK_SERVERS: true,
     ENABLE_EXPERIMENTAL_DOCUMENTATION: true,
+    DISABLE_COOKIES: false,
   }
 }
 

--- a/packages/hoppscotch-common/src/pages/settings.vue
+++ b/packages/hoppscotch-common/src/pages/settings.vue
@@ -185,24 +185,24 @@
             </div>
           </section>
 
-          <section>
-            <h4 class="font-semibold text-secondaryDark">
-              {{ t("settings.network") || 'Network' }}
-            </h4>
-            <div class="mt-4 space-y-2">
+          <div class="mb-8 flex flex-col">
+            <h2 class="mb-4 font-semibold text-secondaryDark">
+              {{ t("settings.network") }}
+            </h2>
+            <div class="flex flex-col space-y-4">
               <div class="flex items-center">
                 <HoppSmartToggle
                   :on="DISABLE_COOKIES"
                   @change="toggleSetting('DISABLE_COOKIES')"
                 >
-                  Disable cookies
+                  {{ t("settings.disable_cookies") }}
                 </HoppSmartToggle>
               </div>
-              <div class="text-secondaryLight">
-                Disable cookie jar for all requests.
-              </div>
+              <p class="mt-2 text-secondaryLight text-tiny">
+                {{ t("settings.disable_cookies_description") }}
+              </p>
             </div>
-          </section>
+          </div>
         </div>
       </div>
 

--- a/packages/hoppscotch-common/src/pages/settings.vue
+++ b/packages/hoppscotch-common/src/pages/settings.vue
@@ -184,6 +184,25 @@
               </div>
             </div>
           </section>
+
+          <section>
+            <h4 class="font-semibold text-secondaryDark">
+              {{ t("settings.network") || 'Network' }}
+            </h4>
+            <div class="mt-4 space-y-2">
+              <div class="flex items-center">
+                <HoppSmartToggle
+                  :on="DISABLE_COOKIES"
+                  @change="toggleSetting('DISABLE_COOKIES')"
+                >
+                  Disable cookies
+                </HoppSmartToggle>
+              </div>
+              <div class="text-secondaryLight">
+                Disable cookie jar for all requests.
+              </div>
+            </div>
+          </section>
         </div>
       </div>
 
@@ -328,6 +347,7 @@ const CUSTOM_NAMING_STYLE = useSetting("CUSTOM_NAMING_STYLE")
 const EXPERIMENTAL_SCRIPTING_SANDBOX = useSetting(
   "EXPERIMENTAL_SCRIPTING_SANDBOX"
 )
+const DISABLE_COOKIES = useSetting("DISABLE_COOKIES")
 const ENABLE_EXPERIMENTAL_MOCK_SERVERS = useSetting(
   "ENABLE_EXPERIMENTAL_MOCK_SERVERS"
 )

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -58,7 +58,6 @@ const SettingsDefSchema = z.object({
       httpRequestBody: z.boolean().catch(true),
       httpResponseBody: z.boolean().catch(true),
       httpHeaders: z.boolean().catch(true),
-      httpParams: z.boolean().catch(true),
       httpUrlEncoded: z.boolean().catch(true),
       httpPreRequest: z.boolean().catch(true),
       httpTest: z.boolean().catch(true),
@@ -86,6 +85,7 @@ const SettingsDefSchema = z.object({
   EXPERIMENTAL_SCRIPTING_SANDBOX: z.optional(z.boolean()),
   ENABLE_EXPERIMENTAL_MOCK_SERVERS: z.optional(z.boolean()),
   ENABLE_EXPERIMENTAL_DOCUMENTATION: z.optional(z.boolean()),
+  DISABLE_COOKIES: z.boolean().catch(false),
 })
 
 const HoppRESTRequestSchema = entityReference(HoppRESTRequest)

--- a/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
+++ b/packages/hoppscotch-common/src/services/persistence/validation-schemas/index.ts
@@ -58,6 +58,7 @@ const SettingsDefSchema = z.object({
       httpRequestBody: z.boolean().catch(true),
       httpResponseBody: z.boolean().catch(true),
       httpHeaders: z.boolean().catch(true),
+      httpParams: z.boolean().catch(true),
       httpUrlEncoded: z.boolean().catch(true),
       httpPreRequest: z.boolean().catch(true),
       httpTest: z.boolean().catch(true),

--- a/packages/hoppscotch-data/src/rest/index.ts
+++ b/packages/hoppscotch-data/src/rest/index.ts
@@ -28,6 +28,7 @@ import V16_VERSION from "./v/16"
 import { HoppRESTRequestResponses } from "../rest-request-response"
 import { generateUniqueRefId } from "../utils/collection"
 import V17_VERSION from "./v/17"
+import V18_VERSION, { HoppRESTRequestOptions } from "./v/18"
 
 export * from "./content-types"
 
@@ -39,6 +40,8 @@ export {
 } from "./v/1"
 
 export { HoppRESTRequestVariables } from "./v/2"
+
+export { HoppRESTRequestOptions } from "./v/18"
 
 export { HoppRESTAuthAPIKey } from "./v/4"
 
@@ -78,7 +81,7 @@ const versionedObject = z.object({
 })
 
 export const HoppRESTRequest = createVersionedEntity({
-  latestVersion: 17,
+  latestVersion: 18,
   versionMap: {
     0: V0_VERSION,
     1: V1_VERSION,
@@ -98,6 +101,7 @@ export const HoppRESTRequest = createVersionedEntity({
     15: V15_VERSION,
     16: V16_VERSION,
     17: V17_VERSION,
+    18: V18_VERSION,
   },
   getVersion(data) {
     // For V1 onwards we have the v string storing the number
@@ -140,9 +144,10 @@ const HoppRESTRequestEq = Eq.struct<HoppRESTRequest>({
   responses: lodashIsEqualEq,
   _ref_id: undefinedEq(S.Eq),
   description: lodashIsEqualEq,
+  requestOptions: lodashIsEqualEq,
 })
 
-export const RESTReqSchemaVersion = "17"
+export const RESTReqSchemaVersion = "18"
 
 export type HoppRESTParam = HoppRESTRequest["params"][number]
 export type HoppRESTHeader = HoppRESTRequest["headers"][number]
@@ -234,6 +239,13 @@ export function safelyExtractRESTRequest(
     if ("description" in x && typeof x.description === "string") {
       req.description = x.description
     }
+
+    if ("requestOptions" in x) {
+      const result = HoppRESTRequestOptions.safeParse(x.requestOptions)
+      if (result.success) {
+        req.requestOptions = result.data
+      }
+    }
   }
 
   return req
@@ -272,6 +284,9 @@ export function getDefaultRESTRequest(): HoppRESTRequest {
     responses: {},
     _ref_id: ref_id,
     description: null,
+    requestOptions: {
+      disableCookies: false,
+    },
   }
 }
 

--- a/packages/hoppscotch-data/src/rest/v/18.ts
+++ b/packages/hoppscotch-data/src/rest/v/18.ts
@@ -10,7 +10,7 @@ export type HoppRESTRequestOptions = z.infer<typeof HoppRESTRequestOptions>
 
 export const V18_SCHEMA = V17_SCHEMA.extend({
   v: z.literal("18"),
-  requestOptions: HoppRESTRequestOptions.catch({ disableCookies: false }).default({ disableCookies: false }),
+  requestOptions: HoppRESTRequestOptions.catch({ disableCookies: false }).optional(),
 })
 
 const V18_VERSION = defineVersion({

--- a/packages/hoppscotch-data/src/rest/v/18.ts
+++ b/packages/hoppscotch-data/src/rest/v/18.ts
@@ -1,0 +1,30 @@
+import { z } from "zod"
+import { defineVersion } from "verzod"
+import { V17_SCHEMA } from "./17"
+
+export const HoppRESTRequestOptions = z.object({
+  disableCookies: z.boolean().catch(false).default(false),
+})
+
+export type HoppRESTRequestOptions = z.infer<typeof HoppRESTRequestOptions>
+
+export const V18_SCHEMA = V17_SCHEMA.extend({
+  v: z.literal("18"),
+  requestOptions: HoppRESTRequestOptions.catch({ disableCookies: false }).default({ disableCookies: false }),
+})
+
+const V18_VERSION = defineVersion({
+  schema: V18_SCHEMA,
+  initial: false,
+  up(old: z.infer<typeof V17_SCHEMA>) {
+    return {
+      ...old,
+      v: "18" as const,
+      requestOptions: {
+        disableCookies: false,
+      },
+    }
+  },
+})
+
+export default V18_VERSION

--- a/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
+++ b/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
@@ -209,23 +209,19 @@
         const disableCookies =
           (currentReqProps.requestOptions &&
             currentReqProps.requestOptions.disableCookies) === true
-        // Only create a patched init when one was provided; passing an empty
-        // object in place of undefined can alter fetch semantics for some hooks.
         const patchedInit = init !== undefined && init !== null
           ? Object.assign({}, init)
-          : undefined
+          : { __hoppInitWasUndefined: true }
           
-        if (patchedInit !== undefined) {
-          // Enumerable so it survives vm.dump serialization across the sandbox bridge
-          Object.defineProperty(patchedInit, "__hoppDisableCookies", {
-            value: disableCookies,
-            enumerable: true,
-            configurable: false,
-            writable: false,
-          })
-        }
+        // Enumerable so it survives vm.dump serialization across the sandbox bridge
+        Object.defineProperty(patchedInit, "__hoppDisableCookies", {
+          value: disableCookies,
+          enumerable: true,
+          configurable: false,
+          writable: false,
+        })
         
-        return _nativeFetch(input, patchedInit !== undefined ? patchedInit : (disableCookies ? { __hoppDisableCookies: true } : undefined))
+        return _nativeFetch(input, patchedInit)
       }
     })(),
   }

--- a/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
+++ b/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
@@ -69,6 +69,26 @@
     })
   })
 
+  // Special handling for requestOptions: support nested mutations via Proxy
+  Object.defineProperty(requestProps, "requestOptions", {
+    enumerable: true,
+    configurable: false,
+    get() {
+      const currentValues = inputs.getRequestProps()
+      const opts = currentValues.requestOptions || {}
+      return new Proxy(opts, {
+        set(target, prop, value) {
+          target[prop] = value
+          inputs.setRequestOptions(target)
+          return true
+        },
+      })
+    },
+    set(_value) {
+      throw new TypeError("hopp.request.requestOptions is read-only")
+    },
+  })
+
   // Freeze the entire requestProps object for additional protection
   Object.freeze(requestProps)
 
@@ -179,10 +199,27 @@
       clear: (domain) => inputs.cookieClear(domain),
     },
     // Expose fetch as hopp.fetch() for explicit access
-    // Note: This exposes the fetch implementation provided by the host environment via hoppFetchHook
-    // (injected in cage.ts during sandbox initialization), not the native browser fetch.
-    // This allows requests to respect interceptor settings.
-    fetch: fetch,
+    // The wrapper reads requestOptions.disableCookies at the time of the call
+    // so that pre-request script mutations are honoured even if the hook was
+    // constructed with the pre-script snapshot.
+    fetch: (function () {
+      const _nativeFetch = fetch
+      return function (input, init) {
+        const currentReqProps = inputs.getRequestProps()
+        const disableCookies =
+          (currentReqProps.requestOptions &&
+            currentReqProps.requestOptions.disableCookies) === true
+        const patchedInit = Object.assign({}, init)
+        // Non-enumerable so user scripts cannot accidentally read or overwrite it
+        Object.defineProperty(patchedInit, "__hoppDisableCookies", {
+          value: disableCookies,
+          enumerable: false,
+          configurable: false,
+          writable: false,
+        })
+        return _nativeFetch(input, patchedInit)
+      }
+    })(),
   }
 
   // Make global fetch() an alias to hopp.fetch()

--- a/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
+++ b/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
@@ -213,15 +213,19 @@
         // object in place of undefined can alter fetch semantics for some hooks.
         const patchedInit = init !== undefined && init !== null
           ? Object.assign({}, init)
-          : {}
-        // Non-enumerable so user scripts cannot accidentally read or overwrite it
-        Object.defineProperty(patchedInit, "__hoppDisableCookies", {
-          value: disableCookies,
-          enumerable: false,
-          configurable: false,
-          writable: false,
-        })
-        return _nativeFetch(input, patchedInit)
+          : undefined
+          
+        if (patchedInit !== undefined) {
+          // Enumerable so it survives vm.dump serialization across the sandbox bridge
+          Object.defineProperty(patchedInit, "__hoppDisableCookies", {
+            value: disableCookies,
+            enumerable: true,
+            configurable: false,
+            writable: false,
+          })
+        }
+        
+        return _nativeFetch(input, patchedInit !== undefined ? patchedInit : (disableCookies ? { __hoppDisableCookies: true } : undefined))
       }
     })(),
   }

--- a/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
+++ b/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
@@ -69,6 +69,13 @@
     })
   })
 
+  // Track cookie isolation activation across the script lifecycle.
+  // Initialized from the starting request policy.
+  const initialReqPropsForLatch = inputs.getRequestProps()
+  let __hoppCookieIsolationLatch = 
+    (initialReqPropsForLatch.requestOptions && 
+     initialReqPropsForLatch.requestOptions.disableCookies) === true
+
   // Special handling for requestOptions: support nested mutations via Proxy
   Object.defineProperty(requestProps, "requestOptions", {
     enumerable: true,
@@ -79,6 +86,9 @@
       return new Proxy(opts, {
         set(target, prop, value) {
           target[prop] = value
+          if (prop === "disableCookies" && value === true) {
+            __hoppCookieIsolationLatch = true
+          }
           inputs.setRequestOptions(target)
           return true
         },
@@ -205,18 +215,12 @@
     fetch: (function () {
       const _nativeFetch = fetch
       
-      // Initialize latch from the starting request policy.
-      // We must retrieve the initial properties right away.
-      const initialProps = inputs.getRequestProps()
-      let isolationActivated = (initialProps.requestOptions && initialProps.requestOptions.disableCookies) === true
-      
       return function (input, init) {
         const currentReqProps = inputs.getRequestProps()
         
-        // If isolation becomes active dynamically, permanently latch it
-        if (currentReqProps.requestOptions && currentReqProps.requestOptions.disableCookies) {
-          isolationActivated = true
-        }
+        // Use the globally maintained latch or current state
+        const isolationActivated = __hoppCookieIsolationLatch || 
+          (currentReqProps.requestOptions && currentReqProps.requestOptions.disableCookies) === true
 
         const patchedInit = init !== undefined && init !== null
           ? Object.assign({}, init)

--- a/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
+++ b/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
@@ -86,10 +86,10 @@
       return new Proxy(opts, {
         set(target, prop, value) {
           target[prop] = value
+          inputs.setRequestOptions(target)
           if (prop === "disableCookies" && value === true) {
             __hoppCookieIsolationLatch = true
           }
-          inputs.setRequestOptions(target)
           return true
         },
       })

--- a/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
+++ b/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
@@ -209,7 +209,11 @@
         const disableCookies =
           (currentReqProps.requestOptions &&
             currentReqProps.requestOptions.disableCookies) === true
-        const patchedInit = Object.assign({}, init)
+        // Only create a patched init when one was provided; passing an empty
+        // object in place of undefined can alter fetch semantics for some hooks.
+        const patchedInit = init !== undefined && init !== null
+          ? Object.assign({}, init)
+          : {}
         // Non-enumerable so user scripts cannot accidentally read or overwrite it
         Object.defineProperty(patchedInit, "__hoppDisableCookies", {
           value: disableCookies,

--- a/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
+++ b/packages/hoppscotch-js-sandbox/src/bootstrap-code/pre-request.js
@@ -201,26 +201,35 @@
     // Expose fetch as hopp.fetch() for explicit access
     // The wrapper reads requestOptions.disableCookies at the time of the call
     // so that pre-request script mutations are honoured even if the hook was
-    // constructed with the pre-script snapshot.
+    // constructed with the pre-script snapshot
     fetch: (function () {
       const _nativeFetch = fetch
+      
+      // Initialize latch from the starting request policy.
+      // We must retrieve the initial properties right away.
+      const initialProps = inputs.getRequestProps()
+      let isolationActivated = (initialProps.requestOptions && initialProps.requestOptions.disableCookies) === true
+      
       return function (input, init) {
         const currentReqProps = inputs.getRequestProps()
-        const disableCookies =
-          (currentReqProps.requestOptions &&
-            currentReqProps.requestOptions.disableCookies) === true
+        
+        // If isolation becomes active dynamically, permanently latch it
+        if (currentReqProps.requestOptions && currentReqProps.requestOptions.disableCookies) {
+          isolationActivated = true
+        }
+
         const patchedInit = init !== undefined && init !== null
           ? Object.assign({}, init)
           : { __hoppInitWasUndefined: true }
-          
+
         // Enumerable so it survives vm.dump serialization across the sandbox bridge
         Object.defineProperty(patchedInit, "__hoppDisableCookies", {
-          value: disableCookies,
+          value: isolationActivated,
           enumerable: true,
           configurable: false,
           writable: false,
         })
-        
+
         return _nativeFetch(input, patchedInit)
       }
     })(),

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/namespaces/hopp-namespace.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/namespaces/hopp-namespace.ts
@@ -10,7 +10,8 @@ import type { EnvAPIOptions } from "~/utils/shared"
 export const createHoppNamespaceMethods = (
   ctx: CageModuleCtx,
   envMethods: EnvMethods,
-  requestProps: RequestProps
+  requestProps: RequestProps,
+  requestSetterMethods?: { setRequestOptions: SandboxFunction }
 ): HoppNamespaceMethods => {
   return {
     // `hopp` namespace environment methods
@@ -71,7 +72,19 @@ export const createHoppNamespaceMethods = (
         get auth() {
           return requestProps.auth
         },
+        get requestOptions() {
+          return requestProps.requestOptions
+        },
       }
     }),
+
+    // Request options setter (only wired in pre-request context)
+    setRequestOptions:
+      requestSetterMethods?.setRequestOptions ??
+      defineSandboxFn(ctx, "setRequestOptions", function () {
+        throw new Error(
+          "hopp.request.requestOptions is read-only in this script context"
+        )
+      }),
   }
 }

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/namespaces/hopp-namespace.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/namespaces/hopp-namespace.ts
@@ -1,6 +1,11 @@
 import { CageModuleCtx, defineSandboxFn } from "faraday-cage/modules"
 
-import type { EnvMethods, RequestProps, HoppNamespaceMethods } from "~/types"
+import type {
+  EnvMethods,
+  RequestProps,
+  HoppNamespaceMethods,
+  SandboxFunction,
+} from "~/types"
 import type { EnvAPIOptions } from "~/utils/shared"
 
 /**

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/scripting-modules.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/scripting-modules.ts
@@ -145,17 +145,9 @@ function createScriptingInputsObj(
   if (type === "pre") {
     const preConfig = config as PreRequestModuleConfig
 
-    // Deferred callback: setRequestOptions needs to notify cookie methods
-    // when disableCookies is set to true, but notifyIsolationEnabled
-    // comes from createBaseInputs which hasn't been called yet.
-    // This holder is populated after createBaseInputs returns.
-    let deferredIsolationNotifier: (() => void) | undefined
-
     // Create request setter methods FIRST for pre-request scripts
     const { methods: requestSetterMethods, getUpdatedRequest } =
-      createRequestSetterMethods(ctx, preConfig.request, {
-        onDisableCookies: () => deferredIsolationNotifier?.(),
-      })
+      createRequestSetterMethods(ctx, preConfig.request)
 
     // Capture the getUpdatedRequest function so the caller can use it
     if (captureGetUpdatedRequest) {
@@ -170,9 +162,6 @@ function createScriptingInputsObj(
       getUpdatedRequest, // Pass the updater function for pre-request
       setRequestOptions: requestSetterMethods.setRequestOptions, // Wire options setter into hopp namespace
     })
-
-    // Now wire the deferred callback to the actual notifyIsolationEnabled
-    deferredIsolationNotifier = baseInputs.notifyIsolationEnabled
 
     // Register hook with helper function
     registerAfterScriptExecutionHook(ctx, "pre", preConfig, baseInputs, {

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/scripting-modules.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/scripting-modules.ts
@@ -145,9 +145,17 @@ function createScriptingInputsObj(
   if (type === "pre") {
     const preConfig = config as PreRequestModuleConfig
 
+    // Deferred callback: setRequestOptions needs to notify cookie methods
+    // when disableCookies is set to true, but notifyIsolationEnabled
+    // comes from createBaseInputs which hasn't been called yet.
+    // This holder is populated after createBaseInputs returns.
+    let deferredIsolationNotifier: (() => void) | undefined
+
     // Create request setter methods FIRST for pre-request scripts
     const { methods: requestSetterMethods, getUpdatedRequest } =
-      createRequestSetterMethods(ctx, preConfig.request)
+      createRequestSetterMethods(ctx, preConfig.request, {
+        onDisableCookies: () => deferredIsolationNotifier?.(),
+      })
 
     // Capture the getUpdatedRequest function so the caller can use it
     if (captureGetUpdatedRequest) {
@@ -162,6 +170,9 @@ function createScriptingInputsObj(
       getUpdatedRequest, // Pass the updater function for pre-request
       setRequestOptions: requestSetterMethods.setRequestOptions, // Wire options setter into hopp namespace
     })
+
+    // Now wire the deferred callback to the actual notifyIsolationEnabled
+    deferredIsolationNotifier = baseInputs.notifyIsolationEnabled
 
     // Register hook with helper function
     registerAfterScriptExecutionHook(ctx, "pre", preConfig, baseInputs, {

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/scripting-modules.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/scripting-modules.ts
@@ -160,6 +160,7 @@ function createScriptingInputsObj(
       request: config.request,
       cookies: config.cookies,
       getUpdatedRequest, // Pass the updater function for pre-request
+      setRequestOptions: requestSetterMethods.setRequestOptions, // Wire options setter into hopp namespace
     })
 
     // Register hook with helper function

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
@@ -35,7 +35,8 @@ export const createBaseInputs = (
   } = getSharedEnvMethods(config.envs, true)
 
   const { methods: cookieMethods, getUpdatedCookies } = getSharedCookieMethods(
-    config.cookies
+    config.cookies,
+    config.getUpdatedRequest
   )
 
   // Get request properties - shared across pre and post request contexts

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
@@ -13,16 +13,11 @@ import { createPmNamespaceMethods } from "../namespaces/pm-namespace"
 import { createPwNamespaceMethods } from "../namespaces/pw-namespace"
 
 type BaseInputsConfig = {
-  /**
-   * Environment variables typed as TestResult["envs"] for external API compatibility.
-   * At runtime, this will be mutated to contain SandboxValue types (arrays, objects, etc.)
-   * during script execution to support PM namespace compatibility.
-   * See `getSharedEnvMethods()` for detailed explanation of the type flow.
-   */
   envs: TestResult["envs"]
   request: HoppRESTRequest
   cookies: Cookie[] | null
   getUpdatedRequest?: () => HoppRESTRequest
+  setRequestOptions?: SandboxFunction
 }
 
 /**
@@ -104,7 +99,14 @@ export const createBaseInputs = (
 
   // Combine all namespace methods
   const pwMethods = createPwNamespaceMethods(ctx, envMethods, requestProps)
-  const hoppMethods = createHoppNamespaceMethods(ctx, envMethods, requestProps)
+  const hoppMethods = createHoppNamespaceMethods(
+    ctx,
+    envMethods,
+    requestProps,
+    config.setRequestOptions
+      ? { setRequestOptions: config.setRequestOptions }
+      : undefined
+  )
   const pmMethods = createPmNamespaceMethods(ctx, config)
 
   // PM namespace-specific setter that accepts any type (for type preservation)

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
@@ -36,6 +36,7 @@ export const createBaseInputs = (
 
   const { methods: cookieMethods, getUpdatedCookies } = getSharedCookieMethods(
     config.cookies,
+    config.request,
     config.getUpdatedRequest
   )
 

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
@@ -34,11 +34,12 @@ export const createBaseInputs = (
     updatedEnvs,
   } = getSharedEnvMethods(config.envs, true)
 
-  const { methods: cookieMethods, getUpdatedCookies } = getSharedCookieMethods(
-    config.cookies,
-    config.request,
-    config.getUpdatedRequest
-  )
+  const { methods: cookieMethods, getUpdatedCookies, notifyIsolationEnabled } =
+    getSharedCookieMethods(
+      config.cookies,
+      config.request,
+      config.getUpdatedRequest
+    )
 
   // Get request properties - shared across pre and post request contexts
   // For pre-request, use the updater function to read from mutated request
@@ -178,5 +179,6 @@ export const createBaseInputs = (
       }
     },
     getUpdatedCookies,
+    notifyIsolationEnabled,
   }
 }

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
@@ -1,7 +1,7 @@
 import { Cookie, HoppRESTRequest } from "@hoppscotch/data"
 import { CageModuleCtx, defineSandboxFn } from "faraday-cage/modules"
 
-import { TestResult, BaseInputs, SandboxValue } from "~/types"
+import { TestResult, BaseInputs, SandboxValue, SandboxFunction } from "~/types"
 import {
   getSharedCookieMethods,
   getSharedEnvMethods,

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/utils/base-inputs.ts
@@ -34,12 +34,11 @@ export const createBaseInputs = (
     updatedEnvs,
   } = getSharedEnvMethods(config.envs, true)
 
-  const { methods: cookieMethods, getUpdatedCookies, notifyIsolationEnabled } =
-    getSharedCookieMethods(
-      config.cookies,
-      config.request,
-      config.getUpdatedRequest
-    )
+  const { methods: cookieMethods, getUpdatedCookies } = getSharedCookieMethods(
+    config.cookies,
+    config.request,
+    config.getUpdatedRequest
+  )
 
   // Get request properties - shared across pre and post request contexts
   // For pre-request, use the updater function to read from mutated request
@@ -179,6 +178,5 @@ export const createBaseInputs = (
       }
     },
     getUpdatedCookies,
-    notifyIsolationEnabled,
   }
 }

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/utils/request-setters.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/utils/request-setters.ts
@@ -16,13 +16,10 @@ import { RequestSetterMethodsResult } from "~/types"
  */
 export const createRequestSetterMethods = (
   ctx: CageModuleCtx,
-  request: HoppRESTRequest,
-  options?: { onDisableCookies?: () => void }
+  request: HoppRESTRequest
 ): RequestSetterMethodsResult => {
   const { methods: requestMethods, updatedRequest } =
-    getRequestSetterMethods(request, {
-      onDisableCookies: options?.onDisableCookies,
-    })
+    getRequestSetterMethods(request)
 
   const setterMethods = {
     // Request setter methods

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/utils/request-setters.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/utils/request-setters.ts
@@ -88,6 +88,13 @@ export const createRequestSetterMethods = (
         requestMethods.setRequestVariable(key as string, value as string)
       }
     ),
+    setRequestOptions: defineSandboxFn(
+      ctx,
+      "setRequestOptions",
+      (options: unknown) => {
+        requestMethods.setRequestOptions(options)
+      }
+    ),
   }
 
   return {

--- a/packages/hoppscotch-js-sandbox/src/cage-modules/utils/request-setters.ts
+++ b/packages/hoppscotch-js-sandbox/src/cage-modules/utils/request-setters.ts
@@ -16,10 +16,13 @@ import { RequestSetterMethodsResult } from "~/types"
  */
 export const createRequestSetterMethods = (
   ctx: CageModuleCtx,
-  request: HoppRESTRequest
+  request: HoppRESTRequest,
+  options?: { onDisableCookies?: () => void }
 ): RequestSetterMethodsResult => {
   const { methods: requestMethods, updatedRequest } =
-    getRequestSetterMethods(request)
+    getRequestSetterMethods(request, {
+      onDisableCookies: options?.onDisableCookies,
+    })
 
   const setterMethods = {
     // Request setter methods

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -342,8 +342,6 @@ export interface BaseInputs
   // Returns serialized env vars (SandboxValue -> string conversion happens here)
   getUpdatedEnvs: () => TestResult["envs"]
   getUpdatedCookies: () => Cookie[] | null
-  // Permanently latches cookie isolation for the script's lifetime
-  notifyIsolationEnabled: () => void
   [key: string]: SandboxValue // Index signature for dynamic namespace properties
 }
 

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -261,6 +261,7 @@ export interface HoppNamespaceMethods {
   envGetInitialRaw: SandboxFunction
   envSetInitial: SandboxFunction
   getRequestProps: SandboxFunction
+  setRequestOptions: SandboxFunction
 }
 
 /**
@@ -321,6 +322,7 @@ export interface RequestSetterMethodsResult {
     setRequestBody: SandboxFunction
     setRequestAuth: SandboxFunction
     setRequestVariable: SandboxFunction
+    setRequestOptions: SandboxFunction
   }
   getUpdatedRequest: () => HoppRESTRequest
 }

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -4,7 +4,7 @@ import { ConsoleEntry, defineSandboxFn } from "faraday-cage/modules"
 import type { EnvAPIOptions } from "~/utils/shared"
 
 // Infer the return type of defineSandboxFn from faraday-cage
-type SandboxFunction = ReturnType<typeof defineSandboxFn>
+export type SandboxFunction = ReturnType<typeof defineSandboxFn>
 
 /**
  * Type alias for values that cross the QuickJS sandbox boundary.
@@ -227,6 +227,7 @@ export type RequestProps = {
   readonly body: HoppRESTRequest["body"]
   readonly auth: HoppRESTRequest["auth"]
   readonly requestVariables: HoppRESTRequest["requestVariables"]
+  readonly requestOptions?: HoppRESTRequest["requestOptions"]
 }
 
 /**

--- a/packages/hoppscotch-js-sandbox/src/types/index.ts
+++ b/packages/hoppscotch-js-sandbox/src/types/index.ts
@@ -342,6 +342,8 @@ export interface BaseInputs
   // Returns serialized env vars (SandboxValue -> string conversion happens here)
   getUpdatedEnvs: () => TestResult["envs"]
   getUpdatedCookies: () => Cookie[] | null
+  // Permanently latches cookie isolation for the script's lifetime
+  notifyIsolationEnabled: () => void
   [key: string]: SandboxValue // Index signature for dynamic namespace properties
 }
 

--- a/packages/hoppscotch-js-sandbox/src/utils/pre-request.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/pre-request.ts
@@ -8,7 +8,10 @@ import {
 } from "@hoppscotch/data"
 import { cloneDeep } from "lodash"
 
-export const getRequestSetterMethods = (request: HoppRESTRequest) => {
+export const getRequestSetterMethods = (
+  request: HoppRESTRequest,
+  options?: { onDisableCookies?: () => void }
+) => {
   // Clone to allow safe mutations internally
   const updatedRequest = <HoppRESTRequest>cloneDeep(request)
 
@@ -137,6 +140,14 @@ export const getRequestSetterMethods = (request: HoppRESTRequest) => {
     }
 
     updatedRequest.requestOptions = parseResult.data
+
+    // Notify cookie methods that isolation was enabled so the cookie
+    // snapshot is immediately purged and the isolation latch is set.
+    // This is a permanent latch — even if the script later sets
+    // disableCookies back to false, staged mutations are discarded.
+    if (parseResult.data.disableCookies) {
+      options?.onDisableCookies?.()
+    }
   }
 
   const setRequestVariable = (key: string, value: string) => {

--- a/packages/hoppscotch-js-sandbox/src/utils/pre-request.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/pre-request.ts
@@ -142,7 +142,7 @@ export const getRequestSetterMethods = (
     // to guarantee cookie isolation for the entire execution.
     const isChangingDisableCookies = 
       parseResult.data.disableCookies !== undefined && 
-      parseResult.data.disableCookies !== updatedRequest.requestOptions?.disableCookies
+      parseResult.data.disableCookies !== (updatedRequest.requestOptions?.disableCookies ?? false)
 
     if (isChangingDisableCookies) {
       throw new Error("Cannot change disableCookies dynamically from sandbox scripts. It must be set prior to script execution.")

--- a/packages/hoppscotch-js-sandbox/src/utils/pre-request.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/pre-request.ts
@@ -9,8 +9,7 @@ import {
 import { cloneDeep } from "lodash"
 
 export const getRequestSetterMethods = (
-  request: HoppRESTRequest,
-  options?: { onDisableCookies?: () => void }
+  request: HoppRESTRequest
 ) => {
   // Clone to allow safe mutations internally
   const updatedRequest = <HoppRESTRequest>cloneDeep(request)
@@ -139,15 +138,17 @@ export const getRequestSetterMethods = (
       throw new Error("Invalid requestOptions object")
     }
 
-    updatedRequest.requestOptions = parseResult.data
+    // Prohibit changing disableCookies dynamically from sandbox scripts
+    // to guarantee cookie isolation for the entire execution.
+    const isChangingDisableCookies = 
+      parseResult.data.disableCookies !== undefined && 
+      parseResult.data.disableCookies !== updatedRequest.requestOptions?.disableCookies
 
-    // Notify cookie methods that isolation was enabled so the cookie
-    // snapshot is immediately purged and the isolation latch is set.
-    // This is a permanent latch — even if the script later sets
-    // disableCookies back to false, staged mutations are discarded.
-    if (parseResult.data.disableCookies) {
-      options?.onDisableCookies?.()
+    if (isChangingDisableCookies) {
+      throw new Error("Cannot change disableCookies dynamically from sandbox scripts. It must be set prior to script execution.")
     }
+
+    updatedRequest.requestOptions = parseResult.data
   }
 
   const setRequestVariable = (key: string, value: string) => {

--- a/packages/hoppscotch-js-sandbox/src/utils/pre-request.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/pre-request.ts
@@ -4,6 +4,7 @@ import {
   HoppRESTParams,
   HoppRESTReqBody,
   HoppRESTRequest,
+  HoppRESTRequestOptions,
 } from "@hoppscotch/data"
 import { cloneDeep } from "lodash"
 
@@ -128,6 +129,16 @@ export const getRequestSetterMethods = (request: HoppRESTRequest) => {
     updatedRequest.auth = { ...parseResult.data }
   }
 
+  const setRequestOptions = (newOptions: unknown) => {
+    const parseResult = HoppRESTRequestOptions.safeParse(newOptions)
+
+    if (!parseResult.success) {
+      throw new Error("Invalid requestOptions object")
+    }
+
+    updatedRequest.requestOptions = parseResult.data
+  }
+
   const setRequestVariable = (key: string, value: string) => {
     const reqVarIndex = updatedRequest.requestVariables.findIndex(
       (reqVar) => reqVar.key === key
@@ -154,6 +165,7 @@ export const getRequestSetterMethods = (request: HoppRESTRequest) => {
       setBody,
       setAuth,
       setRequestVariable,
+      setRequestOptions,
     },
     updatedRequest,
   }

--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -498,6 +498,7 @@ export function getSharedEnvMethods(
 
 export const getSharedCookieMethods = (
   cookies: Cookie[] | null,
+  request: HoppRESTRequest,
   getUpdatedRequest?: () => HoppRESTRequest
 ) => {
   // Incoming `cookies` specified as `null` indicates unsupported platform
@@ -505,10 +506,8 @@ export const getSharedCookieMethods = (
   let updatedCookies: Cookie[] = cookies ?? []
 
   const throwIfCookiesUnsupported = () => {
-    if (
-      getUpdatedRequest &&
-      getUpdatedRequest().requestOptions?.disableCookies
-    ) {
+    const currentRequest = getUpdatedRequest ? getUpdatedRequest() : request
+    if (currentRequest.requestOptions?.disableCookies) {
       throw new Error(
         "Cookies are disabled for this request. Cookie isolation is active."
       )

--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -1005,5 +1005,9 @@ export const getSharedRequestProps = (
       const currentRequest = getUpdatedRequest ? getUpdatedRequest() : request
       return currentRequest.requestVariables
     },
+    get requestOptions() {
+      const currentRequest = getUpdatedRequest ? getUpdatedRequest() : request
+      return currentRequest.requestOptions
+    },
   }
 }

--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -503,23 +503,25 @@ export const getSharedCookieMethods = (
 ) => {
   // Incoming `cookies` specified as `null` indicates unsupported platform
   const cookiesSupported = cookies !== null
-  let updatedCookies: Cookie[] = cookies ?? []
-
   // Track whether cookie isolation was dynamically activated during script
-  // execution. Once set, all cookie reads return empty results and
-  // getUpdatedCookies returns null so the runner discards staged mutations.
-  let isolationActivatedDuringScript = false
+  // execution. Initialized from the starting request policy so requests
+  // that start with isolation enabled can never revert it, completely
+  // blocking access to the initial snapshot.
+  let isolationActivatedDuringScript = request?.requestOptions?.disableCookies ?? false
+  let updatedCookies: Cookie[] = isolationActivatedDuringScript ? [] : (cookies ?? [])
 
   const throwIfCookiesUnsupported = () => {
     const currentRequest = getUpdatedRequest ? getUpdatedRequest() : request
+    
+    // Catch cases where isolation becomes active dynamically
     if (currentRequest?.requestOptions?.disableCookies) {
-      // First time isolation is detected: purge the in-memory snapshot so
-      // any subsequent reads (even from shared/imported scripts that run
-      // after this point) cannot access cookie data.
       if (!isolationActivatedDuringScript) {
         isolationActivatedDuringScript = true
         updatedCookies = []
       }
+    }
+
+    if (isolationActivatedDuringScript) {
       throw new Error(
         "Cookies are disabled for this request. Cookie isolation is active."
       )

--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -496,12 +496,24 @@ export function getSharedEnvMethods(
   }
 }
 
-export const getSharedCookieMethods = (cookies: Cookie[] | null) => {
+export const getSharedCookieMethods = (
+  cookies: Cookie[] | null,
+  getUpdatedRequest?: () => HoppRESTRequest
+) => {
   // Incoming `cookies` specified as `null` indicates unsupported platform
   const cookiesSupported = cookies !== null
   let updatedCookies: Cookie[] = cookies ?? []
 
   const throwIfCookiesUnsupported = () => {
+    if (
+      getUpdatedRequest &&
+      getUpdatedRequest().requestOptions?.disableCookies
+    ) {
+      throw new Error(
+        "Cookies are disabled for this request. Cookie isolation is active."
+      )
+    }
+
     if (cookies === null) {
       throw new Error(
         "Cookies are not supported in the current platform and are exclusive to the Desktop App."

--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -511,16 +511,6 @@ export const getSharedCookieMethods = (
   let updatedCookies: Cookie[] = isolationActivatedDuringScript ? [] : (cookies ?? [])
 
   const throwIfCookiesUnsupported = () => {
-    const currentRequest = getUpdatedRequest ? getUpdatedRequest() : request
-    
-    // Catch cases where isolation becomes active dynamically
-    if (currentRequest?.requestOptions?.disableCookies) {
-      if (!isolationActivatedDuringScript) {
-        isolationActivatedDuringScript = true
-        updatedCookies = []
-      }
-    }
-
     if (isolationActivatedDuringScript) {
       throw new Error(
         "Cookies are disabled for this request. Cookie isolation is active."
@@ -612,27 +602,11 @@ export const getSharedCookieMethods = (
       delete: cookieDeleteFn,
       clear: cookieClearFn,
     },
-    // Called by setRequestOptions when disableCookies is set to true.
-    // This is a permanent latch: once isolation is activated, all staged
-    // cookie mutations are discarded for the rest of the script's lifetime,
-    // even if the script later sets disableCookies back to false.
-    notifyIsolationEnabled: () => {
-      if (!isolationActivatedDuringScript) {
-        isolationActivatedDuringScript = true
-        updatedCookies = []
-      }
-    },
-    // When isolation was activated during script execution (even briefly),
-    // return null to signal that all cookie mutations must be discarded.
-    // Also re-check the live request state as a final defense layer.
     getUpdatedCookies: () => {
       if (isolationActivatedDuringScript) return null
-      // Final check: if disableCookies is currently true but no cookie
-      // API call triggered the guard, catch it here
+      
       const currentRequest = getUpdatedRequest ? getUpdatedRequest() : request
       if (currentRequest?.requestOptions?.disableCookies) {
-        isolationActivatedDuringScript = true
-        updatedCookies = []
         return null
       }
       return cookiesSupported ? cloneDeep(updatedCookies) : null

--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -498,7 +498,7 @@ export function getSharedEnvMethods(
 
 export const getSharedCookieMethods = (
   cookies: Cookie[] | null,
-  request: HoppRESTRequest,
+  request?: HoppRESTRequest,
   getUpdatedRequest?: () => HoppRESTRequest
 ) => {
   // Incoming `cookies` specified as `null` indicates unsupported platform
@@ -507,7 +507,7 @@ export const getSharedCookieMethods = (
 
   const throwIfCookiesUnsupported = () => {
     const currentRequest = getUpdatedRequest ? getUpdatedRequest() : request
-    if (currentRequest.requestOptions?.disableCookies) {
+    if (currentRequest?.requestOptions?.disableCookies) {
       throw new Error(
         "Cookies are disabled for this request. Cookie isolation is active."
       )

--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -505,9 +505,21 @@ export const getSharedCookieMethods = (
   const cookiesSupported = cookies !== null
   let updatedCookies: Cookie[] = cookies ?? []
 
+  // Track whether cookie isolation was dynamically activated during script
+  // execution. Once set, all cookie reads return empty results and
+  // getUpdatedCookies returns null so the runner discards staged mutations.
+  let isolationActivatedDuringScript = false
+
   const throwIfCookiesUnsupported = () => {
     const currentRequest = getUpdatedRequest ? getUpdatedRequest() : request
     if (currentRequest?.requestOptions?.disableCookies) {
+      // First time isolation is detected: purge the in-memory snapshot so
+      // any subsequent reads (even from shared/imported scripts that run
+      // after this point) cannot access cookie data.
+      if (!isolationActivatedDuringScript) {
+        isolationActivatedDuringScript = true
+        updatedCookies = []
+      }
       throw new Error(
         "Cookies are disabled for this request. Cookie isolation is active."
       )
@@ -598,9 +610,13 @@ export const getSharedCookieMethods = (
       delete: cookieDeleteFn,
       clear: cookieClearFn,
     },
-    // Use a function so we always read the latest `updatedCookies` (not a stale snapshot)
-    getUpdatedCookies: () =>
-      cookiesSupported ? cloneDeep(updatedCookies) : null,
+    // When isolation was activated during script execution, return null to
+    // signal that all cookie mutations (including those staged before the
+    // flag was set) must be discarded by the runner.
+    getUpdatedCookies: () => {
+      if (isolationActivatedDuringScript) return null
+      return cookiesSupported ? cloneDeep(updatedCookies) : null
+    },
   }
 }
 

--- a/packages/hoppscotch-js-sandbox/src/utils/shared.ts
+++ b/packages/hoppscotch-js-sandbox/src/utils/shared.ts
@@ -610,11 +610,29 @@ export const getSharedCookieMethods = (
       delete: cookieDeleteFn,
       clear: cookieClearFn,
     },
-    // When isolation was activated during script execution, return null to
-    // signal that all cookie mutations (including those staged before the
-    // flag was set) must be discarded by the runner.
+    // Called by setRequestOptions when disableCookies is set to true.
+    // This is a permanent latch: once isolation is activated, all staged
+    // cookie mutations are discarded for the rest of the script's lifetime,
+    // even if the script later sets disableCookies back to false.
+    notifyIsolationEnabled: () => {
+      if (!isolationActivatedDuringScript) {
+        isolationActivatedDuringScript = true
+        updatedCookies = []
+      }
+    },
+    // When isolation was activated during script execution (even briefly),
+    // return null to signal that all cookie mutations must be discarded.
+    // Also re-check the live request state as a final defense layer.
     getUpdatedCookies: () => {
       if (isolationActivatedDuringScript) return null
+      // Final check: if disableCookies is currently true but no cookie
+      // API call triggered the guard, catch it here
+      const currentRequest = getUpdatedRequest ? getUpdatedRequest() : request
+      if (currentRequest?.requestOptions?.disableCookies) {
+        isolationActivatedDuringScript = true
+        updatedCookies = []
+        return null
+      }
       return cookiesSupported ? cloneDeep(updatedCookies) : null
     },
   }

--- a/packages/hoppscotch-kernel/src/relay/impl/web/v/1.ts
+++ b/packages/hoppscotch-kernel/src/relay/impl/web/v/1.ts
@@ -134,6 +134,7 @@ export const implementation: VersionedAPI<RelayV1> = {
               validateStatus: null,
               cancelToken: cancelTokenSource.token,
               responseType: "arraybuffer",
+              withCredentials: request.meta?.options?.cookies ?? true,
             }
 
             // The following code is temporarily commented out because the auth has been pre-processed in EffectiveURL.ts and added in header


### PR DESCRIPTION
Closes #6526

This PR adds the ability to disable the cookie jar both globally and on a per-request basis. This resolves the problem of cookies polluting requests unexpectedly without visibility, and provides an intuitive UX patterned after Postman's cookie jar settings.

### What's changed

- **Global Setting:** Added a new "Disable cookies" toggle in the main Settings page (`pages/settings.vue`) under a new Network section. When toggled, the cookie jar is disabled for all requests.
- **Per-Request Setting:** Added a new `Settings` tab in the request options area (`RequestOptions.vue`). It includes a "Disable cookie jar" toggle that applies only to the current request.
- **Request Kernel:** Updated `RESTRequest.toRequest` to dynamically calculate whether to send cookies by evaluating an `OR` condition between the global setting and the local request override.
- **Data Migration:** Safely migrated the `HoppRESTRequest` schema to support the new `requestOptions` object without breaking existing request history.

### Notes to reviewers

- The UI for the per-request settings tab intentionally mirrors the language and layout used by Postman to make the migration experience familiar for users. 
- I recommend viewing the visual changes in the screenshots below!

### Screenshots
<img width="1470" height="956" alt="Screenshot 2026-07-30 at 10 56 48 PM" src="https://github.com/user-attachments/assets/32ec5867-d1c9-44f7-91eb-f95b0b7957f6" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add global and per-request controls to disable the cookie jar and enforce request-level isolation. Previously all requests sent and mutated cookies; now you can disable them globally or per request. Scripts cannot change this during execution. Note: due to browser limits, same-origin requests may still include cookies.

- Settings and schema: Adds Settings > Network “Disable cookies” (`DISABLE_COOKIES`) and per-request Options > Settings “Disable cookie jar” (`requestOptions.disableCookies`, defaults to false). Migrates REST schema to v18 in `@hoppscotch/data` with persisted/validated `requestOptions` (no manual action).
- Enforcement: Centralizes policy in `cookiePolicy.ts` and applies it in runners and fetch hooks. `RESTRequest.toRequest` sets `meta.options.cookies`; the web relay maps this to `withCredentials`. Runners skip cookie-jar injection when disabled and drop post-script cookie mutations. Cookie APIs throw when disabled and `getUpdatedCookies` returns null.
- Scripts and fetch: Exposes `hopp.request.requestOptions` read-only in scripts; attempting to change `disableCookies` throws. `hopp.fetch` honors the effective policy (global OR request) captured at start of execution; scripts cannot relax or enable cookies mid-run.
- UI/tests: Adds a Request Settings tab and i18n strings; updates unit tests to assert restrictive policy and the same-origin caveat.

<sup>Written for commit 219f1f98cd1f4f629d59f151b8e1e0ce587ff3c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

