### PR TITLE
fix(MonacoScriptEditor): set explicit width/height for Linux Desktop layout

### DIFF
--- a/packages/hoppscotch-common/src/components/MonacoScriptEditor.vue
+++ b/packages/hoppscotch-common/src/components/MonacoScriptEditor.vue
@@ -5,6 +5,8 @@
     language="typescript"
     :options="MONACO_EDITOR_OPTIONS"
     :model="editorModel"
+    width="100%"
+    height="100%"
   />
 </template>
 


### PR DESCRIPTION
## Summary
- Sets `width="100%"` and `height="100%"` on `vue-monaco-editor` in `MonacoScriptEditor.vue` so Monaco's `automaticLayout` (ResizeObserver) has an explicitly sized container.
- Fixes the Post-request Script editor collapsing to ~1 visible line on Linux Desktop (Pre-request was unaffected in some layouts because of container sizing differences).

**Credit:** Root cause and proposed fix identified by [@waterWang](https://github.com/waterWang) on [#6576](https://github.com/hoppscotch/hoppscotch/issues/6576). Their fork branch `waterWang:fix/post-request-script-editor-height` could not open a PR, so this PR lands the same change on their behalf. Thank you!

Fixes #6576

## Test plan
- [ ] On Linux Desktop, open a request → Scripts → Post-request Script
- [ ] Enter a multiline script and confirm the editor expands to show multiple lines (not ~1 line tall)
- [ ] Confirm Pre-request Script editor still lays out correctly
- [ ] Confirm typing / Enter still works as expected in both editors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets width="100%" and height="100%" on `vue-monaco-editor` in `MonacoScriptEditor.vue` so Monaco’s `automaticLayout` can observe a sized container. On Linux Desktop, the Post-request Script editor previously collapsed to ~1 visible line; it now expands and resizes correctly, with no change to the Pre-request Script editor or typing behavior.

Fixes #6576.

<sup>Written for commit 20678e8026c9dc28ffd5089eba9b9e30789ac7b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

