### PR TITLE
fix: prevent POST method truncation in collections sidebar

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/Request.vue
+++ b/packages/hoppscotch-common/src/components/collections/Request.vue
@@ -35,7 +35,7 @@
         @click="selectRequest()"
       >
         <span
-          class="pointer-events-none flex w-8 items-center justify-start truncate px-0.5"
+          class="pointer-events-none flex w-12 items-center justify-start truncate px-0.5"
           :style="{ color: getMethodLabelColorClassOf(request.method) }"
         >
           <component


### PR DESCRIPTION
## Summary

Fixes the issue where HTTP method labels (like `POST`) were being truncated in the collections sidebar, as reported in #5577.

## Changes

- Increased the width of the HTTP method badge from `w-8` to `w-12` in `packages/hoppscotch-common/src/components/collections/Request.vue` to allow enough space for longer method names like POST, DELETE, etc. without truncation.

Closes #5577
