### PR TITLE
fix(hoppGql): add Zod validation to hoppGqlCollectionsImporter

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppGql.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppGql.ts
@@ -1,12 +1,25 @@
 import { HoppCollection } from "@hoppscotch/data"
+import * as A from "fp-ts/Array"
 import * as E from "fp-ts/Either"
+import * as O from "fp-ts/Option"
+import { flow, pipe } from "fp-ts/function"
+import { safeParseJSON } from "~/helpers/functional/json"
 
-// TODO: add zod validation
 export const hoppGqlCollectionsImporter = (
   contents: string[]
 ): E.Either<"INVALID_JSON", HoppCollection[]> => {
-  return E.tryCatch(
-    () => contents.flatMap((content) => JSON.parse(content)),
-    () => "INVALID_JSON"
+  return pipe(
+    contents,
+    A.traverse(O.Applicative)((str) => safeParseJSON(str, true)),
+    O.chain(
+      flow(
+        A.flatten,
+        A.traverse(O.Applicative)((coll) => {
+          const parsed = HoppCollection.safeParse(coll)
+          return parsed.type === "ok" ? O.some(parsed.value) : O.none
+        })
+      )
+    ),
+    E.fromOption(() => "INVALID_JSON")
   )
 }


### PR DESCRIPTION
## Description

Adds Zod validation to `hoppGqlCollectionsImporter` in `hoppGql.ts`, resolving the `// TODO: add zod validation` comment.

Previously, the importer parsed raw JSON with no validation — any malformed file would silently produce incorrect collection data. Now each parsed collection is validated against the `HoppCollection` schema (verzod, which uses Zod under the hood) before being returned, matching the pattern used by all other importers (Postman, OpenAPI, Insomnia, HAR).

## Changes

- **`packages/hoppscotch-common/src/helpers/import-export/import/hoppGql.ts`** — replaced raw `JSON.parse` with `safeParseJSON` + `HoppCollection.safeParse` validation, using the same fp-ts pipeline pattern (`O.traverse` → `O.chain` → `E.fromOption`) as `hopp.ts`'s `hoppGQLImporter`.

Closes #6530

## How this was tested

- The importer follows the same validation pattern already established in `hopp.ts` (`validateGQLCollection`) and `har.ts`.
- Input flows: `string[]` → `safeParseJSON` (JSON parse + array normalization) → `HoppCollection.safeParse` per collection → validated `HoppCollection[]`.
- If any collection fails validation, the entire import returns `E.left("INVALID_JSON")`, consistent with the existing error type.

## Breaking changes

None. The public API (`hoppGqlCollectionsImporter`) maintains the same signature and return type.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Zod validation to `hoppGqlCollectionsImporter` so malformed GraphQL collections are rejected instead of silently creating bad data, fixing #6530. We now parse with `safeParseJSON` and validate each `HoppCollection`, returning `E.left("INVALID_JSON")` on failure.

- **Bug Fixes**
  - Replaced raw `JSON.parse` with `safeParseJSON` + `HoppCollection.safeParse`.
  - Adopted the same `fp-ts` pipeline used by other importers for consistent validation.

<sup>Written for commit 2bce3b8ec7df06785ef09627a5dd30230648e653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

