### PR TITLE
fix(curl-import): keep headers whose value contains a colon-space

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1159,6 +1159,22 @@ describe("Parse curl command to Hopp REST Request", () => {
     expect(customHeader.value).toBe(`-d {"fake":1}`)
   })
 
+  test("keeps a header whose value itself contains a colon-space", () => {
+    const command = `curl 'https://example.com/api' -H 'X-Custom: foo: bar' -H 'Authorization:Basic dXNlcjpwYXNz'`
+
+    const actual = parseCurlToHoppRESTReq(command)
+
+    expect(actual.headers).toContainEqual(
+      expect.objectContaining({ key: "X-Custom", value: "foo: bar" })
+    )
+    expect(actual.headers).toContainEqual(
+      expect.objectContaining({
+        key: "Authorization",
+        value: "Basic dXNlcjpwYXNz",
+      })
+    )
+  })
+
   for (const [i, { command, response }] of samples.entries()) {
     test(`for sample #${i + 1}:\n\n${command}`, () => {
       const actual = parseCurlToHoppRESTReq(command)

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -2,7 +2,6 @@ import { HoppRESTHeader } from "@hoppscotch/data"
 import * as A from "fp-ts/Array"
 import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
 import parser from "yargs-parser"
 import {
   objHasArrayProperty,
@@ -10,13 +9,24 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
-const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
-)
+// Split only on the first colon so header values that themselves contain
+// "key: value"-shaped text (e.g. JWTs, media-type params) aren't mistaken
+// for extra header pairs and dropped.
+const getHeaderPair = (header: string) => {
+  const separatorIndex = header.indexOf(":")
+
+  return pipe(
+    separatorIndex,
+    O.fromPredicate((index) => index !== -1),
+    O.map(
+      (index) =>
+        [
+          header.slice(0, index).trim(),
+          header.slice(index + 1).trim(),
+        ] as [string, string]
+    )
+  )
+}
 
 export function getHeaders(parsedArguments: parser.Arguments) {
   let headers: Record<string, string> = {}


### PR DESCRIPTION
getHeaderPair normalized every header line with `S.replace(":", ": ")` then `S.split(": ")`, so a value containing its own ": " (e.g. `X-Custom: foo: bar`) produced more than 2 parts and was silently dropped by the length-2 guard.

Split on the first colon only instead, which also keeps working for compact `Key:Value` headers with no space after the colon.

Fixes hoppscotch/hoppscotch#6400

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes curl header parsing to keep headers whose values contain “: ”. Previously such headers were dropped after splitting on “: ”; now we split on the first “:” only, which also supports compact “Key:Value” headers.

- Updates `packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts` to split on the first colon and trim key/value.
- Adds a test in `packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js` covering a value with “: ” and an `Authorization:Basic …` header.
- Parsed output may now include headers that were previously omitted; update any affected snapshots.

<sup>Written for commit a97ea495f1a2816730bcd2e69a2a30293fcc1335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

