### PR TITLE
fix(keybindings): use a lock counter instead of a boolean for disabling

### DIFF
--- a/packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/__tests__/keybindings.spec.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest"
-import { bindings, resolvePressedKey } from "../keybindings"
+import {
+  bindings,
+  isKeybindingsEnabled,
+  resolvePressedKey,
+  useKeybindingDisabler,
+} from "../keybindings"
 
 // Fixture builder to keep individual cases readable. Layout name in the
 // describe block is the conceptual layout; `key` and `code` are what the
@@ -217,5 +222,38 @@ describe("bindings: native word-delete chords stay unmapped", () => {
 
   test("no chord maps to response.erase", () => {
     expect(Object.values(bindings)).not.toContain("response.erase")
+  })
+})
+
+describe("useKeybindingDisabler: reference-counted locks", () => {
+  // hoppscotch/hoppscotch#6531: keybindingsEnabled used to be a plain
+  // boolean, so if two modals both disabled keybindings and the first one
+  // closed, the second modal's still-open lock was clobbered and shortcuts
+  // re-enabled early. It must now behave like a lock count that only
+  // reaches zero once every caller has released its lock.
+  test("stays disabled while a second lock is still held after the first is released", () => {
+    const { disableKeybindings, enableKeybindings } = useKeybindingDisabler()
+
+    disableKeybindings() // modal A opens
+    disableKeybindings() // modal B opens
+    expect(isKeybindingsEnabled()).toBe(false)
+
+    enableKeybindings() // modal A closes
+    expect(isKeybindingsEnabled()).toBe(false) // modal B is still open
+
+    enableKeybindings() // modal B closes
+    expect(isKeybindingsEnabled()).toBe(true)
+  })
+
+  test("an extra enableKeybindings() call does not go negative or re-enable early", () => {
+    const { disableKeybindings, enableKeybindings } = useKeybindingDisabler()
+
+    disableKeybindings()
+    disableKeybindings()
+    enableKeybindings()
+    enableKeybindings()
+    enableKeybindings() // no matching lock left - should be a no-op
+
+    expect(isKeybindingsEnabled()).toBe(true)
   })
 })

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -16,11 +16,13 @@ import { getKernelMode } from "@hoppscotch/kernel"
 import { listen } from "@tauri-apps/api/event"
 
 /**
- * This variable keeps track whether keybindings are being accepted
- * true -> Keybindings are checked
- * false -> Key presses are ignored (Keybindings are not checked)
+ * Number of outstanding `disableKeybindings()` calls that haven't been
+ * matched by a corresponding `enableKeybindings()` yet. Keybindings are
+ * accepted only when this is 0, so bindings stay disabled as long as at
+ * least one caller (e.g. an open modal) still holds a lock, even if other
+ * callers have already released theirs.
  */
-let keybindingsEnabled = true
+let keybindingsDisableLockCount = 0
 
 /**
  * Unlisten function for Tauri event
@@ -175,7 +177,7 @@ export function hookKeybindingsListener() {
 
 function handleKeyDown(ev: KeyboardEvent) {
   // Do not check keybinds if the mode is disabled
-  if (!keybindingsEnabled) return
+  if (keybindingsDisableLockCount > 0) return
 
   // Skip during IME composition (CJK input). Modern browsers report
   // `isComposing`. Older ones use the sentinel `keyCode === 229`.
@@ -271,7 +273,7 @@ function handleTauriShortcut(shortcut: string) {
   console.info("Tauri shortcut:", shortcut)
 
   // Do not check keybinds if the mode is disabled
-  if (!keybindingsEnabled) return
+  if (keybindingsDisableLockCount > 0) return
 
   const activeBindings = getActiveBindings()
   const boundAction = activeBindings[shortcut as ShortcutKey]
@@ -449,17 +451,24 @@ function getActiveModifier(ev: KeyboardEvent): ModifierKeys | null {
  * This composable allows for the UI component to be disabled if the component in question is mounted
  */
 export function useKeybindingDisabler() {
-  // TODO: Move to a lock based system that keeps the bindings disabled until all locks are lifted
   const disableKeybindings = () => {
-    keybindingsEnabled = false
+    keybindingsDisableLockCount += 1
   }
 
   const enableKeybindings = () => {
-    keybindingsEnabled = true
+    keybindingsDisableLockCount = Math.max(0, keybindingsDisableLockCount - 1)
   }
 
   return {
     disableKeybindings,
     enableKeybindings,
   }
+}
+
+/**
+ * Whether keybindings are currently accepted, i.e. no caller (e.g. an open
+ * modal) still holds a `disableKeybindings()` lock.
+ */
+export function isKeybindingsEnabled() {
+  return keybindingsDisableLockCount === 0
 }


### PR DESCRIPTION
useKeybindingDisabler() backed keybindingsEnabled with a single boolean. If two modals both called disableKeybindings() and the first one closed (calling enableKeybindings()), shortcuts re-enabled while the second modal was still open, since the boolean had no way to know another lock was still held.

Replace the boolean with a reference count: disableKeybindings() increments it, enableKeybindings() decrements it (clamped at 0), and keybindings are only accepted once the count reaches 0. Also exports isKeybindingsEnabled() so the lock state is testable, and adds regression tests covering the two-lock race and an unmatched extra enableKeybindings() call.

Fixes hoppscotch/hoppscotch#6531

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents keybindings from re-enabling while any modal still holds a disable lock by replacing the global boolean with a reference-counted lock. Previously, one `enableKeybindings()` could re-enable shortcuts early; now they only re-enable when the lock count returns to 0.

- Switches `useKeybindingDisabler()` to a ref-counted lock: `disableKeybindings()` increments; `enableKeybindings()` decrements (clamped at 0); handlers ignore input while count > 0.
- Exports `isKeybindingsEnabled()` and adds regression tests for the two-lock race and an extra `enableKeybindings()` call.
- No migration: `useKeybindingDisabler()` API is unchanged.

<sup>Written for commit 929fae9c839391773da455bde8ace17a0f17fd93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

