### PR TITLE
fix(curl-import): don't strip asterisk from URL query parameter values

### DIFF
--- a/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
+++ b/packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js
@@ -1159,6 +1159,16 @@ describe("Parse curl command to Hopp REST Request", () => {
     expect(customHeader.value).toBe(`-d {"fake":1}`)
   })
 
+  test("does not strip asterisk from URL query parameter values", () => {
+    const command = `curl -X POST 'https://x.x.cn/x/x/x?bi=%5B%2219ddxx65f6c2%22%2C46001%2C%22Xiaxi%22%2C%22Andxoid%22%2C36%2C16%2C%22x031PN0DC%22%2C%22Xiaomi%22%2C560%2C%221440*2976%22%2C%22wxdxa%22%2C%22WxFI%22%2C%22zh_CN%22%5D&bik=25&pageId=xxx' -H 'content-type: application/json; charset=UTF-8' -d '{"country":"xxx"}'`
+
+    const actual = parseCurlToHoppRESTReq(command)
+
+    const biParam = actual.params.find((p) => p.key === "bi")
+    expect(biParam).toBeDefined()
+    expect(biParam.value).toContain("1440*2976")
+  })
+
   for (const [i, { command, response }] of samples.entries()) {
     test(`for sample #${i + 1}:\n\n${command}`, () => {
       const actual = parseCurlToHoppRESTReq(command)

--- a/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
+++ b/packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts
@@ -53,7 +53,9 @@ const parseURL = (urlText: string | number) =>
       u
         .toString()
         .replace(/^'|'$/g, "")
-        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>\s]/g, "")
+        // `*` is a valid RFC 3986 sub-delim (e.g. in query values) and must
+        // not be stripped out here
+        .replaceAll(/[^a-zA-Z0-9_\-./?&=:@%+#,;()'<>*\s]/g, "")
     ),
     O.filter((u) => u.length > 0),
     O.chain((u) =>


### PR DESCRIPTION
parseURL() sanitizes the raw URL string with a hardcoded whitelist regex before handing it to the URL constructor. '*' is a valid RFC 3986 sub-delim and can legitimately appear in a query value, but it wasn't in the whitelist, so it was silently stripped (e.g. %221440*2976%22 became %2214402976%22).

Add '*' to the allowed character set.

Fixes hoppscotch/hoppscotch#6249

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves asterisks in URL query values during cURL import. Previously the sanitizer removed `*`, turning `%221440*2976%22` into `%2214402976%22`; now `*` is allowed per RFC 3986, so values import intact.

- Adjusts the whitelist regex in `packages/hoppscotch-common/src/helpers/curl/sub_helpers/url.ts` to include `*`.
- Adds a unit test in `packages/hoppscotch-common/src/helpers/curl/__tests__/curlparser.spec.js` to cover asterisk preservation.
- No migrations or config changes; only affects parsing of inputs containing `*` in query values.

<sup>Written for commit 4dc34f286c8183941482b34eefa4ce6a497f211c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

