### PR TITLE
fix(keybindings): keep shortcuts disabled until all locks release

### DIFF
--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -16,11 +16,11 @@ import { getKernelMode } from "@hoppscotch/kernel"
 import { listen } from "@tauri-apps/api/event"
 
 /**
- * This variable keeps track whether keybindings are being accepted
- * true -> Keybindings are checked
- * false -> Key presses are ignored (Keybindings are not checked)
+ * Each active disabler owns one lock. Keybindings remain disabled until all
+ * owners release their locks, so closing one of several open modals cannot
+ * re-enable shortcuts while another modal still needs them disabled.
  */
-let keybindingsEnabled = true
+const keybindingLocks = new Set<symbol>()
 
 /**
  * Unlisten function for Tauri event
@@ -175,7 +175,7 @@ export function hookKeybindingsListener() {
 
 function handleKeyDown(ev: KeyboardEvent) {
   // Do not check keybinds if the mode is disabled
-  if (!keybindingsEnabled) return
+  if (keybindingLocks.size > 0) return
 
   // Skip during IME composition (CJK input). Modern browsers report
   // `isComposing`. Older ones use the sentinel `keyCode === 229`.
@@ -271,7 +271,7 @@ function handleTauriShortcut(shortcut: string) {
   console.info("Tauri shortcut:", shortcut)
 
   // Do not check keybinds if the mode is disabled
-  if (!keybindingsEnabled) return
+  if (keybindingLocks.size > 0) return
 
   const activeBindings = getActiveBindings()
   const boundAction = activeBindings[shortcut as ShortcutKey]
@@ -449,13 +449,14 @@ function getActiveModifier(ev: KeyboardEvent): ModifierKeys | null {
  * This composable allows for the UI component to be disabled if the component in question is mounted
  */
 export function useKeybindingDisabler() {
-  // TODO: Move to a lock based system that keeps the bindings disabled until all locks are lifted
+  const lock = Symbol("keybinding-disabler")
+
   const disableKeybindings = () => {
-    keybindingsEnabled = false
+    keybindingLocks.add(lock)
   }
 
   const enableKeybindings = () => {
-    keybindingsEnabled = true
+    keybindingLocks.delete(lock)
   }
 
   return {

--- a/packages/hoppscotch-common/src/helpers/keybindings.ts
+++ b/packages/hoppscotch-common/src/helpers/keybindings.ts
@@ -20,7 +20,7 @@ import { listen } from "@tauri-apps/api/event"
  * owners release their locks, so closing one of several open modals cannot
  * re-enable shortcuts while another modal still needs them disabled.
  */
-const keybindingLocks = new Set<symbol>()
+const keybindingLocks = new Map<symbol, number>()
 
 /**
  * Unlisten function for Tauri event
@@ -452,11 +452,19 @@ export function useKeybindingDisabler() {
   const lock = Symbol("keybinding-disabler")
 
   const disableKeybindings = () => {
-    keybindingLocks.add(lock)
+    keybindingLocks.set(lock, (keybindingLocks.get(lock) ?? 0) + 1)
   }
 
   const enableKeybindings = () => {
-    keybindingLocks.delete(lock)
+    const count = keybindingLocks.get(lock)
+
+    if (!count) return
+
+    if (count === 1) {
+      keybindingLocks.delete(lock)
+    } else {
+      keybindingLocks.set(lock, count - 1)
+    }
   }
 
   return {


### PR DESCRIPTION
## What
Fixes #6531 by making keybinding disabling composable instances use independent locks.

## Why
When multiple modals disable shortcuts, closing any one modal previously re-enabled keybindings even if another modal was still open.

## How
Each `useKeybindingDisabler` instance owns a unique lock. Disabling adds the lock and enabling removes only that instance's lock; keyboard and Tauri shortcut handling remains disabled while any lock is active.

## Testing
- `git diff --check` passed.
- Targeted Vitest could not run because dependencies are not installed in the fresh checkout (`vitest` unavailable).

## Risk
The change is limited to keybinding-disabler state management and preserves the existing disable/enable API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6531 by switching keybinding disabling to a lock-based system so shortcuts stay disabled until all locks are released. Previously, closing any one modal re-enabled keybindings even while another modal still needed them off.

Each `useKeybindingDisabler` instance now owns a unique lock and counts repeated disable calls, so every `disableKeybindings()` must be matched by a corresponding `enableKeybindings()`. Keyboard and Tauri shortcut handling both check the same lock set.

<sup>Written for commit cbb4aebdd8ba6e05356737bb5f5629eb639b4bb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hoppscotch/hoppscotch/pull/6633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

