### PR TITLE
fix: improve network error message to mention CORS (#1376)

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -855,7 +855,7 @@
     "collection_properties_header": "This header will be set for every request in this collection.",
     "collection_properties_scripts": "These scripts will run for every request in this collection. Pre-request scripts run before the request, test scripts run after the response.",
     "generate_documentation_first": "Generate documentation first",
-    "network_fail": "Unable to reach the API endpoint. Check your network connection or select a different Interceptor and try again.",
+    "network_fail": "Network or CORS error. Check your connection or change the Interceptor to bypass CORS restrictions.",
     "offline": "You're using Hoppscotch offline. Updates will sync when you're online, based on workspace settings.",
     "offline_short": "You're using Hoppscotch offline.",
     "post_request_tests": "Post-request scripts are written in JavaScript, and are run after the response is received.",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -675,7 +675,7 @@
   "error": {
     "network": {
       "heading": "Network Error",
-      "description": "Network connection failed. {message}: {cause}"
+      "description": "Network connection failed or CORS error. {message}: {cause}. To bypass CORS, use the Desktop App or Browser Extension."
     },
     "timeout": {
       "heading": "Timeout Error",
@@ -855,7 +855,7 @@
     "collection_properties_header": "This header will be set for every request in this collection.",
     "collection_properties_scripts": "These scripts will run for every request in this collection. Pre-request scripts run before the request, test scripts run after the response.",
     "generate_documentation_first": "Generate documentation first",
-    "network_fail": "Network or CORS error. Check your connection, use the Desktop App, or install the Browser Extension to bypass CORS.",
+    "network_fail": "Unable to reach the API endpoint. Check your network connection or select a different Interceptor and try again.",
     "offline": "You're using Hoppscotch offline. Updates will sync when you're online, based on workspace settings.",
     "offline_short": "You're using Hoppscotch offline.",
     "post_request_tests": "Post-request scripts are written in JavaScript, and are run after the response is received.",

--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -855,7 +855,7 @@
     "collection_properties_header": "This header will be set for every request in this collection.",
     "collection_properties_scripts": "These scripts will run for every request in this collection. Pre-request scripts run before the request, test scripts run after the response.",
     "generate_documentation_first": "Generate documentation first",
-    "network_fail": "Network or CORS error. Check your connection or change the Interceptor to bypass CORS restrictions.",
+    "network_fail": "Network or CORS error. Check your connection, use the Desktop App, or install the Browser Extension to bypass CORS.",
     "offline": "You're using Hoppscotch offline. Updates will sync when you're online, based on workspace settings.",
     "offline_short": "You're using Hoppscotch offline.",
     "post_request_tests": "Post-request scripts are written in JavaScript, and are run after the response is received.",


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #1376

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This PR improves the first-time user experience when encountering a CORS error. Previously, the browser interceptor would show a generic "Unable to reach the API endpoint" message, masking the actual CORS issue. This PR updates the `network_fail` translation string to explicitly mention CORS as a potential cause and advises the user to switch Interceptors.

### What's changed
- [x] Updated the `network_fail` string in `locales/en.json` to explicitly mention CORS and suggest changing the Interceptor.

### Notes to reviewers
This is a straightforward copy update that directly addresses the ambiguity reported in #1376 without adding complex conditional logic to the UI components. It should provide immediate context for new users facing CORS restrictions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies network errors by mentioning CORS and adding bypass steps for browser users. Previously: "Network connection failed. {message}: {cause}"; now: "Network connection failed or CORS error. {message}: {cause}. To bypass CORS, use the Desktop App or Browser Extension."

- Copy-only change to `error.network.description` in `packages/hoppscotch-common/locales/en.json`; no UI or logic changes.
- Affects English locale only; translate other locales separately.

<sup>Written for commit 3cd511ec982a205b3fc582f7d8fdddadaeb4621d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

