### PR TITLE
fix(context-menu): remove catastrophic backtracking in URL detection regex

### DIFF
--- a/packages/hoppscotch-common/src/services/context-menu/menu/url.menu.ts
+++ b/packages/hoppscotch-common/src/services/context-menu/menu/url.menu.ts
@@ -23,7 +23,7 @@ function checkURL(url: string): boolean {
     new URL(url)
     return true
   } catch {
-    return /^(https?:\/\/)?([\w.-]+)(\.[\w.-]+)+([/?].*)?$/.test(url)
+    return /^(https?:\/\/)?([\w-]+)(\.[\w-]+)+([/?].*)?$/.test(url)
   }
 }
 


### PR DESCRIPTION
The URL detection regex in url.menu.ts has overlapping dot patterns between its character class [\w.-] and the literal separator \. - this causes catastrophic backtracking on certain user-selected text. On a modern machine, n=27 characters can take several seconds and n=100+ is effectively infinite. Removing the dot from the character class ([\w-] instead of [\w.-]) fixes the exponential growth while keeping the URL matching correct.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes catastrophic backtracking in the context-menu URL detection regex to prevent freezes when parsing selected text. Removes the dot from the domain character class so dots are only matched by the literal separator, preserving correct URL matching while eliminating exponential runtime.

<sup>Written for commit fb8bbe977134d871bd3b199d1902af00b09c0fb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

