### PR TITLE
fix: validate GQL collections during import

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/hoppGql.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/hoppGql.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import * as E from "fp-ts/Either"
+
+import { hoppGqlCollectionsImporter } from "../hoppGql"
+
+describe("hoppGqlCollectionsImporter", () => {
+  it("imports a valid Hoppscotch GQL collection", () => {
+    const collection = {
+      v: 12,
+      name: "Test Collection",
+      folders: [],
+      requests: [],
+      auth: {
+        authType: "inherit",
+        authActive: true,
+      },
+      headers: [],
+      variables: [],
+      description: null,
+      preRequestScript: "",
+      testScript: "",
+    }
+
+    const result = hoppGqlCollectionsImporter([JSON.stringify(collection)])
+
+    expect(E.isRight(result)).toBe(true)
+  })
+
+  it("rejects invalid JSON", () => {
+    const result = hoppGqlCollectionsImporter(["invalid json"])
+
+    expect(result).toEqual(E.left("INVALID_JSON"))
+  })
+
+  it("rejects valid JSON that is not a Hoppscotch collection", () => {
+    const result = hoppGqlCollectionsImporter([
+      JSON.stringify({
+        foo: "bar",
+      }),
+    ])
+
+    expect(result).toEqual(E.left("INVALID_JSON"))
+  })
+
+  it("rejects an invalid collection structure", () => {
+    const result = hoppGqlCollectionsImporter([
+      JSON.stringify({
+        v: 12,
+        name: "Invalid Collection",
+        folders: [],
+        requests: "not-an-array",
+      }),
+    ])
+
+    expect(result).toEqual(E.left("INVALID_JSON"))
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/import-export/import/hoppGql.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/hoppGql.ts
@@ -1,12 +1,24 @@
 import { HoppCollection } from "@hoppscotch/data"
 import * as E from "fp-ts/Either"
+import { entityReference } from "verzod"
 
-// TODO: add zod validation
 export const hoppGqlCollectionsImporter = (
   contents: string[]
 ): E.Either<"INVALID_JSON", HoppCollection[]> => {
   return E.tryCatch(
-    () => contents.flatMap((content) => JSON.parse(content)),
+    () => {
+      const parsedContents = contents.flatMap((content) => JSON.parse(content))
+
+      const validationResult = entityReference(HoppCollection)
+        .array()
+        .safeParse(parsedContents)
+
+      if (!validationResult.success) {
+        throw new Error("Invalid Hoppscotch GQL collection")
+      }
+
+      return validationResult.data
+    },
     () => "INVALID_JSON"
   )
 }


### PR DESCRIPTION
## Description

Added schema validation to the Hoppscotch GQL collections importer.

## Changes

- Removed the Zod validation TODO
- Added `HoppCollection` validation using `entityReference`
- Invalid JSON or invalid collection structures now return `INVALID_JSON`
- Added tests for valid and invalid GQL collection input

## Validation

- Targeted ESLint ✅
- GQL importer tests: 4 passed ✅
- Full test suite: 65 files passed, 1065 tests passed, 2 skipped ✅
- `git diff --check` ✅

Closes #6530

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate GraphQL collection imports against `HoppCollection` to reject malformed inputs. Previously we only parsed JSON; now we validate structure and return `INVALID_JSON` for both parse failures and schema mismatches. This may cause some previously accepted inputs to fail import.

- Uses `verzod` `entityReference(HoppCollection).array().safeParse` with types from `@hoppscotch/data`.
- Return type unchanged: `Either<"INVALID_JSON", HoppCollection[]>`, but the error path now includes invalid collection structures.
- Adds unit tests for valid input, invalid JSON, and invalid collection shape.

<sup>Written for commit 334189d9bc6e9b8a53d3fa75488d410f583472f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

