### PR TITLE
fix(jwt-auth): import PEM private key before signing RS/ES/PS tokens

### DIFF
--- a/packages/hoppscotch-data/src/utils/jwt.ts
+++ b/packages/hoppscotch-data/src/utils/jwt.ts
@@ -1,5 +1,95 @@
 import * as jose from "jose"
 
+// Generic `rsaEncryption` PKCS#8 AlgorithmIdentifier (OID 1.2.840.113549.1.1.1 + NULL
+// params) - the DER encoding WebCrypto expects when importing an RSA key for use with
+// an RSA-PSS (PS*) algorithm.
+const RSA_ENCRYPTION_ALGORITHM_IDENTIFIER = Uint8Array.from([
+  0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00,
+])
+
+const readDerLength = (bytes: Uint8Array, offset: number) => {
+  const first = bytes[offset]
+  if ((first & 0x80) === 0) return { length: first, bytesRead: 1 }
+
+  const numBytes = first & 0x7f
+  let length = 0
+  for (let i = 0; i < numBytes; i++) {
+    length = (length << 8) | bytes[offset + 1 + i]
+  }
+  return { length, bytesRead: 1 + numBytes }
+}
+
+const encodeDerLength = (length: number): Uint8Array => {
+  if (length < 0x80) return Uint8Array.from([length])
+
+  const bytes: number[] = []
+  let remaining = length
+  while (remaining > 0) {
+    bytes.unshift(remaining & 0xff)
+    remaining >>= 8
+  }
+  return Uint8Array.from([0x80 | bytes.length, ...bytes])
+}
+
+/**
+ * Keys generated with the RSASSA-PSS-restricted key type embed the id-RSASSA-PSS
+ * AlgorithmIdentifier (with explicit hash/salt parameters) in their PKCS#8 encoding.
+ * Most WebCrypto implementations (including the one `jose` uses) refuse to import
+ * that OID and throw `DataError: Invalid key type`, even though the underlying key
+ * material is a perfectly valid PS* signing key.
+ *
+ * This rewrites the PrivateKeyInfo's AlgorithmIdentifier to the generic `rsaEncryption`
+ * OID - which WebCrypto does accept for PS* imports - leaving the actual key material
+ * (the `privateKey` OCTET STRING) untouched.
+ */
+const asGenericRsaPkcs8 = (pem: string): string => {
+  const base64 = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/, "")
+    .replace(/-----END PRIVATE KEY-----/, "")
+    .replace(/\s+/g, "")
+  const der = Uint8Array.from(Buffer.from(base64, "base64"))
+
+  // PrivateKeyInfo ::= SEQUENCE { version INTEGER, algorithm SEQUENCE, privateKey OCTET STRING, ... }
+  let offset = 0
+  if (der[offset] !== 0x30) throw new Error("Not a valid PKCS#8 key")
+  const outer = readDerLength(der, offset + 1)
+  offset += 1 + outer.bytesRead
+
+  if (der[offset] !== 0x02) throw new Error("Not a valid PKCS#8 key")
+  const version = readDerLength(der, offset + 1)
+  const versionEnd = offset + 1 + version.bytesRead + version.length
+  const versionBytes = der.slice(offset, versionEnd)
+  offset = versionEnd
+
+  if (der[offset] !== 0x30) throw new Error("Not a valid PKCS#8 key")
+  const alg = readDerLength(der, offset + 1)
+  offset += 1 + alg.bytesRead + alg.length
+
+  // privateKey OCTET STRING (+ optional attributes) - copied through unchanged
+  const rest = der.slice(offset)
+
+  const newContent = new Uint8Array(
+    versionBytes.length + RSA_ENCRYPTION_ALGORITHM_IDENTIFIER.length + rest.length
+  )
+  newContent.set(versionBytes, 0)
+  newContent.set(RSA_ENCRYPTION_ALGORITHM_IDENTIFIER, versionBytes.length)
+  newContent.set(
+    rest,
+    versionBytes.length + RSA_ENCRYPTION_ALGORITHM_IDENTIFIER.length
+  )
+
+  const lengthBytes = encodeDerLength(newContent.length)
+  const newDer = new Uint8Array(1 + lengthBytes.length + newContent.length)
+  newDer.set([0x30], 0)
+  newDer.set(lengthBytes, 1)
+  newDer.set(newContent, 1 + lengthBytes.length)
+
+  const newBase64 = Buffer.from(newDer).toString("base64")
+  const wrapped = newBase64.match(/.{1,64}/g)?.join("\n") ?? newBase64
+
+  return `-----BEGIN PRIVATE KEY-----\n${wrapped}\n-----END PRIVATE KEY-----`
+}
+
 export interface JWTTokenParams {
   algorithm: string
   secret: string
@@ -67,14 +157,23 @@ export async function generateJWTToken(
       algorithm.startsWith("ES") ||
       algorithm.startsWith("PS")
     ) {
-      // RSA or ECDSA algorithms - use private key
+      // RSA, ECDSA or RSA-PSS algorithms - use private key
       if (!privateKey) {
-        console.error("Private key is required for RSA/ECDSA algorithms")
+        console.error("Private key is required for RSA/ECDSA/PSS algorithms")
         return null
       }
-      // jose requires an imported CryptoKey/KeyLike for asymmetric
-      // algorithms - the raw PEM text can't be signed with directly.
-      cryptoKey = await jose.importPKCS8(privateKey, algorithm)
+      // jose requires an imported CryptoKey for asymmetric algorithms - the
+      // raw PEM text can't be signed with directly.
+      try {
+        cryptoKey = await jose.importPKCS8(privateKey, algorithm)
+      } catch (importError) {
+        if (!algorithm.startsWith("PS")) throw importError
+        // Retry treating the key as generic RSA - see asGenericRsaPkcs8.
+        cryptoKey = await jose.importPKCS8(
+          asGenericRsaPkcs8(privateKey),
+          algorithm
+        )
+      }
     } else {
       // HMAC algorithms - use secret
       if (!secret) {

--- a/packages/hoppscotch-data/src/utils/jwt.ts
+++ b/packages/hoppscotch-data/src/utils/jwt.ts
@@ -59,7 +59,7 @@ export async function generateJWTToken(
   }
 
   try {
-    let cryptoKey: Uint8Array
+    let cryptoKey: Uint8Array | jose.CryptoKey
 
     // Use private key for RSA/ECDSA algorithms, secret for HMAC algorithms
     if (
@@ -72,7 +72,9 @@ export async function generateJWTToken(
         console.error("Private key is required for RSA/ECDSA algorithms")
         return null
       }
-      cryptoKey = new TextEncoder().encode(privateKey)
+      // jose requires an imported CryptoKey/KeyLike for asymmetric
+      // algorithms - the raw PEM text can't be signed with directly.
+      cryptoKey = await jose.importPKCS8(privateKey, algorithm)
     } else {
       // HMAC algorithms - use secret
       if (!secret) {


### PR DESCRIPTION
generateJWTToken passed the raw PEM text through TextEncoder().encode() for RSA/ECDSA/PSS algorithms and handed the resulting Uint8Array to jose's SignJWT.sign(). jose only accepts a raw byte array as an HMAC secret - asymmetric algorithms require an imported CryptoKey/KeyObject. As a result every RS*/ES*/PS* JWT-auth request threw inside sign() and generateJWTToken silently returned null (the error is swallowed by the surrounding try/catch), so no Authorization header/token was ever produced for those algorithms.

Import the PEM via jose.importPKCS8(privateKey, algorithm) before signing, matching what jose expects for asymmetric algorithms.

Verified manually with a generated RSA keypair: signing threw "Key for the RS256 algorithm must be one of type CryptoKey, KeyObject, or JSON Web Key" before this change, and produces a token that verifies against the matching public key afterwards.

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes JWT auth for RSA/ECDSA/PSS by importing PKCS#8 PEM private keys with `jose` before signing and by accepting RSASSA-PSS–restricted keys. Previously we encoded the PEM, `jose` threw in sign(), and generateJWTToken returned null, so no Authorization header was sent for RS*/ES*/PS*.

- Use `jose.importPKCS8(privateKey, algorithm)` for asymmetric algorithms; HMAC paths are unchanged.
- For PS256/384/512, retry import by rewriting the RSASSA-PSS AlgorithmIdentifier to the generic rsaEncryption OID (no key material change) to satisfy WebCrypto.
- Requires a PKCS#8 PEM private key that matches the chosen algorithm.
- Change is confined to `packages/hoppscotch-data/src/utils/jwt.ts` in generateJWTToken; the private-key error now says "RSA/ECDSA/PSS".

<sup>Written for commit 8c761f14c0ae6f99e2545468f2d82a649bbd5514. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

