### PR TITLE
fix(import): handle non-string environment values in Insomnia import (#6606)

### DIFF
--- a/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/insomniaImport.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/insomniaImport.spec.ts
@@ -1,0 +1,104 @@
+﻿import * as E from "fp-ts/Either"
+import { describe, expect, it } from "vitest"
+
+import { hoppInsomniaImporter } from "../insomnia/insomniaColl"
+import {
+  insomniaEnvImporter,
+  replaceInsomniaTemplating,
+} from "../insomnia/insomniaEnv"
+
+describe("replaceInsomniaTemplating", () => {
+  it("replaces Insomnia template expressions with Hoppscotch variables", () => {
+    expect(replaceInsomniaTemplating("{{ _.baseUrl }}/api")).toBe("<<baseUrl>>/api")
+  })
+
+  it("handles non-string expressions safely without throwing replaceAll error", () => {
+    expect(replaceInsomniaTemplating(12345 as any)).toBe("12345")
+    expect(replaceInsomniaTemplating(true as any)).toBe("true")
+    expect(replaceInsomniaTemplating(null as any)).toBe("")
+    expect(replaceInsomniaTemplating(undefined as any)).toBe("")
+  })
+})
+
+describe("hoppInsomniaImporter - Insomnia v5 Export with non-string environment values", () => {
+  it("successfully imports an Insomnia v5 collection containing numbers and booleans in environment", async () => {
+    const insomniaV5Doc = {
+      type: "collection.insomnia.rest/5.0",
+      name: "Sample V5 Collection",
+      meta: {
+        description: "Test Collection",
+      },
+      environments: {
+        data: {
+          port: 8080,
+          enabled: true,
+          baseUrl: "https://api.example.com",
+          timeout: null,
+        },
+      },
+      collection: [
+        {
+          name: "Test Request",
+          method: "GET",
+          url: "https://api.example.com/users/:userId",
+          headers: [],
+          parameters: [],
+        },
+      ],
+    }
+
+    const result = await hoppInsomniaImporter([JSON.stringify(insomniaV5Doc)])()
+
+    expect(E.isRight(result)).toBe(true)
+    if (E.isRight(result)) {
+      const [collection] = result.right
+      expect(collection.name).toBe("Sample V5 Collection")
+      expect(collection.variables).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ key: "port", initialValue: "8080" }),
+          expect.objectContaining({ key: "enabled", initialValue: "true" }),
+          expect.objectContaining({
+            key: "baseUrl",
+            initialValue: "https://api.example.com",
+          }),
+        ])
+      )
+    }
+  })
+})
+
+describe("insomniaEnvImporter - Insomnia environment resources", () => {
+  it("imports environment resources containing number and boolean values", async () => {
+    const insomniaEnvDoc = {
+      resources: [
+        {
+          _type: "environment",
+          name: "Dev Environment",
+          data: {
+            port: 3000,
+            debug: true,
+            apiUrl: "http://localhost:3000",
+          },
+        },
+      ],
+    }
+
+    const result = await insomniaEnvImporter([JSON.stringify(insomniaEnvDoc)])()
+
+    expect(E.isRight(result)).toBe(true)
+    if (E.isRight(result)) {
+      const [env] = result.right
+      expect(env.name).toBe("Dev Environment")
+      expect(env.variables).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ key: "port", initialValue: "3000" }),
+          expect.objectContaining({ key: "debug", initialValue: "true" }),
+          expect.objectContaining({
+            key: "apiUrl",
+            initialValue: "http://localhost:3000",
+          }),
+        ])
+      )
+    }
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/insomniaImport.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/insomniaImport.spec.ts
@@ -5,9 +5,10 @@ import { hoppInsomniaImporter } from "../insomnia/insomniaColl"
 import {
   insomniaEnvImporter,
   replaceInsomniaTemplating,
+  safeStringifyValue,
 } from "../insomnia/insomniaEnv"
 
-describe("replaceInsomniaTemplating", () => {
+describe("safeStringifyValue and replaceInsomniaTemplating", () => {
   it("replaces Insomnia template expressions with Hoppscotch variables", () => {
     expect(replaceInsomniaTemplating("{{ _.baseUrl }}/api")).toBe("<<baseUrl>>/api")
   })
@@ -18,10 +19,17 @@ describe("replaceInsomniaTemplating", () => {
     expect(replaceInsomniaTemplating(null as any)).toBe("")
     expect(replaceInsomniaTemplating(undefined as any)).toBe("")
   })
+
+  it("preserves nested objects and arrays as valid JSON strings", () => {
+    expect(safeStringifyValue({ key: "value", nested: 42 })).toBe(
+      JSON.stringify({ key: "value", nested: 42 })
+    )
+    expect(safeStringifyValue([1, 2, "three"])).toBe(JSON.stringify([1, 2, "three"]))
+  })
 })
 
-describe("hoppInsomniaImporter - Insomnia v5 Export with non-string environment values", () => {
-  it("successfully imports an Insomnia v5 collection containing numbers and booleans in environment", async () => {
+describe("hoppInsomniaImporter - Insomnia v5 Export with complex environment values", () => {
+  it("successfully imports an Insomnia v5 collection containing numbers, booleans, and nested objects", async () => {
     const insomniaV5Doc = {
       type: "collection.insomnia.rest/5.0",
       name: "Sample V5 Collection",
@@ -34,6 +42,7 @@ describe("hoppInsomniaImporter - Insomnia v5 Export with non-string environment 
           enabled: true,
           baseUrl: "https://api.example.com",
           timeout: null,
+          config: { retries: 3, debug: true },
         },
       },
       collection: [
@@ -61,14 +70,18 @@ describe("hoppInsomniaImporter - Insomnia v5 Export with non-string environment 
             key: "baseUrl",
             initialValue: "https://api.example.com",
           }),
+          expect.objectContaining({
+            key: "config",
+            initialValue: JSON.stringify({ retries: 3, debug: true }),
+          }),
         ])
       )
     }
   })
 })
 
-describe("insomniaEnvImporter - Insomnia environment resources", () => {
-  it("imports environment resources containing number and boolean values", async () => {
+describe("insomniaEnvImporter - Insomnia environment resources with null and object data", () => {
+  it("handles environment resources with null data and preserves object values", async () => {
     const insomniaEnvDoc = {
       resources: [
         {
@@ -78,7 +91,13 @@ describe("insomniaEnvImporter - Insomnia environment resources", () => {
             port: 3000,
             debug: true,
             apiUrl: "http://localhost:3000",
+            headers: { "X-Custom": "header" },
           },
+        },
+        {
+          _type: "environment",
+          name: "Empty Environment",
+          data: null,
         },
       ],
     }
@@ -96,6 +115,10 @@ describe("insomniaEnvImporter - Insomnia environment resources", () => {
           expect.objectContaining({
             key: "apiUrl",
             initialValue: "http://localhost:3000",
+          }),
+          expect.objectContaining({
+            key: "headers",
+            initialValue: JSON.stringify({ "X-Custom": "header" }),
           }),
         ])
       )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/insomniaImport.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/__tests__/insomniaImport.spec.ts
@@ -29,7 +29,7 @@ describe("safeStringifyValue and replaceInsomniaTemplating", () => {
 })
 
 describe("hoppInsomniaImporter - Insomnia v5 Export with complex environment values", () => {
-  it("successfully imports an Insomnia v5 collection containing numbers, booleans, and nested objects", async () => {
+  it("successfully imports an Insomnia v5 collection containing numbers, booleans, nulls, and nested template objects", async () => {
     const insomniaV5Doc = {
       type: "collection.insomnia.rest/5.0",
       name: "Sample V5 Collection",
@@ -42,7 +42,7 @@ describe("hoppInsomniaImporter - Insomnia v5 Export with complex environment val
           enabled: true,
           baseUrl: "https://api.example.com",
           timeout: null,
-          config: { retries: 3, debug: true },
+          config: { retries: 3, endpoint: "{{ _.baseUrl }}/v1" },
         },
       },
       collection: [
@@ -70,9 +70,10 @@ describe("hoppInsomniaImporter - Insomnia v5 Export with complex environment val
             key: "baseUrl",
             initialValue: "https://api.example.com",
           }),
+          expect.objectContaining({ key: "timeout", initialValue: "" }),
           expect.objectContaining({
             key: "config",
-            initialValue: JSON.stringify({ retries: 3, debug: true }),
+            initialValue: JSON.stringify({ retries: 3, endpoint: "<<baseUrl>>/v1" }),
           }),
         ])
       )
@@ -91,7 +92,7 @@ describe("insomniaEnvImporter - Insomnia environment resources with null and obj
             port: 3000,
             debug: true,
             apiUrl: "http://localhost:3000",
-            headers: { "X-Custom": "header" },
+            headers: { "X-Custom": "{{ _.customHeader }}" },
           },
         },
         {
@@ -106,9 +107,9 @@ describe("insomniaEnvImporter - Insomnia environment resources with null and obj
 
     expect(E.isRight(result)).toBe(true)
     if (E.isRight(result)) {
-      const [env] = result.right
-      expect(env.name).toBe("Dev Environment")
-      expect(env.variables).toEqual(
+      const [devEnv, emptyEnv] = result.right
+      expect(devEnv.name).toBe("Dev Environment")
+      expect(devEnv.variables).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ key: "port", initialValue: "3000" }),
           expect.objectContaining({ key: "debug", initialValue: "true" }),
@@ -118,10 +119,13 @@ describe("insomniaEnvImporter - Insomnia environment resources with null and obj
           }),
           expect.objectContaining({
             key: "headers",
-            initialValue: JSON.stringify({ "X-Custom": "header" }),
+            initialValue: JSON.stringify({ "X-Custom": "<<customHeader>>" }),
           }),
         ])
       )
+
+      expect(emptyEnv.name).toBe("Empty Environment")
+      expect(emptyEnv.variables).toEqual([])
     }
   })
 })

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomnia/insomniaColl.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomnia/insomniaColl.ts
@@ -46,19 +46,21 @@ const isV5InsomniaDoc = (data: InsomniaDoc) =>
   typeof data.type === "string" &&
   (data.type as string).startsWith("collection.insomnia.rest/5")
 
-const replacePathVarTemplating = (expression: unknown) => {
-  if (typeof expression !== "string") {
-    return safeStringifyValue(expression)
-  }
-  return expression.replaceAll(/:([^/]+)/g, "<<$1>>")
+const replacePathVarTemplating = (expression: unknown): string => {
+  const str =
+    typeof expression === "string"
+      ? expression
+      : safeStringifyValue(expression)
+  return str.replaceAll(/:([^/]+)/g, "<<$1>>")
 }
 
 const replaceVarTemplating = (expression: unknown, pathVar = false): string => {
-  if (typeof expression !== "string") {
-    return safeStringifyValue(expression)
-  }
+  const str =
+    typeof expression === "string"
+      ? expression
+      : safeStringifyValue(expression)
   return pipe(
-    expression,
+    str,
     pathVar ? replacePathVarTemplating : (x) => x,
     replaceInsomniaTemplating
   )

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomnia/insomniaColl.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomnia/insomniaColl.ts
@@ -20,7 +20,10 @@ import { pipe } from "fp-ts/function"
 import { convert } from "insomnia-importers"
 
 import { IMPORTER_INVALID_FILE_FORMAT } from ".."
-import { replaceInsomniaTemplating } from "./insomniaEnv"
+import {
+  replaceInsomniaTemplating,
+  safeStringifyValue,
+} from "./insomniaEnv"
 import { safeParseJSONOrYAML } from "~/helpers/functional/yaml"
 import {
   InsomniaDoc,
@@ -45,14 +48,14 @@ const isV5InsomniaDoc = (data: InsomniaDoc) =>
 
 const replacePathVarTemplating = (expression: unknown) => {
   if (typeof expression !== "string") {
-    return String(expression ?? "")
+    return safeStringifyValue(expression)
   }
   return expression.replaceAll(/:([^/]+)/g, "<<$1>>")
 }
 
 const replaceVarTemplating = (expression: unknown, pathVar = false): string => {
   if (typeof expression !== "string") {
-    return String(expression ?? "")
+    return safeStringifyValue(expression)
   }
   return pipe(
     expression,

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomnia/insomniaColl.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomnia/insomniaColl.ts
@@ -43,10 +43,17 @@ const isV5InsomniaDoc = (data: InsomniaDoc) =>
   typeof data.type === "string" &&
   (data.type as string).startsWith("collection.insomnia.rest/5")
 
-const replacePathVarTemplating = (expression: string) =>
-  expression.replaceAll(/:([^/]+)/g, "<<$1>>")
+const replacePathVarTemplating = (expression: unknown) => {
+  if (typeof expression !== "string") {
+    return String(expression ?? "")
+  }
+  return expression.replaceAll(/:([^/]+)/g, "<<$1>>")
+}
 
-const replaceVarTemplating = (expression: string, pathVar = false) => {
+const replaceVarTemplating = (expression: unknown, pathVar = false): string => {
+  if (typeof expression !== "string") {
+    return String(expression ?? "")
+  }
   return pipe(
     expression,
     pathVar ? replacePathVarTemplating : (x) => x,
@@ -80,7 +87,7 @@ const getRequestsIn = (
   )
 
 const getCollectionVariables = (
-  environment: Record<string, string> | undefined,
+  environment: Record<string, unknown> | undefined,
   folderRes?: InsomniaFolderResource
 ): HoppCollectionVariable[] => {
   const env =

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomnia/insomniaEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomnia/insomniaEnv.ts
@@ -27,7 +27,10 @@ const insomniaEnvSchema = z.object({
   data: z.record(z.string()),
 })
 
-export const replaceInsomniaTemplating = (expression: string) => {
+export const replaceInsomniaTemplating = (expression: unknown) => {
+  if (typeof expression !== "string") {
+    return String(expression ?? "")
+  }
   const regex = /\{\{ _\.([^}]+) \}\}/g
   return expression.replaceAll(regex, "<<$1>>")
 }

--- a/packages/hoppscotch-common/src/helpers/import-export/import/insomnia/insomniaEnv.ts
+++ b/packages/hoppscotch-common/src/helpers/import-export/import/insomnia/insomniaEnv.ts
@@ -27,9 +27,22 @@ const insomniaEnvSchema = z.object({
   data: z.record(z.string()),
 })
 
+export const safeStringifyValue = (val: unknown): string => {
+  if (val === null || val === undefined) return ""
+  if (typeof val === "string") return val
+  if (typeof val === "object") {
+    try {
+      return JSON.stringify(val)
+    } catch {
+      return String(val)
+    }
+  }
+  return String(val)
+}
+
 export const replaceInsomniaTemplating = (expression: unknown) => {
   if (typeof expression !== "string") {
-    return String(expression ?? "")
+    return safeStringifyValue(expression)
   }
   const regex = /\{\{ _\.([^}]+) \}\}/g
   return expression.replaceAll(regex, "<<$1>>")
@@ -55,11 +68,14 @@ export const insomniaEnvImporter = (contents: string[]) => {
     return resources
       .filter((resource) => resource._type === "environment")
       .map((envResource) => {
-        const envResourceData = envResource.data as Record<string, unknown>
+        const envResourceData =
+          envResource.data && typeof envResource.data === "object"
+            ? (envResource.data as Record<string, unknown>)
+            : {}
         const stringifiedData: Record<string, string> = {}
 
         Object.keys(envResourceData).forEach((key) => {
-          stringifiedData[key] = String(envResourceData[key])
+          stringifiedData[key] = safeStringifyValue(envResourceData[key])
         })
 
         return { ...envResource, data: stringifiedData }


### PR DESCRIPTION
### Description
Fixes #6606

When importing Insomnia collections (especially Insomnia v5 exports), environment objects can contain non-string values such as numbers (e.g. \port: 8080\), booleans (e.g. \enabled: true\), or \
ull\. When \eplaceInsomniaTemplating\ or \eplaceVarTemplating\ was invoked on those values, calling \.replaceAll()\ on non-string primitives resulted in an unhandled \TypeError: e.replaceAll is not a function\ error, causing the import spinner to hang indefinitely.

### Changes
- Updated \eplaceInsomniaTemplating\ in \insomniaEnv.ts\ to safely handle non-string inputs.
- Updated \eplacePathVarTemplating\, \eplaceVarTemplating\, and \getCollectionVariables\ in \insomniaColl.ts\ to safely accept unknown values and stringify non-string inputs.
- Added comprehensive unit tests in \insomniaImport.spec.ts\ covering Insomnia v5 collection imports with number/boolean/null environment values as well as environment resource imports.

### Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Added unit tests verifying the fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Insomnia imports hanging when environment values aren't strings (numbers, booleans, null, objects, arrays). These values are now safely stringified before template replacement—objects and arrays as JSON with their template tokens resolved, and null/undefined as empty—so imports complete without a `.replaceAll()` `TypeError`.

- Adds unit tests covering Insomnia v5 exports and environment resources with numbers, booleans, nulls, and nested objects.

<sup>Written for commit 837b7994acc9cb4af6c179b1779dc301053c88db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

