### PR TITLE
fix(ui): add confirmation prompt to request clear all button

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -357,6 +357,7 @@
     "duplicated": "Collection duplicated"
   },
   "confirm": {
+    "clear_all": "Clear all?",
     "close_unsaved_tab": "Are you sure you want to close this tab?",
     "close_unsaved_tabs": "Are you sure you want to close all tabs? {count} unsaved tabs will be lost.",
     "delete_all_activity_logs": "Are you sure you want to delete all activity logs?",

--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -133,7 +133,7 @@
                 :shortcut="['⌫']"
                 @click="
                   () => {
-                    clearContent()
+                    openClearAllModal()
                     hide()
                   }
                 "
@@ -232,6 +232,16 @@
       :request="request"
       @hide-modal="showSaveRequestModal = false"
     />
+    <HoppSmartConfirmModal
+      :show="confirmClearAll"
+      :title="t('confirm.clear_all')"
+      @hide-modal="confirmClearAll = false"
+      @resolve="
+        () => {
+          confirmClearAllAction()
+        }
+      "
+    />
   </div>
 </template>
 
@@ -314,6 +324,7 @@ const isTabResponseLoading = computed(
 const showCurlImportModal = ref(false)
 const showCodegenModal = ref(false)
 const showSaveRequestModal = ref(false)
+const confirmClearAll = ref(false)
 
 const methodTippyActions = ref<any | null>(null)
 const sendTippyActions = ref<any | null>(null)
@@ -519,7 +530,21 @@ const onSelectMethod = (e: Event | any) => {
 }
 
 const clearContent = () => {
+  tab.value.document.cancelFunction?.()
+  loading.value = false
+
   tab.value.document.request = getDefaultRESTRequest()
+  tab.value.document.response = null
+  tab.value.document.testResults = null
+}
+
+const openClearAllModal = () => {
+  confirmClearAll.value = true
+}
+
+const confirmClearAllAction = () => {
+  clearContent()
+  confirmClearAll.value = false
 }
 
 const updateRESTResponse = (response: HoppRESTResponse | null) => {


### PR DESCRIPTION
Closes #6580

Added a confirmation prompt to prevent accidentally wiping out REST requests when clicking "Clear All" in the Send options menu. 

### What's changed
- Added `<HoppSmartConfirmModal>` to the `Request.vue` HTTP component
- Changed the "Clear All" click handler to open the modal instead of clearing the UI immediately
- Updated `clearContent()` to also clear the `response` and `testResults` so the UI returns to a completely blank, fresh state.

### Notes to reviewers
Used the existing `action.clear_all` i18n string for the modal title.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a confirmation prompt to the HTTP Request “Clear All” action to prevent accidental wipes. Previously it immediately reset only the request; now it asks for confirmation and, on confirm, cancels any in‑flight request, clears request/response/test results, and resets loading. Cancel keeps the state unchanged.

- “Clear All” opens `HoppSmartConfirmModal` from the Send menu and via the ⌫ shortcut.
- Adds i18n key `confirm.clear_all` ("Clear all?") in `packages/hoppscotch-common/locales/en.json`.
- No backend or storage changes.

<sup>Written for commit 7ba03aa9a609180e465fb1337988efa2ddd84066. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

