### PR TITLE
fix: avoid shared global regex in environment variable .test() checks

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/curlparser.ts
@@ -29,7 +29,7 @@ import {
 } from "./sub_helpers/preproc"
 import { getQueries } from "./sub_helpers/queries"
 import { concatParams, getURLObject } from "./sub_helpers/url"
-import { HOPP_ENVIRONMENT_REGEX } from "../environment-regex"
+import { HOPP_ENVIRONMENT_TEST_REGEX } from "../environment-regex"
 
 const defaultRESTReq = getDefaultRESTRequest()
 
@@ -38,7 +38,8 @@ const defaultRESTReq = getDefaultRESTRequest()
  * @param str The string to test for environment variables.
  * @returns A boolean indicating whether the string contains environment variables.
  */
-const containsEnvVariables = (str: string) => HOPP_ENVIRONMENT_REGEX.test(str)
+const containsEnvVariables = (str: string) =>
+  HOPP_ENVIRONMENT_TEST_REGEX.test(str)
 
 export const parseCurlCommand = (curlCommand: string) => {
   // const isDataBinary = curlCommand.includes(" --data-binary")

--- a/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
+++ b/packages/hoppscotch-common/src/helpers/editor/extensions/HoppEnvironment.ts
@@ -39,6 +39,7 @@ import {
 import {
   ENV_VAR_NAME_REGEX,
   HOPP_ENVIRONMENT_REGEX,
+  HOPP_ENVIRONMENT_TEST_REGEX,
 } from "~/helpers/environment-regex"
 import {
   stabilizeTooltipHover,
@@ -89,7 +90,7 @@ const cursorTooltipField = (aggregateEnvs: AggregateEnvironment[]) =>
       if (
         (start === pos && side < 0) ||
         (end === pos && side > 0) ||
-        !HOPP_ENVIRONMENT_REGEX.test(
+        !HOPP_ENVIRONMENT_TEST_REGEX.test(
           text.slice(start - from - 2, end - from + 2)
         )
       )

--- a/packages/hoppscotch-common/src/helpers/environment-regex.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/environment-regex.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import {
+  HOPP_ENVIRONMENT_REGEX,
+  HOPP_ENVIRONMENT_TEST_REGEX,
+} from "./environment-regex"
+
+describe("HOPP_ENVIRONMENT_TEST_REGEX", () => {
+  it("returns a stable result across repeated `.test()` calls", () => {
+    // A global regex keeps `lastIndex` between `.test()` calls, so this would
+    // otherwise alternate true/false. The containment regex must not.
+    for (let i = 0; i < 5; i++) {
+      expect(HOPP_ENVIRONMENT_TEST_REGEX.test("<<token>>")).toBe(true)
+    }
+  })
+
+  it("does not leak `lastIndex` state between strings of different lengths", () => {
+    // Testing a longer match first, then a shorter string that also contains a
+    // variable, must still report the shorter one as containing a variable.
+    expect(HOPP_ENVIRONMENT_TEST_REGEX.test("https://<<host>>/api")).toBe(true)
+    expect(HOPP_ENVIRONMENT_TEST_REGEX.test("<<url>>")).toBe(true)
+  })
+
+  it("returns false for strings without a variable", () => {
+    expect(HOPP_ENVIRONMENT_TEST_REGEX.test("https://example.com")).toBe(false)
+    expect(HOPP_ENVIRONMENT_TEST_REGEX.test("<<not closed")).toBe(false)
+  })
+})
+
+describe("HOPP_ENVIRONMENT_REGEX", () => {
+  it("stays global so `String.match` can extract every occurrence", () => {
+    expect(HOPP_ENVIRONMENT_REGEX.flags).toContain("g")
+    expect("<<a>> and <<b>>".match(HOPP_ENVIRONMENT_REGEX)).toEqual([
+      "<<a>>",
+      "<<b>>",
+    ])
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/environment-regex.ts
+++ b/packages/hoppscotch-common/src/helpers/environment-regex.ts
@@ -2,7 +2,18 @@
 // This is used to identify if the request contains environment variables that need to be handled specially.
 
 const ENV_VAR_NAME_PATTERN = "[a-zA-Z0-9_.-]+"
+
+// Global variant, used to extract every occurrence in a string via
+// `String.prototype.match` and CodeMirror's `MatchDecorator`.
 const HOPP_ENVIRONMENT_REGEX = new RegExp(`(<<${ENV_VAR_NAME_PATTERN}>>)`, "g")
+
+// Non-global variant, used for stateless `.test()` containment checks.
+// A global regex must not be used with `.test()`: it keeps a `lastIndex`
+// between calls, so testing the same (or a shorter) string repeatedly returns
+// alternating/incorrect results, and the state leaks across every module that
+// shares the regex.
+const HOPP_ENVIRONMENT_TEST_REGEX = new RegExp(`(<<${ENV_VAR_NAME_PATTERN}>>)`)
+
 const ENV_VAR_NAME_REGEX = new RegExp(ENV_VAR_NAME_PATTERN)
 
-export { HOPP_ENVIRONMENT_REGEX, ENV_VAR_NAME_REGEX }
+export { HOPP_ENVIRONMENT_REGEX, HOPP_ENVIRONMENT_TEST_REGEX, ENV_VAR_NAME_REGEX }

--- a/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
+++ b/packages/hoppscotch-common/src/services/inspection/inspectors/environment.inspector.ts
@@ -26,9 +26,12 @@ import {
   getEffectiveVariablesForRequest,
   filterNonEmptyEnvironmentVariables,
 } from "~/helpers/utils/environments"
-import { HOPP_ENVIRONMENT_REGEX } from "~/helpers/environment-regex"
+import {
+  HOPP_ENVIRONMENT_REGEX,
+  HOPP_ENVIRONMENT_TEST_REGEX,
+} from "~/helpers/environment-regex"
 
-const isENVInString = (str: string) => HOPP_ENVIRONMENT_REGEX.test(str)
+const isENVInString = (str: string) => HOPP_ENVIRONMENT_TEST_REGEX.test(str)
 
 /**
  * This inspector is responsible for inspecting the environment variables of a input.


### PR DESCRIPTION
## Problem

`HOPP_ENVIRONMENT_REGEX` in `packages/hoppscotch-common/src/helpers/environment-regex.ts` is a module-level regex created with the global (`g`) flag. That is correct for the code that needs every occurrence:

- `environment.inspector.ts` uses `element.match(HOPP_ENVIRONMENT_REGEX)`
- `HoppEnvironment.ts` uses it as the `regexp` for CodeMirror's `MatchDecorator`

But three places use the same shared regex with `.test()`:

- `environment.inspector.ts` -> `isENVInString`
- `curl/curlparser.ts` -> `containsEnvVariables`
- `editor/extensions/HoppEnvironment.ts` -> the tooltip word check

A global regex keeps a `lastIndex` between calls, and `.test()` resumes searching from that position. Since the regex object is shared across all of these modules, the state leaks between them. After one successful match, the next `.test()` can start past the beginning of a shorter string and return `false` even when the string does contain a variable.

## Reproduction

```js
const re = /(<<[a-zA-Z0-9_.-]+>>)/g

re.test("<<token>>") // true
re.test("<<token>>") // false  <- same input, different result

re.test("https://<<host>>/api") // true, lastIndex now past a short string
re.test("<<url>>")              // false, but it clearly has a variable
```

In practice this means, for example, a curl import whose URL uses an environment variable can be treated as having no variables (in `containsEnvVariables`), depending on what was tested just before it.

## Fix

Add a non-global `HOPP_ENVIRONMENT_TEST_REGEX` and use it for the `.test()` containment checks. The global `HOPP_ENVIRONMENT_REGEX` is kept unchanged for `String.match` extraction and the `MatchDecorator`, which need it. Added a spec covering repeated calls, the cross-length state-leak case, and that the global regex still extracts all matches.

No behavior change for the match/highlight paths; only the boolean containment checks become order-independent and correct.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false negatives in environment variable detection by using a non-global regex for `.test()` checks. Detection is now consistent across cURL import, the environment inspector, and editor tooltips; extraction/highlighting remain unchanged.

- **Bug Fixes**
  - Introduced non-global `HOPP_ENVIRONMENT_TEST_REGEX` for containment checks; kept global `HOPP_ENVIRONMENT_REGEX` for extraction and `MatchDecorator`.
  - Replaced `.test()` usages in `curlparser.ts`, `environment.inspector.ts`, and `editor/extensions/HoppEnvironment.ts`.
  - Added tests to ensure stable `.test()` results and that the global regex still extracts all matches.

<sup>Written for commit cd7b89035be2b72dd251313b0fbed2bdc0dedf04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

