### PR TITLE
fix(curl-import): keep headers whose value contains a colon-space

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1159,6 +1159,22 @@ describe("Parse curl command to Hopp REST Request", () => {
     expect(customHeader.value).toBe(`-d {"fake":1}`)
   })
 
+  test("keeps a header whose value itself contains a colon-space", () => {
+    const command = `curl 'https://example.com/api' -H 'X-Custom: foo: bar' -H 'Authorization:Basic dXNlcjpwYXNz'`
+
+    const actual = parseCurlToHoppRESTReq(command)
+
+    expect(actual.headers).toContainEqual(
+      expect.objectContaining({ key: "X-Custom", value: "foo: bar" })
+    )
+    expect(actual.headers).toContainEqual(
+      expect.objectContaining({
+        key: "Authorization",
+        value: "Basic dXNlcjpwYXNz",
+      })
+    )
+  })
+
   for (const [i, { command, response }] of samples.entries()) {
     test(`for sample #${i + 1}:\n\n${command}`, () => {
       const actual = parseCurlToHoppRESTReq(command)

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -2,7 +2,6 @@ import { HoppRESTHeader } from "@hoppscotch/data"
 import * as A from "fp-ts/Array"
 import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
 import parser from "yargs-parser"
 import {
   objHasArrayProperty,
@@ -10,13 +9,24 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
-const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
-)
+// Split only on the first colon so header values that themselves contain
+// "key: value"-shaped text (e.g. JWTs, media-type params) aren't mistaken
+// for extra header pairs and dropped.
+const getHeaderPair = (header: string) => {
+  const separatorIndex = header.indexOf(":")
+
+  return pipe(
+    separatorIndex,
+    O.fromPredicate((index) => index !== -1),
+    O.map(
+      (index) =>
+        [
+          header.slice(0, index).trim(),
+          header.slice(index + 1).trim(),
+        ] as [string, string]
+    )
+  )
+}
 
 export function getHeaders(parsedArguments: parser.Arguments) {
   let headers: Record<string, string> = {}


### PR DESCRIPTION
## Summary
- `getHeaderPair` in `packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts` normalized each `-H` line with `S.replace(":", ": ")` then split on every `": "` occurrence. A header value that itself contains `": "` (e.g. `-H 'X-Custom: foo: bar'`) produced more than 2 parts, tripped the `arr.length === 2` guard, and was silently dropped during cURL import.
- Now splits on the **first** colon only (`indexOf`/`slice`), which still supports the existing no-space form (`-H 'Key:Value'`) covered by prior tests.
- Fixes #6400

## Test plan
- [x] Added a regression test (`keeps a header whose value itself contains a colon-space`) to `packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js` covering both `X-Custom: foo: bar` and compact `Authorization:Basic ...` forms.
- [x] Verified manually: reverted the fix and confirmed `X-Custom` was dropped (`undefined`) on the old code, then confirmed it round-trips correctly (`"foo: bar"`) with the fix applied.
- [ ] Full `vitest` run blocked locally by an unrelated jsdom/`html-encoding-sniffer` ESM interop error in this environment (pre-existing, unrelated to this change — reproducible on `main` too); logic verified directly via `tsx` import instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cURL import dropping headers when the value contains ": " by splitting each header on the first colon only. Previously we split on ": " after normalization, so "-H 'X-Custom: foo: bar'" was misparsed and the header was dropped.

- Updates `getHeaderPair` in `packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts` to use first-colon split; still supports compact `Key:Value`.
- Adds a regression test in `packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js` for `X-Custom: foo: bar` and `Authorization:Basic ...`.
- No other behavior changes; whitespace trimming is unchanged.
- Fixes #6400.

<sup>Written for commit a97ea495f1a2816730bcd2e69a2a30293fcc1335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

