### PR TITLE
fix(collections): allow moving a sub-collection to the top-level list

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/index.vue
+++ b/packages/hoppscotch-common/src/components/collections/index.vue
@@ -3010,6 +3010,16 @@ const isSameSameParent = (
   if (destinationItemPath === null) return false
   const destinationItemIndex = pathToIndex(destinationItemPath)
 
+  // if the destination item is itself at the root (and has no parent of its
+  // own), dropping relative to it means the dragged item ends up at the root
+  // too - regardless of how deeply nested the dragged item currently is
+  if (
+    destinationItemIndex.length === 1 &&
+    destinationCollectionIndex === null
+  ) {
+    return true
+  }
+
   // length of 1 means the request is in the root
   if (draggedItemIndex.length === 1 && destinationItemIndex.length === 1) {
     return true

--- a/packages/hoppscotch-common/src/newstore/__tests__/collections.spec.ts
+++ b/packages/hoppscotch-common/src/newstore/__tests__/collections.spec.ts
@@ -1,0 +1,80 @@
+import { makeCollection } from "@hoppscotch/data"
+import { beforeEach, describe, expect, test } from "vitest"
+
+import {
+  restCollectionStore,
+  setRESTCollections,
+  updateRESTCollectionOrder,
+} from "../collections"
+
+const collection = (
+  name: string,
+  folders: ReturnType<typeof makeCollection>[] = []
+) =>
+  makeCollection({
+    name,
+    folders,
+    requests: [],
+    auth: { authType: "inherit", authActive: true },
+    headers: [],
+    variables: [],
+    id: name,
+    description: null,
+    preRequestScript: "",
+    testScript: "",
+  })
+
+describe("REST collections store - updateCollectionOrder", () => {
+  beforeEach(() => {
+    setRESTCollections([
+      collection("Root A", [collection("Nested A1"), collection("Nested A2")]),
+      collection("Root B"),
+      collection("Root C"),
+    ])
+  })
+
+  test("reorders siblings within the same (root) parent", () => {
+    updateRESTCollectionOrder("2", "0")
+
+    const names = restCollectionStore.value.state.map((c) => c.name)
+    expect(names).toEqual(["Root C", "Root A", "Root B"])
+  })
+
+  test("reorders siblings within the same nested parent", () => {
+    updateRESTCollectionOrder("0/1", "0/0")
+
+    const names = restCollectionStore.value.state[0].folders.map((c) => c.name)
+    expect(names).toEqual(["Nested A2", "Nested A1"])
+  })
+
+  test("moves a nested collection to the end of root when destination is null", () => {
+    updateRESTCollectionOrder("0/0", null)
+
+    const root = restCollectionStore.value.state
+    // it stays within its own parent (moved to the end of Root A's folders)
+    expect(root[0].folders.map((c) => c.name)).toEqual([
+      "Nested A2",
+      "Nested A1",
+    ])
+  })
+
+  test("moves a nested sub-collection into the top-level collection list (issue #6522)", () => {
+    // Drag "Nested A1" (path 0/0) to sit at the position of "Root B" (path 1)
+    updateRESTCollectionOrder("0/0", "1")
+
+    const root = restCollectionStore.value.state
+
+    // it must be removed from its original nested parent
+    expect(root[0].folders.map((c) => c.name)).toEqual(["Nested A2"])
+
+    // ...and re-inserted at the top level, not lost or duplicated
+    const rootNames = root.map((c) => c.name)
+    expect(rootNames).toContain("Nested A1")
+    expect(rootNames).toHaveLength(4)
+
+    // no other root collection should have been corrupted/duplicated
+    expect(rootNames.filter((n) => n === "Root A")).toHaveLength(1)
+    expect(rootNames.filter((n) => n === "Root B")).toHaveLength(1)
+    expect(rootNames.filter((n) => n === "Root C")).toHaveLength(1)
+  })
+})

--- a/packages/hoppscotch-common/src/newstore/collections.ts
+++ b/packages/hoppscotch-common/src/newstore/collections.ts
@@ -645,26 +645,19 @@ const restCollectionDispatchers = defineDispatchers({
       return {}
     }
 
-    // Reordering the collection to the last position
+    const folderIndex = indexPaths.pop() as number
+
+    const sourceContainingFolder = navigateToFolderWithIndexPath(
+      newState,
+      indexPaths
+    )
+    const sourceArray = sourceContainingFolder
+      ? sourceContainingFolder.folders
+      : newState
+
+    // Reordering the collection to the last position within its own parent
     if (destinationCollectionIndex === null) {
-      const folderIndex = indexPaths.pop() as number
-
-      const containingFolder = navigateToFolderWithIndexPath(
-        newState,
-        indexPaths
-      )
-
-      if (containingFolder === null) {
-        newState.push(newState.splice(folderIndex, 1)[0])
-        return {
-          state: newState,
-        }
-      }
-
-      // Pushing the folder to the end of the array (last position)
-      containingFolder.folders.push(
-        containingFolder.folders.splice(folderIndex, 1)[0]
-      )
+      sourceArray.push(sourceArray.splice(folderIndex, 1)[0])
 
       return {
         state: newState,
@@ -680,23 +673,29 @@ const restCollectionDispatchers = defineDispatchers({
       return {}
     }
 
-    const folderIndex = indexPaths.pop() as number
     const destinationFolderIndex = destinationIndexPaths.pop() as number
 
-    const containingFolder = navigateToFolderWithIndexPath(
+    const destinationContainingFolder = navigateToFolderWithIndexPath(
       newState,
       destinationIndexPaths
     )
+    const destinationArray = destinationContainingFolder
+      ? destinationContainingFolder.folders
+      : newState
 
-    if (containingFolder === null) {
-      reorderItems(newState, folderIndex, destinationFolderIndex)
+    if (sourceArray === destinationArray) {
+      reorderItems(sourceArray, folderIndex, destinationFolderIndex)
 
       return {
         state: newState,
       }
     }
 
-    reorderItems(containingFolder.folders, folderIndex, destinationFolderIndex)
+    // Moving to a different parent (e.g. a nested collection dropped among
+    // the top-level collections list) - remove it from its current parent
+    // and insert it into the destination parent at the target position
+    const [movedFolder] = sourceArray.splice(folderIndex, 1)
+    destinationArray.splice(destinationFolderIndex, 0, movedFolder)
 
     return {
       state: newState,


### PR DESCRIPTION
Fixes #6522

Dragging a nested sub-collection to drop it among the top-level collections list was always rejected with "different parent," even though moving it to root is a valid operation.

Two separate bugs contributed:

- isSameSameParent() (components/collections/index.vue) only allowed a move when the dragged and destination items' index-path lengths matched, so a nested item (length 2+) could never be validated against a top-level destination (length 1). It now also accepts the move when the destination item is itself at the root, regardless of the dragged item's depth.

- updateCollectionOrder() (newstore/collections.ts) never actually supported re-parenting: it read the dragged item's local index within its own parent, then spliced that index directly against the *destination's* parent array. When the two parents differ, this index doesn't refer to the same item, so the reorder would touch the wrong entry. Rewrote it to resolve the item's actual source array and the destination array separately - reordering in place when they're the same array (existing behavior, unchanged), and removing-then-inserting when they differ (the missing re-parent case).

Added packages/hoppscotch-common/src/newstore/__tests__/collections.spec.ts covering sibling reorder (root and nested), move-to-end via a null destination, and the reported cross-parent move - plus that unrelated root collections aren't corrupted by the move.

Verified the store algorithm's logic with a faithful standalone copy of updateCollectionOrder/reorderItems/navigateToFolderWithIndexPath run under plain Node (all 5 scenarios pass), since the actual vitest suite needs jsdom, and this environment's Node (20.17.0) is below the 20.19+ this repo's html-encoding-sniffer/jsdom dependency chain requires - CI's node-version: 20 resolves to a current 20.x and should run the real spec file fine. `pnpm run do-typecheck` is clean project-wide with 0 errors.

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows dragging a nested sub-collection into the top-level collections list. Previously the drop was rejected as “different parent”; now it re-parents correctly without corrupting siblings.

- Updates validation in `packages/hoppscotch-common/src/components/collections/index.vue` to accept drops relative to a root item regardless of dragged depth.
- Reworks `updateRESTCollectionOrder` in `packages/hoppscotch-common/src/newstore/collections.ts` to resolve source and destination arrays: reorder in place for same-parent moves; remove and insert for cross-parent moves (including root). Preserves “move to end” when destination is null.
- Adds tests in `packages/hoppscotch-common/src/newstore/__tests__/collections.spec.ts` covering root and nested sibling reorders, move-to-end, and cross-parent move to root.

<sup>Written for commit 905d3910c196480004d7a0d2061d84771b76f65e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

