### PR TITLE
fix: rename bearer auth label to bearer token

### DIFF
--- a/packages/hoppscotch-common/src/components/graphql/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/graphql/Authorization.vue
@@ -296,7 +296,7 @@ const authTypes: AuthType[] = [
   },
   {
     key: "bearer",
-    label: "Bearer",
+    label: "Bearer Token",
   },
   {
     key: "oauth-2",
@@ -317,7 +317,7 @@ const authTypes: AuthType[] = [
 
 const AUTH_KEY_NAME: Record<HoppGQLAuth["authType"], string> = {
   basic: "Basic Auth",
-  bearer: "Bearer",
+  bearer: "Bearer Token",
   "oauth-2": "OAuth 2.0",
   "api-key": "API key",
   none: "None",

--- a/packages/hoppscotch-common/src/components/http/Authorization.vue
+++ b/packages/hoppscotch-common/src/components/http/Authorization.vue
@@ -344,7 +344,7 @@ const authTypes: AuthType[] = [
   },
   {
     key: "bearer",
-    label: "Bearer",
+    label: "Bearer Token",
   },
   {
     key: "oauth-2",


### PR DESCRIPTION
Closes #6485

### What's changed

- Renamed the HTTP Authorization option from **"Bearer"** to **"Bearer Token"**.
- Renamed the GraphQL Authorization option from **"Bearer"** to **"Bearer Token"**.
- Updated the GraphQL selected authorization label to **"Bearer Token"**.
- Kept the internal `bearer` authentication key unchanged.

### Notes to reviewers

This is a UI-only terminology change. No authentication functionality or behavior has been changed.

Tests: `pnpm --filter @hoppscotch/common run test` — 1062 tests passed, 2 skipped.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the Authorization option label from "Bearer" to "Bearer Token" in both HTTP and GraphQL UIs for clarity. The internal key remains `bearer`; no authentication behavior changes.

<sup>Written for commit bf774861d7cb6630005c4cde8203bdb4c6db6763. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

