### PR TITLE
refactor: reduce ternlint complexity

### DIFF
--- a/packages/hoppscotch-common/src/helpers/ternlint.js
+++ b/packages/hoppscotch-common/src/helpers/ternlint.js
@@ -27,6 +27,7 @@ function getArrType(type) {
     }
   }
 }
+
 function getTypeName(type) {
   if (!type) return "Unknown type"
   if (type.types) {

--- a/packages/hoppscotch-common/src/helpers/ternlint.js
+++ b/packages/hoppscotch-common/src/helpers/ternlint.js
@@ -4,7 +4,6 @@ import infer from "tern/lib/infer"
 import tern from "tern/lib/tern"
 import * as walk from "acorn-walk"
 
-
 var defaultRules = {
   UnknownProperty: { severity: "warning" },
   UnknownIdentifier: { severity: "warning" },
@@ -17,6 +16,34 @@ var defaultRules = {
   TypeMismatch: { severity: "warning" },
   Array: { severity: "error" },
   ES6Modules: { severity: "error" },
+}
+
+function getArrType(type) {
+  if (type instanceof infer.Arr) {
+    return type.getObjType()
+  } else if (type.types) {
+    for (var i = 0; i < type.types.length; i++) {
+      if (getArrType(type.types[i])) return type.types[i]
+    }
+  }
+}
+function getTypeName(type) {
+  if (!type) return "Unknown type"
+  if (type.types) {
+    // multiple types
+    var types = type.types,
+      s = ""
+    for (var i = 0; i < types.length; i++) {
+      if (i > 0) s += "|"
+      var t = getTypeName(types[i])
+      if (t != "Unknown type") s += t
+    }
+    return s == "" ? "Unknown type" : s
+  }
+  if (type.name) {
+    return type.name
+  }
+  return type.proto ? type.proto.name : "Unknown type"
 }
 
 function makeVisitors(server, query, file, messages) {
@@ -91,25 +118,6 @@ function makeVisitors(server, query, file, messages) {
       return node.property
     }
     return node
-  }
-
-  function getTypeName(type) {
-    if (!type) return "Unknown type"
-    if (type.types) {
-      // multiple types
-      var types = type.types,
-        s = ""
-      for (var i = 0; i < types.length; i++) {
-        if (i > 0) s += "|"
-        var t = getTypeName(types[i])
-        if (t != "Unknown type") s += t
-      }
-      return s == "" ? "Unknown type" : s
-    }
-    if (type.name) {
-      return type.name
-    }
-    return type.proto ? type.proto.name : "Unknown type"
   }
 
   function hasProto(expectedType, name) {
@@ -241,6 +249,59 @@ function makeVisitors(server, query, file, messages) {
     return type.proto && type.proto.name == "Function.prototype"
   }
 
+  function validateCallArguments(
+    actualArgs,
+    expectedArgs,
+    state,
+    invalidArgument
+  ) {
+    for (var i = 0; i < expectedArgs.length; i++) {
+      var expectedArg = expectedArgs[i]
+
+      if (actualArgs.length <= i) continue
+
+      var actualNode = actualArgs[i]
+
+      if (isRegexExpected(expectedArg.getType())) {
+        var value = getNodeValue(actualNode)
+
+        if (value) {
+          try {
+            var regex = new RegExp(value)
+          } catch (e) {
+            addMessage(
+              actualNode,
+              "Invalid argument at " + (i + 1) + ": " + e,
+              invalidArgument.severity
+            )
+          }
+        }
+      } else {
+        var actualArg = infer.expressionType({
+          node: actualNode,
+          state: state,
+        })
+
+        // if actual type is an Object literal and expected type is an object, we ignore
+        // the comparison type since object literal properties validation is done inside "ObjectExpression".
+        if (!(expectedArg.getObjType() && isObjectLiteral(actualArg))) {
+          if (!compareType(expectedArg, actualArg)) {
+            addMessage(
+              actualNode,
+              "Invalid argument at " +
+                (i + 1) +
+                ": cannot convert from " +
+                getTypeName(actualArg) +
+                " to " +
+                getTypeName(expectedArg),
+              invalidArgument.severity
+            )
+          }
+        }
+      }
+    }
+  }
+
   function validateCallExpression(node, state, c) {
     var notAFunctionRule = getRule("NotAFunction"),
       invalidArgument = getRule("InvalidArgument")
@@ -264,52 +325,17 @@ function makeVisitors(server, query, file, messages) {
       var fnLint = getFunctionLint(fnType)
       var continueLint = fnLint ? fnLint(node, addMessage, getRule) : true
       if (continueLint && fnType.args) {
-        // validate parameters of the function
         if (!invalidArgument) return
+
         var actualArgs = node.arguments
         if (!actualArgs) return
-        var expectedArgs = fnType.args
-        for (var i = 0; i < expectedArgs.length; i++) {
-          var expectedArg = expectedArgs[i]
-          if (actualArgs.length > i) {
-            var actualNode = actualArgs[i]
-            if (isRegexExpected(expectedArg.getType())) {
-              var value = getNodeValue(actualNode)
-              if (value) {
-                try {
-                  var regex = new RegExp(value)
-                } catch (e) {
-                  addMessage(
-                    actualNode,
-                    "Invalid argument at " + (i + 1) + ": " + e,
-                    invalidArgument.severity
-                  )
-                }
-              }
-            } else {
-              var actualArg = infer.expressionType({
-                node: actualNode,
-                state: state,
-              })
-              // if actual type is an Object literal and expected type is an object, we ignore
-              // the comparison type since object literal properties validation is done inside "ObjectExpression".
-              if (!(expectedArg.getObjType() && isObjectLiteral(actualArg))) {
-                if (!compareType(expectedArg, actualArg)) {
-                  addMessage(
-                    actualNode,
-                    "Invalid argument at " +
-                      (i + 1) +
-                      ": cannot convert from " +
-                      getTypeName(actualArg) +
-                      " to " +
-                      getTypeName(expectedArg),
-                    invalidArgument.severity
-                  )
-                }
-              }
-            }
-          }
-        }
+
+        validateCallArguments(
+          actualArgs,
+          fnType.args,
+          state,
+          invalidArgument
+        )
       }
     }
   }
@@ -405,16 +431,6 @@ function makeVisitors(server, query, file, messages) {
             )
         }
         break
-    }
-  }
-
-  function getArrType(type) {
-    if (type instanceof infer.Arr) {
-      return type.getObjType()
-    } else if (type.types) {
-      for (var i = 0; i < type.types.length; i++) {
-        if (getArrType(type.types[i])) return type.types[i]
-      }
     }
   }
 

--- a/packages/hoppscotch-common/src/helpers/ternlint.js
+++ b/packages/hoppscotch-common/src/helpers/ternlint.js
@@ -267,7 +267,7 @@ function makeVisitors(server, query, file, messages) {
 
         if (value) {
           try {
-            var regex = new RegExp(value)
+            new RegExp(value)
           } catch (e) {
             addMessage(
               actualNode,


### PR DESCRIPTION
## Description

Refactored `ternlint.js` to reduce the complexity of `validateCallExpression`.

### Changes

- Extracted call argument validation into `validateCallArguments`
- Moved shared helper functions outside `makeVisitors`
- Preserved the existing linting behavior

### Validation

- `pnpm --filter @hoppscotch/common exec eslint src/helpers/ternlint.js` ✅
- `pnpm --filter @hoppscotch/common test` ✅
- `git diff --check` ✅

The full repository pre-commit hook currently reports unrelated existing lint errors in other files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces `ternlint.js` visitor complexity by hoisting shared helpers and extracting call-argument checks, without changing lint results. This lowers per-visit allocations and clarifies call validation flow.

- Adds `validateCallArguments`; `validateCallExpression` delegates to it, preserving RegExp and type checks.
- Hoists `getTypeName` and `getArrType` to module scope and removes duplicate in-visitor definitions.
- No behavior change: diagnostics, severities, and rule evaluation in `@hoppscotch/common` remain the same.
- Validation: `pnpm --filter @hoppscotch/common exec eslint src/helpers/ternlint.js` and `pnpm --filter @hoppscotch/common test` pass.

<sup>Written for commit 52dc6d75e638d748f5b4f3c1b16177489c44a467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

