### PR TITLE
feat(request): add confirmation prompt to Send Options > Clear All

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -359,6 +359,7 @@
   "confirm": {
     "close_unsaved_tab": "Are you sure you want to close this tab?",
     "close_unsaved_tabs": "Are you sure you want to close all tabs? {count} unsaved tabs will be lost.",
+    "clear_all_fields": "Are you sure you want to clear all fields? This action cannot be undone.",
     "delete_all_activity_logs": "Are you sure you want to delete all activity logs?",
     "exit_team": "Are you sure you want to leave this workspace?",
     "logout": "Are you sure you want to logout?",

--- a/packages/hoppscotch-common/src/components/http/Request.vue
+++ b/packages/hoppscotch-common/src/components/http/Request.vue
@@ -133,7 +133,7 @@
                 :shortcut="['⌫']"
                 @click="
                   () => {
-                    clearContent()
+                    confirmClearAll = true
                     hide()
                   }
                 "
@@ -232,6 +232,17 @@
       :request="request"
       @hide-modal="showSaveRequestModal = false"
     />
+    <HoppSmartConfirmModal
+      :show="confirmClearAll"
+      :title="`${t('confirm.clear_all_fields')}`"
+      @hide-modal="confirmClearAll = false"
+      @resolve="
+        () => {
+          clearContent()
+          confirmClearAll = false
+        }
+      "
+    />
   </div>
 </template>
 
@@ -313,6 +324,7 @@ const isTabResponseLoading = computed(
 
 const showCurlImportModal = ref(false)
 const showCodegenModal = ref(false)
+const confirmClearAll = ref(false)
 const showSaveRequestModal = ref(false)
 
 const methodTippyActions = ref<any | null>(null)


### PR DESCRIPTION
Clicking Clear All in the Send Options dropdown immediately wiped the request with no way to undo it. Now it opens a confirm modal (same pattern used for clearing history) before clearContent() runs.

Fixes hoppscotch/hoppscotch#6580

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a confirmation prompt to Send Options > Clear All to prevent accidental data loss. Previously, clicking Clear All immediately cleared the request; now it shows a confirm modal and only clears after confirmation.

- Adds `confirm.clear_all_fields` to `en.json`.
- Replaces direct `clearContent()` call with `HoppSmartConfirmModal`; confirm executes `clearContent()`, cancel does nothing.
- Scope is limited to the Clear All action in the request view; no other behavior changes or migrations.

<sup>Written for commit 31b5917cfa3efa8d8b3672c88518b1627afe7a39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

