### PR TITLE
fix(common): prevent PATCH method from being trimmed

### DIFF
--- a/packages/hoppscotch-common/src/components/collections/Request.vue
+++ b/packages/hoppscotch-common/src/components/collections/Request.vue
@@ -35,7 +35,7 @@
         @click="selectRequest()"
       >
         <span
-          class="pointer-events-none flex w-10 items-center justify-start truncate px-0.5"
+          class="pointer-events-none flex min-w-10 items-center justify-start truncate px-0.5"
           :style="{
             color: isGQL
               ? undefined

--- a/packages/hoppscotch-common/src/components/collections/Request.vue
+++ b/packages/hoppscotch-common/src/components/collections/Request.vue
@@ -35,7 +35,7 @@
         @click="selectRequest()"
       >
         <span
-          class="pointer-events-none flex min-w-10 items-center justify-start truncate px-0.5"
+          class="pointer-events-none flex min-w-10 shrink-0 items-center justify-start truncate px-0.5"
           :style="{
             color: isGQL
               ? undefined
@@ -59,7 +59,7 @@
           </span>
         </span>
         <span
-          class="pointer-events-none flex min-w-0 flex-1 items-center py-2 pr-2 transition group-hover:text-secondaryDark"
+          class="pointer-events-none flex min-w-0  flex-1 items-center py-2 pr-2 transition group-hover:text-secondaryDark"
         >
           <span class="truncate" :class="{ 'text-accent': isSelected }">
             {{ request.name }}

--- a/packages/hoppscotch-common/src/components/collections/Request.vue
+++ b/packages/hoppscotch-common/src/components/collections/Request.vue
@@ -35,7 +35,7 @@
         @click="selectRequest()"
       >
         <span
-          class="pointer-events-none flex w-8 items-center justify-start truncate px-0.5"
+          class="pointer-events-none flex w-10 items-center justify-start truncate px-0.5"
           :style="{
             color: isGQL
               ? undefined


### PR DESCRIPTION
## Description

Fixes #6629

The PATCH method label in the collection sidebar was being trimmed because the method label container was too narrow and could shrink.

### Changes
- Increased the minimum width of the HTTP method label from `w-8` to `min-w-10`.
- Added `shrink-0` to prevent HTTP method labels from being compressed.
- Kept the request name flexible so long request names continue to truncate normally.

### Verification
- Tested locally with `PATCH`, `OPTIONS`, `CONNECT`, and custom methods.
- Confirmed method labels remain fully visible.
- Confirmed long request names still truncate.
- Confirmed no horizontal overflow.
- Lint/type-check completed successfully.

### Screenshots

**Before**

PATCH was truncated in the sidebar.
<img width="427" height="313" alt="Screenshot 2026-09-03 at 7 24 15 PM" src="https://github.com/user-attachments/assets/9ef401d9-4417-4561-8340-d86e302e7484" />

OPTIONS AND CONNECT was truncated in the sidebar.
<img width="441" height="186" alt="image" src="https://github.com/user-attachments/assets/f54b4df6-bd7d-4335-b5b7-f7f1694b1aea" />


**After**

PATCH, OPTIONS, CONNECT, and custom methods are fully visible.
<img width="448" height="516" alt="Screenshot 2026-09-03 at 7 11 54 PM" src="https://github.com/user-attachments/assets/568bb5fa-eb0b-4196-a31e-01d74f3d939c" />

**FULL SCREEN VIEW**

<img width="1470" height="637" alt="image" src="https://github.com/user-attachments/assets/e9f4e392-062f-4b7c-8c7a-aad8bb95bea5" />
