### PR TITLE
feat: add Actual Request tab in response pane

### DIFF
--- a/packages/hoppscotch-common/src/components/lenses/ActualRequestRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/ActualRequestRenderer.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="flex flex-1 flex-col overflow-y-auto">
+    <!-- Request Method and URL -->
+    <div class="flex items-center border-b border-dividerLight p-4">
+      <span
+        class="font-semibold"
+        :style="{ color: getMethodLabelColorClassOf(response.req.method) }"
+      >
+        {{ response.req.method }}
+      </span>
+      <span class="ml-4 truncate text-secondaryDark font-mono text-tiny">
+        {{ response.req.effectiveFinalURL }}
+      </span>
+    </div>
+
+    <!-- Headers -->
+    <div class="flex flex-col border-b border-dividerLight pb-4">
+      <h3 class="px-4 pt-4 font-semibold text-secondaryLight">
+        {{ t("response.request_headers") }}
+      </h3>
+      <div v-if="headers.length > 0" class="mt-2">
+        <div
+          v-for="(header, index) in headers"
+          :key="index"
+          class="flex px-4 py-1 font-mono text-tiny"
+        >
+          <span class="w-1/3 truncate text-secondary">
+            {{ header.key }}
+          </span>
+          <span class="w-2/3 break-words">
+            {{ header.value }}
+          </span>
+        </div>
+      </div>
+      <div v-else class="px-4 pt-2 text-secondaryLight">
+        {{ t("state.nothing_found") }}
+      </div>
+    </div>
+
+    <!-- Body -->
+    <div class="flex flex-col pb-4">
+      <h3 class="px-4 pt-4 font-semibold text-secondaryLight">
+        {{ t("response.body") }}
+      </h3>
+      <div v-if="hasBody" class="mt-2 px-4">
+        <div class="rounded border border-dividerLight bg-primaryLight p-4 font-mono text-tiny">
+          <pre class="whitespace-pre-wrap break-words text-secondary">{{ bodyString }}</pre>
+        </div>
+      </div>
+      <div v-else class="px-4 pt-2 text-secondaryLight">
+        {{ t("state.nothing_found") }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue"
+import { useI18n } from "@composables/i18n"
+import { getMethodLabelColorClassOf } from "~/helpers/rest/labelColoring"
+import type { HoppRESTResponse } from "~/helpers/types/HoppRESTResponse"
+import type { EffectiveHoppRESTRequest } from "~/helpers/utils/EffectiveURL"
+
+const t = useI18n()
+
+const props = defineProps<{
+  response: HoppRESTResponse
+}>()
+
+const req = computed(() => props.response.req as EffectiveHoppRESTRequest)
+
+const headers = computed(() => {
+  return req.value.effectiveFinalHeaders?.filter((h) => h.active && h.key) || []
+})
+
+const hasBody = computed(() => !!req.value.effectiveFinalBody)
+
+const bodyString = computed(() => {
+  const body = req.value.effectiveFinalBody
+  if (!body) return ""
+  if (typeof body === "string") return body
+  if (body instanceof FormData) {
+    const entries = []
+    for (const [key, value] of body.entries()) {
+      entries.push(`${key}: ${value instanceof File ? "[File]" : value}`)
+    }
+    return entries.join("\n")
+  }
+  return "[Blob or File]"
+})
+</script>

--- a/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/ResponseBodyRenderer.vue
@@ -55,6 +55,14 @@
       />
     </HoppSmartTab>
     <HoppSmartTab
+      v-if="doc.response?.req"
+      id="actual-request"
+      label="Actual Request"
+      class="flex flex-1 flex-col"
+    >
+      <LensesActualRequestRenderer :response="doc.response" />
+    </HoppSmartTab>
+    <HoppSmartTab
       v-if="showConsoleTab"
       id="console"
       label="Console"


### PR DESCRIPTION
## Summary
Resolves #6544 by implementing a dedicated "Actual Request" tab in the response pane that displays the exact HTTP request sent to the server.

## Changes
- Created `ActualRequestRenderer.vue` which extracts the `effectiveFinalURL`, `effectiveFinalHeaders`, and `effectiveFinalBody` directly from the resolved `doc.response.req`.
- Rendered the new component inside a `HoppSmartTab` named "Actual Request" in `ResponseBodyRenderer.vue`.
- Developers can now effortlessly verify exact payload formats, generated HMAC headers, and resolved variables without needing external proxies or browser DevTools.

Closes #6544


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "Actual Request" tab to the response pane so you can see the exact HTTP request sent after variables and pre-request scripts are applied.

- Shows the resolved method, URL, active headers, and body pulled from the response's stored request data.
- Removes the need for external proxies or DevTools to verify payloads like generated HMAC headers or resolved variables.
- New `ActualRequestRenderer` component handles rendering; FormData, Blob, and File bodies display placeholder representations.

<sup>Written for commit 72717dec4233fab3c5383aff4634f5d6c59d04c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

