### PR TITLE
fix(common): preserve request tab description on documentation save

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -426,6 +426,7 @@ const saveRequestAs = async () => {
         originLocation: "user-collection",
         folderPath: picked.value.folderPath,
         requestIndex: picked.value.requestIndex,
+        requestRefID: requestUpdated._ref_id,
       },
     }
 

--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -435,11 +435,19 @@ const saveRequestAs = async () => {
       picked.value.folderPath.split("/").map((x) => parseInt(x))
     )?.requests[picked.value.requestIndex]
 
-    requestUpdated._ref_id =
-      targetRequest && "_ref_id" in targetRequest
-        ? targetRequest._ref_id
-        : undefined
-    requestUpdated.id = targetRequest?.id
+    // Delete rather than assign undefined — an explicit undefined key survives
+    // into the store and not every sync backend tolerates it
+    if (targetRequest && "_ref_id" in targetRequest && targetRequest._ref_id) {
+      requestUpdated._ref_id = targetRequest._ref_id
+    } else {
+      delete requestUpdated._ref_id
+    }
+
+    if (targetRequest?.id) {
+      requestUpdated.id = targetRequest.id
+    } else {
+      delete requestUpdated.id
+    }
 
     editRESTRequest(
       picked.value.folderPath,

--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -122,6 +122,7 @@ import { useToast } from "@composables/toast"
 import {
   HoppGQLRequest,
   HoppRESTRequest,
+  generateUniqueRefId,
   isHoppRESTRequest,
 } from "@hoppscotch/data"
 import { computedWithControl } from "@vueuse/core"
@@ -144,6 +145,8 @@ import {
   cascadeParentCollectionForProperties,
   editGraphqlRequest,
   editRESTRequest,
+  navigateToFolderWithIndexPath,
+  restCollectionStore,
   saveGraphqlRequestAs,
   saveRESTRequestAs,
 } from "~/newstore/collections"
@@ -338,6 +341,19 @@ const saveRequestAs = async () => {
 
   requestUpdated.name = requestName.value
 
+  // Saving into a collection or folder creates a new entry, so it needs its
+  // own `_ref_id` — matching treats equal ref ids as the same request, and a
+  // copy sharing the source's id would leave their tabs bound to each other
+  if (
+    isHoppRESTRequest(requestUpdated) &&
+    (picked.value.pickedType === "my-collection" ||
+      picked.value.pickedType === "my-folder" ||
+      picked.value.pickedType === "teams-collection" ||
+      picked.value.pickedType === "teams-folder")
+  ) {
+    requestUpdated._ref_id = generateUniqueRefId("req")
+  }
+
   if (picked.value.pickedType === "my-collection") {
     if (!isHoppRESTRequest(requestUpdated))
       throw new Error("requestUpdated is not a REST Request")
@@ -411,6 +427,20 @@ const saveRequestAs = async () => {
   } else if (picked.value.pickedType === "my-request") {
     if (!isHoppRESTRequest(requestUpdated))
       throw new Error("requestUpdated is not a REST Request")
+
+    // Overwriting replaces the target entry's content, not its identity —
+    // carry the target's own `_ref_id` rather than the source's, so tabs on
+    // the target stay bound to it and the source doesn't end up sharing
+    // identity with the overwritten copy
+    const targetRequest = navigateToFolderWithIndexPath(
+      restCollectionStore.value.state,
+      picked.value.folderPath.split("/").map((x) => parseInt(x))
+    )?.requests[picked.value.requestIndex]
+
+    requestUpdated._ref_id =
+      targetRequest && "_ref_id" in targetRequest
+        ? targetRequest._ref_id
+        : undefined
 
     editRESTRequest(
       picked.value.folderPath,

--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -426,7 +426,7 @@ const saveRequestAs = async () => {
         originLocation: "user-collection",
         folderPath: picked.value.folderPath,
         requestIndex: picked.value.requestIndex,
-        requestRefID: requestUpdated._ref_id,
+        requestRefID: requestUpdated._ref_id ?? requestUpdated.id,
       },
     }
 

--- a/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
+++ b/packages/hoppscotch-common/src/components/collections/SaveRequest.vue
@@ -341,9 +341,8 @@ const saveRequestAs = async () => {
 
   requestUpdated.name = requestName.value
 
-  // Saving into a collection or folder creates a new entry, so it needs its
-  // own `_ref_id` — matching treats equal ref ids as the same request, and a
-  // copy sharing the source's id would leave their tabs bound to each other
+  // A copy is a new entry and needs its own `_ref_id` — equal ref ids are
+  // treated as the same request, which would bind the copy's tab to the source
   if (
     isHoppRESTRequest(requestUpdated) &&
     (picked.value.pickedType === "my-collection" ||
@@ -428,10 +427,9 @@ const saveRequestAs = async () => {
     if (!isHoppRESTRequest(requestUpdated))
       throw new Error("requestUpdated is not a REST Request")
 
-    // Overwriting replaces the target entry's content, not its identity —
-    // carry the target's own `_ref_id` rather than the source's, so tabs on
-    // the target stay bound to it and the source doesn't end up sharing
-    // identity with the overwritten copy
+    // Overwriting replaces the target's content, not its identity — keep the
+    // target's own `_ref_id` and backend `id` so its tabs stay bound to it and
+    // the source doesn't share identity with the copy
     const targetRequest = navigateToFolderWithIndexPath(
       restCollectionStore.value.state,
       picked.value.folderPath.split("/").map((x) => parseInt(x))
@@ -441,6 +439,7 @@ const saveRequestAs = async () => {
       targetRequest && "_ref_id" in targetRequest
         ? targetRequest._ref_id
         : undefined
+    requestUpdated.id = targetRequest?.id
 
     editRESTRequest(
       picked.value.folderPath,

--- a/packages/hoppscotch-common/src/components/collections/documentation/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/documentation/index.vue
@@ -278,6 +278,8 @@ import {
 } from "~/helpers/backend/helpers"
 import { GQLError } from "~/helpers/backend/GQLClient"
 import { getErrorMessage } from "~/helpers/backend/mutations/MockServer"
+import { HoppRESTSaveContext } from "~/helpers/rest/document"
+import { RESTTabService } from "~/services/tab/rest"
 
 import {
   DocumentationService,
@@ -342,6 +344,32 @@ const props = withDefaults(
 )
 
 const documentationService = useService(DocumentationService)
+const restTabs = useService(RESTTabService)
+
+/**
+ * Mirrors a saved documentation description onto the request tab it belongs to,
+ * if that request happens to be open. Without this the tab keeps its pre-edit
+ * copy of the request and the next save from the tab writes the stale
+ * description back over the one we just saved.
+ */
+const syncOpenRequestTabDescription = (
+  saveContext: HoppRESTSaveContext,
+  description: string
+) => {
+  const possibleTab = restTabs.getTabRefWithSaveContext(saveContext)
+
+  if (!possibleTab || possibleTab.value.document.type !== "request") return
+
+  const wasDirty = possibleTab.value.document.isDirty
+  possibleTab.value.document.request.description = description
+
+  // The tab marks itself dirty on any request change, so restore whatever
+  // dirty state it had before this sync
+  nextTick(() => {
+    if (possibleTab.value.document.type !== "request") return
+    possibleTab.value.document.isDirty = wasDirty
+  })
+}
 
 const isLoadingTeamCollection = ref<boolean>(false)
 const isSavingDocumentation = ref<boolean>(false)
@@ -796,6 +824,13 @@ const saveRequestDocumentation = async () => {
           isSavingDocumentation.value = false
         },
         () => {
+          syncOpenRequestTabDescription(
+            {
+              originLocation: "team-collection",
+              requestID: props.requestID!,
+            },
+            documentationDescription.value
+          )
           toast.success(t("documentation.save_success"))
           isSavingDocumentation.value = false
         }
@@ -804,6 +839,14 @@ const saveRequestDocumentation = async () => {
   } else {
     // Personal request
     editRESTRequest(props.folderPath!, props.requestIndex!, updatedRequest)
+    syncOpenRequestTabDescription(
+      {
+        originLocation: "user-collection",
+        folderPath: props.folderPath!,
+        requestIndex: props.requestIndex!,
+      },
+      documentationDescription.value
+    )
     toast.success(t("documentation.save_success"))
   }
 }
@@ -916,6 +959,13 @@ const saveRequestDocumentationById = async (
             return false
           },
           () => {
+            syncOpenRequestTabDescription(
+              {
+                originLocation: "team-collection",
+                requestID: item.requestID!,
+              },
+              documentation
+            )
             return true
           }
         )
@@ -939,6 +989,14 @@ const saveRequestDocumentationById = async (
 
     try {
       editRESTRequest(folderPath, item.requestIndex, updatedRequest)
+      syncOpenRequestTabDescription(
+        {
+          originLocation: "user-collection",
+          folderPath,
+          requestIndex: item.requestIndex,
+        },
+        documentation
+      )
       return true
     } catch (e) {
       console.error(e)

--- a/packages/hoppscotch-common/src/components/collections/documentation/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/documentation/index.vue
@@ -347,28 +347,33 @@ const documentationService = useService(DocumentationService)
 const restTabs = useService(RESTTabService)
 
 /**
- * Mirrors a saved documentation description onto the request tab it belongs to,
- * if that request happens to be open. Without this the tab keeps its pre-edit
- * copy of the request and the next save from the tab writes the stale
- * description back over the one we just saved.
+ * Mirrors a saved documentation description onto the request tabs it belongs
+ * to, if that request happens to be open. Without this a tab keeps its pre-edit
+ * copy of the request and the next save from it writes the stale description
+ * back over the one we just saved.
+ *
+ * The same request can be open in more than one tab, so every match has to be
+ * updated — skipping one just leaves it holding the stale copy.
  */
 const syncOpenRequestTabDescription = (
   saveContext: HoppRESTSaveContext,
   description: string
 ) => {
-  const possibleTab = restTabs.getTabRefWithSaveContext(saveContext)
+  const possibleTabs = restTabs.getTabsRefWithSaveContext(saveContext)
 
-  if (!possibleTab || possibleTab.value.document.type !== "request") return
+  for (const possibleTab of possibleTabs) {
+    if (possibleTab.value.document.type !== "request") continue
 
-  const wasDirty = possibleTab.value.document.isDirty
-  possibleTab.value.document.request.description = description
+    const wasDirty = possibleTab.value.document.isDirty
+    possibleTab.value.document.request.description = description
 
-  // The tab marks itself dirty on any request change, so restore whatever
-  // dirty state it had before this sync
-  nextTick(() => {
-    if (possibleTab.value.document.type !== "request") return
-    possibleTab.value.document.isDirty = wasDirty
-  })
+    // The tab marks itself dirty on any request change, so restore whatever
+    // dirty state it had before this sync
+    nextTick(() => {
+      if (possibleTab.value.document.type !== "request") return
+      possibleTab.value.document.isDirty = wasDirty
+    })
+  }
 }
 
 const isLoadingTeamCollection = ref<boolean>(false)

--- a/packages/hoppscotch-common/src/components/collections/documentation/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/documentation/index.vue
@@ -347,13 +347,9 @@ const documentationService = useService(DocumentationService)
 const restTabs = useService(RESTTabService)
 
 /**
- * Mirrors a saved documentation description onto the request tabs it belongs
- * to, if that request happens to be open. Without this a tab keeps its pre-edit
- * copy of the request and the next save from it writes the stale description
- * back over the one we just saved.
- *
- * The same request can be open in more than one tab, so every match has to be
- * updated — skipping one just leaves it holding the stale copy.
+ * Mirrors a saved documentation description onto any open tabs of the request —
+ * otherwise a tab keeps its pre-edit copy and its next save writes the stale
+ * description back over the one just saved.
  */
 const syncOpenRequestTabDescription = (
   saveContext: HoppRESTSaveContext,
@@ -362,8 +358,8 @@ const syncOpenRequestTabDescription = (
   const possibleTabs = restTabs.getTabsRefWithSaveContext(saveContext)
 
   for (const possibleTab of possibleTabs) {
-    // Hold the document itself rather than the tab ref: the ref's getter throws
-    // once the tab leaves the tab map, and we read it again after a tick
+    // Hold the document, not the tab ref — the ref's getter throws once the
+    // tab is closed, and it's read again after a tick
     const tabDocument = possibleTab.value.document
 
     if (tabDocument.type !== "request") continue
@@ -371,8 +367,7 @@ const syncOpenRequestTabDescription = (
     const wasDirty = tabDocument.isDirty
     tabDocument.request.description = description
 
-    // The tab marks itself dirty on any request change, so restore whatever
-    // dirty state it had before this sync
+    // The tab marks itself dirty on any request change; restore its prior state
     nextTick(() => {
       tabDocument.isDirty = wasDirty
     })
@@ -810,9 +805,8 @@ const saveCollectionDocumentation = async () => {
 }
 
 const saveRequestDocumentation = async () => {
-  // The editor stays live while the team request is in flight, so hold on to
-  // what we are about to persist rather than re-reading it once the mutation
-  // resolves — otherwise the tab gets synced with text that was never saved
+  // The editor stays live while the team mutation is in flight — sync the tab
+  // with what was persisted, not whatever the editor holds when it resolves
   const savedDescription = documentationDescription.value
 
   const updatedRequest = {

--- a/packages/hoppscotch-common/src/components/collections/documentation/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/documentation/index.vue
@@ -362,16 +362,19 @@ const syncOpenRequestTabDescription = (
   const possibleTabs = restTabs.getTabsRefWithSaveContext(saveContext)
 
   for (const possibleTab of possibleTabs) {
-    if (possibleTab.value.document.type !== "request") continue
+    // Hold the document itself rather than the tab ref: the ref's getter throws
+    // once the tab leaves the tab map, and we read it again after a tick
+    const tabDocument = possibleTab.value.document
 
-    const wasDirty = possibleTab.value.document.isDirty
-    possibleTab.value.document.request.description = description
+    if (tabDocument.type !== "request") continue
+
+    const wasDirty = tabDocument.isDirty
+    tabDocument.request.description = description
 
     // The tab marks itself dirty on any request change, so restore whatever
     // dirty state it had before this sync
     nextTick(() => {
-      if (possibleTab.value.document.type !== "request") return
-      possibleTab.value.document.isDirty = wasDirty
+      tabDocument.isDirty = wasDirty
     })
   }
 }
@@ -854,6 +857,7 @@ const saveRequestDocumentation = async () => {
         originLocation: "user-collection",
         folderPath: props.folderPath!,
         requestIndex: props.requestIndex!,
+        requestRefID: updatedRequest._ref_id ?? updatedRequest.id,
       },
       savedDescription
     )
@@ -1004,6 +1008,7 @@ const saveRequestDocumentationById = async (
           originLocation: "user-collection",
           folderPath,
           requestIndex: item.requestIndex,
+          requestRefID: updatedRequest._ref_id ?? updatedRequest.id,
         },
         documentation
       )

--- a/packages/hoppscotch-common/src/components/collections/documentation/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/documentation/index.vue
@@ -802,9 +802,14 @@ const saveCollectionDocumentation = async () => {
 }
 
 const saveRequestDocumentation = async () => {
+  // The editor stays live while the team request is in flight, so hold on to
+  // what we are about to persist rather than re-reading it once the mutation
+  // resolves — otherwise the tab gets synced with text that was never saved
+  const savedDescription = documentationDescription.value
+
   const updatedRequest = {
     ...props.request!,
-    description: documentationDescription.value,
+    description: savedDescription,
   }
 
   if (props.isTeamCollection && props.requestID) {
@@ -829,7 +834,7 @@ const saveRequestDocumentation = async () => {
               originLocation: "team-collection",
               requestID: props.requestID!,
             },
-            documentationDescription.value
+            savedDescription
           )
           toast.success(t("documentation.save_success"))
           isSavingDocumentation.value = false
@@ -845,7 +850,7 @@ const saveRequestDocumentation = async () => {
         folderPath: props.folderPath!,
         requestIndex: props.requestIndex!,
       },
-      documentationDescription.value
+      savedDescription
     )
     toast.success(t("documentation.save_success"))
   }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/index.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/index.ts
@@ -3,6 +3,7 @@ import type { Component } from "vue"
 import { StepsOutputList } from "../steps"
 import {
   HoppCollection,
+  generateUniqueRefId,
   makeCollection,
   translateToNewRESTCollection,
 } from "@hoppscotch/data"
@@ -91,6 +92,13 @@ export const sanitizeCollection = (
 
   return makeCollection({
     ...rest,
+    // Requests carry identity too — an imported file may hold `_ref_id`/`id`
+    // values that already exist in the workspace, and matching treats equal
+    // identities as the same request
+    requests: rest.requests.map((request) => {
+      const { id: _requestId, ...requestRest } = request
+      return { ...requestRest, _ref_id: generateUniqueRefId("req") }
+    }),
     folders: rest.folders.map(sanitizeCollection),
   })
 }

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -1456,6 +1456,13 @@ const gqlCollectionDispatchers = defineDispatchers({
           ...coll,
           _ref_id: generateUniqueRefId("coll"),
         }
+
+        // Copied requests need fresh `_ref_id`s too, else they alias the originals' tabs
+        next.requests = (next.requests ?? []).map((request) => ({
+          ...request,
+          _ref_id: generateUniqueRefId("req"),
+        }))
+
         next.folders = (next.folders ?? []).map(
           recursiveChangeRefIdToAvoidConflicts
         )

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -730,13 +730,14 @@ const restCollectionDispatchers = defineDispatchers({
           _ref_id: generateUniqueRefId("coll"),
         }
 
-        // Copied requests need their own identity too — tabs match on
-        // `_ref_id`, so a copy sharing the original's would fight it for tabs
+        // Copied requests need their own identity too — matching falls back to
+        // the backend `id`, so even a legacy request copied without a fresh
+        // `_ref_id` would fight the original for tabs
         newCollection.requests = (newCollection.requests ?? []).map(
-          (request) =>
-            "_ref_id" in request
-              ? { ...request, _ref_id: generateUniqueRefId("req") }
-              : request
+          (request) => ({
+            ...request,
+            _ref_id: generateUniqueRefId("req"),
+          })
         )
 
         newCollection.folders = (newCollection.folders ?? []).map((folder) =>

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -730,6 +730,15 @@ const restCollectionDispatchers = defineDispatchers({
           _ref_id: generateUniqueRefId("coll"),
         }
 
+        // Copied requests need their own identity too — tabs match on
+        // `_ref_id`, so a copy sharing the original's would fight it for tabs
+        newCollection.requests = (newCollection.requests ?? []).map(
+          (request) =>
+            "_ref_id" in request
+              ? { ...request, _ref_id: generateUniqueRefId("req") }
+              : request
+        )
+
         newCollection.folders = (newCollection.folders ?? []).map((folder) =>
           recursiveChangeRefIdToAvoidConflicts(folder)
         )

--- a/packages/hoppscotch-common/src/pages/import.vue
+++ b/packages/hoppscotch-common/src/pages/import.vue
@@ -21,7 +21,10 @@ import {
 } from "~/helpers/clientLocalVariables"
 import { useI18n } from "@composables/i18n"
 import { useToast } from "@composables/toast"
-import { IMPORTER_INVALID_FILE_FORMAT } from "~/helpers/import-export/import"
+import {
+  IMPORTER_INVALID_FILE_FORMAT,
+  sanitizeCollection,
+} from "~/helpers/import-export/import"
 import { OPENAPI_DEREF_ERROR } from "~/helpers/import-export/import/openapi"
 import { isOfType } from "~/helpers/functional/primtive"
 import { TELeftType } from "~/helpers/functional/taskEither"
@@ -116,10 +119,11 @@ const handleImportFailure = (error: ImportCollectionsError) => {
 }
 
 const handleImportSuccess = (collections: HoppCollection[]) => {
-  // Mirror the modal-import path: stamp `_ref_id`s, persist any raw
-  // secret values to the local secret store, then append the stripped
-  // tree to newstore so localStorage / future syncs stay clean.
-  const withRefIds = collections.map(ensureRefIds)
+  // Mirror the modal-import path: sanitize file-carried identities, stamp
+  // `_ref_id`s, persist any raw secret values to the local secret store, then
+  // append the stripped tree to newstore so localStorage / future syncs stay
+  // clean.
+  const withRefIds = collections.map(sanitizeCollection).map(ensureRefIds)
 
   withRefIds.forEach(populateLocalStoresFromCollectionTree)
   appendRESTCollections(withRefIds.map(stripCollectionTreeForStore))

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/collections.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/collections.searcher.ts
@@ -312,9 +312,8 @@ export class CollectionsSpotlightSearcherService
 
       if (!req) return
 
-      // `requestRefID` identifies the request independently of its position, so
-      // it has to be recorded here too — a tab opened without one isn't matched
-      // by the lookups that do supply it, and the request ends up open twice
+      // Record `requestRefID` like the sidebar does — a tab opened without one
+      // isn't matched by lookups that supply it, and the request opens twice
       const saveContext = {
         originLocation: "user-collection",
         folderPath: resolvedFolderPath,

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/collections.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/collections.searcher.ts
@@ -6,6 +6,7 @@ import {
   SpotlightSearcherSessionState,
   SpotlightService,
 } from "../"
+import { cloneDeep } from "lodash-es"
 import { Ref, computed, effectScope, markRaw, ref, watch } from "vue"
 import { getI18n } from "~/modules/i18n"
 import MiniSearch from "minisearch"
@@ -304,32 +305,36 @@ export class CollectionsSpotlightSearcherService
         })
       }
 
-      const possibleTab = this.restTab.getTabRefWithSaveContext({
+      const resolvedFolderPath = folderPath.join("/")
+
+      const req = this.getRESTFolderFromFolderPath(resolvedFolderPath)
+        ?.requests[reqIndex] as HoppRESTRequest
+
+      if (!req) return
+
+      // `requestRefID` identifies the request independently of its position, so
+      // it has to be recorded here too — a tab opened without one isn't matched
+      // by the lookups that do supply it, and the request ends up open twice
+      const saveContext = {
         originLocation: "user-collection",
-        folderPath: folderPath.join("/"),
+        folderPath: resolvedFolderPath,
         requestIndex: reqIndex,
-      })
+        requestRefID: req._ref_id ?? req.id,
+      } as const
+
+      const possibleTab = this.restTab.getTabRefWithSaveContext(saveContext)
 
       if (possibleTab) {
         this.restTab.setActiveTab(possibleTab.value.id)
       } else {
-        const req = this.getRESTFolderFromFolderPath(folderPath.join("/"))
-          ?.requests[reqIndex] as HoppRESTRequest
-
-        if (!req) return
-
         this.restTab.createNewTab(
           {
             type: "request",
-            request: req,
+            request: cloneDeep(req),
             isDirty: false,
-            saveContext: {
-              originLocation: "user-collection",
-              folderPath: folderPath.join("/"),
-              requestIndex: reqIndex,
-            },
+            saveContext,
             inheritedProperties: cascadeParentCollectionForProperties(
-              folderPath.join("/"),
+              resolvedFolderPath,
               "rest"
             ),
           },
@@ -352,7 +357,7 @@ export class CollectionsSpotlightSearcherService
           requestIndex: reqIndex,
         },
         cursorPosition: 0,
-        request: req,
+        request: cloneDeep(req),
         isDirty: false,
         inheritedProperties: cascadeParentCollectionForProperties(
           folderPath.join("/"),

--- a/packages/hoppscotch-common/src/services/tab/__tests__/rest-tab.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/tab/__tests__/rest-tab.service.spec.ts
@@ -20,11 +20,11 @@ const makeService = () => {
 const openRequestTab = (
   service: RESTTabService,
   saveContext: HoppRESTSaveContext,
-  requestRefID?: string
+  requestFields?: { _ref_id?: string; id?: string }
 ) =>
   service.createNewTab({
     type: "request",
-    request: { ...getDefaultRESTRequest(), _ref_id: requestRefID },
+    request: { ...getDefaultRESTRequest(), ...requestFields },
     isDirty: false,
     saveContext,
   })
@@ -107,23 +107,23 @@ describe("RESTTabService", () => {
       ).toBeNull()
     })
 
-    it("falls back to position when the tab has no requestRefID but the lookup does", () => {
+    it("does not match an identity-less tab when the lookup names its request", () => {
       const service = makeService()
 
-      const tab = openRequestTab(service, {
+      openRequestTab(service, {
         originLocation: "user-collection",
         folderPath: "0",
         requestIndex: 1,
       })
 
-      const found = service.getTabRefWithSaveContext({
-        originLocation: "user-collection",
-        folderPath: "0",
-        requestIndex: 1,
-        requestRefID: "req_a",
-      })
-
-      expect(found?.value.id).toEqual(tab.id)
+      expect(
+        service.getTabRefWithSaveContext({
+          originLocation: "user-collection",
+          folderPath: "0",
+          requestIndex: 1,
+          requestRefID: "req_a",
+        })
+      ).toBeNull()
     })
 
     it("identifies a tab without a context ref by the request it holds", () => {
@@ -138,7 +138,7 @@ describe("RESTTabService", () => {
           folderPath: "0",
           requestIndex: 5,
         },
-        "req_a"
+        { _ref_id: "req_a" }
       )
 
       const found = service.getTabRefWithSaveContext({
@@ -146,6 +146,29 @@ describe("RESTTabService", () => {
         folderPath: "0",
         requestIndex: 1,
         requestRefID: "req_a",
+      })
+
+      expect(found?.value.id).toEqual(tab.id)
+    })
+
+    it("identifies a legacy tab by the backend id its request holds", () => {
+      const service = makeService()
+
+      const tab = openRequestTab(
+        service,
+        {
+          originLocation: "user-collection",
+          folderPath: "0",
+          requestIndex: 3,
+        },
+        { id: "backend_1" }
+      )
+
+      const found = service.getTabRefWithSaveContext({
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+        requestRefID: "backend_1",
       })
 
       expect(found?.value.id).toEqual(tab.id)
@@ -161,7 +184,7 @@ describe("RESTTabService", () => {
           folderPath: "0",
           requestIndex: 1,
         },
-        "req_other"
+        { _ref_id: "req_other" }
       )
 
       expect(
@@ -193,7 +216,7 @@ describe("RESTTabService", () => {
       expect(found?.value.id).toEqual(tab.id)
     })
 
-    it("treats an empty-string requestRefID as missing", () => {
+    it("treats an empty-string requestRefID as missing on both sides", () => {
       const service = makeService()
 
       // Some creation paths store "" when a request has neither `_ref_id` nor `id`
@@ -208,7 +231,7 @@ describe("RESTTabService", () => {
         originLocation: "user-collection",
         folderPath: "0",
         requestIndex: 1,
-        requestRefID: "req_a",
+        requestRefID: "",
       })
 
       expect(found?.value.id).toEqual(tab.id)

--- a/packages/hoppscotch-common/src/services/tab/__tests__/rest-tab.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/tab/__tests__/rest-tab.service.spec.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from "vitest"
+import { TestContainer } from "dioc/testing"
+
+import { getDefaultRESTRequest } from "~/helpers/rest/default"
+import { HoppRESTSaveContext } from "~/helpers/rest/document"
+import { RESTTabService } from "../rest"
+
+// `RESTTabService` imports the persistence service for tab restoration, whose
+// module graph reaches stores with top-level side effects that cannot run in
+// this bare test container. Matching doesn't touch persistence, so stub it
+// out (`vi.mock` is hoisted above the imports).
+vi.mock("../../persistence", () => ({
+  PersistenceService: class {},
+  STORE_KEYS: {},
+}))
+
+const makeService = () => {
+  const container = new TestContainer()
+  return container.bind(RESTTabService)
+}
+
+const openRequestTab = (
+  service: RESTTabService,
+  saveContext: HoppRESTSaveContext
+) =>
+  service.createNewTab({
+    type: "request",
+    request: getDefaultRESTRequest(),
+    isDirty: false,
+    saveContext,
+  })
+
+describe("RESTTabService", () => {
+  describe("getTabRefWithSaveContext", () => {
+    it("matches positionally when neither side has a requestRefID", () => {
+      const service = makeService()
+
+      const tab = openRequestTab(service, {
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+      })
+
+      const found = service.getTabRefWithSaveContext({
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+      })
+
+      expect(found?.value.id).toEqual(tab.id)
+    })
+
+    it("does not match a different position when neither side has a requestRefID", () => {
+      const service = makeService()
+
+      openRequestTab(service, {
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+      })
+
+      expect(
+        service.getTabRefWithSaveContext({
+          originLocation: "user-collection",
+          folderPath: "0",
+          requestIndex: 0,
+        })
+      ).toBeNull()
+    })
+
+    it("matches on requestRefID even when the tab's index has drifted", () => {
+      const service = makeService()
+
+      const tab = openRequestTab(service, {
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+        requestRefID: "req_a",
+      })
+
+      const found = service.getTabRefWithSaveContext({
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 0,
+        requestRefID: "req_a",
+      })
+
+      expect(found?.value.id).toEqual(tab.id)
+    })
+
+    it("does not match a tab holding a different request at the same position", () => {
+      const service = makeService()
+
+      openRequestTab(service, {
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 0,
+        requestRefID: "req_other",
+      })
+
+      expect(
+        service.getTabRefWithSaveContext({
+          originLocation: "user-collection",
+          folderPath: "0",
+          requestIndex: 0,
+          requestRefID: "req_a",
+        })
+      ).toBeNull()
+    })
+
+    it("falls back to position when the tab has no requestRefID but the lookup does", () => {
+      const service = makeService()
+
+      const tab = openRequestTab(service, {
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+      })
+
+      const found = service.getTabRefWithSaveContext({
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+        requestRefID: "req_a",
+      })
+
+      expect(found?.value.id).toEqual(tab.id)
+    })
+
+    it("falls back to position when the lookup has no requestRefID but the tab does", () => {
+      const service = makeService()
+
+      const tab = openRequestTab(service, {
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+        requestRefID: "req_a",
+      })
+
+      const found = service.getTabRefWithSaveContext({
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+      })
+
+      expect(found?.value.id).toEqual(tab.id)
+    })
+
+    it("treats an empty-string requestRefID as missing", () => {
+      const service = makeService()
+
+      // Some creation paths store "" when the request has neither
+      // `_ref_id` nor `id`
+      const tab = openRequestTab(service, {
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+        requestRefID: "",
+      })
+
+      const found = service.getTabRefWithSaveContext({
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+        requestRefID: "req_a",
+      })
+
+      expect(found?.value.id).toEqual(tab.id)
+    })
+
+    it("scopes example lookups by exampleID", () => {
+      const service = makeService()
+
+      const requestTab = openRequestTab(service, {
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+      })
+
+      const exampleTab = openRequestTab(service, {
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+        exampleID: "0",
+      })
+
+      const foundRequest = service.getTabRefWithSaveContext({
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+      })
+
+      const foundExample = service.getTabRefWithSaveContext({
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+        exampleID: "0",
+      })
+
+      expect(foundRequest?.value.id).toEqual(requestTab.id)
+      expect(foundExample?.value.id).toEqual(exampleTab.id)
+    })
+
+    it("matches team tabs by requestID and exampleID", () => {
+      const service = makeService()
+
+      const tab = openRequestTab(service, {
+        originLocation: "team-collection",
+        requestID: "team_req_1",
+      })
+
+      const found = service.getTabRefWithSaveContext({
+        originLocation: "team-collection",
+        requestID: "team_req_1",
+      })
+
+      expect(found?.value.id).toEqual(tab.id)
+
+      expect(
+        service.getTabRefWithSaveContext({
+          originLocation: "team-collection",
+          requestID: "team_req_1",
+          exampleID: "0",
+        })
+      ).toBeNull()
+    })
+  })
+
+  describe("getTabsRefWithSaveContext", () => {
+    it("returns every tab matching the save context", () => {
+      const service = makeService()
+
+      const first = openRequestTab(service, {
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+        requestRefID: "req_a",
+      })
+
+      // A duplicate of the same request whose index has drifted
+      const second = openRequestTab(service, {
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 0,
+        requestRefID: "req_a",
+      })
+
+      const found = service.getTabsRefWithSaveContext({
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+        requestRefID: "req_a",
+      })
+
+      expect(found.map((tab) => tab.value.id)).toEqual([first.id, second.id])
+    })
+
+    it("returns an empty array when nothing matches", () => {
+      const service = makeService()
+
+      expect(
+        service.getTabsRefWithSaveContext({
+          originLocation: "user-collection",
+          folderPath: "0",
+          requestIndex: 0,
+        })
+      ).toEqual([])
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/services/tab/__tests__/rest-tab.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/tab/__tests__/rest-tab.service.spec.ts
@@ -19,11 +19,12 @@ const makeService = () => {
 
 const openRequestTab = (
   service: RESTTabService,
-  saveContext: HoppRESTSaveContext
+  saveContext: HoppRESTSaveContext,
+  requestRefID?: string
 ) =>
   service.createNewTab({
     type: "request",
-    request: getDefaultRESTRequest(),
+    request: { ...getDefaultRESTRequest(), _ref_id: requestRefID },
     isDirty: false,
     saveContext,
   })
@@ -123,6 +124,54 @@ describe("RESTTabService", () => {
       })
 
       expect(found?.value.id).toEqual(tab.id)
+    })
+
+    it("identifies a tab without a context ref by the request it holds", () => {
+      const service = makeService()
+
+      // Context predates ref ids, but the held request names itself — found
+      // even though its index has drifted
+      const tab = openRequestTab(
+        service,
+        {
+          originLocation: "user-collection",
+          folderPath: "0",
+          requestIndex: 5,
+        },
+        "req_a"
+      )
+
+      const found = service.getTabRefWithSaveContext({
+        originLocation: "user-collection",
+        folderPath: "0",
+        requestIndex: 1,
+        requestRefID: "req_a",
+      })
+
+      expect(found?.value.id).toEqual(tab.id)
+    })
+
+    it("rejects a stale tab holding a different request at reused coordinates", () => {
+      const service = makeService()
+
+      openRequestTab(
+        service,
+        {
+          originLocation: "user-collection",
+          folderPath: "0",
+          requestIndex: 1,
+        },
+        "req_other"
+      )
+
+      expect(
+        service.getTabRefWithSaveContext({
+          originLocation: "user-collection",
+          folderPath: "0",
+          requestIndex: 1,
+          requestRefID: "req_a",
+        })
+      ).toBeNull()
     })
 
     it("falls back to position when the lookup has no requestRefID but the tab does", () => {

--- a/packages/hoppscotch-common/src/services/tab/__tests__/rest-tab.service.spec.ts
+++ b/packages/hoppscotch-common/src/services/tab/__tests__/rest-tab.service.spec.ts
@@ -5,10 +5,8 @@ import { getDefaultRESTRequest } from "~/helpers/rest/default"
 import { HoppRESTSaveContext } from "~/helpers/rest/document"
 import { RESTTabService } from "../rest"
 
-// `RESTTabService` imports the persistence service for tab restoration, whose
-// module graph reaches stores with top-level side effects that cannot run in
-// this bare test container. Matching doesn't touch persistence, so stub it
-// out (`vi.mock` is hoisted above the imports).
+// The persistence import drags in stores with top-level side effects that
+// can't run in this bare container; matching never touches it (hoisted mock)
 vi.mock("../../persistence", () => ({
   PersistenceService: class {},
   STORE_KEYS: {},
@@ -149,8 +147,7 @@ describe("RESTTabService", () => {
     it("treats an empty-string requestRefID as missing", () => {
       const service = makeService()
 
-      // Some creation paths store "" when the request has neither
-      // `_ref_id` nor `id`
+      // Some creation paths store "" when a request has neither `_ref_id` nor `id`
       const tab = openRequestTab(service, {
         originLocation: "user-collection",
         folderPath: "0",

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -90,16 +90,23 @@ export class RESTTabService extends TabService<HoppTabDocument> {
     if (tabCtx?.originLocation !== "user-collection") return false
     if (tabCtx.exampleID !== ctx?.exampleID) return false
 
-    // When both sides carry a ref id it settles the match on its own — a tab
-    // whose index has drifted is still the same request. Truthiness, not a
-    // null check: some creation paths store `""`, which is not an identity.
-    if (ctx?.requestRefID && tabCtx.requestRefID) {
-      return tabCtx.requestRefID === ctx.requestRefID
+    // A tab whose context predates ref ids is still identified by the request
+    // it holds. Truthiness, not a null check: some creation paths store `""`,
+    // which is not an identity.
+    const tabRefID =
+      tabCtx.requestRefID ||
+      (tab.document.type === "request"
+        ? tab.document.request._ref_id
+        : undefined)
+
+    // When both sides carry an identity it settles the match on its own — a
+    // tab whose index has drifted is still the same request, and a stale tab
+    // that merely sits at reused coordinates is not.
+    if (ctx?.requestRefID && tabRefID) {
+      return tabRefID === ctx.requestRefID
     }
 
-    // `_ref_id` is optional, so a context missing it can only be matched by
-    // position — a mismatch here would make such tabs invisible to every
-    // lookup that supplies one.
+    // Position is all that's left when either side has no usable identity
     return (
       tabCtx.folderPath === ctx?.folderPath &&
       tabCtx.requestIndex === ctx?.requestIndex

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -5,7 +5,7 @@ import { HoppRESTSaveContext, HoppTabDocument } from "~/helpers/rest/document"
 import { getService } from "~/modules/dioc"
 import { PersistenceService, STORE_KEYS } from "../persistence"
 import { TabService } from "./tab"
-import { PersistableTabState } from "."
+import { HoppTab, PersistableTabState } from "."
 
 export class RESTTabService extends TabService<HoppTabDocument> {
   public static readonly ID = "REST_TAB_SERVICE"
@@ -70,33 +70,49 @@ export class RESTTabService extends TabService<HoppTabDocument> {
     return savedState
   }
 
-  public getTabRefWithSaveContext(ctx: HoppRESTSaveContext) {
-    for (const tab of this.tabMap.values()) {
-      // For `team-collection` request id can be considered unique
-      if (tab.document.type === "test-runner") continue
+  private matchesSaveContext(
+    tab: HoppTab<HoppTabDocument>,
+    ctx: HoppRESTSaveContext
+  ) {
+    if (tab.document.type === "test-runner") return false
 
-      if (ctx?.originLocation === "team-collection") {
-        if (
-          tab.document.saveContext?.originLocation === "team-collection" &&
-          tab.document.saveContext.requestID === ctx.requestID &&
-          tab.document.saveContext.exampleID === ctx.exampleID
-        ) {
-          return this.getTabRef(tab.id)
-        }
-      } else if (
-        tab.document.saveContext?.originLocation === "user-collection" &&
-        tab.document.saveContext.folderPath === ctx?.folderPath &&
-        tab.document.saveContext.requestIndex === ctx?.requestIndex &&
-        tab.document.saveContext.exampleID === ctx?.exampleID &&
-        (ctx?.requestRefID != null
-          ? tab.document.saveContext.requestRefID === ctx.requestRefID
-          : true)
-      ) {
-        return this.getTabRef(tab.id)
-      }
+    // For `team-collection` request id can be considered unique
+    if (ctx?.originLocation === "team-collection") {
+      return (
+        tab.document.saveContext?.originLocation === "team-collection" &&
+        tab.document.saveContext.requestID === ctx.requestID &&
+        tab.document.saveContext.exampleID === ctx.exampleID
+      )
     }
 
-    return null
+    return (
+      tab.document.saveContext?.originLocation === "user-collection" &&
+      tab.document.saveContext.folderPath === ctx?.folderPath &&
+      tab.document.saveContext.requestIndex === ctx?.requestIndex &&
+      tab.document.saveContext.exampleID === ctx?.exampleID &&
+      (ctx?.requestRefID != null
+        ? tab.document.saveContext.requestRefID === ctx.requestRefID
+        : true)
+    )
+  }
+
+  /**
+   * Returns every tab matching the save context, not just the first.
+   *
+   * A request can end up open in more than one tab whenever two tabs were
+   * created with save contexts that don't match each other — most easily when
+   * one of them omits `requestRefID`, since a lookup that supplies one won't
+   * find it. Callers writing back into a tab need all of the matches: any they
+   * skip keeps stale content and overwrites the write on its next save.
+   */
+  public getTabsRefWithSaveContext(ctx: HoppRESTSaveContext) {
+    return Array.from(this.tabMap.values())
+      .filter((tab) => this.matchesSaveContext(tab, ctx))
+      .map((tab) => this.getTabRef(tab.id))
+  }
+
+  public getTabRefWithSaveContext(ctx: HoppRESTSaveContext) {
+    return this.getTabsRefWithSaveContext(ctx)[0] ?? null
   }
 
   public getDirtyTabsCount() {

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -90,21 +90,16 @@ export class RESTTabService extends TabService<HoppTabDocument> {
     if (tabCtx?.originLocation !== "user-collection") return false
     if (tabCtx.exampleID !== ctx?.exampleID) return false
 
-    // `_ref_id` names the request wherever it currently sits, so when both
-    // sides carry one it settles the match on its own: a tab whose index has
-    // drifted is still the same request, and a tab that merely inherited those
-    // coordinates is not. Truthiness rather than a null check, because some
-    // creation paths store `""` when the request has neither `_ref_id` nor
-    // `id` — an empty string is junk, not an identity, so let it fall through
-    // to the positional match instead of pinning the comparison on it.
+    // When both sides carry a ref id it settles the match on its own — a tab
+    // whose index has drifted is still the same request. Truthiness, not a
+    // null check: some creation paths store `""`, which is not an identity.
     if (ctx?.requestRefID && tabCtx.requestRefID) {
       return tabCtx.requestRefID === ctx.requestRefID
     }
 
-    // `_ref_id` is optional and plenty of requests don't carry one (see
-    // `getDefaultRESTRequest`), so contexts missing it can only be matched by
-    // position — treat the absent ref as a wildcard rather than a mismatch,
-    // otherwise those tabs are invisible to every lookup that supplies one.
+    // `_ref_id` is optional, so a context missing it can only be matched by
+    // position — a mismatch here would make such tabs invisible to every
+    // lookup that supplies one.
     return (
       tabCtx.folderPath === ctx?.folderPath &&
       tabCtx.requestIndex === ctx?.requestIndex
@@ -112,13 +107,9 @@ export class RESTTabService extends TabService<HoppTabDocument> {
   }
 
   /**
-   * Returns every tab matching the save context, not just the first.
-   *
-   * A request can end up open in more than one tab whenever two tabs were
-   * created with save contexts that don't match each other — most easily when
-   * one of them omits `requestRefID`, since a lookup that supplies one won't
-   * find it. Callers writing back into a tab need all of the matches: any they
-   * skip keeps stale content and overwrites the write on its next save.
+   * Returns every tab matching the save context — a request can be open in
+   * more than one tab, and a write-back that skips one leaves it holding
+   * stale content that its next save persists.
    */
   public getTabsRefWithSaveContext(ctx: HoppRESTSaveContext) {
     return Array.from(this.tabMap.values())

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -93,8 +93,11 @@ export class RESTTabService extends TabService<HoppTabDocument> {
     // `_ref_id` names the request wherever it currently sits, so when both
     // sides carry one it settles the match on its own: a tab whose index has
     // drifted is still the same request, and a tab that merely inherited those
-    // coordinates is not.
-    if (ctx?.requestRefID != null && tabCtx.requestRefID != null) {
+    // coordinates is not. Truthiness rather than a null check, because some
+    // creation paths store `""` when the request has neither `_ref_id` nor
+    // `id` — an empty string is junk, not an identity, so let it fall through
+    // to the positional match instead of pinning the comparison on it.
+    if (ctx?.requestRefID && tabCtx.requestRefID) {
       return tabCtx.requestRefID === ctx.requestRefID
     }
 
@@ -124,7 +127,11 @@ export class RESTTabService extends TabService<HoppTabDocument> {
   }
 
   public getTabRefWithSaveContext(ctx: HoppRESTSaveContext) {
-    return this.getTabsRefWithSaveContext(ctx)[0] ?? null
+    for (const tab of this.tabMap.values()) {
+      if (this.matchesSaveContext(tab, ctx)) return this.getTabRef(tab.id)
+    }
+
+    return null
   }
 
   public getDirtyTabsCount() {

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -96,17 +96,17 @@ export class RESTTabService extends TabService<HoppTabDocument> {
     const tabRefID =
       tabCtx.requestRefID ||
       (tab.document.type === "request"
-        ? tab.document.request._ref_id
+        ? tab.document.request._ref_id || tab.document.request.id
         : undefined)
 
-    // When both sides carry an identity it settles the match on its own — a
-    // tab whose index has drifted is still the same request, and a stale tab
-    // that merely sits at reused coordinates is not.
-    if (ctx?.requestRefID && tabRefID) {
+    // A lookup that names its request is authoritative — a tab with a
+    // different or missing identity is not that request, even at matching
+    // coordinates, which may have been reused since the tab was bound.
+    if (ctx?.requestRefID) {
       return tabRefID === ctx.requestRefID
     }
 
-    // Position is all that's left when either side has no usable identity
+    // Position is all that's left when the lookup carries no identity
     return (
       tabCtx.folderPath === ctx?.folderPath &&
       tabCtx.requestIndex === ctx?.requestIndex

--- a/packages/hoppscotch-common/src/services/tab/rest.ts
+++ b/packages/hoppscotch-common/src/services/tab/rest.ts
@@ -85,14 +85,26 @@ export class RESTTabService extends TabService<HoppTabDocument> {
       )
     }
 
+    const tabCtx = tab.document.saveContext
+
+    if (tabCtx?.originLocation !== "user-collection") return false
+    if (tabCtx.exampleID !== ctx?.exampleID) return false
+
+    // `_ref_id` names the request wherever it currently sits, so when both
+    // sides carry one it settles the match on its own: a tab whose index has
+    // drifted is still the same request, and a tab that merely inherited those
+    // coordinates is not.
+    if (ctx?.requestRefID != null && tabCtx.requestRefID != null) {
+      return tabCtx.requestRefID === ctx.requestRefID
+    }
+
+    // `_ref_id` is optional and plenty of requests don't carry one (see
+    // `getDefaultRESTRequest`), so contexts missing it can only be matched by
+    // position — treat the absent ref as a wildcard rather than a mismatch,
+    // otherwise those tabs are invisible to every lookup that supplies one.
     return (
-      tab.document.saveContext?.originLocation === "user-collection" &&
-      tab.document.saveContext.folderPath === ctx?.folderPath &&
-      tab.document.saveContext.requestIndex === ctx?.requestIndex &&
-      tab.document.saveContext.exampleID === ctx?.exampleID &&
-      (ctx?.requestRefID != null
-        ? tab.document.saveContext.requestRefID === ctx.requestRefID
-        : true)
+      tabCtx.folderPath === ctx?.folderPath &&
+      tabCtx.requestIndex === ctx?.requestIndex
     )
   }
 


### PR DESCRIPTION
Closes FE-1326 #6591 

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->
This pull request improves the way documentation descriptions are synchronized between saved requests and open request tabs in the Hoppscotch application. Now, when a documentation description is updated and saved, the change is immediately reflected in any corresponding open request tab, preventing stale data from being overwritten on subsequent saves. The changes focus on ensuring data consistency and a better user experience when editing documentation.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs saved REST request documentation into all open request tabs and preserves in-progress edits during async saves. Standardizes tab identification using `requestRefID` with legacy `id` fallback to prevent duplicate tabs and ensure correct synchronization (fixes #6591 / FE-1326).

- Mirrors the saved description into all matching tabs (personal/team, including save-by-ID) and restores each tab's previous dirty state.
- Adds tab fan-out and robust matching via `RESTTabService.getTabsRefWithSaveContext`: prefers `requestRefID` (from context or the held request), treats empty `requestRefID` as absent, falls back to the held request's backend `id`, then to folderPath + requestIndex; scopes by exampleID; matches team tabs by requestID.
- Propagates `requestRefID` in save contexts when opening/finding tabs (Spotlight and "Save as"), falling back to `id`; opens tabs with a cloned request to avoid cross-tab mutations and duplicate openings.
- Assigns fresh `_ref_id`s to copies so they don't share identity with the original — when saving a request as a copy, duplicating a collection/folder (REST and GQL), or importing; on overwrite, keeps the target's `_ref_id` and backend `id` so existing tabs stay bound.
- Adds unit tests covering identity fallbacks (ref id/backend id/position), example scoping, team matching, and multi-tab synchronization.

<sup>Written for commit 11fe7833b65421c8baac7c5a800a5f01d941ac27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

