### PR TITLE
fix(desktop): increase on-prem bundle download timeout beyond 30s

### DIFF
--- a/packages/hoppscotch-selfhost-web/src/platform/instance/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/instance/desktop/index.ts
@@ -36,14 +36,14 @@ import {
 import { Store } from "@app/kernel/store"
 import { getKernelMode } from "@hoppscotch/kernel"
 import { getService } from "@hoppscotch/common/modules/dioc"
+import { useDesktopSettings } from "@hoppscotch/common/composables/desktop-settings"
 
 const STORE_NAMESPACE = "hoppscotch-desktop.v1"
 
 // Must match `DOWNLOAD_TIMEOUT_FACTOR` in tauri-plugin-appload's ApiClient.
 // `download()` fetches key + manifest + the ~35 MB bundle; Rust times the
-// bundle GET at 10x the connection timeout. This JS race wraps the whole
-// call, so it cannot be shorter or it wins with
-// "Connection timeout after 30000ms" while the zip is still transferring.
+// bundle GET at 10x the persisted `connectionTimeoutMs`. This JS race wraps
+// the whole call, so it must use the same base or it wins first.
 const BUNDLE_DOWNLOAD_TIMEOUT_FACTOR = 10
 
 type RecentInstances = Instance[]
@@ -843,12 +843,20 @@ export class DesktopInstanceService
   ): TE.TaskEither<string, DownloadResponse> {
     console.log(`[InstanceService] Downloading from: ${serverUrl}`)
 
-    const connectionTimeout = this.config?.connectionTimeout || 30000
-    const timeout = connectionTimeout * BUNDLE_DOWNLOAD_TIMEOUT_FACTOR
-
     return TE.tryCatch(
-      () =>
-        Promise.race([
+      async () => {
+        const desktopSettings = useDesktopSettings()
+        await desktopSettings.ready()
+
+        // Same base Rust reads from the store (`connectionTimeoutMs`).
+        // `this.config.connectionTimeout` is the compile-time default only.
+        const connectionTimeout =
+          desktopSettings.settings.connectionTimeoutMs ||
+          this.config?.connectionTimeout ||
+          30000
+        const timeout = connectionTimeout * BUNDLE_DOWNLOAD_TIMEOUT_FACTOR
+
+        return Promise.race([
           download({ serverUrl }),
           new Promise<never>((_, reject) =>
             setTimeout(
@@ -856,7 +864,8 @@ export class DesktopInstanceService
               timeout
             )
           ),
-        ]),
+        ])
+      },
       (error) => `Failed to download instance: ${error}`
     )
   }

--- a/packages/hoppscotch-selfhost-web/src/platform/instance/desktop/index.ts
+++ b/packages/hoppscotch-selfhost-web/src/platform/instance/desktop/index.ts
@@ -39,6 +39,13 @@ import { getService } from "@hoppscotch/common/modules/dioc"
 
 const STORE_NAMESPACE = "hoppscotch-desktop.v1"
 
+// Must match `DOWNLOAD_TIMEOUT_FACTOR` in tauri-plugin-appload's ApiClient.
+// `download()` fetches key + manifest + the ~35 MB bundle; Rust times the
+// bundle GET at 10x the connection timeout. This JS race wraps the whole
+// call, so it cannot be shorter or it wins with
+// "Connection timeout after 30000ms" while the zip is still transferring.
+const BUNDLE_DOWNLOAD_TIMEOUT_FACTOR = 10
+
 type RecentInstances = Instance[]
 
 const sortByLastUsedDesc = A.sort(
@@ -836,7 +843,8 @@ export class DesktopInstanceService
   ): TE.TaskEither<string, DownloadResponse> {
     console.log(`[InstanceService] Downloading from: ${serverUrl}`)
 
-    const timeout = this.config?.connectionTimeout || 30000
+    const connectionTimeout = this.config?.connectionTimeout || 30000
+    const timeout = connectionTimeout * BUNDLE_DOWNLOAD_TIMEOUT_FACTOR
 
     return TE.tryCatch(
       () =>

--- a/packages/hoppscotch-selfhost-web/webapp-server/README.md
+++ b/packages/hoppscotch-selfhost-web/webapp-server/README.md
@@ -20,7 +20,7 @@ docker build -t hoppscotch-webapp-server .
 |----------------------------------|------------------------------------------------------------|------------------------------------------------|
 | `WEBAPP_SERVER_PORT`             | Server port                                                | `3200`                                         |
 | `WEBAPP_SERVER_READ_TIMEOUT`     | HTTP read timeout (Go duration, e.g. `30s`; `0` disables)  | `15s`                                          |
-| `WEBAPP_SERVER_WRITE_TIMEOUT`    | HTTP write timeout (Go duration, e.g. `30s`; `0` disables) | `15s`                                          |
+| `WEBAPP_SERVER_WRITE_TIMEOUT`    | HTTP write timeout (Go duration, e.g. `30s`; `0` disables) | `5m`                                           |
 | `WEBAPP_SERVER_IDLE_TIMEOUT`     | HTTP idle timeout (Go duration, e.g. `2m`; `0` disables)   | `60s`                                          |
 | `FRONTEND_PATH`                  | Path to frontend assets                                    | `/site/selfhost-web` (prod) or `../dist` (dev) |
 | `WEBAPP_SERVER_SIGNING_SECRET`   | Secret string for key derivation                           | None                                           |

--- a/packages/hoppscotch-selfhost-web/webapp-server/internal/config/config.go
+++ b/packages/hoppscotch-selfhost-web/webapp-server/internal/config/config.go
@@ -13,7 +13,9 @@ const (
 	DevFrontendPath     = "../dist"
 
 	DefaultReadTimeout  = 15 * time.Second
-	DefaultWriteTimeout = 15 * time.Second
+	// Bundle GET streams ~35 MB; 15s is too short for VPN/WAN clients
+	// hitting :3200 directly (write tcp ... i/o timeout).
+	DefaultWriteTimeout = 5 * time.Minute
 	DefaultIdleTimeout  = 60 * time.Second
 )
 


### PR DESCRIPTION
## Summary

- On-prem desktop "Add instance" downloads a ~33–35 MB signed zip from `{instance}/desktop-app-server/api/v1/bundle`. Over HTTPS + VPN that transfer often takes more than 30s. The UI then fails with `Connection timeout after 30000ms` even though the origin already finished sending the zip.
- [#4844](https://github.com/hoppscotch/hoppscotch/pull/4844) already raised the **Rust** reqwest timeout for the bundle GET to 10× the connection timeout (5 minutes by default). That is still in 26.1.1. The TypeScript `performDownloadTE` wrapper races the entire `download()` call (key + manifest + bundle) against `connectionTimeout` (30s) **without** the 10× factor, so the JS timer wins and surfaces the exact 30s error. Settings copy already says downloads get ten times the connection limit.
- This aligns the JS race with `DOWNLOAD_TIMEOUT_FACTOR` (10) so the default bundle allowance is 5 minutes. Key/manifest still fail fast at 30s in Rust.
- Also raises the Go `webapp-server` default `WriteTimeout` from 15s to 5m. Hitting `:3200` directly on a slow client currently dies with `write tcp ... i/o timeout` / `error decoding response body`. Still overridable via `WEBAPP_SERVER_WRITE_TIMEOUT`.

Related: [#4842](https://github.com/hoppscotch/hoppscotch/issues/4842) (closed after 4844; 26.1.1 still hits the JS 30s path).

## Test plan

- [ ] Desktop: Add instance `https://<self-host-domain>` on a link that needs **>30s** to pull ~35 MB — should succeed (or fail only on a real network error).
- [ ] Desktop: Add instance `http://<host>:3200` still works.
- [ ] Dead host: key/manifest still fail in ~30s (do not wait 5 minutes).
- [ ] Optional: Settings → Connection timeout still scales the Rust client after restart; JS download race is now 10× that same base (default 30s → 5 min).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes on-prem desktop bundle downloads timing out after 30 seconds by aligning the JavaScript download race with the Rust client's 10× timeout factor, and raises the webapp-server default write timeout so direct `:3200` transfers don't die mid-stream.

- The desktop download race now reads the persisted connection timeout and applies the 10× factor (default 5 minutes), matching the Rust bundle GET timeout.
- Key and manifest requests still fail fast at 30s.
- `WEBAPP_SERVER_WRITE_TIMEOUT` default changes from `15s` to `5m`; it remains overridable via the environment variable.

<sup>Written for commit 2476801460deecd93749bef83b5290bf078a2d8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

