### PR TITLE
test(cli): widen transient-failure classification for e2e retries

### DIFF
--- a/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
@@ -1052,7 +1052,7 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
           ? fs.readFileSync(absPath).toString()
           : "";
         const combinedOutput = `${result.stdout}\n${result.stderr}\n${fileContents}`;
-        const { isTransient } = isTransientCliFailure(combinedOutput);
+        const { isTransient, detail } = isTransientCliFailure(combinedOutput);
         const isLastAttempt = attempt === maxAttempts - 1;
 
         // Non-transient outcome — surface to caller (real bug or intentional
@@ -1063,7 +1063,7 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
 
         if (!isLastAttempt) {
           console.log(
-            `⚠️  Transient signal in JUnit snapshot run — retrying once for a clean snapshot...`
+            `⚠️  Transient signal (${detail}) in JUnit snapshot run — retrying once for a clean snapshot...`
           );
           if (xmlOnDisk) {
             try {
@@ -1075,7 +1075,7 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
         }
 
         console.warn(
-          `⚠️  Skipping snapshot test: transient signals persisted after retry. External services may be degraded.`
+          `⚠️  Skipping snapshot test: transient signal persisted after retry (${detail}). External services may be degraded.`
         );
         return null;
       }

--- a/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/e2e/commands/test.spec.ts
@@ -7,6 +7,7 @@ import { HoppErrorCode } from "../../../types/errors";
 import {
   getErrorCode,
   getTestJsonFilePath,
+  isTransientCliFailure,
   runCLI,
   runCLIWithNetworkRetry,
 } from "../../utils";
@@ -301,26 +302,8 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
       expect(result.error).toBeNull();
     });
 
-    /**
-     * Tests pm.sendRequest() functionality with external HTTP endpoints.
-     *
-     * Network Resilience Strategy:
-     * - Retries once (2 total attempts) on transient network errors
-     * - Detects and logs specific errors (ECONNRESET, ETIMEDOUT, etc.)
-     * - Validates JUnit XML completeness (60+ test suites) before accepting success
-     * - Auto-skips on network failures to prevent blocking PRs
-     */
+    // Validates the full `hopp`/`pm` scripting surface and JUnit report structure.
     test("Supports the new scripting API method additions under the `hopp` and `pm` namespaces and validates JUnit report structure", async () => {
-      // First, run without JUnit report to ensure basic functionality works
-      const basicArgs = `test ${getTestJsonFilePath(
-        "scripting-revamp-coll.json",
-        "collection"
-      )}`;
-      const basicResult = await runCLIWithNetworkRetry(basicArgs);
-      if (basicResult === null) return;
-      expect(basicResult.error).toBeNull();
-
-      // Then, run with JUnit report and validate structure
       const junitPath = path.join(
         __dirname,
         "scripting-revamp-snapshot-junit.xml"
@@ -335,25 +318,10 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
         "collection"
       )} --reporter-junit ${junitPath}`;
 
-      // Enhanced retry for JUnit run - also validate output completeness
+      // Retry wrapper with XML-completeness check; retries only on transient signals.
       const runWithValidation = async () => {
-        const minExpectedTestSuites = 60; // Should have 67+ test suites
-        const maxAttempts = 2; // Only retry once (2 total attempts)
-
-        const extractNetworkError = (output: string): string => {
-          const econnresetMatch = output.match(/ECONNRESET/i);
-          const eaiAgainMatch = output.match(/EAI_AGAIN/i);
-          const enotfoundMatch = output.match(/ENOTFOUND/i);
-          const etimedoutMatch = output.match(/ETIMEDOUT/i);
-          const econnrefusedMatch = output.match(/ECONNREFUSED/i);
-
-          if (econnresetMatch) return "ECONNRESET (connection reset by peer)";
-          if (eaiAgainMatch) return "EAI_AGAIN (DNS lookup timeout)";
-          if (enotfoundMatch) return "ENOTFOUND (DNS lookup failed)";
-          if (etimedoutMatch) return "ETIMEDOUT (connection timeout)";
-          if (econnrefusedMatch) return "ECONNREFUSED (connection refused)";
-          return "Unknown network error";
-        };
+        const minExpectedTestSuites = 60;
+        const maxAttempts = 2;
 
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
           if (fs.existsSync(junitPath)) {
@@ -361,73 +329,52 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
           }
 
           const result = await runCLI(junitArgs);
-
-          // Check for transient errors in output (network or httpbin 5xx)
           const output = `${result.stdout}\n${result.stderr}`;
-          const hasNetworkError =
-            /ECONNRESET|EAI_AGAIN|ENOTFOUND|ETIMEDOUT|ECONNREFUSED|REQUEST_ERROR/i.test(
-              output
-            );
-          const hasHttpbin5xx =
-            /httpbin\.org is down \(5xx\)|httpbin\.org is down \(503\)/i.test(
-              output
-            );
+          const { isTransient, detail } = isTransientCliFailure(output);
+          const isLastAttempt = attempt === maxAttempts - 1;
 
-          // If successful and JUnit file exists, validate completeness
           if (!result.error && fs.existsSync(junitPath)) {
             const xml = fs.readFileSync(junitPath, "utf-8");
             const testsuiteCount = (xml.match(/<testsuite /g) || []).length;
 
-            // If we have the expected number of test suites and no httpbin issues, we're good
-            if (testsuiteCount >= minExpectedTestSuites && !hasHttpbin5xx) {
+            if (testsuiteCount >= minExpectedTestSuites && !isTransient) {
               return result;
             }
 
-            // Incomplete output or httpbin issues - retry once if transient
-            if (
-              (hasNetworkError || hasHttpbin5xx) &&
-              attempt < maxAttempts - 1
-            ) {
-              const errorDetail = hasHttpbin5xx
-                ? "httpbin.org 5xx response"
-                : `incomplete output (${testsuiteCount}/${minExpectedTestSuites} test suites) with ${extractNetworkError(output)}`;
+            // Incomplete XML without transient signal — real reporter regression.
+            if (!isTransient) {
+              return result;
+            }
+
+            if (!isLastAttempt) {
               console.log(
-                `⚠️  Transient error detected: ${errorDetail}. Retrying once...`
+                `⚠️  Transient error detected: incomplete output (${testsuiteCount}/${minExpectedTestSuites} test suites) with ${detail}. Retrying once...`
               );
               await new Promise((r) => setTimeout(r, 2000));
               continue;
             }
           }
 
-          // Non-transient error - fail fast
-          if (result.error && !hasNetworkError && !hasHttpbin5xx) {
+          // Non-transient error — real failure, surface to caller.
+          if (!isTransient) {
             return result;
           }
 
-          // Transient error - retry once
-          const isLastAttempt = attempt === maxAttempts - 1;
           if (!isLastAttempt) {
-            const errorDetail = hasHttpbin5xx
-              ? "httpbin.org 5xx response"
-              : extractNetworkError(output);
             console.log(
-              `⚠️  Transient error detected: ${errorDetail}. Retrying once...`
+              `⚠️  Transient error detected: ${detail}. Retrying once...`
             );
             await new Promise((r) => setTimeout(r, 2000));
             continue;
           }
 
-          // Last attempt exhausted due to transient issues - skip test to avoid blocking PR
-          const errorDetail = hasHttpbin5xx
-            ? "httpbin.org service degradation (5xx)"
-            : extractNetworkError(output);
+          // Transient on last attempt — skip.
           console.warn(
-            `⚠️  Skipping test: Retry exhausted due to ${errorDetail}. External services may be unavailable.`
+            `⚠️  Skipping test: Retry exhausted due to ${detail}. External services may be unavailable.`
           );
-          return null; // Signal to skip test
+          return null;
         }
 
-        // Should never reach here - all paths above should return
         throw new Error("Unexpected: retry loop completed without returning");
       };
 
@@ -1062,12 +1009,79 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
         );
 
     beforeAll(() => {
+      // Force-clean to recover from a prior interrupted run leaving stale
+      // files or the directory itself behind.
+      fs.rmSync(genPath, { recursive: true, force: true });
       fs.mkdirSync(genPath);
     });
 
     afterAll(() => {
-      fs.rmdirSync(genPath, { recursive: true });
+      fs.rmSync(genPath, { recursive: true, force: true });
     });
+
+    // Retries JUnit snapshot on transient signals; returns null only on confirmed flake.
+    // `preSeed`, if provided, runs before each attempt so tests that need a
+    // pre-existing file (e.g. overwrite-log coverage) can re-seed between retries.
+    const runJUnitSnapshot = async (
+      args: string,
+      exportPath: string,
+      preSeed?: () => void
+    ): Promise<{
+      result: Awaited<ReturnType<typeof runCLI>>;
+      fileContents: string;
+    } | null> => {
+      const maxAttempts = 2;
+      const absPath = path.resolve(genPath, exportPath);
+
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (preSeed) {
+          if (fs.existsSync(absPath)) {
+            try {
+              fs.unlinkSync(absPath);
+            } catch {}
+          }
+          preSeed();
+        }
+
+        const result = await runCLI(args, {
+          cwd: path.resolve("hopp-cli-test"),
+        });
+
+        const xmlOnDisk = fs.existsSync(absPath);
+        const fileContents = xmlOnDisk
+          ? fs.readFileSync(absPath).toString()
+          : "";
+        const combinedOutput = `${result.stdout}\n${result.stderr}\n${fileContents}`;
+        const { isTransient } = isTransientCliFailure(combinedOutput);
+        const isLastAttempt = attempt === maxAttempts - 1;
+
+        // Non-transient outcome — surface to caller (real bug or intentional
+        // error-path fixture); callers own their own assertions.
+        if (!isTransient) {
+          return { result, fileContents };
+        }
+
+        if (!isLastAttempt) {
+          console.log(
+            `⚠️  Transient signal in JUnit snapshot run — retrying once for a clean snapshot...`
+          );
+          if (xmlOnDisk) {
+            try {
+              fs.unlinkSync(absPath);
+            } catch {}
+          }
+          await new Promise((r) => setTimeout(r, 2000));
+          continue;
+        }
+
+        console.warn(
+          `⚠️  Skipping snapshot test: transient signals persisted after retry. External services may be degraded.`
+        );
+        return null;
+      }
+
+      throw new Error("Unexpected: retry loop completed without returning");
+    };
 
     test("Report export fails with the code `REPORT_EXPORT_FAILED` while encountering an error during path creation", async () => {
       const exportPath = "hopp-junit-report.xml";
@@ -1093,7 +1107,7 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
       );
     });
 
-    test("Generates a JUnit report at the default path", async () => {
+    test("Generates a JUnit report at the default path", async ({ skip }) => {
       const exportPath = "hopp-junit-report.xml";
 
       const COLL_PATH = getTestJsonFilePath(
@@ -1103,67 +1117,26 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
 
       const args = `test ${COLL_PATH} --reporter-junit`;
 
-      // Use retry logic to handle transient network errors (ECONNRESET, etc.)
-      // that can corrupt JUnit XML structure and cause snapshot mismatches
-      const maxAttempts = 2; // Only retry once (2 total attempts)
-      let lastResult: Awaited<ReturnType<typeof runCLI>> | null = null;
-      let lastFileContents = "";
-
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        lastResult = await runCLI(args, {
-          cwd: path.resolve("hopp-cli-test"),
-        });
-
-        // Read JUnit XML file
-        const fileContents = fs
-          .readFileSync(path.resolve(genPath, exportPath))
-          .toString();
-
-        lastFileContents = fileContents;
-
-        const hasNetworkErrorInXML =
-          /ECONNRESET|EAI_AGAIN|ENOTFOUND|ETIMEDOUT|ECONNREFUSED/i.test(
-            fileContents
-          ) ||
-          (/REQUEST_ERROR/i.test(fileContents) &&
-            !/Invalid URL/i.test(fileContents));
-
-        if (!hasNetworkErrorInXML) {
-          break;
-        }
-
-        // Network error detected - retry once if not last attempt
-        if (attempt < maxAttempts - 1) {
-          console.log(
-            `⚠️  Network error detected in JUnit XML (ECONNRESET/DNS). Retrying once to get clean snapshot...`
-          );
-          // Delete corrupted XML file before retry
-          try {
-            fs.unlinkSync(path.resolve(genPath, exportPath));
-          } catch {}
-          await new Promise((r) => setTimeout(r, 2000));
-          continue;
-        }
-
-        // Last attempt exhausted - skip test to avoid false positive
-        console.warn(
-          `⚠️  Skipping snapshot test: Network errors persisted in JUnit XML after retry. External services may be degraded.`
-        );
-        return; // Skip test - don't fail on infrastructure issues
+      const outcome = await runJUnitSnapshot(args, exportPath);
+      // `skip()` keeps snapshots deferred rather than obsolete when transient flakes abort the run.
+      if (outcome === null) {
+        skip();
+        return;
       }
+      const { result, fileContents } = outcome;
 
-      expect(lastResult?.stdout).not.toContain(
+      expect(result.stdout).not.toContain(
         `Overwriting the pre-existing path: ${exportPath}`
       );
 
-      expect(lastResult?.stdout).toContain(
+      expect(result.stdout).toContain(
         `Successfully exported the JUnit report to: ${exportPath}`
       );
 
-      expect(replaceDynamicValuesInStr(lastFileContents)).toMatchSnapshot();
+      expect(replaceDynamicValuesInStr(fileContents)).toMatchSnapshot();
     });
 
-    test("Generates a JUnit report at the specified path", async () => {
+    test("Generates a JUnit report at the specified path", async ({ skip }) => {
       const exportPath = "outer-dir/inner-dir/report.xml";
 
       const COLL_PATH = getTestJsonFilePath(
@@ -1173,138 +1146,50 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
 
       const args = `test ${COLL_PATH} --reporter-junit ${exportPath}`;
 
-      // Use retry logic to handle transient network errors (ECONNRESET, etc.)
-      // that can corrupt JUnit XML structure and cause snapshot mismatches
-      const maxAttempts = 2; // Only retry once (2 total attempts)
-      let lastResult: Awaited<ReturnType<typeof runCLI>> | null = null;
-      let lastFileContents = "";
-
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        lastResult = await runCLI(args, {
-          cwd: path.resolve("hopp-cli-test"),
-        });
-
-        // Read JUnit XML file
-        const fileContents = fs
-          .readFileSync(path.resolve(genPath, exportPath))
-          .toString();
-
-        lastFileContents = fileContents;
-
-        const hasNetworkErrorInXML =
-          /ECONNRESET|EAI_AGAIN|ENOTFOUND|ETIMEDOUT|ECONNREFUSED/i.test(
-            fileContents
-          ) ||
-          (/REQUEST_ERROR/i.test(fileContents) &&
-            !/Invalid URL/i.test(fileContents));
-
-        if (!hasNetworkErrorInXML) {
-          break;
-        }
-
-        // Network error detected - retry once if not last attempt
-        if (attempt < maxAttempts - 1) {
-          console.log(
-            `⚠️  Network error detected in JUnit XML (ECONNRESET/DNS). Retrying once to get clean snapshot...`
-          );
-          // Delete corrupted XML file before retry
-          try {
-            fs.unlinkSync(path.resolve(genPath, exportPath));
-          } catch {}
-          await new Promise((r) => setTimeout(r, 2000));
-          continue;
-        }
-
-        // Last attempt exhausted - skip test to avoid false positive
-        console.warn(
-          `⚠️  Skipping snapshot test: Network errors persisted in JUnit XML after retry. External services may be degraded.`
-        );
-        return; // Skip test - don't fail on infrastructure issues
+      const outcome = await runJUnitSnapshot(args, exportPath);
+      if (outcome === null) {
+        skip();
+        return;
       }
+      const { result, fileContents } = outcome;
 
-      expect(lastResult?.stdout).not.toContain(
+      expect(result.stdout).not.toContain(
         `Overwriting the pre-existing path: ${exportPath}`
       );
 
-      expect(lastResult?.stdout).toContain(
+      expect(result.stdout).toContain(
         `Successfully exported the JUnit report to: ${exportPath}`
       );
 
-      expect(replaceDynamicValuesInStr(lastFileContents)).toMatchSnapshot();
+      expect(replaceDynamicValuesInStr(fileContents)).toMatchSnapshot();
     });
 
-    test("Generates a JUnit report for a collection with authorization/headers set at the collection level", async () => {
-      const exportPath = "hopp-junit-report.xml";
+    test("Generates a JUnit report for a collection with authorization/headers set at the collection level", async ({ skip }) => {
+      const exportPath = "collection-level-auth-headers-report.xml";
 
       const COLL_PATH = getTestJsonFilePath(
         "collection-level-auth-headers-coll.json",
         "collection"
       );
 
-      const args = `test ${COLL_PATH} --reporter-junit`;
+      const args = `test ${COLL_PATH} --reporter-junit ${exportPath}`;
 
-      // Use retry logic to handle transient network errors (ECONNRESET, etc.)
-      // that can corrupt JUnit XML structure and cause snapshot mismatches
-      const maxAttempts = 2; // Only retry once (2 total attempts)
-      let lastResult: Awaited<ReturnType<typeof runCLI>> | null = null;
-      let lastFileContents = "";
-
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        lastResult = await runCLI(args, {
-          cwd: path.resolve("hopp-cli-test"),
-        });
-
-        // Read JUnit XML file
-        const fileContents = fs
-          .readFileSync(path.resolve(genPath, exportPath))
-          .toString();
-
-        lastFileContents = fileContents;
-
-        const hasNetworkErrorInXML =
-          /ECONNRESET|EAI_AGAIN|ENOTFOUND|ETIMEDOUT|ECONNREFUSED/i.test(
-            fileContents
-          ) ||
-          (/REQUEST_ERROR/i.test(fileContents) &&
-            !/Invalid URL/i.test(fileContents));
-
-        if (!hasNetworkErrorInXML) {
-          break;
-        }
-
-        // Network error detected - retry once if not last attempt
-        if (attempt < maxAttempts - 1) {
-          console.log(
-            `⚠️  Network error detected in JUnit XML (ECONNRESET/DNS). Retrying once to get clean snapshot...`
-          );
-          // Delete corrupted XML file before retry
-          try {
-            fs.unlinkSync(path.resolve(genPath, exportPath));
-          } catch {}
-          await new Promise((r) => setTimeout(r, 2000));
-          continue;
-        }
-
-        // Last attempt exhausted - skip test to avoid false positive
-        console.warn(
-          `⚠️  Skipping snapshot test: Network errors persisted in JUnit XML after retry. External services may be degraded.`
-        );
-        return; // Skip test - don't fail on infrastructure issues
+      const outcome = await runJUnitSnapshot(args, exportPath);
+      if (outcome === null) {
+        skip();
+        return;
       }
+      const { result, fileContents } = outcome;
 
-      expect(lastResult?.stdout).toContain(
-        `Overwriting the pre-existing path: ${exportPath}`
-      );
-
-      expect(lastResult?.stdout).toContain(
+      expect(result.stdout).toContain(
         `Successfully exported the JUnit report to: ${exportPath}`
       );
 
-      expect(replaceDynamicValuesInStr(lastFileContents)).toMatchSnapshot();
+      expect(replaceDynamicValuesInStr(fileContents)).toMatchSnapshot();
     });
 
-    test("Generates a JUnit report for a collection referring to environment variables", async () => {
-      const exportPath = "hopp-junit-report.xml";
+    test("Generates a JUnit report for a collection referring to environment variables", async ({ skip }) => {
+      const exportPath = "env-vars-report.xml";
 
       const COLL_PATH = getTestJsonFilePath(
         "req-body-env-vars-coll.json",
@@ -1315,66 +1200,50 @@ describe("hopp test [options] <file_path_or_id>", { timeout: 100000 }, () => {
         "environment"
       );
 
-      const args = `test ${COLL_PATH} --env ${ENV_PATH} --reporter-junit`;
+      const args = `test ${COLL_PATH} --env ${ENV_PATH} --reporter-junit ${exportPath}`;
 
-      // Use retry logic to handle transient network errors (ECONNRESET, etc.)
-      // that can corrupt JUnit XML structure and cause snapshot mismatches
-      const maxAttempts = 2; // Only retry once (2 total attempts)
-      let lastResult: Awaited<ReturnType<typeof runCLI>> | null = null;
-      let lastFileContents = "";
-
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        lastResult = await runCLI(args, {
-          cwd: path.resolve("hopp-cli-test"),
-        });
-
-        // Read JUnit XML file
-        const fileContents = fs
-          .readFileSync(path.resolve(genPath, exportPath))
-          .toString();
-
-        lastFileContents = fileContents;
-
-        const hasNetworkErrorInXML =
-          /ECONNRESET|EAI_AGAIN|ENOTFOUND|ETIMEDOUT|ECONNREFUSED/i.test(
-            fileContents
-          ) ||
-          (/REQUEST_ERROR/i.test(fileContents) &&
-            !/Invalid URL/i.test(fileContents));
-
-        if (!hasNetworkErrorInXML) {
-          break;
-        }
-
-        // Network error detected - retry once if not last attempt
-        if (attempt < maxAttempts - 1) {
-          console.log(
-            `⚠️  Network error detected in JUnit XML (ECONNRESET/DNS). Retrying once to get clean snapshot...`
-          );
-          // Delete corrupted XML file before retry
-          try {
-            fs.unlinkSync(path.resolve(genPath, exportPath));
-          } catch {}
-          await new Promise((r) => setTimeout(r, 2000));
-          continue;
-        }
-
-        // Last attempt exhausted - skip test to avoid false positive
-        console.warn(
-          `⚠️  Skipping snapshot test: Network errors persisted in JUnit XML after retry. External services may be degraded.`
-        );
-        return; // Skip test - don't fail on infrastructure issues
+      const outcome = await runJUnitSnapshot(args, exportPath);
+      if (outcome === null) {
+        skip();
+        return;
       }
+      const { result, fileContents } = outcome;
 
-      expect(lastResult?.stdout).toContain(
-        `Overwriting the pre-existing path: ${exportPath}`
-      );
-
-      expect(lastResult?.stdout).toContain(
+      expect(result.stdout).toContain(
         `Successfully exported the JUnit report to: ${exportPath}`
       );
 
-      expect(replaceDynamicValuesInStr(lastFileContents)).toMatchSnapshot();
+      expect(replaceDynamicValuesInStr(fileContents)).toMatchSnapshot();
+    });
+
+    test("Logs overwrite message when the JUnit target file already exists", async ({ skip }) => {
+      const exportPath = "overwrite-test-report.xml";
+      const absPath = path.resolve(genPath, exportPath);
+
+      const COLL_PATH = getTestJsonFilePath(
+        "test-junit-report-export-coll.json",
+        "collection"
+      );
+      const args = `test ${COLL_PATH} --reporter-junit ${exportPath}`;
+
+      // Re-seed a placeholder before each attempt so the reporter's
+      // overwrite branch fires on retry just as it does on attempt 0.
+      const outcome = await runJUnitSnapshot(args, exportPath, () => {
+        fs.writeFileSync(absPath, "<placeholder />");
+      });
+
+      if (outcome === null) {
+        skip();
+        return;
+      }
+
+      const { result } = outcome;
+      expect(result.stdout).toContain(
+        `Overwriting the pre-existing path: ${exportPath}`
+      );
+      expect(result.stdout).toContain(
+        `Successfully exported the JUnit report to: ${exportPath}`
+      );
     });
   });
 

--- a/packages/hoppscotch-cli/src/__tests__/unit/transient-classifier.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/transient-classifier.spec.ts
@@ -48,6 +48,7 @@ describe("isTransientCliFailure", () => {
       ["echo 429", " GET  https://echo.hoppscotch.io  429 : Too Many Requests"],
       ["postman-echo 500", " GET  https://postman-echo.com/get  500 : Internal Server Error"],
       ["hoppscotch.io 504", " HEAD  https://hoppscotch.io  504 : Gateway Timeout"],
+      ["echo 503 with query-only URL", " GET  https://echo.hoppscotch.io?key=value  503 : Service Unavailable"],
     ])("classifies %s runner line as transient", (_name, line) => {
       const { isTransient } = isTransientCliFailure(`\n${line}\n`);
       expect(isTransient).toBe(true);

--- a/packages/hoppscotch-cli/src/__tests__/unit/transient-classifier.spec.ts
+++ b/packages/hoppscotch-cli/src/__tests__/unit/transient-classifier.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "vitest";
+
+import { isTransientCliFailure } from "../utils";
+
+const RED = "\u001b[31m";
+const RESET = "\u001b[0m";
+
+describe("isTransientCliFailure", () => {
+  describe("low-level network errors", () => {
+    test.each([
+      ["ECONNRESET", "read ECONNRESET"],
+      ["EAI_AGAIN", "getaddrinfo EAI_AGAIN echo.hoppscotch.io"],
+      ["ENOTFOUND", "getaddrinfo ENOTFOUND echo.hoppscotch.io"],
+      ["ETIMEDOUT", "connect ETIMEDOUT 104.21.0.1:443"],
+      ["ECONNREFUSED", "connect ECONNREFUSED 127.0.0.1:443"],
+    ])("classifies %s as transient", (code, output) => {
+      const { isTransient } = isTransientCliFailure(output);
+      expect(isTransient).toBe(true);
+    });
+
+    test("matches ANSI-wrapped error codes", () => {
+      const { isTransient } = isTransientCliFailure(
+        `${RED}read ECONNRESET${RESET}`
+      );
+      expect(isTransient).toBe(true);
+    });
+
+    test("reports the matched code in detail", () => {
+      const { detail } = isTransientCliFailure("read ECONNRESET");
+      expect(detail).toBe("ECONNRESET (connection reset)");
+    });
+  });
+
+  describe("httpbin.org guard messages", () => {
+    test.each([
+      ["httpbin.org is down (5xx), skipping assertions"],
+      ["httpbin.org is down (503), skipping assertions"],
+    ])("classifies fixture guard text as transient: %s", (output) => {
+      const { isTransient } = isTransientCliFailure(output);
+      expect(isTransient).toBe(true);
+    });
+  });
+
+  describe("external service degradation (runner status lines)", () => {
+    test.each([
+      ["echo 503", " GET  https://echo.hoppscotch.io  503 : Service Unavailable"],
+      ["echo 502", " POST  https://echo.hoppscotch.io/post  502 : Bad Gateway"],
+      ["echo 429", " GET  https://echo.hoppscotch.io  429 : Too Many Requests"],
+      ["postman-echo 500", " GET  https://postman-echo.com/get  500 : Internal Server Error"],
+      ["hoppscotch.io 504", " HEAD  https://hoppscotch.io  504 : Gateway Timeout"],
+    ])("classifies %s runner line as transient", (_name, line) => {
+      const { isTransient } = isTransientCliFailure(`\n${line}\n`);
+      expect(isTransient).toBe(true);
+    });
+
+    test("matches ANSI-colored status lines", () => {
+      const { isTransient } = isTransientCliFailure(
+        `\n ${RED}GET${RESET}  https://echo.hoppscotch.io  ${RED}503 : Service Unavailable${RESET}\n`
+      );
+      expect(isTransient).toBe(true);
+    });
+
+    test.each([
+      ["httpbin.org excluded (intentional /status fixtures)", " GET  https://httpbin.org/status/503  503 : Service Unavailable"],
+      ["4xx is not degradation", " GET  https://echo.hoppscotch.io  404 : Not Found"],
+      ["2xx is not degradation", " GET  https://echo.hoppscotch.io  200 : OK"],
+      ["mid-line mention is not a runner line", "Request to GET https://echo.hoppscotch.io 500 failed"],
+    ])("does not classify: %s", (_name, line) => {
+      const { isTransient } = isTransientCliFailure(`\n${line}\n`);
+      expect(isTransient).toBe(false);
+    });
+  });
+
+  describe("script errors caused by request failure", () => {
+    const typeErrorCrash =
+      "TEST_SCRIPT_ERROR Script execution failed: TypeError: cannot read property 'host' of undefined";
+    const preRequestFetchCrash =
+      "PRE_REQUEST_SCRIPT_ERROR Script execution failed: FetchError: Fetch failed: socket hang up";
+    const requestError = "REQUEST_ERROR socket hang up";
+
+    test("REQUEST_ERROR followed by TypeError crash", () => {
+      const { isTransient } = isTransientCliFailure(
+        `${requestError}\n${typeErrorCrash}`
+      );
+      expect(isTransient).toBe(true);
+    });
+
+    test("TypeError crash followed by REQUEST_ERROR", () => {
+      const { isTransient } = isTransientCliFailure(
+        `${typeErrorCrash}\n${requestError}`
+      );
+      expect(isTransient).toBe(true);
+    });
+
+    test("pre-request FetchError with REQUEST_ERROR co-occurrence", () => {
+      const { isTransient } = isTransientCliFailure(
+        `${requestError}\n${preRequestFetchCrash}`
+      );
+      expect(isTransient).toBe(true);
+    });
+
+    test("script crash alone is not transient (could be a real bug)", () => {
+      const { isTransient } = isTransientCliFailure(typeErrorCrash);
+      expect(isTransient).toBe(false);
+    });
+
+    test("REQUEST_ERROR alone is not transient (could be an intentional bad-URL fixture)", () => {
+      const { isTransient } = isTransientCliFailure(
+        "REQUEST_ERROR Error: Invalid URL"
+      );
+      expect(isTransient).toBe(false);
+    });
+
+    test("co-occurrence beyond the proximity window is not matched", () => {
+      const { isTransient } = isTransientCliFailure(
+        `${requestError}\n${"x".repeat(600)}\n${typeErrorCrash}`
+      );
+      expect(isTransient).toBe(false);
+    });
+  });
+
+  describe("non-transient shapes stay visible", () => {
+    test.each([
+      ["clean success output", "✔ All tests passed\nTest Cases: 0 failed 76 passed"],
+      ["plain assertion failure", "- Expected '502' to be '200'\nTest Cases: 1 failed 75 passed"],
+      ["bare exit-1 with no signal", "Exited with code 1"],
+    ])("%s", (_name, output) => {
+      const { isTransient } = isTransientCliFailure(output);
+      expect(isTransient).toBe(false);
+    });
+  });
+});

--- a/packages/hoppscotch-cli/src/__tests__/utils.ts
+++ b/packages/hoppscotch-cli/src/__tests__/utils.ts
@@ -42,22 +42,66 @@ export const getTestJsonFilePath = (
   return filePath;
 };
 
-/**
- * Runs CLI with automatic retry for transient infrastructure failures.
- *
- * IMPORTANT: Only use this for tests that EXPECT SUCCESS.
- * For tests that intentionally test error scenarios (bad URLs, script errors, etc.),
- * use plain `runCLI()` instead to avoid false skips.
- *
- * Retries on:
- * - Low-level network errors (ECONNRESET, DNS timeouts, connection refused)
- * - Service degradation (httpbin.org 5xx)
- * - Response undefined errors from network failures
- *
- * Does NOT retry on:
- * - REQUEST_ERROR alone (could be intentional bad URL)
- * - TEST_SCRIPT_ERROR alone (could be intentional script error)
- */
+// REQUEST_ERROR and TEST_SCRIPT_ERROR alone are ambiguous (bad-URL tests, script errors).
+const TRANSIENT_PATTERN =
+  /ECONNRESET|EAI_AGAIN|ENOTFOUND|ETIMEDOUT|ECONNREFUSED/i;
+const HTTPBIN_5XX_PATTERN =
+  /httpbin\.org is down \(5xx\)|httpbin\.org is down \(503\)/i;
+// Line-anchored match on request-runner output: METHOD + URL + 5xx/429 status.
+// Excludes httpbin.org (intentional /status/500 fixtures exist there) and
+// failure-message/XML content (no METHOD prefix at line start).
+const EXTERNAL_SERVICE_DEGRADATION_PATTERN =
+  /(?:^|\n)\s+(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+https?:\/\/(?:echo\.hoppscotch\.io|hoppscotch\.io|postman-echo\.com)(?:\/\S*)?\s+(?:429|5\d{2})(?:\s|$)/i;
+// Co-located REQUEST_ERROR + sandbox script crash from network failure. Matches
+// both TEST_SCRIPT_ERROR (test-script phase) and PRE_REQUEST_SCRIPT_ERROR
+// (pre-request phase), and both TypeError shape (response undefined from
+// REQUEST_ERROR) and FetchError shape (hopp.fetch / pm.sendRequest subrequest).
+// REQUEST_ERROR co-occurrence anchor distinguishes network failure from a
+// real script bug. No existing fixture asserts against this combined shape.
+const TEST_SCRIPT_NETWORK_PATTERN =
+  /REQUEST_ERROR[\s\S]{0,500}(?:TEST|PRE_REQUEST)_SCRIPT_ERROR[\s\S]{0,120}Script execution failed:[\s\S]{0,200}(?:TypeError:[\s\S]{0,80}cannot read propert(?:y|ies)|FetchError: Fetch failed)|(?:TEST|PRE_REQUEST)_SCRIPT_ERROR[\s\S]{0,120}Script execution failed:[\s\S]{0,200}(?:TypeError:[\s\S]{0,80}cannot read propert(?:y|ies)|FetchError: Fetch failed)[\s\S]{0,500}REQUEST_ERROR/i;
+
+export type TransientClassification = {
+  isTransient: boolean;
+  detail: string;
+};
+
+export const isTransientCliFailure = (
+  output: string
+): TransientClassification => {
+  const cleaned = trimAnsi(output);
+  const hasLowLevelNetworkError = TRANSIENT_PATTERN.test(cleaned);
+  const hasHttpbin5xx = HTTPBIN_5XX_PATTERN.test(cleaned);
+  const hasExternalServiceDegradation =
+    EXTERNAL_SERVICE_DEGRADATION_PATTERN.test(cleaned);
+  const hasTestScriptErrorFromNetworkFailure =
+    TEST_SCRIPT_NETWORK_PATTERN.test(cleaned);
+
+  const isTransient =
+    hasLowLevelNetworkError ||
+    hasHttpbin5xx ||
+    hasExternalServiceDegradation ||
+    hasTestScriptErrorFromNetworkFailure;
+
+  let detail = "Network failure";
+  if (/ECONNRESET/i.test(cleaned)) detail = "ECONNRESET (connection reset)";
+  else if (/EAI_AGAIN/i.test(cleaned)) detail = "EAI_AGAIN (DNS timeout)";
+  else if (/ENOTFOUND/i.test(cleaned)) detail = "ENOTFOUND (DNS lookup failed)";
+  else if (/ETIMEDOUT/i.test(cleaned))
+    detail = "ETIMEDOUT (connection timeout)";
+  else if (/ECONNREFUSED/i.test(cleaned))
+    detail = "ECONNREFUSED (connection refused)";
+  else if (hasHttpbin5xx) detail = "httpbin.org service degradation (5xx)";
+  else if (hasExternalServiceDegradation)
+    detail = "external service degradation (5xx/429)";
+  else if (hasTestScriptErrorFromNetworkFailure)
+    detail = "TEST_SCRIPT_ERROR (response undefined - likely network failure)";
+
+  return { isTransient, detail };
+};
+
+// For success-path tests only; error-path tests should call `runCLI` directly to
+// avoid masking assertion failures as transient.
 export const runCLIWithNetworkRetry = async (
   args: string,
   options = {},
@@ -66,70 +110,36 @@ export const runCLIWithNetworkRetry = async (
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const result = await runCLI(args, options);
     const combinedOutput = `${result.stdout}\n${result.stderr}`;
-
-    // Only detect low-level TCP/DNS errors - these are always transient
-    const hasLowLevelNetworkError =
-      /ECONNRESET|EAI_AGAIN|ENOTFOUND|ETIMEDOUT|ECONNREFUSED/i.test(
-        combinedOutput
-      );
-
-    // Special case: TEST_SCRIPT_ERROR when response is undefined due to REQUEST_ERROR
-    // This is the actual CI failure mode when external services go down
-    const hasTestScriptErrorFromNetworkFailure =
-      /TEST_SCRIPT_ERROR Script execution failed: TypeError: cannot read property/.test(
-        combinedOutput
-      ) && /REQUEST_ERROR/.test(combinedOutput);
-
-    // Service degradation
-    const hasHttpbin5xx =
-      /httpbin\.org is down \(5xx\)|httpbin\.org is down \(503\)/i.test(
-        combinedOutput
-      );
-
-    // Success - return immediately
-    if (!result.error && !hasHttpbin5xx) {
-      return result;
-    }
-
-    // Not a transient error - return immediately (don't mask real failures)
-    if (
-      !hasLowLevelNetworkError &&
-      !hasHttpbin5xx &&
-      !hasTestScriptErrorFromNetworkFailure
-    ) {
-      return result;
-    }
-
-    const extractErrorDetails = (output: string): string => {
-      if (/ECONNRESET/i.test(output)) return "ECONNRESET (connection reset)";
-      if (/EAI_AGAIN/i.test(output)) return "EAI_AGAIN (DNS timeout)";
-      if (/ENOTFOUND/i.test(output)) return "ENOTFOUND (DNS lookup failed)";
-      if (/ETIMEDOUT/i.test(output)) return "ETIMEDOUT (connection timeout)";
-      if (/ECONNREFUSED/i.test(output))
-        return "ECONNREFUSED (connection refused)";
-      if (/httpbin\.org is down/i.test(output))
-        return "httpbin.org service degradation (5xx)";
-      if (/TEST_SCRIPT_ERROR.*cannot read property/i.test(output))
-        return "TEST_SCRIPT_ERROR (response undefined - likely REQUEST_ERROR)";
-      return "Network failure";
-    };
-
-    const errorDetail = extractErrorDetails(combinedOutput);
-    const argsPreview =
-      args.length > 100 ? `${args.substring(0, 100)}...` : args;
-
+    const { isTransient, detail } = isTransientCliFailure(combinedOutput);
     const isLastAttempt = attempt === maxAttempts - 1;
+
+    // CLI exits 0 on httpbin 5xx (guards absorb it); check transient signal too.
+    if (!result.error && !isTransient) {
+      return result;
+    }
+
+    // Non-transient outcome — surface the result so the caller's assertions
+    // fire on the real error instead of being masked as a flake skip.
+    if (!isTransient) {
+      return result;
+    }
+
     if (!isLastAttempt) {
+      const argsPreview =
+        args.length > 100 ? `${args.substring(0, 100)}...` : args;
       console.log(
-        `⚠️  Network error detected: ${errorDetail}\n   Command: ${argsPreview}\n   Retrying once...`
+        `⚠️  Network error detected: ${detail}\n   Command: ${argsPreview}\n   Retrying once...`
       );
       await new Promise((resolve) => setTimeout(resolve, 2000));
       continue;
     }
 
+    // Transient on last attempt → skip.
+    const argsPreview =
+      args.length > 100 ? `${args.substring(0, 100)}...` : args;
     console.warn(
       `⚠️  Skipping test after retry exhausted\n` +
-        `   Error: ${errorDetail}\n` +
+        `   Error: ${detail}\n` +
         `   Command: ${argsPreview}\n` +
         `   External services may be unavailable. Test will be skipped to avoid blocking CI.`
     );

--- a/packages/hoppscotch-cli/src/__tests__/utils.ts
+++ b/packages/hoppscotch-cli/src/__tests__/utils.ts
@@ -51,7 +51,7 @@ const HTTPBIN_5XX_PATTERN =
 // Excludes httpbin.org (intentional /status/500 fixtures exist there) and
 // failure-message/XML content (no METHOD prefix at line start).
 const EXTERNAL_SERVICE_DEGRADATION_PATTERN =
-  /(?:^|\n)\s+(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+https?:\/\/(?:echo\.hoppscotch\.io|hoppscotch\.io|postman-echo\.com)(?:\/\S*)?\s+(?:429|5\d{2})(?:\s|$)/i;
+  /(?:^|\n)\s+(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\s+https?:\/\/(?:echo\.hoppscotch\.io|hoppscotch\.io|postman-echo\.com)(?:[\/?#]\S*)?\s+(?:429|5\d{2})(?:\s|$)/i;
 // Co-located REQUEST_ERROR + sandbox script crash from network failure. Matches
 // both TEST_SCRIPT_ERROR (test-script phase) and PRE_REQUEST_SCRIPT_ERROR
 // (pre-request phase), and both TypeError shape (response undefined from
@@ -95,7 +95,7 @@ export const isTransientCliFailure = (
   else if (hasExternalServiceDegradation)
     detail = "external service degradation (5xx/429)";
   else if (hasTestScriptErrorFromNetworkFailure)
-    detail = "TEST_SCRIPT_ERROR (response undefined - likely network failure)";
+    detail = "script error co-occurring with REQUEST_ERROR (likely network failure)";
 
   return { isTransient, detail };
 };


### PR DESCRIPTION
This PR hardens the CLI e2e suite against external service degradation, which has been hard-failing CI whenever `echo.hoppscotch.io` or `postman-echo.com` degrade.

### What's changed

- Centralized transient-failure detection into `isTransientCliFailure()` with two new signals: request-runner `5xx`/`429` status lines from `echo.hoppscotch.io` / `hoppscotch.io` / `postman-echo.com` (`httpbin.org` stays excluded — fixtures intentionally request `/status/5xx` there), and pre-request/`FetchError` sandbox-subrequest crashes anchored to `REQUEST_ERROR` co-occurrence.
- Removed the duplicated non-JUnit scripting-revamp run — the JUnit run now carries the assertions, halving live-service calls for the heaviest spec.
- Consolidated the JUnit snapshot tests behind a shared `runJUnitSnapshot` helper with per-test export paths and a `preSeed` hook; overwrite-warning behavior has a dedicated test.
- Added 28 table-driven unit tests pinning the classifier: positive shapes, false-positive guards, ANSI handling, and the `REQUEST_ERROR` proximity window.

### Notes to reviewers

- Scope: only classifiable transient shapes retry/skip (loudly, via console output). Degradation with no recognizable signal — e.g. a `200` with a degraded body crashing a script — still fails CI visibly; that class can't be classified from output without masking real bugs and is tracked in #TBD (hermetic test doubles).
- Deliberately does not reintroduce `previousAttemptWasTransient` suppression (removed in `518224b84` after it masked a real regression): unrecognized failures always surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the CLI e2e suite so external service degradation no longer hard-fails CI when `echo.hoppscotch.io` or `postman-echo.com` return 5xx/429. Transient detection is centralized in `isTransientCliFailure()`, which now flags runner 5xx/429 status lines — including query-only URLs like `https://echo.hoppscotch.io?key=value` — while still excluding `httpbin.org` (fixtures intentionally request `/status/5xx` there), plus script crashes co-occurring with `REQUEST_ERROR`; failures without a recognizable signal still surface.

**Test suite changes**
- Removed the duplicated non-JUnit scripting-revamp run; the JUnit run now carries the assertions, halving live-service calls.
- Consolidated JUnit snapshot tests behind a shared `runJUnitSnapshot` helper with per-test export paths and a `preSeed` hook.
- Snapshot retry exhaustion now calls `skip()` instead of silently passing, so snapshots stay deferred rather than falsely green.
- Retry and skip logs name the matched classifier signal, so skips during degradation are auditable.
- Added 28 table-driven unit tests pinning classifier shapes, false-positive guards, ANSI handling, and the `REQUEST_ERROR` proximity window.

<sup>Written for commit f229cbef800ae8bd71e6c2317247850587257f8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

