### PR TITLE
fix(spotlight): fetch all pages of teams when searching workspaces

### DIFF
--- a/packages/hoppscotch-common/src/services/spotlight/searchers/__tests__/workspace.searcher.spec.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/__tests__/workspace.searcher.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest"
+import { TestContainer } from "dioc/testing"
+import { ref, nextTick } from "vue"
+import * as E from "fp-ts/Either"
+import { SwitchWorkspaceSpotlightSearcherService } from "../workspace.searcher"
+import { SpotlightService } from "../.."
+import { WorkspaceService } from "~/services/workspace.service"
+import { platform } from "~/platform"
+
+vi.mock("~/modules/i18n", () => ({
+  __esModule: true,
+  getI18n: () => (x: string) => x,
+}))
+
+vi.mock("~/platform", () => ({
+  platform: {
+    auth: {
+      getCurrentUser: vi.fn(),
+    },
+    backend: {
+      getUserTeams: vi.fn(),
+    },
+  },
+}))
+
+async function flushPromises() {
+  return await new Promise((r) => setTimeout(r))
+}
+
+const makeTeam = (id: string) => ({ id, name: `Team ${id}` })
+
+describe("SwitchWorkspaceSpotlightSearcherService: team pagination", () => {
+  // hoppscotch/hoppscotch#6096: fetchMyTeams() computed a pagination cursor
+  // but only ever called getUserTeams() once, so with more teams than fit
+  // on a single backend page, teams past the first page were never added
+  // to the search index and couldn't be found.
+  it("fetches every page of teams, not just the first", async () => {
+    const container = new TestContainer()
+
+    container.bindMock(SpotlightService, {
+      registerSearcher: vi.fn(),
+    })
+
+    container.bindMock(WorkspaceService, {
+      currentWorkspace: ref({ type: "personal" }),
+    })
+
+    vi.mocked(platform.auth.getCurrentUser).mockReturnValue({} as any)
+
+    // 12 teams total, backend page size is 10 - so this only resolves
+    // correctly if a second page is fetched using the returned cursor.
+    const page1 = Array.from({ length: 10 }, (_, i) => makeTeam(`${i + 1}`))
+    const page2 = [makeTeam("11"), makeTeam("12")]
+
+    vi.mocked(platform.backend.getUserTeams).mockImplementation(
+      async (cursor?: string) =>
+        cursor
+          ? (E.right({ myTeams: page2 }) as any)
+          : (E.right({ myTeams: page1 }) as any)
+    )
+
+    const searcher = container.bind(SwitchWorkspaceSpotlightSearcherService)
+
+    const query = ref("")
+    const [state] = searcher.createSearchSession(query)
+
+    // let fetchMyTeams's pagination loop resolve and populate the index
+    await flushPromises()
+
+    query.value = "Team 12"
+    await nextTick()
+
+    expect(platform.backend.getUserTeams).toHaveBeenCalledTimes(2)
+    expect(state.value.results).toContainEqual(
+      expect.objectContaining({ id: "workspace-12" })
+    )
+  })
+
+  it("stops after a single page when there's no more data", async () => {
+    const container = new TestContainer()
+
+    container.bindMock(SpotlightService, {
+      registerSearcher: vi.fn(),
+    })
+
+    container.bindMock(WorkspaceService, {
+      currentWorkspace: ref({ type: "personal" }),
+    })
+
+    vi.mocked(platform.auth.getCurrentUser).mockReturnValue({} as any)
+
+    const page1 = [makeTeam("1"), makeTeam("2")]
+
+    vi.mocked(platform.backend.getUserTeams).mockResolvedValue(
+      E.right({ myTeams: page1 }) as any
+    )
+
+    const searcher = container.bind(SwitchWorkspaceSpotlightSearcherService)
+
+    const query = ref("")
+    searcher.createSearchSession(query)
+
+    await flushPromises()
+
+    expect(platform.backend.getUserTeams).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/hoppscotch-common/src/services/spotlight/searchers/workspace.searcher.ts
+++ b/packages/hoppscotch-common/src/services/spotlight/searchers/workspace.searcher.ts
@@ -150,6 +150,11 @@ export class WorkspaceSpotlightSearcherService extends StaticSpotlightSearcherSe
   }
 }
 
+// Matches the GetMyTeams GraphQL query's page size (see also
+// TeamListAdapter.ts's identically-valued BACKEND_PAGE_SIZE) - a page
+// shorter than this means there are no more teams to fetch.
+const WORKSPACE_SEARCH_PAGE_SIZE = 10
+
 /**
  * This searcher is responsible for searching through the environment.
  * And switching between them.
@@ -172,21 +177,29 @@ export class SwitchWorkspaceSpotlightSearcherService
     this.spotlight.registerSearcher(this)
   }
 
-  private fetchMyTeams(): Promise<GetMyTeamsQuery["myTeams"]> {
-    return new Promise(async (resolve) => {
-      const currentUser = platform.auth.getCurrentUser()
-      if (!currentUser) return resolve([])
+  private async fetchMyTeams(): Promise<GetMyTeamsQuery["myTeams"]> {
+    const currentUser = platform.auth.getCurrentUser()
+    if (!currentUser) return []
 
-      const results: GetMyTeamsQuery["myTeams"] = []
+    const results: GetMyTeamsQuery["myTeams"] = []
 
+    // Paginated - keep fetching pages until a partial (or empty) page
+    // tells us we've reached the end, otherwise only the first page of
+    // teams would ever be searchable.
+    while (true) {
       const cursor =
         results.length > 0 ? results[results.length - 1].id : undefined
 
       const result = await platform.backend.getUserTeams(cursor)
 
-      if (E.isRight(result)) results.push(...result.right.myTeams)
-      resolve(results)
-    })
+      if (E.isLeft(result)) break
+
+      results.push(...result.right.myTeams)
+
+      if (result.right.myTeams.length !== WORKSPACE_SEARCH_PAGE_SIZE) break
+    }
+
+    return results
   }
 
   private workspace = this.workspaceService.currentWorkspace


### PR DESCRIPTION
fetchMyTeams() computed a pagination cursor from an always-empty results array and called getUserTeams() exactly once, so only the first backend page of teams (10) was ever added to the workspace search index. With more teams than that, the search box in the workspace switcher silently failed to find anything past the first page.

Loop over pages using the same cursor/BACKEND_PAGE_SIZE pattern TeamListAdapter.fetchList() already uses, stopping once a page comes back shorter than the page size.

Fixes hoppscotch/hoppscotch#6096

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

<!-- Add an introduction into what this PR tries to solve in a couple of sentences -->

### What's changed
<!-- Describe point by point the different things you have changed in this PR -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

### Notes to reviewers
<!-- Any information you feel the reviewer should know about when reviewing your PR -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetches all pages of user teams when building the workspace search index so the workspace switcher can find teams beyond the first 10. Previously we fetched only the first backend page; now we paginate until a short page signals the end. Fixes hoppscotch/hoppscotch#6096.

**Review notes**
- Rewrote `fetchMyTeams` to loop with a cursor and `WORKSPACE_SEARCH_PAGE_SIZE` (10), breaking when a page is shorter or on backend error; returns an empty list when no user is authenticated.
- Added tests in `packages/hoppscotch-common/src/services/spotlight/searchers/__tests__/workspace.searcher.spec.ts` covering multi-page and single-page cases.
- Slightly increases backend calls only for users with more than 10 teams; no API or UI changes.

<sup>Written for commit a4cc748a08f6cb686cfb14aaf3953d7dddff409d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

