### PR TITLE
fix(common): agent Set-Cookie header fallback

### DIFF
--- a/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
@@ -410,7 +410,7 @@ describe("CookieJarService", () => {
   })
 
   describe("captureResponseCookies header fallback", () => {
-    it("parses the Set-Cookie header when structured cookies is undefined", async () => {
+    it("parses the Set-Cookie header when structured cookies are undefined", async () => {
       await service.captureResponseCookies(
         { headers: { "set-cookie": "sid=abc123; Path=/; HttpOnly" } },
         "https://example.com/"
@@ -419,6 +419,27 @@ describe("CookieJarService", () => {
       expect(stored).toHaveLength(1)
       expect(stored[0].name).toBe("sid")
       expect(stored[0].value).toBe("abc123")
+    })
+
+    it("resolves Max-Age into an expiry on the header fallback", async () => {
+      await service.captureResponseCookies(
+        { headers: { "set-cookie": "sid=abc; Max-Age=60; Path=/" } },
+        "https://example.com/"
+      )
+      const stored = service.getCookiesForURL(new URL("https://example.com/"))
+      expect(stored).toHaveLength(1)
+      expect(stored[0].expires).toBeDefined()
+      expect(new Date(stored[0].expires!).getTime()).toBeGreaterThan(Date.now())
+    })
+
+    it("keeps a percent-encoded value undecoded on the header fallback", async () => {
+      await service.captureResponseCookies(
+        { headers: { "set-cookie": "sid=abc%20123; Path=/" } },
+        "https://example.com/"
+      )
+      const stored = service.getCookiesForURL(new URL("https://example.com/"))
+      expect(stored).toHaveLength(1)
+      expect(stored[0].value).toBe("abc%20123")
     })
 
     it("splits newline-joined Set-Cookie headers the agent relay concatenates", async () => {

--- a/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
@@ -420,6 +420,27 @@ describe("CookieJarService", () => {
       ).toHaveLength(1)
     })
 
+    it("rejects a partial IP suffix as a Domain attribute", async () => {
+      await service.extractFromResponse(
+        [{ name: "sid", value: "1", domain: "1.1" }],
+        new URL("https://192.168.1.1/")
+      )
+      expect(service.cookieJar.value.size).toBe(0)
+      expect(
+        service.getCookiesForURL(new URL("https://10.0.1.1/"))
+      ).toHaveLength(0)
+    })
+
+    it("accepts a Domain attribute equal to the IP host", async () => {
+      await service.extractFromResponse(
+        [{ name: "sid", value: "1", domain: "192.168.1.1" }],
+        new URL("https://192.168.1.1/")
+      )
+      expect(
+        service.getCookiesForURL(new URL("https://192.168.1.1/"))
+      ).toHaveLength(1)
+    })
+
     it("falls back to default-path when the Path attribute does not start with /", async () => {
       await service.extractFromResponse(
         [{ name: "a", value: "1", path: "foo" }],

--- a/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { TestContainer } from "dioc/testing"
 import { Cookie } from "@hoppscotch/data"
 
@@ -471,6 +471,29 @@ describe("CookieJarService", () => {
       const stored = service.getCookiesForURL(new URL("https://example.com/"))
       expect(stored).toHaveLength(2)
       expect(stored.map((c) => c.name).sort()).toEqual(["a", "b"])
+    })
+
+    it("drops an existing cookie on a Max-Age=0 fallback capture", async () => {
+      // Frozen so the read happens at the same instant as the
+      // capture, which is the only window in which an expiry equal
+      // to the capture time still reads as live.
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"))
+      try {
+        await service.captureResponseCookies(
+          { headers: { "set-cookie": "sid=abc; Path=/" } },
+          "https://example.com/"
+        )
+        await service.captureResponseCookies(
+          { headers: { "set-cookie": "sid=abc; Max-Age=0; Path=/" } },
+          "https://example.com/"
+        )
+        expect(
+          service.getCookiesForURL(new URL("https://example.com/"))
+        ).toHaveLength(0)
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it("rejects a cross-domain Domain on the header fallback", async () => {

--- a/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
@@ -409,6 +409,45 @@ describe("CookieJarService", () => {
     })
   })
 
+  describe("captureResponseCookies header fallback", () => {
+    it("parses the Set-Cookie header when structured cookies is undefined", async () => {
+      await service.captureResponseCookies(
+        { headers: { "set-cookie": "sid=abc123; Path=/; HttpOnly" } },
+        "https://example.com/"
+      )
+      const stored = service.getCookiesForURL(new URL("https://example.com/"))
+      expect(stored).toHaveLength(1)
+      expect(stored[0].name).toBe("sid")
+      expect(stored[0].value).toBe("abc123")
+    })
+
+    it("splits newline-joined Set-Cookie headers the agent relay concatenates", async () => {
+      await service.captureResponseCookies(
+        { headers: { "set-cookie": "a=1; Path=/\nb=2; Path=/" } },
+        "https://example.com/"
+      )
+      const stored = service.getCookiesForURL(new URL("https://example.com/"))
+      expect(stored).toHaveLength(2)
+      expect(stored.map((c) => c.name).sort()).toEqual(["a", "b"])
+    })
+
+    it("does not re-parse headers when cookies is a defined empty array", async () => {
+      await service.captureResponseCookies(
+        { cookies: [], headers: { "set-cookie": "sid=abc123; Path=/" } },
+        "https://example.com/"
+      )
+      expect(service.cookieJar.value.size).toBe(0)
+    })
+
+    it("does nothing when cookies is undefined and no Set-Cookie header is present", async () => {
+      await service.captureResponseCookies(
+        { headers: { "content-type": "application/json" } },
+        "https://example.com/"
+      )
+      expect(service.cookieJar.value.size).toBe(0)
+    })
+  })
+
   describe("serializeCookieHeader", () => {
     it("joins `name=value` pairs with `; `", () => {
       expect(

--- a/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/__tests__/cookie-jar.service.spec.ts
@@ -399,6 +399,27 @@ describe("CookieJarService", () => {
       expect(service.cookieJar.value.size).toBe(0)
     })
 
+    it("rejects a Domain the response host does not domain-match", async () => {
+      await service.extractFromResponse(
+        [{ name: "sid", value: "attacker", domain: "example.com" }],
+        new URL("https://attacker.invalid/")
+      )
+      expect(service.cookieJar.value.size).toBe(0)
+      expect(
+        service.getCookiesForURL(new URL("https://example.com/"))
+      ).toHaveLength(0)
+    })
+
+    it("accepts a parent Domain from a subdomain host", async () => {
+      await service.extractFromResponse(
+        [{ name: "sid", value: "1", domain: "example.com" }],
+        new URL("https://api.example.com/")
+      )
+      expect(
+        service.getCookiesForURL(new URL("https://example.com/"))
+      ).toHaveLength(1)
+    })
+
     it("falls back to default-path when the Path attribute does not start with /", async () => {
       await service.extractFromResponse(
         [{ name: "a", value: "1", path: "foo" }],
@@ -450,6 +471,21 @@ describe("CookieJarService", () => {
       const stored = service.getCookiesForURL(new URL("https://example.com/"))
       expect(stored).toHaveLength(2)
       expect(stored.map((c) => c.name).sort()).toEqual(["a", "b"])
+    })
+
+    it("rejects a cross-domain Domain on the header fallback", async () => {
+      await service.captureResponseCookies(
+        {
+          headers: {
+            "set-cookie": "sid=attacker; Domain=example.com; Path=/",
+          },
+        },
+        "https://attacker.invalid/"
+      )
+      expect(service.cookieJar.value.size).toBe(0)
+      expect(
+        service.getCookiesForURL(new URL("https://example.com/"))
+      ).toHaveLength(0)
     })
 
     it("does not re-parse headers when cookies is a defined empty array", async () => {

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -850,9 +850,12 @@ export class CookieJarService extends Service {
   // multiple Set-Cookie headers with newlines (see the agent
   // interceptor's multiHeaders split), so each line is parsed on its
   // own. Lines the parser cannot resolve to a name are dropped rather
-  // than stored as `undefined=...`. Returns undefined when the header
-  // is absent so the caller can distinguish "no header" from "header
-  // with no usable cookies".
+  // than stored as `undefined=...`. Returns undefined when there is no
+  // Set-Cookie header to read, empty value included, and an array
+  // otherwise. `decodeValues` is off so a percent-encoded value is
+  // stored exactly as the relay's structured path stores it, since a
+  // decoded value would be re-emitted unencoded by
+  // `serializeCookieHeader`.
   private cookiesFromSetCookieHeader(
     headers: Record<string, string> | undefined
   ): ResponseCookie[] | undefined {
@@ -874,7 +877,7 @@ export class CookieJarService extends Service {
       .split("\n")
       .map((s) => s.trim())
       .filter(Boolean)) {
-      const parsed = this.parseSetCookieString(line)
+      const parsed = setCookieParse(line, { decodeValues: false })
       if (!parsed.name) {
         continue
       }
@@ -883,7 +886,15 @@ export class CookieJarService extends Service {
         value: parsed.value,
         domain: parsed.domain,
         path: parsed.path,
-        expires: parsed.expires,
+        // RFC 6265 4.1.2.2, Max-Age takes precedence over Expires, and
+        // the structured relay path has already resolved it into an
+        // expiry by the time cookies arrive that way. Converting here
+        // keeps a `Max-Age` cookie from being stored as a session
+        // cookie, and lets `Max-Age=0` expire an entry on capture.
+        expires:
+          parsed.maxAge !== undefined && Number.isFinite(parsed.maxAge)
+            ? new Date(Date.now() + parsed.maxAge * 1000)
+            : parsed.expires,
         secure: parsed.secure,
         httpOnly: parsed.httpOnly,
         sameSite: this.normalizeSameSite(parsed.sameSite),

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -4,6 +4,7 @@ import { parseString as setCookieParse } from "set-cookie-parser-es"
 import { Cookie } from "@hoppscotch/data"
 import * as E from "fp-ts/Either"
 import { Store } from "~/kernel/store"
+import type { SetCookieValues } from "set-cookie-parser-es"
 
 // Cookies are per-organization state, so they persist through the
 // org-scoped `Store` (`~/kernel/store`), which resolves to
@@ -822,10 +823,79 @@ export class CookieJarService extends Service {
     request.headers["Cookie"] = serialized
   }
 
+  // Maps the `set-cookie-parser-es` SameSite union (lowercase or a
+  // bare boolean) onto the `@hoppscotch/data` casing
+  // `extractFromResponse` expects. An unrecognized or boolean value
+  // yields undefined so the extractor applies its "Lax" default.
+  private normalizeSameSite(
+    raw: SetCookieValues["sameSite"]
+  ): ResponseCookie["sameSite"] {
+    if (typeof raw !== "string") {
+      return undefined
+    }
+    switch (raw.toLowerCase()) {
+      case "strict":
+        return "Strict"
+      case "lax":
+        return "Lax"
+      case "none":
+        return "None"
+      default:
+        return undefined
+    }
+  }
+
+  // Parses raw Set-Cookie header strings into the response-cookie
+  // objects `extractFromResponse` canonicalizes. The agent relay joins
+  // multiple Set-Cookie headers with newlines (see the agent
+  // interceptor's multiHeaders split), so each line is parsed on its
+  // own. Lines the parser cannot resolve to a name are dropped rather
+  // than stored as `undefined=...`. Returns undefined when the header
+  // is absent so the caller can distinguish "no header" from "header
+  // with no usable cookies".
+  private cookiesFromSetCookieHeader(
+    headers: Record<string, string> | undefined
+  ): ResponseCookie[] | undefined {
+    if (!headers) {
+      return undefined
+    }
+    const key = Object.keys(headers).find(
+      (h) => h.toLowerCase() === "set-cookie"
+    )
+    if (key === undefined) {
+      return undefined
+    }
+    const raw = headers[key]
+    if (!raw) {
+      return undefined
+    }
+    const cookies: ResponseCookie[] = []
+    for (const line of raw
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
+      const parsed = this.parseSetCookieString(line)
+      if (!parsed.name) {
+        continue
+      }
+      cookies.push({
+        name: parsed.name,
+        value: parsed.value,
+        domain: parsed.domain,
+        path: parsed.path,
+        expires: parsed.expires,
+        secure: parsed.secure,
+        httpOnly: parsed.httpOnly,
+        sameSite: this.normalizeSameSite(parsed.sameSite),
+      })
+    }
+    return cookies
+  }
+
   // The one shared receive path. Captures structured cookies the
   // relay parsed out of the response into the jar.
   public async captureResponseCookies(
-    response: { cookies?: ResponseCookie[] },
+    response: { cookies?: ResponseCookie[]; headers?: Record<string, string> },
     requestUrl: string | undefined
   ): Promise<void> {
     if (!requestUrl) {
@@ -833,6 +903,21 @@ export class CookieJarService extends Service {
     }
     const url = this.parseRequestURL(requestUrl)
     if (url === null) {
+      return
+    }
+    // Agent binaries built against a relay revision without
+    // `parse_cookies` return no structured `cookies` while the
+    // Set-Cookie headers are still present in `headers`. Parsing the
+    // header string in that case keeps the jar working on older agent
+    // builds. The fallback runs only when `cookies` is absent, since a
+    // present array (even empty) is the relay's own answer that the
+    // response had no cookies, and re-parsing headers would risk
+    // double-counting.
+    if (response.cookies === undefined) {
+      await this.extractFromResponse(
+        this.cookiesFromSetCookieHeader(response.headers),
+        url
+      )
       return
     }
     await this.extractFromResponse(response.cookies, url)

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -442,6 +442,32 @@ export class CookieJarService extends Service {
     return stripped.toLowerCase()
   }
 
+  // Whether a response from `host` may set a cookie for `domain`.
+  // RFC 6265 5.3 step 5 treats an IP-literal host as an address
+  // rather than as a label chain, so only an exact match is allowed
+  // there. Running `domainMatches` on `192.168.1.1` would accept
+  // `Domain=1.1` as a parent, and the cookie would then attach to
+  // the unrelated address `10.0.1.1`, which shares the suffix and
+  // nothing else. Everything else is the 5.1.3 comparison, so a
+  // subdomain setting its parent domain still passes.
+  private hostAcceptsDomain(host: string, domain: string): boolean {
+    if (this.isIPLiteral(host)) {
+      return host === domain
+    }
+    return this.domainMatches(host, domain)
+  }
+
+  // `URL.hostname` renders an IPv6 address bracketed, so the two
+  // forms are recognized separately. An IPv4 check on the four
+  // dotted fields is enough here, since a host that reached this
+  // point already parsed as a URL.
+  private isIPLiteral(host: string): boolean {
+    if (host.startsWith("[") && host.endsWith("]")) {
+      return true
+    }
+    return /^\d{1,3}(\.\d{1,3}){3}$/.test(host)
+  }
+
   // Canonicalizes a cookie domain that came from a Set-Cookie
   // `Domain` attribute. Calls `canonStoreDomain` then rejects a
   // single-label domain that would let the cookie attach to every
@@ -505,7 +531,7 @@ export class CookieJarService extends Service {
         // here. `api.example.com` setting `Domain=example.com` still
         // passes, since `domainMatches` is the same 5.1.3 comparison
         // the read side uses.
-        if (domain !== null && !this.domainMatches(requestHost, domain)) {
+        if (domain !== null && !this.hostAcceptsDomain(requestHost, domain)) {
           console.warn(
             "[CookieJar] Dropped cookie with a cross-domain Domain:",
             c.domain

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -906,9 +906,16 @@ export class CookieJarService extends Service {
         // expiry by the time cookies arrive that way. Converting here
         // keeps a `Max-Age` cookie from being stored as a session
         // cookie, and lets `Max-Age=0` expire an entry on capture.
+        // A non-positive age resolves one millisecond behind the
+        // capture instant rather than onto it, since `pruneExpired`
+        // and the read filter both keep an entry while its expiry
+        // equals the current time, which would carry a deleted
+        // cookie into a read taken in that same millisecond.
         expires:
           parsed.maxAge !== undefined && Number.isFinite(parsed.maxAge)
-            ? new Date(Date.now() + parsed.maxAge * 1000)
+            ? new Date(
+                Date.now() + (parsed.maxAge > 0 ? parsed.maxAge * 1000 : -1)
+              )
             : parsed.expires,
         secure: parsed.secure,
         httpOnly: parsed.httpOnly,

--- a/packages/hoppscotch-common/src/services/cookie-jar.service.ts
+++ b/packages/hoppscotch-common/src/services/cookie-jar.service.ts
@@ -497,6 +497,21 @@ export class CookieJarService extends Service {
       let domain: string | null
       if (c.domain) {
         domain = this.canonAttrDomain(c.domain)
+        // RFC 6265 5.3 step 6 rejects a `Domain` attribute the
+        // request host does not domain-match. Without it a response
+        // from one host writes a cookie stored under another, and
+        // the next request to that other host attaches it, which is
+        // a cross-origin write for every capture path that reaches
+        // here. `api.example.com` setting `Domain=example.com` still
+        // passes, since `domainMatches` is the same 5.1.3 comparison
+        // the read side uses.
+        if (domain !== null && !this.domainMatches(requestHost, domain)) {
+          console.warn(
+            "[CookieJar] Dropped cookie with a cross-domain Domain:",
+            c.domain
+          )
+          continue
+        }
       } else {
         domain = this.canonHostOnly(requestHost)
       }


### PR DESCRIPTION
The agent code path captures no cookies when the Hoppscotch Agent is a stable build. The agent interceptor reads structured cookies from `response.cookies`, which the agent binary populates only when it was built against a relay revision that has `parse_cookies`. An older agent leaves the field undefined, the capture path returns without doing anything, and the `Set-Cookie` headers it did return, joined with newlines in the response headers, are never read. The app and the agent update separately, so this applies to every user until they update the agent.

Closes FE-1286

### What's changed

- `captureResponseCookies` reads the `set-cookie` response header when `response.cookies` is undefined, splits on newlines, and parses each line with the parser the jar already uses.
- Parsed results go through `extractFromResponse`, so canonicalisation, domain defaulting and expiry handling are not duplicated.
- `normalizeSameSite` maps the parser's SameSite union, lowercase strings or a bare boolean, onto the casing `@hoppscotch/data` expects, leaving anything unrecognised undefined so the extractor applies its `Lax` default.
- `headers` added as an optional field on the existing response parameter.
- Four tests covering the fallback and its guard.

### Notes to reviewers

The fallback runs when `cookies` is undefined and not when it is an empty array. An empty array is the relay reporting no cookies in that response, and parsing the headers again would store each cookie twice. The third test covers that case.

`headers` is optional on the existing parameter, so the native and proxy interceptors need no change. Both already pass an object that includes `headers`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves cookie capture with older Hoppscotch Agent builds and blocks cross-domain Domain attributes. Previously, older agents returned no response.cookies so we dropped cookies, and responses could set cookies for unrelated hosts. For IP hosts, only an exact Domain match is allowed. Addresses FE-1286.

- Fallback runs only when response.cookies is undefined; a defined empty array means "no cookies."
- Reads newline-joined Set-Cookie header values, parses with the existing parser (no value decoding), and passes results to extractFromResponse.
- Resolves Max-Age into expires with RFC precedence; Max-Age=0 expires one millisecond before capture so same-tick reads do not see it.
- Normalizes SameSite to `@hoppscotch/data` casing; unrecognized/boolean values become undefined so the extractor applies its Lax default.
- Rejects a Domain that does not domain-match the request host (RFC 6265 5.3); IP literals must match exactly; enforced during canonicalization for both structured and header-parsed cookies.
- Adds optional headers to the captureResponseCookies input; native and proxy interceptors already include headers, so no caller changes.
- Tests cover the header fallback, domain-match rejection and parent-domain acceptance, IP-literal equality and partial-suffix rejection, no re-parse when cookies is [], Max-Age handling (including 0), raw value preservation, header splitting, and the header-absent case.

<sup>Written for commit d2e0c8757f598da62ceee541ac1cfa11f0091b65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

