### PR TITLE
fix(common): preserve large integer precision and add fullscreen toggle

### DIFF
--- a/packages/hoppscotch-common/locales/en.json
+++ b/packages/hoppscotch-common/locales/en.json
@@ -1286,7 +1286,9 @@
     "data_schema": "Data Schema",
     "saved": "Response saved",
     "save_as_example": "Save as example",
-    "invalid_name": "Please provide a name for the response"
+    "invalid_name": "Please provide a name for the response",
+    "fullscreen": "Full screen",
+    "exit_fullscreen": "Exit full screen"
   },
   "script": {
     "inheriting": "Inheriting scripts from",

--- a/packages/hoppscotch-common/src/components/http/Response.vue
+++ b/packages/hoppscotch-common/src/components/http/Response.vue
@@ -1,9 +1,16 @@
 <template>
-  <div class="relative flex flex-1 flex-col overflow-auto">
+  <div
+    class="relative flex flex-1 flex-col overflow-auto"
+    :class="{
+      '!fixed !inset-0 !z-30 !h-screen !w-screen bg-primary': isFullscreen,
+    }"
+  >
     <HttpResponseMeta
       :response="doc.response"
       :is-embed="isEmbed"
       :is-loading="loading"
+      :is-fullscreen="isFullscreen"
+      @toggle-fullscreen="toggleFullscreen"
     />
     <LensesResponseBodyRenderer
       v-if="!loading && hasResponse"
@@ -23,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-import { useVModel } from "@vueuse/core"
+import { useEventListener, useVModel } from "@vueuse/core"
 import { computed, ref } from "vue"
 import { HoppRequestDocument } from "~/helpers/tab/document"
 import { useResponseBody } from "@composables/lens-actions"
@@ -54,6 +61,18 @@ const emit = defineEmits<{
 }>()
 
 const doc = useVModel(props, "document", emit)
+
+const isFullscreen = ref(false)
+
+const toggleFullscreen = () => {
+  isFullscreen.value = !isFullscreen.value
+}
+
+useEventListener("keydown", (e: KeyboardEvent) => {
+  if (e.key === "Escape" && isFullscreen.value) {
+    isFullscreen.value = false
+  }
+})
 
 const hasResponse = computed(
   () =>

--- a/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
+++ b/packages/hoppscotch-common/src/components/http/ResponseMeta.vue
@@ -122,15 +122,30 @@
         </div>
       </div>
     </div>
-    <AppInspection
-      v-if="response?.type !== 'loading'"
-      :inspection-results="tabResults"
+    <div
+      class="flex items-center space-x-2"
       :class="[
         response === null || response?.type === 'network_fail'
           ? 'absolute right-2 top-2'
           : '-m-2 ml-2',
       ]"
-    />
+    >
+      <AppInspection
+        v-if="response?.type !== 'loading'"
+        :inspection-results="tabResults"
+      />
+      <HoppButtonSecondary
+        v-if="!isEmbed"
+        v-tippy="{ theme: 'tooltip' }"
+        :title="
+          isFullscreen
+            ? t('response.exit_fullscreen')
+            : t('response.fullscreen')
+        "
+        :icon="isFullscreen ? IconMinimize2 : IconMaximize2"
+        @click="emit('toggle-fullscreen')"
+      />
+    </div>
   </div>
 </template>
 
@@ -145,6 +160,8 @@ import { useService } from "dioc/vue"
 import { InspectionService } from "~/services/inspection"
 import { WorkspaceTabsService } from "~/services/tab/workspace-tabs"
 import IconExternalLink from "~icons/lucide/external-link"
+import IconMaximize2 from "~icons/lucide/maximize-2"
+import IconMinimize2 from "~icons/lucide/minimize-2"
 
 const t = useI18n()
 const colorMode = useColorMode()
@@ -155,11 +172,17 @@ const props = withDefaults(
     response: HoppRESTResponse | null | undefined
     isEmbed?: boolean
     isLoading?: boolean
+    isFullscreen?: boolean
   }>(),
   {
     isLoading: false,
+    isFullscreen: false,
   }
 )
+
+const emit = defineEmits<{
+  (e: "toggle-fullscreen"): void
+}>()
 
 /**
  * Gives the response size in a human readable format

--- a/packages/hoppscotch-common/src/helpers/new-codegen/__tests__/index.spec.ts
+++ b/packages/hoppscotch-common/src/helpers/new-codegen/__tests__/index.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest"
+import { makeRESTRequest } from "@hoppscotch/data"
+import { getDefaultRESTRequest } from "~/helpers/rest/default"
+import { generateCode, protectLargeIntegers } from "../index"
+import * as O from "fp-ts/Option"
+
+describe("new-codegen", () => {
+  describe("protectLargeIntegers", () => {
+    it("preserves large integers > Number.MAX_SAFE_INTEGER in JSON strings", () => {
+      const json = JSON.stringify({
+        largeInt: 9007199254740993n.toString(),
+      }).replace('"9007199254740993"', "9007199254740993")
+
+      const { processed, restore } = protectLargeIntegers(json)
+      expect(processed).toContain("__HOPP_BIGINT_")
+      const restored = restore(processed)
+      expect(restored).toBe(json)
+    })
+
+    it("does not modify numbers within the safe integer range", () => {
+      const json = JSON.stringify({ safeInt: 42, floatNum: 3.14 })
+      const { processed } = protectLargeIntegers(json)
+      expect(processed).toBe(json)
+    })
+
+    it("does not modify numbers inside string literals or keys", () => {
+      const json = JSON.stringify({
+        "9007199254740993": "value with 9007199254740993 inside",
+      })
+      const { processed } = protectLargeIntegers(json)
+      expect(processed).toBe(json)
+    })
+  })
+
+  describe("generateCode", () => {
+    it("generates cURL without truncating 64-bit large integers in JSON body", () => {
+      const req = makeRESTRequest({
+        ...getDefaultRESTRequest(),
+        method: "POST",
+        endpoint: "https://example.com/api/test",
+        headers: [
+          {
+            active: true,
+            key: "Content-Type",
+            value: "application/json",
+            description: "",
+          },
+        ],
+        body: {
+          contentType: "application/json",
+          body: JSON.stringify({
+            id: 9007199254740993n.toString(),
+            hugeId: 12345678901234567890n.toString(),
+            nested: {
+              val: 9007199254740995n.toString(),
+            },
+          })
+            .replace('"9007199254740993"', "9007199254740993")
+            .replace('"12345678901234567890"', "12345678901234567890")
+            .replace('"9007199254740995"', "9007199254740995"),
+        },
+      })
+
+      const curlResult = generateCode("shell-curl", req)
+      expect(O.isSome(curlResult)).toBe(true)
+      if (O.isSome(curlResult)) {
+        expect(curlResult.value).toContain("9007199254740993")
+        expect(curlResult.value).toContain("12345678901234567890")
+        expect(curlResult.value).toContain("9007199254740995")
+        expect(curlResult.value).not.toContain("9007199254740992")
+      }
+
+      const phpResult = generateCode("php-curl", req)
+      expect(O.isSome(phpResult)).toBe(true)
+      if (O.isSome(phpResult)) {
+        expect(phpResult.value).toContain("9007199254740993")
+        expect(phpResult.value).toContain("12345678901234567890")
+        expect(phpResult.value).not.toContain("9007199254740992")
+      }
+
+      const jsResult = generateCode("javascript-fetch", req)
+      expect(O.isSome(jsResult)).toBe(true)
+      if (O.isSome(jsResult)) {
+        expect(jsResult.value).toContain("9007199254740993")
+        expect(jsResult.value).toContain("12345678901234567890")
+        expect(jsResult.value).not.toContain("9007199254740992")
+      }
+
+      const pythonResult = generateCode("python-requests", req)
+      expect(O.isSome(pythonResult)).toBe(true)
+      if (O.isSome(pythonResult)) {
+        expect(pythonResult.value).toContain("9007199254740993")
+        expect(pythonResult.value).toContain("12345678901234567890")
+        expect(pythonResult.value).not.toContain("9007199254740992")
+      }
+    })
+  })
+})

--- a/packages/hoppscotch-common/src/helpers/new-codegen/index.ts
+++ b/packages/hoppscotch-common/src/helpers/new-codegen/index.ts
@@ -199,6 +199,55 @@ export type CodegenName = (typeof CodegenDefinitions)[number]["name"]
 export type CodegenLang = (typeof CodegenDefinitions)[number]["lang"]
 
 /**
+ * Protects 64-bit / large integers in JSON request bodies from IEEE-754 precision loss
+ * during codegen JSON serialization. Replaces unquoted large integers with temporary
+ * string placeholders before passing to HTTPSnippet, and restores the unquoted literal
+ * integers in the generated snippet output.
+ */
+export function protectLargeIntegers(bodyStr: string): {
+  processed: string
+  restore: (code: string) => string
+} {
+  const map = new Map<string, string>()
+  let id = 0
+
+  const processed = bodyStr.replace(
+    /("(?:\\.|[^"\\])*")|(-?\b\d+\b)/g,
+    (match, stringLiteral, numberLiteral) => {
+      if (stringLiteral) return stringLiteral
+      if (numberLiteral) {
+        try {
+          const big = BigInt(numberLiteral)
+          if (
+            big > BigInt(Number.MAX_SAFE_INTEGER) ||
+            big < BigInt(Number.MIN_SAFE_INTEGER)
+          ) {
+            const placeholder = `__HOPP_BIGINT_${id++}__`
+            map.set(placeholder, numberLiteral)
+            return `"${placeholder}"`
+          }
+        } catch {
+          // not a valid BigInt, leave as is
+        }
+      }
+      return match
+    }
+  )
+
+  const restore = (code: string) => {
+    if (map.size === 0) return code
+    let result = code
+    for (const [placeholder, original] of map.entries()) {
+      const regex = new RegExp(`(\\\\*["'])?${placeholder}(\\\\*["'])?`, "g")
+      result = result.replace(regex, () => original)
+    }
+    return result
+  }
+
+  return { processed, restore }
+}
+
+/**
  * Generates Source Code for the given codgen
  * @param codegen The codegen to apply
  * @param req The request to generate using
@@ -211,14 +260,37 @@ export const generateCode = (
   // Since the Type contract guarantees a match in the array, we are enforcing non-null
   const codegenInfo = CodegenDefinitions.find((v) => v.name === codegen)!
 
+  let modifiedReq = req
+  let restore = (code: string) => code
+
+  if (
+    req.body.contentType &&
+    typeof req.body.body === "string" &&
+    req.body.body.length > 0
+  ) {
+    const protection = protectLargeIntegers(req.body.body)
+    if (protection.processed !== req.body.body) {
+      modifiedReq = {
+        ...req,
+        body: {
+          ...req.body,
+          body: protection.processed,
+        },
+      }
+      restore = protection.restore
+    }
+  }
+
   return pipe(
     E.tryCatch(
-      () =>
-        new HTTPSnippet({
-          ...buildHarRequest(req),
+      () => {
+        const generated = new HTTPSnippet({
+          ...buildHarRequest(modifiedReq),
         }).convert(codegenInfo.lang, codegenInfo.mode, {
           indent: "  ",
-        }),
+        })
+        return typeof generated === "string" ? restore(generated) : generated
+      },
       (e) => {
         console.error(e)
         return e


### PR DESCRIPTION
Closes #6612
Closes #6615

Fixes #6612
Fixes #6615

### What's changed

1. **Large Integer Precision Preservation in Codegen (#6612)**:
   - Protected 64-bit and large integers (> `Number.MAX_SAFE_INTEGER` / < `Number.MIN_SAFE_INTEGER`) in JSON request bodies during codegen serialization by replacing unquoted large numbers with sentinels prior to HTTPSnippet processing and restoring the raw numeric literal representation in the generated snippet.
   - Prevents IEEE-754 double precision truncation across cURL (`shell-curl`, `c-curl`, `php-curl`) and other code generators (`javascript-fetch`, `python-requests`, etc.).
   - Added unit tests in `packages/hoppscotch-common/src/helpers/new-codegen/__tests__/index.spec.ts`.

2. **HTTP Response Panel Fullscreen Toggle (#6615)**:
   - Added fullscreen expand/collapse toggle button in the HTTP response panel header (`HttpResponseMeta.vue`).
   - Bound `Escape` shortcut key listener to seamlessly exit fullscreen mode.
   - Added localized tooltip strings (`fullscreen`, `exit_fullscreen`) to `en.json`.

### Testing

- Ran `pnpm --filter @hoppscotch/common test` (80 test files, 1202 passed).
- Ran `pnpm lint` and `pnpm typecheck` across the entire workspace (passed with 0 errors).

### Notes to reviewers
All commits follow Conventional Commits with sign-off.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes large integer precision loss in generated code snippets and adds a fullscreen toggle to the HTTP response panel.

**Bug Fixes**
- Large integers outside the safe range in JSON request bodies were truncated by IEEE-754 precision across all code generators. They're now preserved via temporary placeholders during HTTPSnippet processing and restored in the final snippet.

**New Features**
- The response panel header now has a fullscreen toggle, with Escape to exit. The toggle is hidden in embed mode.
- Adds `fullscreen` and `exit_fullscreen` locale strings to `en.json`.

<sup>Written for commit 5e0c18a634d1d83cdfd842e759cec878dec28286. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

