### PR TITLE
fix(common): cap connection timeout dropdown width

### DIFF
--- a/packages/hoppscotch-common/src/components/settings/Desktop.vue
+++ b/packages/hoppscotch-common/src/components/settings/Desktop.vue
@@ -86,7 +86,7 @@
           <label class="text-secondaryLight">{{
             t("settings.connection_timeout")
           }}</label>
-          <div class="mt-3">
+          <div class="mt-3 w-[15rem]">
             <tippy
               interactive
               trigger="click"


### PR DESCRIPTION
The connection timeout tippy in `settings/Desktop.vue` was in a full-width block, and both the vue-tippy reference span and `HoppSmartSelectWrapper`'s `.select-wrapper`, which is flex 110%, expand to the full width of their container.

So the reference measured the whole 613px settings row, the absolutely positioned chevron rendered at the far right, and the options popup centered on that full-width reference above the row rather than under the 15rem trigger. 

Capping the wrapping div at `w-[15rem]` bounds the reference to the trigger, so the chevron renders beside the label and the popup anchors under it. Confirmed in the running app that the reference measures 240px after the change, down from 613px.

Closes FE-1323


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the connection timeout select container in `packages/hoppscotch-common/src/components/settings/Desktop.vue` to `w-[15rem]` so the tippy reference matches the trigger and the dropdown anchors correctly. Addresses FE-1323.

Old behavior: the tippy reference spanned the full settings row (~613px), the chevron rendered at the far right, and the options popup centered above the row. New behavior: the reference is bounded (~240px), the chevron sits beside the label, and the popup opens under the 15rem trigger. No functional changes; only this field’s layout is width-capped.

<sup>Written for commit 8f43b6186be43cf05a008e934fc5df1b161a4af7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

