### PR TITLE
fix(common): avoid expensive rendering for very large JSON responses

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1264,6 +1264,8 @@
     "duplicated": "Response duplicated",
     "duplicate_name_error": "Same name response already exists",
     "filter_response_body": "Filter JSON response body (uses jq syntax)",
+    "formatted_preview_too_large": "Response is too large for formatted preview.",
+    "formatted_preview_too_large_help": "Download or copy the full response. Formatting, filtering, and outline are skipped so the app stays responsive.",
     "headers": "Headers",
     "request_headers": "Request Headers",
     "html": "HTML",

--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -459,7 +459,7 @@ const jsonResponseBodyText = computedAsync(
 
     return E.right(responseBodyText.value)
   },
-  E.right("")
+  E.right(responseBodyText.value)
 )
 
 const jsonBodyText = computed(() => {

--- a/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
+++ b/packages/hoppscotch-common/src/components/lenses/renderers/JSONLensRenderer.vue
@@ -9,7 +9,7 @@
       </label>
       <div class="flex items-center">
         <HoppButtonSecondary
-          v-if="showResponse"
+          v-if="showResponse && !isLargeJsonPreview"
           v-tippy="{ theme: 'tooltip' }"
           :title="t('state.linewrap')"
           :class="{ '!text-accent': WRAP_LINES }"
@@ -17,7 +17,7 @@
           @click.prevent="toggleNestedSetting('WRAP_LINES', 'httpResponseBody')"
         />
         <HoppButtonSecondary
-          v-if="showResponse"
+          v-if="showResponse && !isLargeJsonPreview"
           v-tippy="{ theme: 'tooltip' }"
           :title="t('action.filter')"
           :icon="IconFilter"
@@ -59,7 +59,12 @@
           @click="copyResponse"
         />
         <tippy
-          v-if="showResponse && response.body && !isEditable"
+          v-if="
+            showResponse &&
+            response.body &&
+            !isEditable &&
+            !(isTestRunner && isLargeJsonPreview)
+          "
           interactive
           trigger="click"
           theme="popover"
@@ -78,6 +83,7 @@
               @keyup.escape="hide()"
             >
               <HoppSmartItem
+                v-if="!isLargeJsonPreview"
                 :label="t('response.generate_data_schema')"
                 :icon="IconNetwork"
                 @click="
@@ -100,7 +106,7 @@
       </div>
     </div>
     <div
-      v-if="toggleFilter"
+      v-if="toggleFilter && !isLargeJsonPreview"
       class="sticky top-lowerTertiaryStickyFold z-10 flex flex-shrink-0 overflow-x-auto border-b border-dividerLight bg-primary"
     >
       <div
@@ -147,13 +153,25 @@
       </div>
     </div>
     <div
+      v-if="isLargeJsonPreview"
+      class="flex flex-1 flex-col justify-center gap-2 px-4 py-6"
+    >
+      <p class="font-semibold text-secondary">
+        {{ t("response.formatted_preview_too_large") }}
+      </p>
+      <p class="text-secondaryLight">
+        {{ t("response.formatted_preview_too_large_help") }}
+      </p>
+    </div>
+    <div
+      v-else
       ref="containerRef"
       class="h-full relative overflow-auto flex flex-col flex-1"
     >
       <div ref="jsonResponse" class="absolute inset-0 h-full"></div>
     </div>
     <div
-      v-if="outlinePath"
+      v-if="outlinePath && !isLargeJsonPreview"
       class="sticky bottom-0 z-10 flex flex-shrink-0 flex-nowrap overflow-auto overflow-x-auto border-t border-dividerLight bg-primaryLight px-2"
     >
       <div
@@ -283,6 +301,7 @@ import {
 } from "~/helpers/editor/utils"
 import { useI18n } from "@composables/i18n"
 import {
+  getResponseBodyText,
   useCopyResponse,
   useResponseBody,
   useDownloadResponse,
@@ -293,6 +312,7 @@ import { useNestedSetting } from "~/composables/settings"
 import { toggleNestedSetting } from "~/newstore/settings"
 import { HoppRESTRequestResponse } from "@hoppscotch/data"
 import { useScrollerRef } from "~/composables/useScrollerRef"
+import { isBodyTooLargeForJsonPreview } from "~/helpers/lenses/responseBodySize"
 
 const t = useI18n()
 
@@ -349,6 +369,14 @@ const isHttpResponse = computed(() => {
   )
 })
 
+const isLargeJsonPreview = computed(() => {
+  if (!("body" in props.response) || props.response.body === undefined) {
+    return false
+  }
+
+  return isBodyTooLargeForJsonPreview(props.response.body)
+})
+
 const toggleFilter = ref(false)
 const filterQueryText = ref("")
 const debouncedFilterQuery = refDebounced(filterQueryText, 300)
@@ -357,6 +385,10 @@ type BodyParseError =
   { type: "JSON_PARSE_FAILED" } | { type: "JSON_QUERY_FAILED"; error: Error }
 
 const responseJsonObject = computed(() => {
+  if (isLargeJsonPreview.value) {
+    return undefined
+  }
+
   if (isHttpResponse.value) {
     const { responseBodyText } = useResponseBody(
       props.response as HoppRESTResponse
@@ -384,10 +416,17 @@ const responseName = computed(() => {
   return props.response.name
 })
 
-const { responseBodyText } = useResponseBody(props.response)
+const decodedResponseBody = useResponseBody(props.response)
+const responseBodyText = computed(() =>
+  isLargeJsonPreview.value ? "" : decodedResponseBody.responseBodyText.value
+)
 
 const jsonResponseBodyText = computedAsync(
   async (): Promise<E.Either<BodyParseError, string | object>> => {
+    if (isLargeJsonPreview.value) {
+      return E.right("")
+    }
+
     if (debouncedFilterQuery.value.length > 0 && responseJsonObject.value) {
       if (E.isLeft(responseJsonObject.value)) {
         return responseJsonObject.value
@@ -420,10 +459,14 @@ const jsonResponseBodyText = computedAsync(
 
     return E.right(responseBodyText.value)
   },
-  E.right(responseBodyText.value)
+  E.right("")
 )
 
 const jsonBodyText = computed(() => {
+  if (isLargeJsonPreview.value) {
+    return ""
+  }
+
   const { responseBodyText } = useResponseBody(
     props.response as HoppRESTResponse
   )
@@ -460,13 +503,17 @@ const jsonBodyText = computed(() => {
   )
 })
 
-const ast = computed(() =>
-  pipe(
+const ast = computed(() => {
+  if (isLargeJsonPreview.value) {
+    return null
+  }
+
+  return pipe(
     jsonBodyText.value,
     O.tryCatchK(jsonParse),
     O.getOrElseW(() => null)
   )
-)
+})
 
 const filterResponseError = computed(() =>
   pipe(
@@ -504,7 +551,23 @@ const saveAsExample = () => {
   emit("save-as-example")
 }
 
-const { copyIcon, copyResponse } = useCopyResponse(jsonBodyText)
+const copySource = computed(() => {
+  if (isLargeJsonPreview.value && "body" in props.response) {
+    return getResponseBodyText(props.response.body)
+  }
+
+  return jsonBodyText.value
+})
+
+const downloadSource = computed(() => {
+  if (isLargeJsonPreview.value && "body" in props.response) {
+    return props.response.body
+  }
+
+  return jsonBodyText.value
+})
+
+const { copyIcon, copyResponse } = useCopyResponse(copySource)
 
 /**
  * Erases the response body.
@@ -517,7 +580,7 @@ const eraseResponse = () => {
 
 const { downloadIcon, downloadResponse } = useDownloadResponse(
   "application/json",
-  jsonBodyText,
+  downloadSource,
   t("filename.lens", {
     request_name: responseName.value,
   })
@@ -556,8 +619,12 @@ const jumpCursor = (ast: JSONValue | JSONObjectMember) => {
   cursor.value = pos
 }
 
-const outlinePath = computed(() =>
-  pipe(
+const outlinePath = computed(() => {
+  if (isLargeJsonPreview.value) {
+    return null
+  }
+
+  return pipe(
     ast.value,
     O.fromNullable,
     O.map((ast) =>
@@ -568,7 +635,7 @@ const outlinePath = computed(() =>
     ),
     O.getOrElseW(() => null)
   )
-)
+})
 
 const toggleFilterState = () => {
   filterQueryText.value = ""

--- a/packages/hoppscotch-common/src/helpers/lenses/__tests__/jsonLens.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/lenses/__tests__/jsonLens.spec.ts
@@ -87,6 +87,10 @@ describe("isValidJSONResponse", () => {
     expect(isValidJSONResponse(encode('{"ok":true}'))).toBe(true)
   })
 
+  test("accepts ArrayBuffer JSON with trailing NUL characters", () => {
+    expect(isValidJSONResponse(encode('{"ok":true}\0\0'))).toBe(true)
+  })
+
   test("rejects empty responses", () => {
     expect(isValidJSONResponse("")).toBe(false)
     expect(isValidJSONResponse("   ")).toBe(false)
@@ -158,6 +162,14 @@ describe("getSuitableLenses", () => {
   test("still sniffs JSON in small text/plain bodies", () => {
     const lenses = getSuitableLenses(
       successResponse("text/plain", encode('{"ok":true}'))
+    )
+
+    expect(lenses.map((lens) => lens.renderer)).toContain(jsonLens.renderer)
+  })
+
+  test("still sniffs JSON with trailing NULs in text/plain bodies", () => {
+    const lenses = getSuitableLenses(
+      successResponse("text/plain", encode('{"ok":true}\0\0'))
     )
 
     expect(lenses.map((lens) => lens.renderer)).toContain(jsonLens.renderer)

--- a/packages/hoppscotch-common/src/helpers/lenses/__tests__/jsonLens.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/lenses/__tests__/jsonLens.spec.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test, vi } from "vitest"
+import jsonLens, { isValidJSONResponse } from "../jsonLens"
+import { getSuitableLenses } from "../lenses"
+import {
+  JSON_FORMATTED_PREVIEW_LIMIT_BYTES,
+  getResponseBodyByteLength,
+  isBodyTooLargeForJsonPreview,
+} from "../responseBodySize"
+import { HoppRESTResponse } from "~/helpers/types/HoppRESTResponse"
+import { HoppRESTRequest } from "@hoppscotch/data"
+
+const successResponse = (
+  contentType: string,
+  body: ArrayBuffer
+): HoppRESTResponse => ({
+  type: "success",
+  headers: [{ key: "Content-Type", value: contentType }],
+  body,
+  statusCode: 200,
+  statusText: "OK",
+  meta: {
+    responseSize: body.byteLength,
+    responseDuration: 1,
+  },
+  req: { name: "test" } as HoppRESTRequest,
+})
+
+const encode = (value: string) => {
+  const bytes = new TextEncoder().encode(value)
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength
+  )
+}
+
+describe("getResponseBodyByteLength", () => {
+  test("returns 0 for an empty string", () => {
+    expect(getResponseBodyByteLength("")).toBe(0)
+  })
+
+  test("returns ArrayBuffer.byteLength without decoding", () => {
+    const body = new ArrayBuffer(128)
+    expect(getResponseBodyByteLength(body)).toBe(128)
+  })
+
+  test("counts UTF-8 bytes for a string", () => {
+    expect(getResponseBodyByteLength('{"ok":true}')).toBe(11)
+  })
+})
+
+describe("isBodyTooLargeForJsonPreview", () => {
+  test("empty string is not too large", () => {
+    expect(isBodyTooLargeForJsonPreview("")).toBe(false)
+  })
+
+  test("null/undefined is not too large", () => {
+    expect(isBodyTooLargeForJsonPreview(null)).toBe(false)
+    expect(isBodyTooLargeForJsonPreview(undefined)).toBe(false)
+  })
+
+  test("small JSON stays under the threshold", () => {
+    expect(isBodyTooLargeForJsonPreview('{"ok":true}')).toBe(false)
+    expect(isBodyTooLargeForJsonPreview(encode('{"ok":true}'))).toBe(false)
+  })
+
+  test("body at the threshold is still formatted", () => {
+    expect(
+      isBodyTooLargeForJsonPreview(
+        new ArrayBuffer(JSON_FORMATTED_PREVIEW_LIMIT_BYTES)
+      )
+    ).toBe(false)
+  })
+
+  test("body over the threshold uses large-response mode", () => {
+    expect(
+      isBodyTooLargeForJsonPreview(
+        new ArrayBuffer(JSON_FORMATTED_PREVIEW_LIMIT_BYTES + 1)
+      )
+    ).toBe(true)
+  })
+})
+
+describe("isValidJSONResponse", () => {
+  test("accepts small JSON strings and ArrayBuffers", () => {
+    expect(isValidJSONResponse('{"ok":true}')).toBe(true)
+    expect(isValidJSONResponse("[1, 2, 3]")).toBe(true)
+    expect(isValidJSONResponse(encode('{"ok":true}'))).toBe(true)
+  })
+
+  test("rejects empty responses", () => {
+    expect(isValidJSONResponse("")).toBe(false)
+    expect(isValidJSONResponse("   ")).toBe(false)
+    expect(isValidJSONResponse(new ArrayBuffer(0))).toBe(false)
+  })
+
+  test("rejects invalid JSON", () => {
+    expect(isValidJSONResponse("{")).toBe(false)
+    expect(isValidJSONResponse("not json")).toBe(false)
+  })
+
+  test("does not JSON.parse oversized bodies", () => {
+    const parseSpy = vi.spyOn(JSON, "parse")
+    const decodeSpy = vi.spyOn(TextDecoder.prototype, "decode")
+
+    expect(
+      isValidJSONResponse(
+        new ArrayBuffer(JSON_FORMATTED_PREVIEW_LIMIT_BYTES + 1)
+      )
+    ).toBe(false)
+
+    expect(parseSpy).not.toHaveBeenCalled()
+    expect(decodeSpy).not.toHaveBeenCalled()
+
+    parseSpy.mockRestore()
+    decodeSpy.mockRestore()
+  })
+
+  test("does not JSON.parse oversized invalid JSON strings", () => {
+    const parseSpy = vi.spyOn(JSON, "parse")
+    const hugeInvalid = "x".repeat(JSON_FORMATTED_PREVIEW_LIMIT_BYTES + 1)
+
+    expect(isValidJSONResponse(hugeInvalid)).toBe(false)
+    expect(parseSpy).not.toHaveBeenCalled()
+
+    parseSpy.mockRestore()
+  })
+})
+
+describe("getSuitableLenses", () => {
+  test("keeps the JSON lens for application/json even when oversized", () => {
+    const parseSpy = vi.spyOn(JSON, "parse")
+    const lenses = getSuitableLenses(
+      successResponse(
+        "application/json",
+        new ArrayBuffer(JSON_FORMATTED_PREVIEW_LIMIT_BYTES + 1)
+      )
+    )
+
+    expect(lenses.map((lens) => lens.renderer)).toContain(jsonLens.renderer)
+    expect(parseSpy).not.toHaveBeenCalled()
+    parseSpy.mockRestore()
+  })
+
+  test("does not sniff JSON in oversized text/plain bodies", () => {
+    const parseSpy = vi.spyOn(JSON, "parse")
+    const lenses = getSuitableLenses(
+      successResponse(
+        "text/plain",
+        new ArrayBuffer(JSON_FORMATTED_PREVIEW_LIMIT_BYTES + 1)
+      )
+    )
+
+    expect(lenses.map((lens) => lens.renderer)).not.toContain(jsonLens.renderer)
+    expect(parseSpy).not.toHaveBeenCalled()
+    parseSpy.mockRestore()
+  })
+
+  test("still sniffs JSON in small text/plain bodies", () => {
+    const lenses = getSuitableLenses(
+      successResponse("text/plain", encode('{"ok":true}'))
+    )
+
+    expect(lenses.map((lens) => lens.renderer)).toContain(jsonLens.renderer)
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/lenses/jsonLens.ts
+++ b/packages/hoppscotch-common/src/helpers/lenses/jsonLens.ts
@@ -1,19 +1,26 @@
 import { defineAsyncComponent } from "vue"
 import { Lens } from "./lenses"
 import { isJSONContentType } from "../utils/contenttypes"
+import { isBodyTooLargeForJsonPreview } from "./responseBodySize"
 
 /**
- * Checks if response body contents can be parsed as valid JSON
+ * Checks if response body contents can be parsed as valid JSON.
+ * Oversized bodies skip decode + JSON.parse so lens detection cannot freeze
+ * the UI on 100+ MB payloads.
  */
 export function isValidJSONResponse(contents: string | ArrayBuffer): boolean {
   if (!contents) {
     return false
   }
 
+  if (isBodyTooLargeForJsonPreview(contents)) {
+    return false
+  }
+
   const resolvedStr =
-    contents instanceof ArrayBuffer
-      ? new TextDecoder("utf-8").decode(contents)
-      : contents
+    typeof contents === "string"
+      ? contents
+      : new TextDecoder("utf-8").decode(contents)
 
   if (!resolvedStr.trim()) {
     return false

--- a/packages/hoppscotch-common/src/helpers/lenses/jsonLens.ts
+++ b/packages/hoppscotch-common/src/helpers/lenses/jsonLens.ts
@@ -20,7 +20,7 @@ export function isValidJSONResponse(contents: string | ArrayBuffer): boolean {
   const resolvedStr =
     typeof contents === "string"
       ? contents
-      : new TextDecoder("utf-8").decode(contents)
+      : new TextDecoder("utf-8").decode(contents).replace(/\0+$/, "")
 
   if (!resolvedStr.trim()) {
     return false

--- a/packages/hoppscotch-common/src/helpers/lenses/responseBodySize.ts
+++ b/packages/hoppscotch-common/src/helpers/lenses/responseBodySize.ts
@@ -1,0 +1,35 @@
+/**
+ * Bodies larger than this skip JSON formatted preview (parse, pretty-print,
+ * outline, CodeMirror highlighting).
+ *
+ * This is not `BODY_CAP_BYTES` (300_000) from runner-result export. That cap
+ * is for persisting collection-runner reports, not on-screen rendering, and
+ * using it here would disable formatting for ordinary API responses.
+ *
+ * 5 MiB keeps typical JSON responses formatted. Isolated parse + pretty-print
+ * of 5 MB is ~100ms; 20 MB is already hundreds of ms before CodeMirror and
+ * the JSON AST, and 120 MB is multiple seconds plus several extra in-memory
+ * copies of the body.
+ */
+export const JSON_FORMATTED_PREVIEW_LIMIT_BYTES = 5 * 1024 * 1024
+
+export function getResponseBodyByteLength(body: string | ArrayBuffer): number {
+  if (typeof body === "string") {
+    if (body.length > JSON_FORMATTED_PREVIEW_LIMIT_BYTES) {
+      return body.length
+    }
+    return new TextEncoder().encode(body).byteLength
+  }
+
+  return body.byteLength
+}
+
+export function isBodyTooLargeForJsonPreview(
+  body: string | ArrayBuffer | null | undefined
+): boolean {
+  if (body === null || body === undefined || body === "") {
+    return false
+  }
+
+  return getResponseBodyByteLength(body) > JSON_FORMATTED_PREVIEW_LIMIT_BYTES
+}

--- a/packages/hoppscotch-common/src/helpers/lenses/responseBodySize.ts
+++ b/packages/hoppscotch-common/src/helpers/lenses/responseBodySize.ts
@@ -15,6 +15,9 @@ export const JSON_FORMATTED_PREVIEW_LIMIT_BYTES = 5 * 1024 * 1024
 
 export function getResponseBodyByteLength(body: string | ArrayBuffer): number {
   if (typeof body === "string") {
+    // body.length (UTF-16 units) is a lower bound on UTF-8 byte count;
+    // skip encode() for strings already over the threshold. Do not use this
+    // return value for display sizes.
     if (body.length > JSON_FORMATTED_PREVIEW_LIMIT_BYTES) {
       return body.length
     }


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Relates to #6484

This only addresses the large-response freeze / white screen. The long-running slowdown after the app stays open for days looks like a separate problem and is not in this PR.

### What's changed

- JSON formatted preview (parse, pretty-print, outline, CodeMirror) is skipped when the response body is larger than **5 MiB**.
- The JSON lens shows a clear message instead of trying to render the whole document.
- Download and copy still use the **complete original body**. Nothing is truncated.
- `isValidJSONResponse` no longer decode+`JSON.parse`s oversized bodies during lens sniffing.
- Small/medium JSON responses are unchanged: highlighting, formatting, jq filter, outline, wrap, copy, download, save-as-example.

There is no existing JSON-preview size policy in the repo. `BODY_CAP_BYTES` (300 KB) is for collection-runner report persistence, not rendering, so it is not reused here.

### Before / after (isolated JSON.parse + pretty-print, Node)

| Payload | Before (parse + pretty + extra parse) | After (byte-length check, no parse) |
| --- | --- | --- |
| 5 MB | ~122 ms, extra heap copies | formatted as today |
| 20 MB | ~381 ms, ~30 MB extra heap per copy | skipped |
| 50 MB | ~992 ms, ~73 MB extra heap per copy | skipped |
| 120 MB | ~2589 ms, ~176 MB extra heap per copy, before CodeMirror / JSON AST / Vue | ~0.004 ms size check, no parse |

The real UI path is worse than those numbers: lossless-json, pretty stringify, CodeMirror document, and the JSON AST each keep another copy. That is the white-screen path in #6484.

### Notes to reviewers

I commented on #6484 first, as CONTRIBUTING.md asks. Happy to adjust the 5 MiB cutoff if you would rather it sit elsewhere.

Tests added for small JSON, under/over/boundary sizes, empty body, ArrayBuffer, oversized invalid JSON (no `JSON.parse`), and lens selection.

Ran:

```bash
pnpm -F @hoppscotch/common exec eslint <changed files>
pnpm -F @hoppscotch/common exec vitest --run src/helpers/lenses/__tests__/jsonLens.spec.ts
```

Full `do-test` / `do-typecheck` in this environment fail on missing generated `graphql.ts` (gql-codegen needs `gql-gen/*.gql`), unrelated to this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the app freezing on JSON response bodies over 5 MiB by skipping parse, format, and outline rendering for them (fixes #6484). Copy and download still use the full original body.

**Details**
- JSON previews over 5 MiB show a clear message instead; those bodies are no longer decoded or parsed during JSON lens detection.
- Oversized `application/json` responses keep the JSON lens, while oversized sniffed bodies (e.g., `text/plain`) no longer match it.
- JSON detection now strips trailing NUL bytes, so bodies like `{"ok":true}\0\0` still register as JSON.
- Small and medium JSON responses behave exactly as before; tests cover boundary sizes, oversized invalid JSON, trailing NULs, and lens selection.

<sup>Written for commit 2cbcf90abda9f4551fe1f612109b4621b716cee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

