### PR TITLE
feat: add Ctrl+D / Cmd+D shortcut to duplicate line or selection (#6270)

### DIFF
--- a/packages/hoppscotch-common/src/composables/codemirror.ts
+++ b/packages/hoppscotch-common/src/composables/codemirror.ts
@@ -24,6 +24,7 @@ import {
   indentLess,
   insertTab,
   redo,
+  copyLineDown,
 } from "@codemirror/commands"
 import { Completion, autocompletion } from "@codemirror/autocomplete"
 import { linter } from "@codemirror/lint"
@@ -521,6 +522,16 @@ export function useCodemirror(
             mac: "Cmd-Enter" /* Mac */,
             preventDefault: true,
             run: () => true,
+          },
+        ])
+      ),
+      Prec.highest(
+        keymap.of([
+          {
+            key: "Ctrl-d",
+            mac: "Cmd-d",
+            preventDefault: true,
+            run: copyLineDown,
           },
         ])
       ),


### PR DESCRIPTION
## Description

Implements the "Duplicate Line / Selection" shortcut requested in #6270.

### Changes

**File modified:** `packages/hoppscotch-common/src/composables/codemirror.ts`

- Imports `copyLineDown` from `@codemirror/commands` — this built-in CodeMirror 6 command already handles both behaviors:
  - **No selection** → duplicates the current line below the cursor
  - **Text selected** → duplicates the entire selected block below
- Binds the command to `Ctrl+D` (Windows/Linux) and `Cmd+D` (macOS)
- Uses `Prec.highest` to override the browser's default bookmark shortcut (`Ctrl+D`)
- Cursor position is maintained logically in the duplicated copy (bottom), matching VS Code behavior

### Where it works

All CodeMirror-based editors throughout the app:
- ✅ Request body editors (JSON, GraphQL, XML, etc.)
- ✅ Pre-request scripts
- ✅ Test scripts
- ✅ Any other editor using the `useCodemirror` composable

### Why `copyLineDown` from `@codemirror/commands`

Rather than implementing custom duplication logic, this uses the official CodeMirror command which:
1. Correctly handles multi-cursor scenarios
2. Properly preserves indentation and line breaks
3. Works with multi-line selections spanning partial lines
4. Is already a dependency of the project (`@codemirror/commands@6.10.0`)

### Testing

- Verified the shortcut does not conflict with any existing keybinding in the codebase
- TypeScript compilation passes with no new errors
- The `@codemirror/commands` package is already installed — no new dependencies added

Closes #6270


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Ctrl+D (Windows/Linux) and Cmd+D (macOS) to duplicate the current line or the current selection in all CodeMirror editors. Previously Ctrl+D opened the browser bookmark dialog and duplication was unavailable; now it uses CodeMirror’s built-in behavior and matches VS Code.

**Review notes**
- Modifies `packages/hoppscotch-common/src/composables/codemirror.ts` to import `copyLineDown` from `@codemirror/commands` and bind it via `keymap` with `Prec.highest` and `preventDefault`.
- Applies to every editor using `useCodemirror` (request bodies, pre-request scripts, test scripts).
- Behavior: no selection duplicates the current line below; a selection duplicates the whole block below; cursor moves to the new copy; multi-cursor supported.
- No new dependencies or migrations; `@codemirror/commands` is already installed.

<sup>Written for commit 7661c1f39c6fc5e4d98d7aa0ea68566039a82dea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

