### PR TITLE
fix(curl-import): don't drop headers whose value contains ': '

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1159,6 +1159,20 @@ describe("Parse curl command to Hopp REST Request", () => {
     expect(customHeader.value).toBe(`-d {"fake":1}`)
   })
 
+  test("does not drop a header whose value contains a colon and space", () => {
+    const command = `curl https://httpbin.org/get -H "X-Note: hello: world" -H "Accept: application/json"`
+
+    const actual = parseCurlToHoppRESTReq(command)
+
+    const noteHeader = actual.headers.find((h) => h.key === "X-Note")
+    expect(noteHeader).toBeDefined()
+    expect(noteHeader.value).toBe("hello: world")
+
+    const acceptHeader = actual.headers.find((h) => h.key === "Accept")
+    expect(acceptHeader).toBeDefined()
+    expect(acceptHeader.value).toBe("application/json")
+  })
+
   for (const [i, { command, response }] of samples.entries()) {
     test(`for sample #${i + 1}:\n\n${command}`, () => {
       const actual = parseCurlToHoppRESTReq(command)

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts
@@ -2,7 +2,6 @@ import { HoppRESTHeader } from "@hoppscotch/data"
 import * as A from "fp-ts/Array"
 import { flow, pipe } from "fp-ts/function"
 import * as O from "fp-ts/Option"
-import * as S from "fp-ts/string"
 import parser from "yargs-parser"
 import {
   objHasArrayProperty,
@@ -10,13 +9,18 @@ import {
 } from "~/helpers/functional/object"
 import { tupleToRecord } from "~/helpers/functional/record"
 
-const getHeaderPair = flow(
-  S.replace(":", ": "),
-  S.split(": "),
-  // must have a key and a value
-  O.fromPredicate((arr) => arr.length === 2),
-  O.map(([k, v]) => [k.trim(), v?.trim() ?? ""] as [string, string])
-)
+// A header is `name: value` (RFC 9110) - split only on the first colon so
+// values that themselves contain ": " (e.g. `X-Note: hello: world`) survive.
+const getHeaderPair = (raw: string) =>
+  pipe(
+    raw.indexOf(":"),
+    O.fromPredicate((colonIndex) => colonIndex !== -1),
+    O.map((colonIndex) => [
+      raw.slice(0, colonIndex).trim(),
+      raw.slice(colonIndex + 1).trim(),
+    ] as [string, string]),
+    O.filter(([key]) => key.length > 0)
+  )
 
 export function getHeaders(parsedArguments: parser.Arguments) {
   let headers: Record<string, string> = {}


### PR DESCRIPTION
getHeaderPair() normalized the raw '-H' string to always have a colon+space after the header name, then split on every ': ' in the string. A header value that itself contained ': ' (e.g. 'X-Note: hello: world') produced more than 2 parts and got silently filtered out.

Split on the first colon only, per RFC 9110 (name is everything before the first colon, value is everything after).

Fixes hoppscotch/hoppscotch#6400

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes curl import dropping headers when the value contains “: ”. Old behavior split on every “: ” and silently discarded such headers; new behavior splits only on the first colon per RFC 9110 so the full value is preserved.

- Update header parsing in `packages/hoppscotch-common/src/helpers/curl/sub_helpers/headers.ts`: take name before the first “:”, value is the rest; trim both; ignore entries without a colon or with an empty name.
- Add a unit test to cover values containing “: ” (e.g., `X-Note: hello: world`).
- No migrations or downstream changes expected.

<sup>Written for commit 12cc4a7f227bdbbf9eb21932e629eb27726149b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

